### PR TITLE
Fix stale Master Bedroom Lovelace tile entities

### DIFF
--- a/lovelace/tiles/tiles_master_bedroom.yaml
+++ b/lovelace/tiles/tiles_master_bedroom.yaml
@@ -4,7 +4,7 @@ cards:
   - type: horizontal-stack
     cards:
       - type: entity-button
-        entity: light.master_bedroom
+        entity: light.owner_suite_lamps
         state_color: true
         name: " "
         tap_action:
@@ -12,7 +12,7 @@ cards:
         hold_action:
           action: more-info
       - type: entity-button
-        entity: fan.master_bedroom_fan
+        entity: fan.owner_suite
         state_color: true
         name: " "
         icon: mdi:fan
@@ -21,7 +21,7 @@ cards:
         hold_action:
           action: toggle
       - type: entity-button
-        entity: light.master_bedroom_fan_light
+        entity: light.owner_suite_ceiling
         name: "Light"
         icon: mdi:fan
         tap_action:
@@ -68,7 +68,7 @@ cards:
             brightness_pct: 20
             transition: 5
             entity_id:
-              - light.master_bedroom
+              - light.owner_suite_lamps
         # hold_action:
         #   action: more-info
     #   - type: "custom:button-card"
@@ -82,7 +82,7 @@ cards:
         group: false
         align_state: center
         entities:
-          - sensor.master_bedroom_temperature
+          - sensor.owner_suite_tph_temperature
         color_thresholds:
           - value: 68
             color: "red"
@@ -99,7 +99,7 @@ cards:
         name: Humidity
         align_state: center
         entities:
-          - sensor.master_bedroom_humidity
+          - sensor.owner_suite_tph_humidity
         graph: line
         show:
           name: false


### PR DESCRIPTION
## Summary
- replace the dead `master_bedroom` Lovelace tile entity IDs with the current live `owner_suite` and `sensor.owner_suite_tph_*` entities
- keep the tile structure and behavior the same while aligning it with the current Home Assistant registry

## Validation
- confirmed the replacement entities exist in live Home Assistant:
  - `light.owner_suite_lamps`
  - `fan.owner_suite`
  - `light.owner_suite_ceiling`
  - `sensor.owner_suite_tph_temperature`
  - `sensor.owner_suite_tph_humidity`
- verified the active tile no longer references live-missing `master_bedroom` entity IDs (only one commented legacy example remains)
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" lovelace/tiles/tiles_master_bedroom.yaml`