### PR TITLE
Fix display mode selection for traveling devices

### DIFF
--- a/packages/themes.yaml
+++ b/packages/themes.yaml
@@ -105,7 +105,8 @@ automation:
     description: >-
       Set backend-preferred light and dark themes without tying light/dark mode
       to the house timezone. Clients that use User Profile theme mode "Auto"
-      will follow their own local device settings instead.
+      will follow their own local device settings instead, while dark mode
+      keeps a random theme choice at Home Assistant startup.
     trigger:
       - trigger: homeassistant
         event: start
@@ -113,7 +114,8 @@ automation:
       - action: frontend.set_theme
         data:
           name: ios-light-mode-dark-green
-          name_dark: ios-dark-mode-dark-green
+          name_dark: >-
+            {{ ["ios-dark-mode-dark-green", "midnight_blue", "noctis-solarized", "oxfordblue", "slate_red", "synthwave"] | random }}
 
 ########################
 # Binary Sensors


### PR DESCRIPTION
## Summary
- stop switching the frontend theme from the house sun state
- set backend-preferred light and dark themes once at startup so clients can resolve mode locally
- keep the existing automation id stable while documenting the per-device behavior

Fixes #74

## Validation
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml packages zigbee2mqtt`
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- local `docker` is not installed in this environment, so `homeassistant --script check_config` is deferred to CI
