### PR TITLE
Geodesy tracker

### DIFF
--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -35,7 +35,7 @@ Add GPS to Binary Sensor:
     - device_tracker.honda
   bayesian_input: binary_sensor.bayesian_zeke_home
   bayesian_device_tracker_name: "bayesian_zeke_home"
-  minimum_update_distance: .1
+  minimum_update_distance: 3
   minimum_update_window: 60
   
   

--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -31,10 +31,11 @@ Add GPS to Binary Sensor:
   gps_location_sources: 
     - device_tracker.wethop
     - device_tracker.wethop_2
-    - device_tracker.android
+    - device_tracker.android_1
     - device_tracker.honda
   bayesian_input: binary_sensor.bayesian_zeke_home
   bayesian_device_tracker_name: "bayesian_zeke_home"
+  gps_accuracy_tolerance: 100
   minimum_update_distance: 3
   minimum_update_window: 60
   

--- a/appdaemon/apps/tracker.py
+++ b/appdaemon/apps/tracker.py
@@ -3,15 +3,17 @@ import appdaemon.plugins.hass.hassapi as hass
 import copy
 from datetime import datetime, timedelta, timezone
 
-
 from geopy.distance import great_circle
+
+from pygeodesy import ellipsoidalNvector
+from pygeodesy import ellipsoidalVincenty
 
 class add_gps(hass.Hass):
 
   def initialize(self):
-    self.device_id = self.args["bayesian_device_tracker_name"]
+    self.bayesian_device_tracker_id = self.args["bayesian_device_tracker_name"]
     self.bayesian = self.args["bayesian_input"]
-    self.gps_sensors = self.args["gps_location_sources"]
+    self.gps_sensor_sources = self.args["gps_location_sources"]
     self.minimum_update_distance = self.args["minimum_update_distance"]
     self.minimum_update_window = self.args["minimum_update_window"]
     
@@ -19,32 +21,22 @@ class add_gps(hass.Hass):
     self.bayes_updated(entity=self.bayesian, attribute={}, old={}, new={}, kwargs={})
     #self.log('done with init')
     
-    #self.log("registering callback {} {}".format(self.location_update, self.gps_sensors))
+    #self.log("registering callback {} {}".format(self.location_update, self.gps_sensor_sources))
     self.listen_state(self.bayes_updated, entity = self.bayesian)
-    for tracker in self.gps_sensors:
+    for tracker in self.gps_sensor_sources:
       self.listen_state(self.location_update, entity = tracker, attribute="all")
-    
-  
+
+
   def bayes_updated(self, entity, attribute, old, new, kwargs):
     sensor_state = self.get_state(entity, attribute="all")
     if sensor_state['state'] == 'on':
       config = self.get_plugin_config()
       self.log("bayes says I am home")
       #self.log("My current position is {}(Lat), {}(Long)".format(config["latitude"], config["longitude"]))
-      #self.log("here we go setting {} to home with GPS: Accuracy {}, Latitude: {}, Longitude: {}".format(self.device_id, 0, config["latitude"], config["longitude"]))
-      self.call_service("device_tracker/see", dev_id=self.device_id, attributes={"course": 0.0, "home_probability": sensor_state["attributes"]["probability"]}, gps=[config["latitude"], config["longitude"]]) 
+      #self.log("here we go setting {} to home with GPS: Accuracy {}, Latitude: {}, Longitude: {}".format(self.bayesian_device_tracker_id, 0, config["latitude"], config["longitude"]))
+      self.call_service("device_tracker/see", dev_id=self.bayesian_device_tracker_id, attributes={"course": 0.0, "home_probability": sensor_state["attributes"]["probability"]}, gps=[config["latitude"], config["longitude"]]) 
     else:
       return
