### PR TITLE
Implement iOS wakeup alarm sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,4 +208,58 @@ Software on the NUC:
 
 **Apple Shortcuts**
 * [Set wakeup time](https://www.icloud.com/shortcuts/61be3701823f444dbae0de1626020025) - [Slowly turn on bedroom lights in the morning before a meeting](https://github.com/rtclauss/hass-config/blob/master/packages/workday.yaml#L107)
-* iOS personal automation: run every day at `9:00 PM`, find the wake-up alarm you want to mirror on the phone, format its time as `HH:mm`, and `POST` JSON to `https://<your-home-assistant>/api/webhook/ios_phone_wakeup_alarm_sync` with `{"alarm_time":"07:30"}`. If JSON is awkward, the webhook also accepts `?alarm_time=07:30`. If you only keep one wake-up alarm, use the first enabled alarm; otherwise filter by a stable label such as `Wake Up`.
+* iOS personal automation: run every day at `9:00 PM`, find the wake-up alarm you want to mirror on the phone, format its time as `HH:mm`, and `POST` JSON to `https://<your-home-assistant>/api/webhook/ios_phone_wakeup_alarm_sync` with `{"alarm_time":"07:30"}`. If there is no enabled alarm for the next day, send `{"alarm_enabled": false}` instead. If JSON is awkward, the webhook also accepts query parameters.
+
+Shortcut recipe:
+
+1. In `Shortcuts` create a `Personal Automation`.
+2. Choose `Time of Day`, set it to `9:00 PM`, select `Daily`, and disable `Run After Confirmation`.
+3. Add `Find Alarms` and filter to the alarm you want Home Assistant to mirror.
+4. Recommended filter: `Label is Wake Up` and `Is Enabled is On`.
+5. If you only keep one wake-up alarm on the phone, using the first enabled alarm is fine.
+6. Add `If` and branch on whether `Find Alarms` has any value.
+7. In the `If` branch, add `Get Item from List` and choose the `First Item`.
+8. Add `Get Details of Alarm` and select `Time`.
+9. Add `Format Date` and use custom format `HH:mm`.
+10. Add `Dictionary` with one key: `alarm_time`.
+11. Set the `alarm_time` value to the formatted date output from the previous step.
+12. In the `Otherwise` branch, add `Dictionary` with one key: `alarm_enabled`.
+13. Set the `alarm_enabled` value to `false`.
+14. After the `If`, add `Get Contents of URL`.
+15. Set the URL to `https://<your-home-assistant>/api/webhook/ios_phone_wakeup_alarm_sync`.
+16. Set `Method` to `POST`.
+17. Set `Request Body` to `JSON`.
+18. Set the JSON payload to the dictionary output from the `If`.
+
+Expected payload when an alarm exists:
+
+```json
+{
+  "alarm_time": "07:30"
+}
+```
+
+Expected payload when there is no alarm:
+
+```json
+{
+  "alarm_enabled": false
+}
+```
+
+Suggested Shortcut action flow:
+
+```text
+Find Alarms
+If Find Alarms has any value
+  Get Item from List (First Item)
+  Get Details of Alarm (Time)
+  Format Date (HH:mm)
+  Dictionary
+    alarm_time: Formatted Date
+Otherwise
+  Dictionary
+    alarm_enabled: false
+End If
+Get Contents of URL
+```

--- a/packages/alarms.yaml
+++ b/packages/alarms.yaml
@@ -397,6 +397,9 @@ automation:
         entity_id: "binary_sensor.workday_sensor"
         state: "on"
       - condition: state
+        entity_id: input_boolean.special_meeting
+        state: "on"
+      - condition: state
         entity_id: device_tracker.bayesian_zeke_home
         state: "home"
       - condition: state

--- a/packages/ios_wakeup.yaml
+++ b/packages/ios_wakeup.yaml
@@ -53,6 +53,16 @@ automation:
           {% set alarm_time = trigger.query.alarm_time %}
         {% endif %}
         {{ alarm_time | string | trim }}
+      alarm_enabled_raw: >-
+        {% set alarm_enabled = '' %}
+        {% if trigger.json is defined and trigger.json.alarm_enabled is defined %}
+          {% set alarm_enabled = trigger.json.alarm_enabled %}
+        {% elif trigger.data is defined and trigger.data.alarm_enabled is defined %}
+          {% set alarm_enabled = trigger.data.alarm_enabled %}
+        {% elif trigger.query is defined and trigger.query.alarm_enabled is defined %}
+          {% set alarm_enabled = trigger.query.alarm_enabled %}
+        {% endif %}
+        {{ alarm_enabled }}
       alarm_time: >-
         {% set raw = alarm_time_raw %}
         {% if raw %}
@@ -60,18 +70,23 @@ automation:
         {% else %}
           {{ '' }}
         {% endif %}
-    condition:
-      - condition: template
-        value_template: "{{ alarm_time != '' }}"
+      alarm_enabled: >-
+        {% set raw = alarm_enabled_raw | string | lower | trim %}
+        {% if raw != '' %}
+          {{ raw in ['true', '1', 'on', 'yes'] }}
+        {% else %}
+          {{ alarm_time_raw != '' }}
+        {% endif %}
     action:
       - action: input_text.set_value
         target:
           entity_id: input_text.phone_wakeup_alarm_time
         data:
-          value: "{{ alarm_time_raw }}"
+          value: "{{ alarm_time_raw if alarm_enabled else '' }}"
       - action: script.set_wakeup_from_phone_alarm
         data:
           alarm_time: "{{ alarm_time }}"
+          alarm_enabled: "{{ alarm_enabled }}"
 
 ################################################
 ## Input Text
@@ -80,4 +95,3 @@ automation:
 input_text:
   phone_wakeup_alarm_time:
     max: 16
-

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -190,14 +190,36 @@ script:
       alarm_time:
         description: Alarm time from iOS, in HH:mm or HH:mm:ss format.
         example: "07:30"
+      alarm_enabled:
+        description: Whether the phone has a wake-up alarm enabled for tomorrow.
+        example: "true"
     sequence:
       - variables:
+          alarm_time_text: "{{ alarm_time | default('') | string | trim }}"
+          sync_alarm_enabled: >-
+            {% set raw = alarm_enabled | default('') %}
+            {% set has_alarm_time = alarm_time | default('') | string | trim != '' %}
+            {% if raw is boolean %}
+              {{ raw }}
+            {% elif raw | string | trim != '' %}
+              {{ raw | string | lower | trim in ['true', '1', 'on', 'yes'] }}
+            {% else %}
+              {{ has_alarm_time }}
+            {% endif %}
           normalized_alarm_time: >-
-            {% set parts = alarm_time.split(':') %}
-            {{ '%02d:%02d' | format(parts[0] | int, parts[1] | int) }}
+            {% if alarm_time_text != '' %}
+              {% set parts = alarm_time_text.split(':') %}
+              {{ '%02d:%02d' | format(parts[0] | int, parts[1] | int) }}
+            {% else %}
+              {{ '' }}
+            {% endif %}
           meeting_alarm_time: >-
-            {% set meeting_time = today_at(normalized_alarm_time) - timedelta(minutes=5) %}
-            {{ meeting_time.strftime('%H:%M:%S') }}
+            {% if alarm_time_text != '' %}
+              {% set meeting_time = today_at(normalized_alarm_time) - timedelta(minutes=5) %}
+              {{ meeting_time.strftime('%H:%M:%S') }}
+            {% else %}
+              00:00:00
+            {% endif %}
           tomorrow_start: "{{ (now().date() + timedelta(days=1)).isoformat() }}T00:00:00"
           day_after_tomorrow_start: "{{ (now().date() + timedelta(days=2)).isoformat() }}T00:00:00"
       - action: calendar.get_events
@@ -216,7 +238,7 @@ script:
       - choose:
           - conditions:
               - condition: template
-                value_template: "{{ tomorrow_is_workday }}"
+                value_template: "{{ sync_alarm_enabled and tomorrow_is_workday }}"
             sequence:
               - action: input_datetime.set_datetime
                 target:
@@ -230,13 +252,41 @@ script:
                   time: "{{ meeting_alarm_time }}"
               - action: input_boolean.turn_on
                 target:
+                  entity_id: input_boolean.weekday_alarm_on
+              - action: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.special_meeting
+          - conditions:
+              - condition: template
+                value_template: "{{ sync_alarm_enabled and not tomorrow_is_workday }}"
+            sequence:
+              - action: input_datetime.set_datetime
+                target:
+                  entity_id: input_datetime.weekend_alarm
+                data:
+                  time: "{{ normalized_alarm_time }}"
+              - action: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.weekend_alarm_on
+              - action: input_boolean.turn_off
+                target:
                   entity_id: input_boolean.special_meeting
         default:
-          - action: input_datetime.set_datetime
-            target:
-              entity_id: input_datetime.weekend_alarm
-            data:
-              time: "{{ normalized_alarm_time }}"
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ tomorrow_is_workday }}"
+                sequence:
+                  - action: input_boolean.turn_off
+                    target:
+                      entity_id: input_boolean.weekday_alarm_on
+              - conditions:
+                  - condition: template
+                    value_template: "{{ not tomorrow_is_workday }}"
+                sequence:
+                  - action: input_boolean.turn_off
+                    target:
+                      entity_id: input_boolean.weekend_alarm_on
           - action: input_boolean.turn_off
             target:
               entity_id: input_boolean.special_meeting


### PR DESCRIPTION
## Summary
- add a dedicated iOS wake-up sync package with a webhook-driven nightly alarm ingest path
- restore the missing wake-up scheduling bridge in packages/workday.yaml so synced phone alarms update weekday/weekend helpers and set the meeting pre-alarm offset
- guard the existing weekday alarm branch so workday syncs do not double-fire alongside input_boolean.special_meeting
- document the 9:00 PM iOS personal automation flow in the README

Closes #86.

## Testing
- yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt
- python3 scripts/check_ha_python_support.py --python-version-file .python-version
- git diff --check
- Home Assistant check_config not run locally because this workspace does not have Docker or a local homeassistant module installed

## Coverage
- N/A for this YAML-only Home Assistant config change; validation is covered by repo linting plus follow-up GitHub Actions config checks
