### PR TITLE
Fix Ecobee vacation schedule sensor and cleanup

### DIFF
--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -321,6 +321,14 @@ automation:
       vacation_name: >-
         {% set planned_name = state_attr('sensor.ecobee_calendar_vacation_schedule', 'vacation_name') | default('', true) | trim %}
         {{ planned_name[:12] if planned_name else 'CalAutoVac' }}
+      delete_vacation_name: >-
+        {% set previous_name = '' %}
+        {% if trigger is defined and trigger.platform == 'state' and trigger.from_state is not none %}
+          {% set previous_name = trigger.from_state.attributes.vacation_name | default('', true) | trim %}
+        {% endif %}
+        {% set current_name = state_attr('sensor.ecobee_calendar_vacation_schedule', 'vacation_name') | default('', true) | trim %}
+        {% set delete_name = previous_name if previous_name else current_name %}
+        {{ delete_name[:12] if delete_name else 'CalAutoVac' }}
       vacation_state: "{{ states('sensor.ecobee_calendar_vacation_schedule') }}"
       schedule_start: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'start') }}"
       schedule_end: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'end') }}"
@@ -331,7 +339,7 @@ automation:
         continue_on_error: true
         data:
           entity_id: climate.my_ecobee
-          vacation_name: "{{ vacation_name }}"
+          vacation_name: "{{ delete_vacation_name }}"
       - if:
           - condition: template
             value_template: >-


### PR DESCRIPTION
## Summary
- fix the `sensor.ecobee_calendar_vacation_schedule` trigger-based template so it handles both `calendar.get_events` response shapes without going unavailable
- make `binary_sensor.planned_vacation_calendar` follow the schedule sensor's active window instead of two missing calendar entities
- use the previous schedule-derived vacation name for `ecobee.delete_vacation` on state-triggered runs so renamed or ended trips clean up the old Ecobee vacation correctly

## Validation
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/trips.yaml`
- local Home Assistant `check_config` under `homeassistant==2026.2.3` in a temporary Python 3.13 venv

## Notes
- local `check_config` reported the same pre-existing warning from `weatheralerts`: `No module named custom_components.weatheralerts.const`
- this supersedes the unmerged follow-up commit that never made it into the already-merged PR #59