-  
-  # def setup_location(self, tracker):
-  #   #self.log("in setup_location")
-  #   #self.log("calling get_state on {}".format(tracker))
-  #   sensor_state = self.get_state(tracker, attribute="all")
-  #   #self.log("got gps data {}".format(sensor_state))
-  #   #self.log("calling get_state on {}".format(self.bayesian))
-  #   bayesian_state = self.get_state(self.bayesian, attribute="all")
-  #   #self.log("got state data {}".format(bayesian_state, ))
-  #   self.run_update(bayesian_state=bayesian_state, sensor_state=sensor_state)
 
 
   def location_update(self, entity, attribute, old, new, kwargs):
@@ -60,18 +52,22 @@ class add_gps(hass.Hass):
       return
     gps_sensors_state = self.get_state(entity, attribute="all")
     #self.log("here is the GPS state: {}".format(gps_sensors_state))
-    #qbayes_location = self.get_state("device_tracker."+self.device_id, attribute="all")
-    old_lat_long = (old["attributes"].get("latitude"), old["attributes"].get("longitude"))
-    #self.log("old location is: {}".format(old_lat_long))
-    new_lat_long = (new["attributes"].get("latitude"), new["attributes"].get("longitude"))
-    #self.log("new location is: {}".format(new_lat_long))
-    distance = great_circle(old_lat_long, new_lat_long).meters
-    self.log("distance between updates is: {}".format(distance))
+    
+    #qbayes_location = self.get_state("device_tracker."+self.bayesian_device_tracker_id, attribute="all")
+    old_lat_log = ellipsoidalNvector.LatLon(lat=old["attributes"].get("latitude"), lon=old["attributes"].get("longitude"))
+    new_lat_log = ellipsoidalNvector.LatLon(lat=new["attributes"].get("latitude"), lon=new["attributes"].get("longitude"))
+    
+    mean_of_points = ellipsoidalNvector.meanOf([old_lat_log,new_lat_log], LatLon=ellipsoidalVincenty.LatLon)
+    #self.log("Mean of old and new location is {}".format(mean_of_points))
+    
+    # Get Vincenty distance between old and new points
+    distance=new_lat_log.distanceTo(old_lat_log)
+    self.log("Vincenty Distance between updates is: {}".format(distance))
     if distance <= self.minimum_update_distance:
       self.log("Looks like sensor {} is pretty stationary. Not Updating.".format(entity))
       return
     self.run_update(bayesian_state=bayesian_state, sensor_state=gps_sensors_state)
-    
+
 
   def run_update(self, bayesian_state, sensor_state):
     #self.log("in run_update")
@@ -84,8 +80,8 @@ class add_gps(hass.Hass):
       config = self.get_plugin_config()
       self.log("bayes says I am home")
       #self.log("My current position is {}(Lat), {}(Long)".format(config["latitude"], config["longitude"]))
-      #self.log("here we go setting {} to home with GPS: Accuracy {}, Latitude: {}, Longitude: {}".format(self.device_id, 0, config["latitude"], config["longitude"]))
-      self.call_service("device_tracker/see", dev_id=self.device_id, attributes={"course": 0.0, "speed": 0.0, "home_probability": bayesian_state["attributes"]["probability"]}, gps=[config["latitude"], config["longitude"]]) 
+      #self.log("here we go setting {} to home with GPS: Accuracy {}, Latitude: {}, Longitude: {}".format(self.bayesian_device_tracker_id, 0, config["latitude"], config["longitude"]))
+      self.call_service("device_tracker/see", dev_id=self.bayesian_device_tracker_id, attributes={"course": 0.0, "speed": 0.0, "home_probability": bayesian_state["attributes"]["probability"]}, gps=[config["latitude"], config["longitude"]]) 
     else:
       #self.log("bayes says I am away")
       if gps_attributes.keys() != {"latitude", "longitude", "gps_accuracy"}:
@@ -96,7 +92,7 @@ class add_gps(hass.Hass):
         else:
           try:
             #self.log("My current position is {}(Lat), {}(Long)".format(gps_attributes["latitude"], gps_attributes["longitude"]))
