### PR TITLE
Use destination names for Ecobee calendar vacations

### DIFF
--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -318,7 +318,9 @@ automation:
         id: daily_refresh
         at: "03:05:00"
     variables:
-      vacation_name: "Calendar Auto Vacation"
+      vacation_name: >-
+        {% set planned_name = state_attr('sensor.ecobee_calendar_vacation_schedule', 'vacation_name') | default('', true) | trim %}
+        {{ planned_name[:12] if planned_name else 'CalAutoVac' }}
       vacation_state: "{{ states('sensor.ecobee_calendar_vacation_schedule') }}"
       schedule_start: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'start') }}"
       schedule_end: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'end') }}"
@@ -988,7 +990,7 @@ template:
               | default([], true)
             }}
           vacation_plan_json: >-
-            {% set ns = namespace(curling_event=None, outbound=None, return_home=None) %}
+            {% set ns = namespace(curling_event=None, outbound=None, return_home=None, target_city='', target_city_ts=None) %}
             {% for event in curling_events %}
               {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
               {% set end_raw = event.end.dateTime | default(event.end.date, true) | default(event.end, true) %}
@@ -1005,7 +1007,8 @@ template:
                   'summary': event.summary | default('Curling', true),
                   'start': (start_dt | as_local).isoformat(),
                   'end': (end_dt | as_local).isoformat(),
-                  'return_summary': ''
+                  'return_summary': '',
+                  'vacation_name': event.summary | default('Curling', true)
                 } %}
               {% endif %}
             {% endfor %}
@@ -1017,10 +1020,25 @@ template:
                 {% set summary = event.summary | default('Flight', true) %}
                 {% set description = event.description | default('', true) %}
                 {% set location = event.location | default('', true) %}
+                {% set summary_text = summary | string %}
                 {% set flight_text = ([summary, description, location] | join(' ') | lower) %}
                 {% set looks_like_flight = 'airport' in flight_text or 'flight' in flight_text or 'airlines' in flight_text or 'delta' in flight_text or 'united' in flight_text or 'southwest' in flight_text or 'sun country' in flight_text %}
                 {% set is_msp_flight = 'msp' in flight_text or 'minneapolis-st paul' in flight_text or 'minneapolis st paul' in flight_text or 'wold-chamberlain' in flight_text %}
                 {% set start_ts = as_timestamp(start_dt) %}
+                {% set destination_name = '' %}
+                {% if summary_text.startswith('Flight to ') %}
+                  {% set destination_name = summary_text.split('Flight to ', 1)[1].split(' (', 1)[0].strip() %}
+                {% elif summary_text.startswith('Flight: ') and ' to ' in summary_text %}
+                  {% set destination_name = summary_text.split(' to ', 1)[1].strip() %}
+                {% elif '→' in summary_text %}
+                  {% set destination_name = summary_text.split('→', 1)[1].split('•', 1)[0].strip() %}
+                {% endif %}
+                {% if looks_like_flight and start_ts >= (as_timestamp(now()) - 3600) and destination_name not in ['', 'MSP'] %}
+                  {% if ns.target_city_ts is none or start_ts < ns.target_city_ts or (start_ts == ns.target_city_ts and (destination_name | length) > (ns.target_city | length)) %}
+                    {% set ns.target_city = destination_name %}
+                    {% set ns.target_city_ts = start_ts %}
+                  {% endif %}
+                {% endif %}
                 {% if looks_like_flight and not is_msp_flight and start_ts >= (as_timestamp(now()) - 3600) %}
                   {% if ns.outbound is none or start_ts < ns.outbound.start_ts %}
                     {% set ns.outbound = {
@@ -1063,13 +1081,14 @@ template:
                   'summary': ns.outbound.summary,
                   'start': ns.outbound.start,
                   'end': ((ns.return_home.start | as_datetime | as_local) - timedelta(hours=2)).isoformat(),
-                  'return_summary': ns.return_home.summary
+                  'return_summary': ns.return_home.summary,
+                  'vacation_name': ns.target_city | default(ns.outbound.summary, true)
                 } | to_json
               }}
             {% elif ns.curling_event is not none %}
               {{ ns.curling_event | to_json }}
             {% else %}
-              {{ {'reason': 'off', 'summary': '', 'start': '', 'end': '', 'return_summary': ''} | to_json }}
+              {{ {'reason': 'off', 'summary': '', 'start': '', 'end': '', 'return_summary': '', 'vacation_name': ''} | to_json }}
             {% endif %}
     sensor:
       - name: Ecobee Calendar Vacation Schedule
@@ -1087,6 +1106,7 @@ template:
           start: "{{ (vacation_plan_json | from_json).start | default('') }}"
           end: "{{ (vacation_plan_json | from_json).end | default('') }}"
           return_summary: "{{ (vacation_plan_json | from_json).return_summary | default('') }}"
+          vacation_name: "{{ (vacation_plan_json | from_json).vacation_name | default('') }}"
   - sensor:
       - name: time_to_home
         default_entity_id: sensor.me_to_home


### PR DESCRIPTION
## Summary
- derive the Ecobee vacation name from the planned trip destination city when available
- publish the derived name on `sensor.ecobee_calendar_vacation_schedule`
- keep the final `vacation_name` capped at 12 characters for Ecobee compatibility, with `CalAutoVac` as fallback

## Validation
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- local Home Assistant `check_config` under `homeassistant==2026.2.3` in a temporary Python 3.13 venv

## Notes
- local `check_config` reported a pre-existing warning: `weatheralerts` custom component import issue (`No module named custom_components.weatheralerts.const`)