### PR TITLE
Update notify groups to current devices

### DIFF
--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -366,9 +366,17 @@ notify:
       #    - action: telegram
       - action: mobile_app_faro
       - action: mobile_app_wethop
-      - action: mobile_app_rtclauss
-      - action: mobile_app_ryans_macbook_pro
-      - action: lg_webos_tv_oled65cxpua
+      - action: mobile_app_f7m69c_5d3d6e76
+      - action: mobile_app_personal_macbook
+      - action: lg_webos_tv_oled65c4aua_dusqljr
+  - name: notify_all
+    platform: group
+    services:
+      - action: mobile_app_faro
+      - action: mobile_app_wethop
+      - action: mobile_app_f7m69c_5d3d6e76
+      - action: mobile_app_personal_macbook
+      - action: lg_webos_tv_oled65c4aua_dusqljr
 
 ########################
 # Scenes


### PR DESCRIPTION
## Summary
- update the `notify.all` group to the current live mobile app and TV notifier service names
- add a `notify_all` group alias so both `notify.all` and `notify.notify_all` are available after reload

## Validation
- `python scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- local `homeassistant --script check_config` could not complete in this workspace because the path contains a space and Home Assistant package installation aborted before validation; GitHub Actions will run the authoritative containerized config check

## Coverage
- N/A, config-only change

## Manual Test Cases
1. Reload Home Assistant config or restart Home Assistant.
2. Confirm `notify.all` appears in Developer Tools > Actions.
3. Confirm `notify.notify_all` appears in Developer Tools > Actions.
4. Send a test message through both services and verify delivery to Faro, Wethop, Personal MacBook, the `f7m69c_5d3d6e76` device, and the LG WebOS TV notifier.