-            #self.log("here we go setting {} to somewhere with GPS: Accuracy {}, Latitude: {}, Longitude: {}".format(self.device_id, gps_attributes["gps_accuracy"], gps_attributes["latitude"], gps_attributes["longitude"]))
+            #self.log("here we go setting {} to somewhere with GPS: Accuracy {}, Latitude: {}, Longitude: {}".format(self.bayesian_device_tracker_id, gps_attributes["gps_accuracy"], gps_attributes["latitude"], gps_attributes["longitude"]))
             attributes = copy.deepcopy(gps_attributes)
             #self.log("{}".format(attributes['battery']))
             probability = bayesian_state["attributes"]["probability"]
@@ -148,15 +144,30 @@ class add_gps(hass.Hass):
               #self.error("KeyError deleting {}: missing information from gps sensor. continuing...".format(ke))
               pass
             
+            ## To try and eliminate flashes backward in location from older/stale data, let's find the mean of the old location
+            ## and the new sensor data and use that mean as the location.  
+            dev_tracker_state= self.get_state("device_tracker."+self.bayesian_device_tracker_id, attribute="all")
+            old_lat_log_p = ellipsoidalNvector.LatLon(lat=dev_tracker_state["attributes"]["latitude"], lon=dev_tracker_state["attributes"]["longitude"])
+            self.log("old location is: {}".format(old_lat_log_p))
+            new_lat_log_p = ellipsoidalNvector.LatLon(lat=gps_attributes.get("latitude"), lon=gps_attributes.get("longitude"))
+            self.log("new location is: {}".format(new_lat_log_p))
+            
+            mean_of_points = ellipsoidalNvector.meanOf([old_lat_log_p,new_lat_log_p], LatLon=ellipsoidalVincenty.LatLon)
+            self.log("Mean of location between old and new is {}".format(mean_of_points))
+            
             #self.log("{}".format(attributes))
-            self.call_service("device_tracker/see", dev_id=self.device_id, 
-            attributes = attributes, 
-            gps_accuracy = gps_attributes["gps_accuracy"], 
-            gps = [gps_attributes["latitude"], gps_attributes["longitude"]])
+            #For some reason setting attributes of gps coordinates overrides the gps data in device_tracker/see
+            attributes['latitude']=mean_of_points.lat
+            attributes['longitude']=mean_of_points.lon
+            self.call_service("device_tracker/see", dev_id=self.bayesian_device_tracker_id, 
+              attributes = attributes, 
+              gps_accuracy = gps_attributes["gps_accuracy"], 
+              ##rtclauss 11/15/18 - use mean location
+              gps = [mean_of_points.lat, mean_of_points.lon])
           except KeyError as e:
             self.error("KeyError {}: missing information from sensor. Returning with no action.".format(e))
-            #self.call_service("device_tracker/see", dev_id=self.device_id, attributes={"home_probability": bayesian_state["attributes"]["probability"]})
+            #self.call_service("device_tracker/see", dev_id=self.bayesian_device_tracker_id, attributes={"home_probability": bayesian_state["attributes"]["probability"]})
       else:
         self.error("missing information from gps sensor. Returning with no action.")
-        #self.call_service("device_tracker/see", dev_id=self.device_id, attributes={"home_probability": bayesian_state["attributes"]["probability"]})
+        #self.call_service("device_tracker/see", dev_id=self.bayesian_device_tracker_id, attributes={"home_probability": bayesian_state["attributes"]["probability"]})
         

--- a/appdaemon/apps/tracker.py
+++ b/appdaemon/apps/tracker.py
@@ -71,7 +71,7 @@ class add_gps(hass.Hass):
     new_lat_log = ellipsoidalNvector.LatLon(lat=new["attributes"].get("latitude"), lon=new["attributes"].get("longitude"))
     try:
       old_lat_log = ellipsoidalNvector.LatLon(lat=old["attributes"].get("latitude"), lon=old["attributes"].get("longitude"))
-    except KeyError as ke:
+    except:
       # Home Assistant has restarted so we have no previous state for the device tracker. Let's use the new location state
       # for the old value.
       old_lat_log = new_lat_log

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -235,11 +235,10 @@ automation:
         from: 'away'
     condition: 
     action:
