### PR TITLE
Fix stale basement motion sensor reference

### DIFF
--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -228,7 +228,7 @@ automation:
     trigger:
       - trigger: state
         entity_id:
-          - binary_sensor.basement_motion_sensor
+          - binary_sensor.basement_motion
           - binary_sensor.livingroom_motion_sensor
         from: "off"
         to: "on"
@@ -241,7 +241,7 @@ automation:
           message: >-
             Stream from {{ trigger.to_state.attributes.friendly_name }}
           entity_id: >-
-            {% if trigger.entity_id == "binary_sensor.basement_motion_sensor" %}
+            {% if trigger.entity_id == "binary_sensor.basement_motion" %}
               camera.tikiroomcamera
             {% else %}
               camera.livingroomcamera

--- a/packages/camera.yaml
+++ b/packages/camera.yaml
@@ -28,7 +28,7 @@ homeassistant:
     ################################################
     ## Binary Sensors
     ################################################
-    binary_sensor.basement_motion_sensor:
+    binary_sensor.basement_motion:
       <<: *customize
       device_class: motion
       friendly_name: "Basement Camera Motion"


### PR DESCRIPTION
## Summary
- replace stale `binary_sensor.basement_motion_sensor` references with the live `binary_sensor.basement_motion` entity
- update both the alert automation and the camera package customize entry

## Validation
- `python3 scripts/check_ha_python_support.py`
- `ruby -e 'require "yaml"; YAML.load_file("packages/alerts.yaml"); YAML.load_file("packages/camera.yaml"); puts "alert and camera files parse successfully"'`
- `yamllint -f parsable packages/alerts.yaml packages/camera.yaml` *(shows pre-existing file style issues outside this change)*