### PR TITLE
Fix Inovelli reset mappings and morning switch mode

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1575,6 +1575,9 @@ automation:
         data:
           entity_id:
             - switch.sleep_mode
+      - action: script.turn_on
+        target:
+          entity_id: script.day_mode_switches
 
   - alias: button_reset_basement
     id: button_reset_basement

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1773,12 +1773,20 @@ script:
         {%- for device in states.number | select('match', '.*ledintensitywhenon.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
       all_switches_led_intensity_off: >
         {%- for device in states.number | select('match', '.*ledintensitywhenoff.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+      all_day_mode_singletapbehavior_switches: >
+        {%- for device in states.select
+          | selectattr('entity_id', 'search', 'singletapbehavior')
+          | rejectattr('entity_id', 'search', 'exhaust')
+          | rejectattr('entity_id', 'search', 'fan_switch')
+          | rejectattr('entity_id', 'search', 'overhead_outlet') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
     sequence:
       - action: logbook.log
         data:
           entity_id: script.day_mode_switches
           name: Exclude log
-          message: "Setting all light switch colors to blue"
+          message: "Setting light switch day mode colors and full-brightness single tap"
           domain: script
       - action: number.set_value
         data_template:
@@ -1804,6 +1812,12 @@ script:
             {{all_on_led_switches}}
         data:
           value: "170"
+      - action: select.select_option
+        data_template:
+          entity_id: >
+            {{all_day_mode_singletapbehavior_switches}}
+        data:
+          option: "New Behavior"
 
   reset_inovelli_switches:
     icon: mdi:light-switch
@@ -1825,7 +1839,12 @@ script:
       all_inovelli_switches_bindingofftoonsynclevel_mode: >
         {%- for device in states.select | select('match', '.*bindingofftoonsynclevel.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
       all_inovelli_switches_switchtype_mode: >
-        {%- for device in states.select | select('match', '.*switchtype.*') | reject('match','.*exhaust.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.select
+          | selectattr('entity_id', 'search', 'switchtype')
+          | rejectattr('entity_id', 'search', 'exhaust')
+          | rejectattr('entity_id', 'equalto', 'select.hall_transition_switch_switchtype') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
     sequence:
       - action: logbook.log
         data:
@@ -1893,20 +1912,20 @@ script:
       - delay: 10 # seconds
       - action: select.select_option
         data_template:
-          entity_id:
-            - select.hall_stairway_smartbulbmode
-            - select.owner_suite_bathroom_exhaust_smartbulbmode
-            - select.owner_suite_bathroom_vanity_smartbulbmode
-            - select.owner_suite_closet_smartbulbmode
-            - select.kitchen_nook_switch_smartbulbmode # TODO Maybe remove this
-            - select.hall_stairway_smartbulbmode # TODO Maybe remove this when new light installed
-            - select.garage_overhead_switch_smartbulbmode
-            # - select.deck_kitchen_door_smartbulbmode
-            - select.deck_flood_lights_smartbulbmode
-            - select.laundry_wall_switch_smartbulbmode
-            - select.kitchen_under_cabinet_smartbulbmode
-            - select.basement_overhead_outlet_smartbulbmode # Todo maybe remove this when something is plugged in?
-            # -
+          entity_id: >
+            select.hall_stairway_smartbulbmode,
+            select.owner_suite_bathroom_exhaust_smartbulbmode,
+            select.owner_suite_bathroom_vanity_smartbulbmode,
+            select.owner_suite_closet_smartbulbmode,
+            select.kitchen_bay_switch_smartbulbmode,
+            select.hall_stairway_smartbulbmode,
+            select.garage_overhead_switch_smartbulbmode,
+            select.deck_flood_lights_smartbulbmode,
+            select.laundry_wall_switch_smartbulbmode,
+            select.kitchen_under_cabinet_smartbulbmode,
+            select.basement_overhead_outlet_smartbulbmode,
+            select.hall_transition_switch_smartbulbmode,
+            select.kitchen_switch_smartbulbmode
         data:
           option: "Disabled"
       - delay: 10 # seconds
@@ -1961,12 +1980,18 @@ script:
             - select.deck_flood_lights_switchtype
             - select.hall_garage_laundry_switch_switchtype
             - select.kitchen_switch_switchtype
-            - select.hall_transition_switch_switchtype
             - select.hall_upstairs_switch_switchtype
             - select.hall_stairway_switchtype
             - select.garage_overhead_switch_switchtype
+            - select.kitchen_bay_switch_switchtype
         data:
           option: "3-Way Aux Switch"
+      - action: select.select_option
+        data_template:
+          entity_id: >
+            select.hall_transition_switch_switchtype
+        data:
+          option: "Aux Switch"
       # Now redo the bindings of switches to bulbs/etc
       - delay: 10 # seconds
       # TODO: Z2M 2.0 I need to update these bindings: https://github.com/Koenkk/zigbee2mqtt/pull/24432

--- a/zigbee2mqtt/configuration.yaml
+++ b/zigbee2mqtt/configuration.yaml
@@ -228,7 +228,7 @@ devices:
     friendly_name: Hall/Stairway
   '0x943469fffe05d25a':
     friendly_name: Kitchen/Overhead Lights Switch
-  '0x70ac08fffe7353a5':
+  '0x0c2a6ffffef7a057':
     friendly_name: Hall/Transition Switch
   '0x943469fffe0895fb':
     friendly_name: Kitchen/Under Cabinet


### PR DESCRIPTION
## Summary
- fix the Inovelli reset script so `hall_transition_switch` is excluded from the bulk single-pole pass and then explicitly set to `Aux Switch`
- map the old kitchen nook reset entry to `Kitchen/Bay Switch` and add the current kitchen switch/bay switch select targets needed by the reset flow
- extend the 8:00 AM wake-up automation to call `script.day_mode_switches`, and update that script to set single-tap behavior to `New Behavior`
- update the checked-in Zigbee2MQTT Hall/Transition IEEE to `0x0c2a6ffffef7a057`

## Validation
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `ruby -e 'require "yaml"; YAML.load_file("packages/light.yaml"); YAML.load_file("packages/zigbee_zwave.yaml"); YAML.load_file("zigbee2mqtt/configuration.yaml"); puts "yaml-ok"'`
- `ha_check_config` -> valid

## Test Cases
- reran `automation.reset_inovelli_config` and verified the live error remained the old `hall_transition_switch_switchtype` bulk-setting failure before this branch was pushed
- verified the patched selector template excludes `select.hall_transition_switch_switchtype` and the dedicated `Aux Switch` override is present in the YAML
- verified the morning automation now calls `script.day_mode_switches` at 08:00 and that the day-mode script targets `singletapbehavior` selects

## Coverage
- N/A for Home Assistant YAML configuration changes