-      - service: scene.turn_on
-        entity_id: scene.arrive_home
       - service: cover.open_cover
         entity_id: cover.garage_door_opener
-
+      - service: scene.turn_on
+        entity_id: scene.arrive_home
 
   - id: notify_home_zone
     alias: notify_home_zone
@@ -509,6 +508,8 @@ automation:
       entity_id: input_boolean.guest_mode
       state: 'off'
     action:
+    - service: cover.close_cover
+      entity_id: cover.garage_door_opener
     - service: scene.turn_on
       entity_id: scene.leave_home
     - delay: 25
@@ -713,7 +714,7 @@ proximity:
       # - Work
       # - home
       # - twincities
-    tolerance: 300
+    tolerance: 150
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -724,7 +725,7 @@ proximity:
     #   - SPCC
     #   - Work
     #   - home
-    tolerance: 300
+    tolerance: 150
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -735,7 +736,7 @@ proximity:
       # - OCC
       # - Work
       # - home
-    tolerance: 300
+    tolerance: 150
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -746,7 +747,7 @@ proximity:
   #     - OCC
   #     - SPCC
   #     - home
-    tolerance: 300
+    tolerance: 150
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -756,7 +757,7 @@ proximity:
     ignored_zones:
       # - Work
       # - OCC
-    tolerance: 300
+    tolerance: 150
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -766,7 +767,7 @@ proximity:
     ignored_zones:
       # - Work
       # - OCC
-    tolerance: 300
+    tolerance: 150
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -622,7 +622,7 @@ binary_sensor:
       prob_given_false: 0.1
       platform: 'state'
       to_state: 'home'
-    - entity_id: device_tracker.android
+    - entity_id: device_tracker.android_1
       prob_given_true: 0.60
       prob_given_false: 0.1
       platform: 'state'
@@ -714,7 +714,7 @@ proximity:
       # - Work
       # - home
       # - twincities
-    tolerance: 150
+    tolerance: 50
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -725,7 +725,7 @@ proximity:
     #   - SPCC
     #   - Work
     #   - home
-    tolerance: 150
+    tolerance: 50
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -736,7 +736,7 @@ proximity:
       # - OCC
       # - Work
       # - home
-    tolerance: 150
+    tolerance: 50
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -747,7 +747,7 @@ proximity:
   #     - OCC
   #     - SPCC
   #     - home
-    tolerance: 150
+    tolerance: 50
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -757,7 +757,7 @@ proximity:
     ignored_zones:
       # - Work
       # - OCC
-    tolerance: 150
+    tolerance: 50
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -767,7 +767,7 @@ proximity:
     ignored_zones:
       # - Work
       # - OCC
-    tolerance: 150
+    tolerance: 50
     unit_of_measurement: m
     devices:
       - device_tracker.bayesian_zeke_home
@@ -817,7 +817,7 @@ sensor:
         entity_id: 
           - device_tracker.bayesian_zeke_home
           - device_tracker.wethop
-          #- device_tracker.android
+          #- device_tracker.android_1
           - device_tracker.honda
         value_template: >-
           {% if (state_attr('device_tracker.bayesian_zeke_home', 'course') | int) >=0 -%}
@@ -829,7 +829,7 @@ sensor:
 
   # - platform: places
   #   name: android
-  #   devicetracker_id: device_tracker.android
+  #   devicetracker_id: device_tracker.android_1
   #   options: place
   #   map_provider: google
   #   map_zoom: 17


### PR DESCRIPTION
Updated Bayesian device tracker so that instead of blindly using the most-recently sent GPS coordinates to update the Bayesian device tracker I use the mean of the old Bayesian GPS coordinates and the incoming GPS coordinates.  This means the Bayesian GPS will lag behind the GPS a little bit but it helps smooth the data overall.

You can see this in 3ed63fe1e96bb46ec6a5ab28a8e4d0457e8f06bc