### PR TITLE
Trigger Z2M recovery when recovery candidates exceed 20

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1249,6 +1249,11 @@ automation:
         to: "off"
         for:
           minutes: 10
+      - trigger: numeric_state
+        entity_id: sensor.z2m_recovery_candidates
+        below: 21
+        for:
+          minutes: 10
     condition:
       - condition: state
         entity_id: binary_sensor.zigbee2mqtt_running
@@ -1256,6 +1261,9 @@ automation:
       - condition: state
         entity_id: binary_sensor.z2m_failing
         state: "off"
+      - condition: numeric_state
+        entity_id: sensor.z2m_recovery_candidates
+        below: 21
       - condition: numeric_state
         entity_id: counter.reboot_counter
         above: 0
@@ -1319,18 +1327,27 @@ automation:
       - trigger: time_pattern
         minutes: "/10"
         id: watchdog_tick
+      - trigger: numeric_state
+        entity_id: sensor.z2m_recovery_candidates
+        above: 20
+        for:
+          minutes: 5
+        id: recovery_candidates_high
     variables:
       max_restart_attempts: 3
       issue_active: >-
         {{
           is_state('binary_sensor.zigbee2mqtt_running', 'off')
           or is_state('binary_sensor.z2m_failing', 'on')
+          or (states('sensor.z2m_recovery_candidates') | int(0) > 20)
         }}
       issue_reason: >-
         {% if is_state('binary_sensor.zigbee2mqtt_running', 'off') %}
           Zigbee2MQTT add-on is not running
         {% elif is_state('binary_sensor.z2m_failing', 'on') %}
           Router offline threshold exceeded
+        {% elif states('sensor.z2m_recovery_candidates') | int(0) > 20 %}
+          Z2M recovery candidates exceeded threshold (20)
         {% else %}
           Unknown
         {% endif %}
@@ -1401,6 +1418,7 @@ automation:
                   {{
                     not is_state('binary_sensor.zigbee2mqtt_running', 'off')
                     and not is_state('binary_sensor.z2m_failing', 'on')
+                    and (states('sensor.z2m_recovery_candidates') | int(0) <= 20)
                   }}
             then:
               - action: notify.mobile_app_wethop
@@ -1417,6 +1435,7 @@ automation:
               {{
                 is_state('binary_sensor.zigbee2mqtt_running', 'off')
                 or is_state('binary_sensor.z2m_failing', 'on')
+                or (states('sensor.z2m_recovery_candidates') | int(0) > 20)
               }}
           - condition: numeric_state
             entity_id: counter.reboot_counter
@@ -1455,6 +1474,7 @@ automation:
                   {{
                     not is_state('binary_sensor.zigbee2mqtt_running', 'off')
                     and not is_state('binary_sensor.z2m_failing', 'on')
+                    and (states('sensor.z2m_recovery_candidates') | int(0) <= 20)
                   }}
             then:
               - action: notify.mobile_app_wethop


### PR DESCRIPTION
## Summary
- Add `sensor.z2m_recovery_candidates > 20` as a trigger path to `automation.shutdown_proxmox_z2m_unavailable` (5-minute hold).
- Include recovery-candidate threshold in `issue_active` and `issue_reason` so the watchdog can restart Z2M based on unavailable entities.
- Update recovery-success checks to require candidates `<= 20` before declaring recovery/resetting counter.
- Update `automation.reset_z2m_reboot_counter_on_recovery` to require candidates below threshold for 10 minutes before resetting.

## Behavior change
- If `sensor.z2m_recovery_candidates` stays above `20` for 5 minutes, the existing Z2M restart/escalation flow now activates.

## Validation
- YAML parse with Home Assistant tags (`!secret`) succeeded.
- `pytest -q` run locally (`no tests ran`).
