### PR TITLE
Fix stale Home Assistant area references

### DIFF
--- a/.storage/lovelace.dashboard_strategy
+++ b/.storage/lovelace.dashboard_strategy
@@ -14,10 +14,10 @@
             ]
           },
           "areas": {
-            "4927cd530ee44a9e9eefc33f0de6c90e": {
+            "basement_greatroom": {
               "icon": "mdi:home-floor-0"
             },
-            "owner_suite_bathroom": {
+            "bathroom": {
               "icon": "mdi:bathtub"
             },
             "basement_bathroom": {
@@ -32,32 +32,26 @@
             "tiki_room": {
               "icon": "mdi:palm-tree"
             },
-            "997d5f472a2e4838b40ab9c1c60d85ef": {
+            "bedroom": {
               "icon": "mdi:bed"
             },
-            "bb7a5b0c18c7427bb10b6f761bb05861": {
+            "guest_room": {
               "icon": "mdi:bed"
             },
-            "54913feabaa14cf88ff2190e25bef547": {
+            "office": {
               "icon": "mdi:desk"
             },
             "laundry_room": {
               "icon": "mdi:washing-machine"
             },
-            "7cd73f11a4bf476e839c61b4a3090edd": {
+            "kitchen": {
               "icon": "mdi:stove"
-            },
-            "sonos_move_2": {
-              "hidden": true
             },
             "dining_room": {
               "icon": "mdi:knife"
             },
-            "72a8db21bc2d457e80748541dc138d07": {
+            "living_room": {
               "icon": "mdi:television"
-            },
-            "front_door": {
-              "hidden": true
             },
             "deck": {
               "icon": "mdi:tree"

--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -75,7 +75,7 @@
                         {
                           "type": "custom:minimalistic-area-card",
                           "title": "Bedroom",
-                          "area": "997d5f472a2e4838b40ab9c1c60d85ef",
+                          "area": "bedroom",
                           "hide_unavailable": false,
                           "tap_action": {
                             "action": "navigate",
@@ -107,11 +107,11 @@
                         {
                           "type": "custom:minimalistic-area-card",
                           "title": "Office",
-                          "area": "54913feabaa14cf88ff2190e25bef547",
+                          "area": "office",
                           "hide_unavailable": false,
                           "tap_action": {
                             "action": "navigate",
-                            "navigation_path": "/dashboard-strategy/54913feabaa14cf88ff2190e25bef547"
+                            "navigation_path": "/dashboard-strategy/office"
                           },
                           "entities": [
                             "light.office_all",
@@ -127,11 +127,11 @@
                         {
                           "type": "custom:minimalistic-area-card",
                           "title": "Basement",
-                          "area": "4927cd530ee44a9e9eefc33f0de6c90e",
+                          "area": "basement_greatroom",
                           "hide_unavailable": false,
                           "tap_action": {
                             "action": "navigate",
-                            "navigation_path": "/dashboard-strategy/4927cd530ee44a9e9eefc33f0de6c90e"
+                            "navigation_path": "/dashboard-strategy/basement_greatroom"
                           },
                           "entities": [
                             "light.all_basement_lights",
@@ -166,11 +166,11 @@
                         {
                           "type": "custom:minimalistic-area-card",
                           "title": "My Bath",
-                          "area": "owner_suite_bathroom",
+                          "area": "bathroom",
                           "hide_unavailable": false,
                           "tap_action": {
                             "action": "navigate",
-                            "navigation_path": "/dashboard-strategy/owner_suite_bathroom"
+                            "navigation_path": "/dashboard-strategy/bathroom"
                           },
                           "entities": [
                             {
@@ -193,11 +193,11 @@
                         {
                           "type": "custom:minimalistic-area-card",
                           "title": "Kitchen",
-                          "area": "7cd73f11a4bf476e839c61b4a3090edd",
+                          "area": "kitchen",
                           "hide_unavailable": false,
                           "tap_action": {
                             "action": "navigate",
-                            "navigation_path": "/dashboard-strategy/7cd73f11a4bf476e839c61b4a3090edd"
+                            "navigation_path": "/dashboard-strategy/kitchen"
                           },
                           "entities": [
                             "light.kitchen_all",
@@ -232,11 +232,11 @@
                         {
                           "type": "custom:minimalistic-area-card",
                           "title": "Hallway",
-                          "area": "13b74091cb0d4c85b33aa3c02110dc61",
+                          "area": "hallway",
                           "hide_unavailable": false,
                           "tap_action": {
                             "action": "navigate",
-                            "navigation_path": "/dashboard-strategy/13b74091cb0d4c85b33aa3c02110dc61"
+                            "navigation_path": "/dashboard-strategy/hallway"
                           },
                           "entities": [
                             "light.hall_all",
@@ -251,11 +251,11 @@
                         {
                           "type": "custom:minimalistic-area-card",
                           "title": "Outside",
-                          "area": "8144b95c1eb245499ecaf8d49e4ffe30",
+                          "area": "outside",
                           "hide_unavailable": false,
                           "tap_action": {
                             "action": "navigate",
-                            "navigation_path": "/dashboard-strategy/8144b95c1eb245499ecaf8d49e4ffe30"
+                            "navigation_path": "/dashboard-strategy/outside"
                           },
                           "entities": [
                             {

--- a/packages/alarms.yaml
+++ b/packages/alarms.yaml
@@ -261,8 +261,8 @@ automation:
       - action: light.turn_off
         data:
           area_id:
-            - 997d5f472a2e4838b40ab9c1c60d85ef # Owner Suite
-            - owner_suite_bathroom
+            - bedroom # Owner Suite
+            - bathroom # Owner Suite Bathroom
 
   - id: alarm_wake_up
     alias: alarm_wake_up


### PR DESCRIPTION
## Summary
- replace stale Owner Suite area IDs in the noon shutoff automation with the current `bedroom` and `bathroom` area slugs
- update storage-backed dashboard area references and dashboard-strategy navigation paths to live area IDs
- remove non-area placeholders from the dashboard strategy area map so they do not generate unknown-area repair items

## Validation
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt` (run in a temporary virtualenv)
- parsed `.storage/lovelace.dashboard_strategy` and `.storage/lovelace.ryan_new_mushroom` as JSON
- scanned the changed config/storage files for remaining invalid tracked area references

## Notes
- Home Assistant `check_config` was not runnable locally because `docker` is not installed in this environment.