### PR TITLE
Fix stale kitchen action sensor reference

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -928,27 +928,27 @@ automation:
     mode: restart
     trigger:
       - trigger: state
-        entity_id: sensor.kitchen_overhead_lights_switch_action
+        entity_id: sensor.kitchen_switch_action
         to: "up_single"
         id: up-single
       - trigger: state
-        entity_id: sensor.kitchen_overhead_lights_switch_action
+        entity_id: sensor.kitchen_switch_action
         to: "down_single"
         id: down-single
       - trigger: state
-        entity_id: sensor.kitchen_overhead_lights_switch_action
+        entity_id: sensor.kitchen_switch_action
         to: "up_double"
         id: up-double
       - trigger: state
-        entity_id: sensor.kitchen_overhead_lights_switch_action
+        entity_id: sensor.kitchen_switch_action
         to: "down_double"
         id: down-double
       - trigger: state
-        entity_id: sensor.kitchen_overhead_lights_switch_action
+        entity_id: sensor.kitchen_switch_action
         to: "up_held"
         id: up-held
       - trigger: state
-        entity_id: sensor.kitchen_overhead_lights_switch_action
+        entity_id: sensor.kitchen_switch_action
         to: "down_held"
         id: down-held
     action:
@@ -986,7 +986,7 @@ automation:
                   - condition: or
                     conditions:
                       - condition: state
-                        entity_id: sensor.kitchen_overhead_lights_switch_action
+                        entity_id: sensor.kitchen_switch_action
                         state: "up_release"
                       - alias: "condition alias (name)"
                         condition: numeric_state
@@ -1010,7 +1010,7 @@ automation:
                   - condition: or
                     conditions:
                       - condition: state
-                        entity_id: sensor.kitchen_overhead_lights_switch_action
+                        entity_id: sensor.kitchen_switch_action
                         state: "down_release"
                       - alias: "condition alias (name)"
                         condition: numeric_state


### PR DESCRIPTION
## Summary
- replace stale `sensor.kitchen_overhead_lights_switch_action` references with the live `sensor.kitchen_switch_action` entity
- update both the trigger and release-state checks in the kitchen switch automation

## Validation
- `python3 scripts/check_ha_python_support.py`
- `ruby -e 'require "yaml"; YAML.load_file("packages/zigbee_zwave.yaml"); puts "packages/zigbee_zwave.yaml parses successfully"'`
- `yamllint -f parsable packages/zigbee_zwave.yaml` *(shows pre-existing file style issues outside this change)*