### PR TITLE
Fix stale dining room action sensor reference

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -449,19 +449,19 @@ automation:
     id: dining_room_switch_actions
     trigger:
       - trigger: state
-        entity_id: sensor.dining_room_overhead_action
+        entity_id: sensor.dining_room_wall_switch_action
         to: "up_single"
         id: up-single
       - trigger: state
-        entity_id: sensor.dining_room_overhead_action
+        entity_id: sensor.dining_room_wall_switch_action
         to: "down_single"
         id: down-single
       - trigger: state
-        entity_id: sensor.dining_room_overhead_action
+        entity_id: sensor.dining_room_wall_switch_action
         to: "up_double"
         id: up-double
       - trigger: state
-        entity_id: sensor.dining_room_overhead_action
+        entity_id: sensor.dining_room_wall_switch_action
         to: "down_double"
         id: down-double
     action:


### PR DESCRIPTION
## Summary
- replace stale `sensor.dining_room_overhead_action` trigger references with the live `sensor.dining_room_wall_switch_action` entity
- keep the dining room switch automation behavior intact while clearing the unknown-entity repair

## Validation
- `python3 scripts/check_ha_python_support.py`
- `ruby -e 'require "yaml"; YAML.load_file("packages/zigbee_zwave.yaml"); puts "packages/zigbee_zwave.yaml parses successfully"'`
- `yamllint -f parsable packages/zigbee_zwave.yaml` *(shows pre-existing file style issues outside this change)*