### PR TITLE
Broaden MSP matching for trip mode trigger

### DIFF
--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -244,11 +244,18 @@ automation:
                 state: "off"
               - condition: template
                 value_template: >-
-                  {% set summary = trigger.calendar_event.summary | default('') | lower %}
-                  {{
-                    trigger.calendar_event.location == "Minneapolis-St Paul Intl/Wold-Chamberlain"
-                    and "friend" not in summary
-                  }}
+                  {% set summary = trigger.calendar_event.summary | default('', true) | lower %}
+                  {% set description = trigger.calendar_event.description | default('', true) | lower %}
+                  {% set location = trigger.calendar_event.location | default('', true) | lower %}
+                  {% set trip_text = [summary, description, location] | join(' ') %}
+                  {% set is_msp_departure = (
+                    location == "minneapolis-st paul intl/wold-chamberlain"
+                    or "msp airport" in location
+                    or "minneapolis msp" in location
+                    or ("minneapolis" in location and ("saint paul" in location or "st paul" in location))
+                    or "wold-chamberlain" in location
+                  ) %}
+                  {{ is_msp_departure and "friend" not in trip_text }}
             sequence:
               - action: input_boolean.turn_on
                 target:


### PR DESCRIPTION
## Summary
- Update `trip_mode_manager` calendar-trip condition to match MSP location variants instead of one exact string.
- Keep friend-flight suppression by checking `friend` across summary, description, and location text.

## Validation
- `yamllint` passed for `packages/trips.yaml`.
- Home Assistant `check_config` passed locally, with only the existing `weatheralerts` warning.
- Template check in Home Assistant: MSP variants evaluate `true`; friend-flight summary evaluates `false`.
