### PR TITLE
Fix Inovelli reset switch target states

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1842,7 +1842,9 @@ script:
         {%- for device in states.select
           | selectattr('entity_id', 'search', 'switchtype')
           | rejectattr('entity_id', 'search', 'exhaust')
-          | rejectattr('entity_id', 'equalto', 'select.hall_transition_switch_switchtype') -%}
+          | rejectattr('entity_id', 'equalto', 'select.hall_transition_switch_switchtype')
+          | rejectattr('entity_id', 'equalto', 'select.kitchen_switch_switchtype')
+          | rejectattr('entity_id', 'equalto', 'select.kitchen_bay_switch_switchtype') -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
     sequence:
@@ -1917,15 +1919,12 @@ script:
             select.owner_suite_bathroom_exhaust_smartbulbmode,
             select.owner_suite_bathroom_vanity_smartbulbmode,
             select.owner_suite_closet_smartbulbmode,
-            select.kitchen_bay_switch_smartbulbmode,
             select.hall_stairway_smartbulbmode,
             select.garage_overhead_switch_smartbulbmode,
             select.deck_flood_lights_smartbulbmode,
             select.laundry_wall_switch_smartbulbmode,
             select.kitchen_under_cabinet_smartbulbmode,
-            select.basement_overhead_outlet_smartbulbmode,
-            select.hall_transition_switch_smartbulbmode,
-            select.kitchen_switch_smartbulbmode
+            select.basement_overhead_outlet_smartbulbmode
         data:
           option: "Disabled"
       - delay: 10 # seconds
@@ -1970,6 +1969,9 @@ script:
             - select.owner_suite_bathroom_exhaust_switchtype
             - select.basement_bathroom_exhaust_switchtype
             - select.guest_bathroom_exhaust_switchtype
+            - select.hall_transition_switch_switchtype
+            - select.kitchen_switch_switchtype
+            - select.kitchen_bay_switch_switchtype
         data:
           option: "Single Pole"
       - delay: 10 # seconds
@@ -1979,19 +1981,11 @@ script:
             - select.basement_landing_switch_switchtype
             - select.deck_flood_lights_switchtype
             - select.hall_garage_laundry_switch_switchtype
-            - select.kitchen_switch_switchtype
             - select.hall_upstairs_switch_switchtype
             - select.hall_stairway_switchtype
             - select.garage_overhead_switch_switchtype
-            - select.kitchen_bay_switch_switchtype
         data:
           option: "3-Way Aux Switch"
-      - action: select.select_option
-        data_template:
-          entity_id: >
-            select.hall_transition_switch_switchtype
-        data:
-          option: "Aux Switch"
       # Now redo the bindings of switches to bulbs/etc
       - delay: 10 # seconds
       # TODO: Z2M 2.0 I need to update these bindings: https://github.com/Koenkk/zigbee2mqtt/pull/24432

--- a/zigbee2mqtt/configuration.yaml
+++ b/zigbee2mqtt/configuration.yaml
@@ -355,8 +355,6 @@ devices:
     friendly_name: Tiki Room/Camera
   '0x0000000000000000':
     friendly_name: '0x0000000000000000'
-  '0x0c2a6ffffef7a057':
-    friendly_name: Hall/Transition Switch
   '0xf044d3fffe6dd409':
     friendly_name: Kitchen/Bay Switch
   '0xf044d3fffe6d977b':


### PR DESCRIPTION
## Summary
- keep Hall/Transition, Kitchen/Switch, and Kitchen/Bay Switch out of the bulk full-sine-wave/3-way reset paths
- explicitly reset those three switches to `SwitchType = Single Pole` while allowing `SmartBulbMode = Smart Bulb Mode`
- remove the duplicate Hall/Transition IEEE entry from Zigbee2MQTT config so the repo lints cleanly

## Test cases
- run `script.reset_inovelli_switches` after the Zigbee entities are back and verify:
  - `select.hall_transition_switch_switchtype = Single Pole`
  - `select.hall_transition_switch_smartbulbmode = Smart Bulb Mode`
  - `select.kitchen_switch_switchtype = Single Pole`
  - `select.kitchen_switch_smartbulbmode = Smart Bulb Mode`
  - `select.kitchen_bay_switch_switchtype = Single Pole`
  - `select.kitchen_bay_switch_smartbulbmode = Smart Bulb Mode`

## Validation
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d {extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}} configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `ruby -e require "yaml"; YAML.load_file("packages/zigbee_zwave.yaml"); puts "yaml-ok"`
- `ha_check_config`

## Runtime note
- I did not rerun the live reset after this change because the six relevant select entities were still `unavailable` with `restored: true` in Home Assistant.