### PR TITLE
Add ecobee calendar vacation sync for #48

### DIFF
--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -312,7 +312,11 @@ automation:
     mode: restart
     trigger:
       - trigger: state
+        id: schedule_changed
         entity_id: sensor.ecobee_calendar_vacation_schedule
+      - trigger: time
+        id: daily_refresh
+        at: "03:05:00"
     variables:
       vacation_name: "Calendar Auto Vacation"
       vacation_state: "{{ states('sensor.ecobee_calendar_vacation_schedule') }}"
@@ -931,7 +935,7 @@ template:
       - trigger: homeassistant
         event: start
       - trigger: time_pattern
-        hours: "/6"
+        hours: "/1"
       - trigger: state
         entity_id:
           - calendar.curling


### PR DESCRIPTION
## Summary
- add configurable ecobee vacation heat/cool helpers for calendar-driven trips
- compute an ecobee vacation window from long all-day curling events or flight-style events on the personal/work calendars
- keep a single named ecobee vacation schedule in sync with that computed window

## Validation
- python scripts/check_ha_python_support.py --python-version-file .python-version
- yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt

Closes #48