### PR TITLE
Migrate z2m_failing to modern template binary sensor syntax

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1514,16 +1514,6 @@ automation:
 # Binary Sensors
 ########################
 binary_sensor:
-  - platform: template
-    sensors:
-      z2m_failing:
-        friendly_name: z2m_failing
-        device_class: problem
-        value_template: >-
-          {% set total = states('sensor.z2m_router_total') | int(0) %}
-          {% set offline_pct = states('sensor.z2m_router_offline_pct') | float(0) %}
-          {% set threshold_pct = states('input_number.z2m_router_offline_threshold_pct') | float(15) %}
-          {{ total > 0 and offline_pct >= threshold_pct }}
   - platform: bayesian
     name: "Bayesian Bed Occupancy"
     prior: 0.40
@@ -2214,6 +2204,14 @@ template:
         # Use below when Bed Load Cell 2 has been fixed
         # state: >-
         #   {{ states('sensor.average_bed_load')| int(0) > 20 }}
+
+      - name: z2m_failing
+        device_class: problem
+        state: >-
+          {% set total = states('sensor.z2m_router_total') | int(0) %}
+          {% set offline_pct = states('sensor.z2m_router_offline_pct') | float(0) %}
+          {% set threshold_pct = states('input_number.z2m_router_offline_threshold_pct') | float(15) %}
+          {{ total > 0 and offline_pct >= threshold_pct }}
 
   - lock:
       - name: Front door lock


### PR DESCRIPTION
## Summary
- Keep `binary_sensor.z2m_failing` because it is still used by automations and Lovelace.
- Remove legacy `binary_sensor` platform template definition for `z2m_failing`.
- Recreate `z2m_failing` under modern `template:` `binary_sensor` syntax with the same router-failure logic:
  - `total > 0`
  - `sensor.z2m_router_offline_pct >= input_number.z2m_router_offline_threshold_pct`

## Validation
- YAML syntax validated with a custom loader that supports Home Assistant tags like `!secret`.
- `pytest -q` run in repo (currently reports: `no tests ran`).
