### PR TITLE
Fix stale downstairs motion reference

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1777,7 +1777,7 @@ automation:
     mode: restart
     trigger:
       - trigger: state
-        entity_id: binary_sensor.downstairs_motion
+        entity_id: binary_sensor.basement_motion
         to: "off"
     condition:
       condition: and


### PR DESCRIPTION
## Summary
- replace the stale `binary_sensor.downstairs_motion` trigger with the live `binary_sensor.basement_motion` entity
- keep the basement light automation behavior intact while clearing the unknown-entity repair

## Validation
- `python3 scripts/check_ha_python_support.py`
- `ruby -e 'require "yaml"; YAML.load_file("packages/light.yaml"); puts "packages/light.yaml parses successfully"'`
- `yamllint -f parsable packages/light.yaml` *(shows pre-existing file style issues outside this change)*