### PR TITLE
Remove deprecated InfluxDB YAML host config

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -108,7 +108,6 @@ recorder:
       - sensor.time
 
 influxdb:
-  host: !secret influx_db_host
   exclude:
     domains:
       - media_player
@@ -263,4 +262,3 @@ stream:
 #     source:
 #       - entity_id: camera.livingroom
 #         name: face_counter
-


### PR DESCRIPTION
## Summary
- remove the deprecated `influxdb.host` YAML connection setting
- keep the supported `influxdb.exclude` filters in YAML
- align the config with the UI-managed InfluxDB config entry already imported by Home Assistant

## Validation
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml`
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `python -m homeassistant --config "$PWD" --script check_config` in a temporary Python 3.14.3 venv with `homeassistant==2026.3.1`