### PR TITLE
Align Inovelli reset mappings with wiring

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1838,15 +1838,6 @@ script:
         {%- for device in states.number | select('match', '.*brightnesslevelfordoubletapup.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
       all_inovelli_switches_bindingofftoonsynclevel_mode: >
         {%- for device in states.select | select('match', '.*bindingofftoonsynclevel.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
-      all_inovelli_switches_switchtype_mode: >
-        {%- for device in states.select
-          | selectattr('entity_id', 'search', 'switchtype')
-          | rejectattr('entity_id', 'search', 'exhaust')
-          | rejectattr('entity_id', 'equalto', 'select.hall_transition_switch_switchtype')
-          | rejectattr('entity_id', 'equalto', 'select.kitchen_switch_switchtype')
-          | rejectattr('entity_id', 'equalto', 'select.kitchen_bay_switch_switchtype') -%}
-          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
-        {%- endfor %}
     sequence:
       - action: logbook.log
         data:
@@ -1957,35 +1948,43 @@ script:
           option: "Exhaust Fan (On/Off)"
       - delay: 10 # seconds
       - action: select.select_option
-        data_template:
-          entity_id: >
-            {{all_inovelli_switches_switchtype_mode}}
         data:
-          option: "Single-Pole Full Sine Wave"
-      - delay: 10 # seconds
-      - action: select.select_option
-        data_template:
           entity_id:
             - select.owner_suite_bathroom_exhaust_switchtype
             - select.basement_bathroom_exhaust_switchtype
             - select.guest_bathroom_exhaust_switchtype
-            - select.hall_transition_switch_switchtype
-            - select.kitchen_switch_switchtype
+            - select.basement_great_room_landing_switch_2_switchtype
+            - select.basement_great_room_west_switch_switchtype
+            - select.basement_landing_switch_switchtype
+            - select.basement_north_hallway_switch_switchtype
+            - select.basement_overhead_outlet_switchtype
+            - select.deck_flood_lights_switchtype
+            - select.dining_room_wall_switch_switchtype
+            - select.garage_overhead_switch_switchtype
             - select.kitchen_bay_switch_switchtype
-        data:
+            - select.kitchen_sink_overhead_switch_switchtype
+            - select.kitchen_switch_switchtype
+            - select.kitchen_under_cabinet_switchtype
+            - select.laundry_wall_switch_switchtype
+            - select.office_fan_switch_switchtype
+            - select.owner_suite_bathroom_shower_switch_switchtype
+            - select.owner_suite_bathroom_tub_switch_switchtype
+            - select.owner_suite_bathroom_vanity_switchtype
+            - select.owner_suite_closet_switchtype
+            - select.owner_suite_fan_switch_switchtype
           option: "Single Pole"
       - delay: 10 # seconds
       - action: select.select_option
-        data_template:
-          entity_id:
-            - select.basement_landing_switch_switchtype
-            - select.deck_flood_lights_switchtype
-            - select.hall_garage_laundry_switch_switchtype
-            - select.hall_upstairs_switch_switchtype
-            - select.hall_stairway_switchtype
-            - select.garage_overhead_switch_switchtype
         data:
+          entity_id:
+            - select.hall_garage_laundry_switch_switchtype
+            - select.hall_stairway_switchtype
+            - select.hall_upstairs_switch_switchtype
           option: "3-Way Aux Switch"
+      - action: select.select_option
+        data:
+          entity_id: select.hall_transition_switch_switchtype
+          option: "Aux Switch"
       # Now redo the bindings of switches to bulbs/etc
       - delay: 10 # seconds
       # TODO: Z2M 2.0 I need to update these bindings: https://github.com/Koenkk/zigbee2mqtt/pull/24432


### PR DESCRIPTION
## Summary
- replace the old bulk `switchtype` reset with explicit `Single Pole`, `3-Way Aux Switch`, and `Aux Switch` mappings based on the current Inovelli wiring inventory
- keep exhaust circuits on `Exhaust Fan (On/Off)` and stop forcing `Kitchen/Bay Switch` and `Kitchen/Switch` into the smart-bulb disabled exception list
- remove the duplicate Hall/Transition IEEE entry from Zigbee2MQTT config so the branch validates cleanly

## Test cases
- run `script.reset_inovelli_switches` after deploy and verify these targets:
  - `Hall/Garage Laundry`, `Hall/Stairway`, `Hall/Upstairs/Switch` => `3-Way Aux Switch`
  - `Hall/Transition Switch` => `Aux Switch`
  - `Kitchen/Bay Switch`, `Kitchen/Switch`, `Kitchen/Sink Overhead Switch`, `Garage/Overhead Switch`, `Laundry/Wall Switch`, `Dining Room/Wall Switch`, `Basement/Landing Switch`, `Basement/Great Room West Switch`, `Basement/Great Room Landing Switch 2`, `Basement/North Hallway Switch`, `Owner Suite/Closet`, `Owner Suite/Bathroom/Shower Switch`, `Owner Suite/Bathroom/Tub Switch`, `Owner Suite/Bathroom/Vanity`, `Owner Suite/Fan Switch`, `Office/Fan Switch`, `Deck/Flood Lights`, `Basement/Overhead Outlet` => `Single Pole`
  - bathroom exhaust switches stay `Single Pole` with `OutputMode = Exhaust Fan (On/Off)`

## Validation
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d {extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}} configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `ruby -e require "yaml"; YAML.load_file("packages/zigbee_zwave.yaml"); YAML.load_file("zigbee2mqtt/configuration.yaml"); puts "yaml-ok"`
- `ha_check_config`

## Notes
- `Den/Wall Switch` was not hardcoded because HA does not currently expose a live `select.*switchtype` entity for it.
- `Kitchen/Overhead Lights Switch` appears to be a stale friendly name; the live switchtype entities are `Kitchen/Switch` and `Kitchen/Sink Overhead Switch`, and only the live entities are targeted.