### PR TITLE
Fix stale Den occupancy sensor reference

### DIFF
--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -92,11 +92,11 @@ automation:
     id: den_fan_control
     trigger:
       - trigger: state
-        entity_id: binary_sensor.den_occupancy
+        entity_id: binary_sensor.den_occupancy_2
         to: "on"
         id: den-occupied
       - trigger: state
-        entity_id: binary_sensor.den_occupancy
+        entity_id: binary_sensor.den_occupancy_2
         to: "off"
         for:
           minutes: 30


### PR DESCRIPTION
## Summary
- replace the stale `binary_sensor.den_occupancy` trigger references with `binary_sensor.den_occupancy_2`
- keep the Den fan automation behavior unchanged while clearing the unknown-entity repair

## Validation
- `python3 scripts/check_ha_python_support.py`
- `ruby -e 'require "yaml"; YAML.load_file("packages/fans.yaml"); puts "packages/fans.yaml parses successfully"'`
- `yamllint -f parsable packages/fans.yaml` *(shows pre-existing file style issues outside this change)*