### PR TITLE
Fix stale guest room ceiling light reference

### DIFF
--- a/lovelace/tiles/tiles_guest_room.yaml
+++ b/lovelace/tiles/tiles_guest_room.yaml
@@ -12,7 +12,7 @@ cards:
         hold_action:
           action: more-info
       - type: entity-button
-        entity: light.guest_ceiling
+        entity: light.guest_room_ceiling
         state_color: true
         name: " "
         icon: mdi:fan

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -137,7 +137,7 @@ homeassistant:
       friendly_name: "Front Door"
       icon: mdi:home
 
-    light.guest_ceiling:
+    light.guest_room_ceiling:
       <<: *customize
       friendly_name: "Guest Ceiling Light"
       icon: mdi:home
@@ -698,7 +698,7 @@ automation:
       - action: homeassistant.toggle
         data:
           entity_id:
-            - light.guest_ceiling
+            - light.guest_room_ceiling
 
   - id: hallway_light_toggle_at_night
     alias: hallway_light_toggle_at_night


### PR DESCRIPTION
## Summary
- replace stale `light.guest_ceiling` references with the live `light.guest_room_ceiling` entity
- update both the package config and the active Guest Room Lovelace tile

## Validation
- `python3 scripts/check_ha_python_support.py`
- `ruby -e 'require "yaml"; YAML.load_file("packages/light.yaml"); YAML.load_file("lovelace/tiles/tiles_guest_room.yaml"); puts "guest room files parse successfully"'`
- `yamllint -f parsable packages/light.yaml lovelace/tiles/tiles_guest_room.yaml` *(shows pre-existing file style issues outside this change)*