### PR TITLE
Fix mushroom-strategy badges config for #49

### DIFF
--- a/.storage/lovelace.dashboard_strategy
+++ b/.storage/lovelace.dashboard_strategy
@@ -63,10 +63,10 @@
               "icon": "mdi:tree"
             }
           },
-          "chips": {
+          "badges": {
             "weather_entity": "weather.my_ecobee",
             "switch_count": false,
-            "extra_chips": [
+            "extra_badges": [
               {
                 "type": "conditional",
                 "conditions": [
@@ -75,7 +75,7 @@
                     "state": "unlocked"
                   }
                 ],
-                "chip": {
+                "badge": {
                   "type": "entity",
                   "entity": "lock.front_door_lock",
                   "icon_color": "red",
@@ -93,7 +93,7 @@
                     "state_not": "closed"
                   }
                 ],
-                "chip": {
+                "badge": {
                   "type": "entity",
                   "entity": "cover.garage_door",
                   "icon_color": "red",


### PR DESCRIPTION
## Summary
- rename deprecated mushroom-strategy `chips` config to `badges`
- rename `extra_chips` entries to `extra_badges`
- rename nested conditional `chip` configs to `badge`

Closes #49

## Testing
- no automated unit tests are present in this repository
- validated `.storage/lovelace.dashboard_strategy` with `jq empty`