### PR TITLE
Add Uplift BLE desk automation and remote control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 !scripts/
 !scripts/*.py
 !scripts/*.sh
+!scripts/*.example
+!scripts/*.conf.example
+!scripts/*.authorized_keys.example
 
 ########################################
 # Explicitly ignore sensitive files

--- a/packages/desk.yaml
+++ b/packages/desk.yaml
@@ -1,0 +1,323 @@
+################################################################
+## Packages / Desk
+################################################################
+
+################################################
+## Customize
+################################################
+
+homeassistant:
+  customize:
+    ################################################
+    ## Node Anchors
+    ################################################
+
+    package.node_anchors:
+      customize: &customize
+        package: "desk"
+
+    ################################################
+    ## Automation
+    ################################################
+
+    automation.uplift_desk_raise_for_guest_mode:
+      <<: *customize
+      friendly_name: "Desk Raise for Guest Mode"
+      icon: mdi:desk
+
+    automation.uplift_desk_raise_for_trip_mode:
+      <<: *customize
+      friendly_name: "Desk Raise for Trip Mode"
+      icon: mdi:bag-suitcase
+
+    automation.uplift_desk_raise_for_work_camera:
+      <<: *customize
+      friendly_name: "Desk Raise for Work Camera"
+      icon: mdi:camera
+
+    automation.uplift_desk_raise_when_departing:
+      <<: *customize
+      friendly_name: "Desk Raise on Departure"
+      icon: mdi:exit-run
+
+    automation.uplift_desk_raise_in_evening:
+      <<: *customize
+      friendly_name: "Desk Raise in Evening"
+      icon: mdi:clock-outline
+
+    automation.uplift_desk_reset_overnight:
+      <<: *customize
+      friendly_name: "Desk Reset Overnight"
+      icon: mdi:weather-night
+
+    ################################################
+    ## Script
+    ################################################
+
+    script.uplift_desk_auto_move_max:
+      <<: *customize
+      friendly_name: "Desk Auto Move Max"
+
+    script.uplift_desk_auto_move_preset_1:
+      <<: *customize
+      friendly_name: "Desk Auto Move Preset 1"
+
+    script.uplift_desk_auto_move_preset_2:
+      <<: *customize
+      friendly_name: "Desk Auto Move Preset 2"
+
+    script.uplift_desk_manual_move_max:
+      <<: *customize
+      friendly_name: "Desk Manual Move Max"
+
+    script.uplift_desk_manual_move_preset_1:
+      <<: *customize
+      friendly_name: "Desk Manual Move Preset 1"
+
+    script.uplift_desk_manual_move_preset_2:
+      <<: *customize
+      friendly_name: "Desk Manual Move Preset 2"
+
+    ################################################
+    ## Timer
+    ################################################
+
+    timer.uplift_desk_motion_window:
+      <<: *customize
+      friendly_name: "Desk Motion Window"
+      icon: mdi:timer-sand
+
+########################
+# Automation
+########################
+automation:
+  - id: uplift_desk_raise_for_guest_mode
+    alias: uplift_desk_raise_for_guest_mode
+    description: >
+      Raise the desk to its configured maximum height whenever guest mode
+      turns on. Guest mode is the highest-priority desk state.
+    trigger:
+      - trigger: state
+        entity_id: input_boolean.guest_mode
+        to: "on"
+    action:
+      - action: script.uplift_desk_auto_move_max
+
+  - id: uplift_desk_raise_for_trip_mode
+    alias: uplift_desk_raise_for_trip_mode
+    description: >
+      Raise the desk to its configured maximum height whenever trip mode
+      turns on, unless guest mode is already active.
+    trigger:
+      - trigger: state
+        entity_id: input_boolean.trip
+        to: "on"
+    condition:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "off"
+    action:
+      - action: script.uplift_desk_auto_move_max
+
+  - id: uplift_desk_raise_for_work_camera
+    alias: uplift_desk_raise_for_work_camera
+    description: >
+      Move the desk to preset 2 when the work laptop camera turns on,
+      unless guest or trip mode has already taken control.
+    trigger:
+      - trigger: state
+        entity_id: binary_sensor.f7m69c_5d3d6e76_camera_in_use
+        to: "on"
+    condition:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "off"
+      - condition: state
+        entity_id: input_boolean.trip
+        state: "off"
+    action:
+      - action: script.uplift_desk_auto_move_preset_2
+
+  - id: uplift_desk_raise_when_departing
+    alias: uplift_desk_raise_when_departing
+    description: >
+      Raise the desk when leaving home, using both person and zone tracking.
+      Time-based moves are suppressed whenever guest mode, trip mode, or the
+      work camera has higher priority.
+    trigger:
+      - trigger: state
+        entity_id: person.ryan
+        to: "not_home"
+      - trigger: zone
+        entity_id: device_tracker.bayesian_zeke_home
+        zone: zone.home
+        event: leave
+    condition:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "off"
+      - condition: state
+        entity_id: input_boolean.trip
+        state: "off"
+      - condition: state
+        entity_id: binary_sensor.f7m69c_5d3d6e76_camera_in_use
+        state: "off"
+      - condition: state
+        entity_id: person.ryan
+        state: "not_home"
+      - condition: not
+        conditions:
+          - condition: zone
+            entity_id: device_tracker.bayesian_zeke_home
+            zone: zone.home
+    action:
+      - action: script.uplift_desk_auto_move_max
+
+  - id: uplift_desk_raise_in_evening
+    alias: uplift_desk_raise_in_evening
+    description: >
+      Raise the desk to max height every day at 6 PM or when the work laptop
+      has been inactive long enough to be treated as asleep. These are
+      considered timed moves and are suppressed by guest mode, trip mode, and
+      the work camera rule.
+    trigger:
+      - trigger: time
+        id: evening
+        at: "18:00:00"
+      - trigger: state
+        id: laptop_sleep
+        entity_id: binary_sensor.f7m69c_5d3d6e76_active
+        to: "off"
+        for:
+          minutes: 10
+    condition:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "off"
+      - condition: state
+        entity_id: input_boolean.trip
+        state: "off"
+      - condition: state
+        entity_id: binary_sensor.f7m69c_5d3d6e76_camera_in_use
+        state: "off"
+    action:
+      - action: script.uplift_desk_auto_move_max
+
+  - id: uplift_desk_reset_overnight
+    alias: uplift_desk_reset_overnight
+    description: >
+      Return the desk to preset 1 at 4 AM, but only when no higher-priority
+      mode is active.
+    trigger:
+      - trigger: time
+        at: "04:00:00"
+    condition:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "off"
+      - condition: state
+        entity_id: input_boolean.trip
+        state: "off"
+      - condition: state
+        entity_id: binary_sensor.f7m69c_5d3d6e76_camera_in_use
+        state: "off"
+    action:
+      - action: script.uplift_desk_auto_move_preset_1
+
+########################
+# Script
+########################
+script:
+  uplift_desk_auto_move_max:
+    alias: uplift_desk_auto_move_max
+    description: >
+      Automation-only wrapper that sends the desk to the configured maximum
+      height when no other automated desk motion is already in progress.
+    mode: single
+    sequence:
+      - condition: state
+        entity_id: timer.uplift_desk_motion_window
+        state: "idle"
+      - action: shell_command.uplift_desk_auto_move_max
+      - action: timer.start
+        target:
+          entity_id: timer.uplift_desk_motion_window
+
+  uplift_desk_auto_move_preset_1:
+    alias: uplift_desk_auto_move_preset_1
+    description: >
+      Automation-only wrapper that sends the desk to preset 1 when no other
+      automated desk motion is already in progress.
+    mode: single
+    sequence:
+      - condition: state
+        entity_id: timer.uplift_desk_motion_window
+        state: "idle"
+      - action: shell_command.uplift_desk_auto_move_preset_1
+      - action: timer.start
+        target:
+          entity_id: timer.uplift_desk_motion_window
+
+  uplift_desk_auto_move_preset_2:
+    alias: uplift_desk_auto_move_preset_2
+    description: >
+      Automation-only wrapper that sends the desk to preset 2 when no other
+      automated desk motion is already in progress.
+    mode: single
+    sequence:
+      - condition: state
+        entity_id: timer.uplift_desk_motion_window
+        state: "idle"
+      - action: shell_command.uplift_desk_auto_move_preset_2
+      - action: timer.start
+        target:
+          entity_id: timer.uplift_desk_motion_window
+
+  uplift_desk_manual_move_max:
+    alias: uplift_desk_manual_move_max
+    description: >
+      Manual desk control for dashboards and UI buttons. This bypasses the
+      Home Assistant automation guard and sends the desk to the configured
+      maximum height immediately.
+    mode: single
+    icon: mdi:arrow-up-bold-box
+    sequence:
+      - action: shell_command.uplift_desk_manual_move_max
+
+  uplift_desk_manual_move_preset_1:
+    alias: uplift_desk_manual_move_preset_1
+    description: >
+      Manual desk control for dashboards and UI buttons. This bypasses the
+      Home Assistant automation guard and sends the desk to preset 1.
+    mode: single
+    icon: mdi:numeric-1-box
+    sequence:
+      - action: shell_command.uplift_desk_manual_move_preset_1
+
+  uplift_desk_manual_move_preset_2:
+    alias: uplift_desk_manual_move_preset_2
+    description: >
+      Manual desk control for dashboards and UI buttons. This bypasses the
+      Home Assistant automation guard and sends the desk to preset 2.
+    mode: single
+    icon: mdi:numeric-2-box
+    sequence:
+      - action: shell_command.uplift_desk_manual_move_preset_2
+
+########################
+# Shell Command
+########################
+shell_command:
+  uplift_desk_auto_move_max: "bash /config/scripts/uplift_ble_remote.sh auto-max"
+  uplift_desk_auto_move_preset_1: "bash /config/scripts/uplift_ble_remote.sh auto-preset1"
+  uplift_desk_auto_move_preset_2: "bash /config/scripts/uplift_ble_remote.sh auto-preset2"
+  uplift_desk_manual_move_max: "bash /config/scripts/uplift_ble_remote.sh manual-max"
+  uplift_desk_manual_move_preset_1: "bash /config/scripts/uplift_ble_remote.sh manual-preset1"
+  uplift_desk_manual_move_preset_2: "bash /config/scripts/uplift_ble_remote.sh manual-preset2"
+
+########################
+# Timer
+########################
+timer:
+  uplift_desk_motion_window:
+    duration: "00:00:45"

--- a/scripts/uplift_ble_authorized_keys.example
+++ b/scripts/uplift_ble_authorized_keys.example
@@ -1,0 +1,1 @@
+command="/usr/local/bin/uplift-desk-remote",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAREPLACE_WITH_HOME_ASSISTANT_PUBLIC_KEY uplift-ble-ha

--- a/scripts/uplift_ble_remote.conf.example
+++ b/scripts/uplift_ble_remote.conf.example
@@ -1,0 +1,6 @@
+SSH_TARGET="homeassistant@desk-ble-host"
+SSH_PORT="22"
+SSH_KEY="/config/ssh/uplift_ble_ed25519"
+SSH_KNOWN_HOSTS="/config/ssh/uplift_ble_known_hosts"
+SSH_STRICT_HOST_KEY_CHECKING="yes"
+REMOTE_COMMAND="/usr/local/bin/uplift-desk-remote"

--- a/scripts/uplift_ble_remote.sh
+++ b/scripts/uplift_ble_remote.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+set -eu
+
+CONFIG_FILE="${UPLIFT_BLE_REMOTE_CONFIG:-/config/scripts/uplift_ble_remote.conf}"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Missing config file: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+. "$CONFIG_FILE"
+
+if [ -z "${SSH_TARGET:-}" ]; then
+  echo "SSH_TARGET must be set in $CONFIG_FILE" >&2
+  exit 1
+fi
+
+REMOTE_COMMAND="${REMOTE_COMMAND:-/usr/local/bin/uplift-desk-remote}"
+SSH_PORT="${SSH_PORT:-22}"
+SSH_KEY="${SSH_KEY:-}"
+SSH_KNOWN_HOSTS="${SSH_KNOWN_HOSTS:-}"
+SSH_STRICT_HOST_KEY_CHECKING="${SSH_STRICT_HOST_KEY_CHECKING:-yes}"
+ACTION="${1:-}"
+
+if [ -z "$ACTION" ]; then
+  echo "Usage: $0 <action>" >&2
+  exit 1
+fi
+
+set -- ssh \
+  -o BatchMode=yes \
+  -o ConnectTimeout=10 \
+  -o StrictHostKeyChecking="$SSH_STRICT_HOST_KEY_CHECKING" \
+  -p "$SSH_PORT"
+
+if [ -n "$SSH_KEY" ]; then
+  set -- "$@" -i "$SSH_KEY"
+fi
+
+if [ -n "$SSH_KNOWN_HOSTS" ]; then
+  set -- "$@" -o UserKnownHostsFile="$SSH_KNOWN_HOSTS"
+fi
+
+exec "$@" \
+  "$SSH_TARGET" \
+  "$REMOTE_COMMAND" \
+  "$ACTION"

--- a/scripts/uplift_ble_server.sh.example
+++ b/scripts/uplift_ble_server.sh.example
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+set -eu
+
+DESK_ADDRESS="${DESK_ADDRESS:-AA:BB:CC:DD:EE:FF}"
+UPLIFT_BLE_BIN="${UPLIFT_BLE_BIN:-/usr/local/bin/uplift-ble-cli}"
+MAX_HEIGHT="${MAX_HEIGHT:-1270mm}"
+MOTION_GUARD_SECONDS="${MOTION_GUARD_SECONDS:-45}"
+LOCK_FILE="${LOCK_FILE:-/tmp/uplift-desk-remote.lock}"
+STAMP_FILE="${STAMP_FILE:-/tmp/uplift-desk-remote.last_move}"
+
+ACTION=""
+
+if [ -n "${SSH_ORIGINAL_COMMAND:-}" ]; then
+  # With a forced command in authorized_keys, SSH passes the original client
+  # command string here. Use the last token as the requested desk action.
+  set -- $SSH_ORIGINAL_COMMAND
+  while [ "$#" -gt 1 ]; do
+    shift
+  done
+  ACTION="${1:-}"
+else
+  ACTION="${1:-}"
+fi
+
+if [ -z "$ACTION" ]; then
+  echo "Usage: $0 <auto-max|auto-preset1|auto-preset2|manual-max|manual-preset1|manual-preset2|stop>" >&2
+  exit 1
+fi
+
+run_cli() {
+  "$UPLIFT_BLE_BIN" --address "$DESK_ADDRESS" "$@"
+}
+
+(
+  flock -n 9 || exit 0
+
+  NOW="$(date +%s)"
+
+  if [ -f "$STAMP_FILE" ]; then
+    LAST_MOVE="$(cat "$STAMP_FILE")"
+    if [ $((NOW - LAST_MOVE)) -lt "$MOTION_GUARD_SECONDS" ]; then
+      exit 0
+    fi
+  fi
+
+  case "$ACTION" in
+    auto-max)
+      printf '%s\n' "$NOW" >"$STAMP_FILE"
+      run_cli move_to_specified_height "$MAX_HEIGHT"
+      ;;
+    auto-preset1)
+      printf '%s\n' "$NOW" >"$STAMP_FILE"
+      run_cli move_to_height_preset_1
+      ;;
+    auto-preset2)
+      printf '%s\n' "$NOW" >"$STAMP_FILE"
+      run_cli move_to_height_preset_2
+      ;;
+    manual-max)
+      run_cli move_to_specified_height "$MAX_HEIGHT"
+      ;;
+    manual-preset1)
+      run_cli move_to_height_preset_1
+      ;;
+    manual-preset2)
+      run_cli move_to_height_preset_2
+      ;;
+    stop)
+      run_cli stop_movement
+      ;;
+    *)
+      echo "Unsupported action: $ACTION" >&2
+      exit 1
+      ;;
+  esac
+) 9>"$LOCK_FILE"


### PR DESCRIPTION
## Summary
- add a dedicated desk package with prioritized automations for guest, trip, camera, departure, evening, and overnight desk moves
- add manual desk scripts for preset 1, preset 2, and max height buttons in Home Assistant
- add SSH-based helper scripts and example config for securely calling uplift-ble-cli on a separate BLE host

## Validation
- parsed packages/desk.yaml with PyYAML
- ran shell syntax checks on scripts/uplift_ble_remote.sh and scripts/uplift_ble_server.sh.example
- no repo test suite is present in this worktree