### PR TITLE
Fix stale kitchen switchtype select reference

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1960,7 +1960,7 @@ script:
             - select.basement_landing_switch_switchtype
             - select.deck_flood_lights_switchtype
             - select.hall_garage_laundry_switch_switchtype
-            - select.kitchen_overhead_lights_switch_switchtype
+            - select.kitchen_switch_switchtype
             - select.hall_transition_switch_switchtype
             - select.hall_upstairs_switch_switchtype
             - select.hall_stairway_switchtype


### PR DESCRIPTION
## Summary
- replace the stale `select.kitchen_overhead_lights_switch_switchtype` entry with the live `select.kitchen_switch_switchtype` entity
- keep the existing switchtype automation list intact while clearing the unknown-entity repair

## Validation
- `python3 scripts/check_ha_python_support.py`
- `ruby -e 'require "yaml"; YAML.load_file("packages/zigbee_zwave.yaml"); puts "packages/zigbee_zwave.yaml parses successfully"'`
- `yamllint -f parsable packages/zigbee_zwave.yaml` *(shows pre-existing file style issues outside this change)*