### PR TITLE
Use calendar offsets for garbage reminders

### DIFF
--- a/packages/other_holidays.yaml
+++ b/packages/other_holidays.yaml
@@ -43,24 +43,6 @@ homeassistant:
 # Automations
 ########################
 automation:
-  - alias: Trash reminder evening before pickup
-    trigger:
-      - trigger: time
-        at: "14:30:00"
-    condition:
-      - condition: template
-        value_template: >
-          {% set p = states('sensor.garbage_pickup_date') %}
-          {% if p in ['unknown','unavailable',''] %}
-            false
-          {% else %}
-            {{ (as_datetime(p) - timedelta(days=1)).date() == now().date() }}
-          {% endif %}
-    action:
-      - action: notify.all
-        data:
-          message: >
-            Trash pickup is tomorrow ({{ states('sensor.garbage_pickup_date') }}).
   - id: reset_after_holiday
     alias: reset_after_holiday
     # initial_state: false

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -377,69 +377,46 @@ automation:
 
             The sump pump ran {{states("sensor.sump_runs")}}x for {{ values | join(',') }} in the last 24 hours.
 
-  # - alias: Notify Garbage Tomorrow
-  #   id: notify_garbage_day_tomorrow
-  #   description: Notify garbage day is tomorrow
-  #   trigger:
-  #     - platform: time
-  #       at: "14:30:00"
-  #   condition:
-  #     - alias: "Garbage day tomorrow"
-  #       condition: state
-  #       entity_id: sensor.waste_management
-  #       state: "1"
-  #   action:
-  #     - action: notify.all
-  #       data:
-  #         message: >-
-  #           Put out bins tonight. Garbage tomorrow.
-
-  # - alias: Notify Garbage Day Changed
-  #   id: notify_garbage_day_changed
-  #   description: Notify garbage day is NOT tomorrow
-  #   trigger:
-  #     - platform: time
-  #       at: "14:30:00"
-  #   condition:
-  #     - alias: Only on Tuesdays (Day before Garbage Day/Wednesday)
-  #       condition: time
-  #       weekday:
-  #         - tue
-  #     - alias: Garbage day tomorrow
-  #       condition: state
-  #       entity_id: sensor.waste_management
-  #       state: "2"
-  #   action:
-  #     - action: notify.all
-  #       data:
-  #         message: DON't put out bins tonight. Garbage day has changed!
-
   - alias: Notify Garbage
     id: notify_garbage_day
     description: Notify garbage day
     trigger:
-      - trigger: time
-        at: "14:30:00"
+      - trigger: calendar
+        id: day_changed
+        entity_id: calendar.garbage_collection
+        event: start
+        offset: "-33:30:00"
+      - trigger: calendar
+        id: pickup_tomorrow
+        entity_id: calendar.garbage_collection
+        event: start
+        offset: "-09:30:00"
+    variables:
+      garbage_summary: "{{ state_attr('sensor.waste_management', 'friendly_name') | default('Waste Management', true) }}"
     action:
       - choose:
           - conditions:
+              - condition: trigger
+                id: day_changed
               - alias: Only on Tuesdays (Day before Garbage Day/Wednesday)
                 condition: time
                 weekday:
                   - tue
-              - alias: Garbage day tomorrow
-                condition: state
-                entity_id: sensor.waste_management
-                state: "2"
+              - alias: Waste Management event
+                condition: template
+                value_template: >-
+                  {{ trigger.calendar_event.summary | default('', true) == garbage_summary }}
             sequence:
               - action: notify.all
                 data:
                   message: DO NOT put out bins tonight. Garbage day has changed!
           - conditions:
-              - alias: "Garbage day tomorrow"
-                condition: state
-                entity_id: sensor.waste_management
-                state: "1"
+              - condition: trigger
+                id: pickup_tomorrow
+              - alias: Waste Management event
+                condition: template
+                value_template: >-
+                  {{ trigger.calendar_event.summary | default('', true) == garbage_summary }}
             sequence:
               - action: notify.all
                 data:


### PR DESCRIPTION
## Summary
- migrate the active garbage reminder automation to native `calendar` triggers on `calendar.garbage_collection`
- preserve the holiday-shift warning by using an earlier offset trigger instead of polling `sensor.waste_management` at a fixed time
- remove the stale duplicate trash reminder in `other_holidays` so there is a single reminder path

## Validation
- `python scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/other_holidays.yaml packages/utilities.yaml`
- `python -m homeassistant --config . --script check_config` (via temporary Python 3.13 venv); Home Assistant reported an existing unrelated warning: `weatheralerts` custom component missing `custom_components.weatheralerts.const`

Closes #36