### PR TITLE
Add IDs for UI-manageable YAML entities

### DIFF
--- a/packages/airplanes.yaml
+++ b/packages/airplanes.yaml
@@ -266,6 +266,7 @@ script: {}
 sensor:
   - platform: rest
     name: "ADSB Aircraft Raw"
+    unique_id: adsb_aircraft_raw
     resource: http://10.24.1.188:8080/data/aircraft.json
     scan_interval: 15
     value_template: "{{ value_json.now }}"
@@ -274,6 +275,7 @@ sensor:
 
   - platform: rest
     name: Closest Aircraft Photo Raw
+    unique_id: closest_aircraft_photo_raw
     resource_template: >-
       {% set hx = state_attr('sensor.closest_aircraft_overhead','hex') %}
       {% if hx %}
@@ -291,6 +293,7 @@ sensor:
 
   - platform: rest
     name: Closest Aircraft Route Raw
+    unique_id: closest_aircraft_route_raw
     resource_template: >-
       {% set cs = state_attr('sensor.closest_aircraft_overhead','callsign') %}
       {% if cs %}
@@ -338,6 +341,7 @@ switch: []
 template:
   - sensor:
       - name: "Closest Aircraft Overhead"
+        unique_id: closest_aircraft_overhead
         icon: mdi:airplane
 
         # State: callsign if present, else HEX, else "none"
@@ -471,6 +475,7 @@ template:
 
   - sensor:
       - name: "Closest Aircraft Photo"
+        unique_id: closest_aircraft_photo
         state: >-
           {% set photos = state_attr('sensor.closest_aircraft_photo_raw','photos') or [] %}
           {{ 'ok' if (photos | length) > 0 else 'none' }}
@@ -502,6 +507,7 @@ template:
 
   - sensor:
       - name: "Closest Aircraft Route"
+        unique_id: closest_aircraft_route
         state: >-
           {% set r = state_attr('sensor.closest_aircraft_route_raw','response') %}
           {% if r and r.flightroute is defined %}
@@ -576,6 +582,7 @@ template:
 
   - sensor:
       - name: airport_codes_icao
+        unique_id: airport_codes_icao
         state: >-
           {% set raw = states('sensor.closest_aircraft_routeset_raw') %}
           {% if raw in ['unknown','unavailable','none',''] %}
@@ -590,6 +597,7 @@ template:
           {% endif %}
 
       - name: airports_names
+        unique_id: airports_names
         state: >-
           {% set raw = states('sensor.closest_aircraft_routeset_raw') %}
           {% if raw in ['unknown','unavailable','none',''] %}
@@ -605,6 +613,7 @@ template:
 
       # Helpful when debugging: if ADSB.im returns {"detail":[...]} you'll see it here
       - name: error_detail
+        unique_id: closest_aircraft_error_detail
         state: >-
           {% set raw = states('sensor.closest_aircraft_routeset_raw') %}
           {% if raw in ['unknown','unavailable','none',''] %}
@@ -643,6 +652,7 @@ rest:
       {% endif %}
     sensor:
       - name: Closest Aircraft Routeset
+        unique_id: closest_aircraft_routeset
         value_template: >-
           {% set j = value | from_json %}
           {% if j is sequence and j|length > 0 and j[0]._airport_codes_iata is defined %}
@@ -675,6 +685,7 @@ rest:
       {% endif %}
     sensor:
       - name: Closest Aircraft Routeset Names
+        unique_id: closest_aircraft_routeset_names
         value_template: >-
           {% set j = value | from_json %}
           {% if j is sequence and j|length > 0 and j[0]._airports is defined %}

--- a/packages/birds.yaml
+++ b/packages/birds.yaml
@@ -216,6 +216,7 @@ media_player: []
 mqtt:
   - sensor:
       - name: "Garden Birds"
+        unique_id: garden_birds
         state_topic: "birdpi/apprise"
         json_attributes_topic: "birdpi/apprise"
         value_template: "{{ value_json.common_name }}"
@@ -252,6 +253,7 @@ script: {}
 sensor:
   - platform: rest
     name: Top 50 Bird Species
+    unique_id: top_50_bird_species
     resource: https://app.birdweather.com/api/v1/stations/v13SVjSLeUURwbirfciJoN71/species/?period=day&limit=50
 
     value_template: "{{ value_json.species[0].commonName }}"
@@ -260,6 +262,7 @@ sensor:
 
   - platform: rest
     name: Latest Bird Detection
+    unique_id: latest_bird_detection
     resource: https://app.birdweather.com/api/v1/stations/v13SVjSLeUURwbirfciJoN71/detections/?limit=1
     value_template: >
       {% if value_json.detections and value_json.detections | length > 0 %}
@@ -281,6 +284,7 @@ switch: []
 template:
   - image:
       - name: Bird-Pi Photo
+        unique_id: bird_pi_photo
         verify_ssl: false
         url: "{{ state_attr('sensor.garden_birds','image') }}"
 ########################

--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -580,6 +580,7 @@ sensor: []
 template:
   - binary_sensor:
       - name: upcoming_trip_charging
+        unique_id: upcoming_trip_charging
         availability: >-
           {{ state_attr("sensor.waze_next_trip_distance", "distance") != None }}
         attributes:
@@ -744,6 +745,7 @@ template:
           {% endif %}
   - sensor:
       - name: charge_complete
+        unique_id: charge_complete
         device_class: timestamp
         availability: >-
           {{ states.sensor.nigori_charging_rate.last_updated is defined and state_attr('sensor.nigori_charging_rate','time_left') != None }}
@@ -761,6 +763,7 @@ template:
       #   state: >-
       #     {{ state_attr("sensor.waze_next_trip_distance", "distance") | int }}
       - default_entity_id: sensor.calendar_destination
+        unique_id: calendar_destination
         name: Next Calendar Destination
         state: >-
           {% if state_attr("calendar.ryan_claussen", "start_time")  != None %}

--- a/packages/christmas.yaml
+++ b/packages/christmas.yaml
@@ -316,5 +316,6 @@ script:
 template:
   - binary_sensor:
       - default_entity_id: binary_sensor.christmas_season
+        unique_id: christmas_season
         state: '{{ now().strftime("%m") |int in [12] }}'
         name: christmas_season

--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -274,16 +274,19 @@ template:
       - delay_off: 0:10:00
         delay_on: 0:05:00
         default_entity_id: binary_sensor.dishwasher_running
+        unique_id: dishwasher_running
         state: "{{ is_state('binary_sensor.dishwasher', 'on') }}"
         name: dishwasher_running
       - delay_off: 0:10:00
         delay_on: 0:05:00
         default_entity_id: binary_sensor.dryer_running
+        unique_id: dryer_running
         state: "{{ is_state('binary_sensor.dryer', 'on') }}"
         name: dryer_running
       - delay_off: 0:10:00
         delay_on: 0:05:00
         default_entity_id: binary_sensor.washing_machine_running
+        unique_id: washing_machine_running
         state: "{{ is_state('binary_sensor.washer', 'on') }}"
         name: washing_machine_running
   - trigger:
@@ -295,6 +298,7 @@ template:
         to: "cleaning"
     sensor:
       - name: "Vacuum last ran"
+        unique_id: vacuum_last_ran
         state_class: measurement
         device_class: timestamp
         state: >-

--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -650,6 +650,7 @@ sensor:
 template:
   - binary_sensor:
       - default_entity_id: binary_sensor.bathroom_humidity_high
+        unique_id: bathroom_humidity_high
         state: >-
           {% if (states('sensor.owner_suite_bathroom_tph_humidity')|float(default=0)) > (states('sensor.average_house_humidity')|float(default=0) + 10) %}
             True
@@ -658,6 +659,7 @@ template:
           {% endif %}
         name: bathroom_humidity_high
       - default_entity_id: binary_sensor.basement_bathroom_humidity_high
+        unique_id: basement_bathroom_humidity_high
         state: >-
           {% if(states('sensor.basement_bathroom_tph_humidity')|float(default=0))> (states('sensor.average_house_humidity')|float(default=0) + 10) %}
             True
@@ -666,6 +668,7 @@ template:
           {% endif %}
         name: basement_bathroom_humidity_high
       - default_entity_id: binary_sensor.guest_bathroom_humidity_high
+        unique_id: guest_bathroom_humidity_high
         state: >-
           {% if(states('sensor.guest_bathroom_tph_humidity')|float(default=0))> (states('sensor.average_house_humidity')|float(default=0) + 10) %}
             True
@@ -675,6 +678,7 @@ template:
         name: guest_bathroom_humidity_high
       - device_class: heat
         default_entity_id: binary_sensor.ecobee_aux
+        unique_id: ecobee_aux
         state: >-
           {% if 'aux' in state_attr('climate.my_ecobee', 'equipment_running') %}
             True
@@ -684,6 +688,7 @@ template:
         name: ecobee_aux
       - device_class: presence
         default_entity_id: binary_sensor.ecobee_home
+        unique_id: ecobee_home
         state: >-
           {% if is_state_attr('climate.my_ecobee', 'preset_mode', 'away_indefinitely') or is_state_attr('climate.my_ecobee', 'preset_mode', 'Away') %}
             False
@@ -693,6 +698,7 @@ template:
         name: ecobee_home
       - device_class: window
         default_entity_id: binary_sensor.fresh_air_open
+        unique_id: fresh_air_open
         state: >-
           {{ is_state('binary_sensor.ene_window_contact', 'on') or is_state('binary_sensor.ese_window_contact',
           'on') or is_state('binary_sensor.nne_window_contact', 'on') or is_state('binary_sensor.north_kitchen_sink_window_contact',
@@ -703,15 +709,18 @@ template:
         name: fresh_air_open
   - sensor:
       - name: HVAC Activity
+        unique_id: hvac_activity
         state: "{{ state_attr('climate.my_ecobee', 'hvac_action') }}"
       - device_class: temperature
         unit_of_measurement: °F
         default_entity_id: sensor.ecobee_temperature
+        unique_id: ecobee_temperature
         availability: '{{ states("climate.my_ecobee") != None }}'
         state: "{{ state_attr('climate.my_ecobee', 'current_temperature') }}"
         name: ecobee_temperature
       - unit_of_measurement: °F/5 minute
         default_entity_id: sensor.rate_of_house_temp_change_5m
+        unique_id: rate_of_house_temp_change_5m
         availability: >-
           {{ states("sensor.rate_of_house_temp_change_5m", "change_rate") != None }}
         state: >-
@@ -719,6 +728,7 @@ template:
         name: rate_of_house_temp_change_5m
       - unit_of_measurement: °F/5 minute
         default_entity_id: sensor.rate_of_house_temp_change_10m
+        unique_id: rate_of_house_temp_change_10m
         availability: >-
           {{ states("sensor.rate_of_house_temp_change_10m", "change_rate") != None }}
         state: >-
@@ -726,6 +736,7 @@ template:
         name: rate_of_house_temp_change_10m
       - unit_of_measurement: °F/5 minute
         default_entity_id: sensor.rate_of_house_temp_change_1h
+        unique_id: rate_of_house_temp_change_1h
         availability: >-
           {{ states("sensor.house_temperature_stats_1h", "change_rate") != None }}
         state: >-
@@ -733,6 +744,7 @@ template:
         name: rate_of_house_temp_change_1h
       - unit_of_measurement: °F/5 minute
         default_entity_id: sensor.rate_of_house_temp_change_30m
+        unique_id: rate_of_house_temp_change_30m
         availability: >-
           {{ states("sensor.house_temperature_stats_30m", "change_rate") != None }}
         state: >-
@@ -741,6 +753,7 @@ template:
       - device_class: temperature
         unit_of_measurement: °F
         default_entity_id: sensor.ecobee_active_target_temperature
+        unique_id: ecobee_active_target_temperature
         availability: "{{ states('climate.my_ecobee') not in ['unknown', 'unavailable'] }}"
         state: >-
           {% set action = states('sensor.hvac_activity') %}
@@ -762,6 +775,7 @@ template:
         name: ecobee_active_target_temperature
       - unit_of_measurement: °F/min
         default_entity_id: sensor.ecobee_modeled_rate_deg_per_min
+        unique_id: ecobee_modeled_rate_deg_per_min
         availability: >-
           {{ has_value('sensor.outside_temperature') and has_value('sensor.rate_of_house_temp_change_10m') and states('sensor.hvac_activity') in ['heating', 'cooling'] }}
         state: >-

--- a/packages/curling.yaml
+++ b/packages/curling.yaml
@@ -280,10 +280,12 @@ sensor: []
 template:
   - binary_sensor:
       - default_entity_id: binary_sensor.curling_season
+        unique_id: curling_season
         state: '{{ now().strftime("%m") |int in [1,2,3,10,11,12] }}'
         name: curling_season
   - sensor:
       - name: OCC Time
+        unique_id: occ_time
         state: >-
           {% if states.sensor.owatonna_curling_club_nearest_direction_of_travel.last_changed is defined %}
              {{ (as_timestamp(now(), default=now()) - as_timestamp(states.sensor.owatonna_curling_club_nearest_direction_of_travel.last_changed, default=now())) | int //60 }}
@@ -293,6 +295,7 @@ template:
         unit_of_measurement: "minutes"
         device_class: duration
       - name: SPCC Time
+        unique_id: spcc_time
         state: >-
           {% if states.sensor.st_paul_curling_club_nearest_direction_of_travel.last_changed is defined %}
              {{ (as_timestamp(now(), default=now()) - as_timestamp(states.sensor.st_paul_curling_club_nearest_direction_of_travel.last_changed, default=now())) | int //60 }}

--- a/packages/guest.yaml
+++ b/packages/guest.yaml
@@ -328,6 +328,7 @@ switch: []
 template:
   - binary_sensor:
       - default_entity_id: binary_sensor.guest_on_wifi
+        unique_id: guest_on_wifi
         state: >-
           {% set state = states('sensor.barley_guest') %} {% if is_number(state) and state | float >= 1 %}
             True
@@ -337,6 +338,7 @@ template:
         name: guest_on_wifi
   - sensor:
       - name: guests_on_wifi
+        unique_id: guests_on_wifi
         state: >-
           {{ (states.device_tracker | selectattr('state','eq','home') | selectattr('attributes.is_guest', 'eq', true) | list) }}
 

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1874,6 +1874,7 @@ automation:
                   entity_id: input_boolean.office_auto_on
 
   - alias: "Tiki Room Animation Speed"
+    id: tiki_room_animation_speed
     initial_state: True
     trigger:
       - trigger: state
@@ -1924,6 +1925,7 @@ input_number:
 light:
   - platform: group
     name: laundry_room
+    unique_id: laundry_room
     entities:
       - light.laundry_room_north
       - light.laundry_room_south
@@ -1982,6 +1984,7 @@ light:
 mqtt:
   light:
     - name: "Tiki Room Strip"
+      unique_id: tiki_room_strip
       schema: json
       state_topic: "leds/tikiroom"
       command_topic: "leds/tikiroom/set"
@@ -2181,10 +2184,12 @@ switch: []
 template:
   - sensor:
       - name: circadian_brightness
+        unique_id: circadian_brightness
         unit_of_measurement: "%"
         state: >-
           {{ state_attr('switch.adaptive_lighting_hallway', 'brightness_pct') |int }}
       - name: circadian_temperature
+        unique_id: circadian_temperature
         unit_of_measurement: "°K"
         state: >-
           {{ state_attr('switch.adaptive_lighting_hallway', 'color_temp_kelvin') }}

--- a/packages/octoprint.yaml
+++ b/packages/octoprint.yaml
@@ -273,6 +273,7 @@ switch: []
 template:
   - sensor:
       - name: "OctoPrint Time Elapsed"
+        unique_id: octoprint_time_elapsed
         unit_of_measurement: "s"
         availability: >
           {{ not is_state('sensor.octoprint_start_time', 'unavailable') }}
@@ -286,6 +287,7 @@ template:
         attributes:
           start_time: "states('sensor.octoprint_start_time')"
       - name: "OctoPrint Time Remaining"
+        unique_id: octoprint_time_remaining
         unit_of_measurement: "s"
         availability: >
           {{ not is_state('sensor.octoprint_estimated_finish_time', 'unavailable') }}

--- a/packages/plants.yaml
+++ b/packages/plants.yaml
@@ -299,105 +299,125 @@ light: []
 mqtt:
   sensor:
     - name: east_hanging_nepenthes_battery
+      unique_id: east_hanging_nepenthes_battery
       state_topic: haplants/sensor/east_hanging_nepenthes_battery/state
       unit_of_measurement: "%"
       device_class: battery
 
     - name: east_hanging_nepenthes_conductivity
+      unique_id: east_hanging_nepenthes_conductivity
       state_topic: haplants/sensor/east_hanging_nepenthes_conductivity/state
       unit_of_measurement: "\u00b5S/cm"
       icon: mdi:flash-circle
 
     - name: east_hanging_nepenthes_light_intensity
+      unique_id: east_hanging_nepenthes_light_intensity
       state_topic: haplants/sensor/east_hanging_nepenthes_light_intensity/state
       unit_of_measurement: "lx"
       device_class: illuminance
 
     - name: east_hanging_nepenthes_moisture
+      unique_id: east_hanging_nepenthes_moisture
       state_topic: haplants/sensor/east_hanging_nepenthes_moisture/state
       unit_of_measurement: "%"
       icon: mdi:water-percent
 
     #
     - name: elkhorn_battery
+      unique_id: elkhorn_battery
       state_topic: haplants/sensor/elkhorn_battery/state
       unit_of_measurement: "%"
       device_class: battery
 
     - name: elkhorn_conductivity
+      unique_id: elkhorn_conductivity
       state_topic: haplants/sensor/elkhorn_conductivity/state
       unit_of_measurement: "\u00b5S/cm"
       icon: mdi:flash-circle
 
     - name: elkhorn_light_intensity
+      unique_id: elkhorn_light_intensity
       state_topic: haplants/sensor/elkhorn_illuminance/state
       unit_of_measurement: "lx"
       device_class: illuminance
 
     - name: elkhorn_moisture
+      unique_id: elkhorn_moisture
       state_topic: haplants/sensor/elkhorn_moisture/state
       unit_of_measurement: "%"
       icon: mdi:water-percent
 
     - name: elkhorn_temperature
+      unique_id: elkhorn_temperature
       state_topic: haplants/sensor/elkhorn_temperature/state
       unit_of_measurement: "\u00b0F"
       device_class: temperature
     #
 
     - name: east_hanging_nepenthes_temperature
+      unique_id: east_hanging_nepenthes_temperature
       state_topic: haplants/sensor/east_hanging_nepenthes_temperature/state
       unit_of_measurement: "\u00b0F"
       device_class: temperature
 
     - name: west_hanging_nepenthes_battery
+      unique_id: west_hanging_nepenthes_battery
       state_topic: haplants/sensor/west_hanging_nepenthes_battery/state
       unit_of_measurement: "%"
       device_class: battery
 
     - name: terrarium_battery
+      unique_id: terrarium_battery
       state_topic: haplants/sensor/terrarium_battery/state
       unit_of_measurement: "%"
       device_class: battery
 
     - name: terrarium_conductivity
+      unique_id: terrarium_conductivity
       state_topic: haplants/sensor/terrarium_conductivity/state
       unit_of_measurement: "\u00b5S/cm"
       icon: mdi:flash-circle
 
     - name: terrarium_light_intensity
+      unique_id: terrarium_light_intensity
       state_topic: haplants/sensor/terrarium_light_intensity/state
       unit_of_measurement: "lx"
       device_class: illuminance
 
     - name: terrarium_moisture
+      unique_id: terrarium_moisture
       state_topic: haplants/sensor/terrarium_moisture/state
       unit_of_measurement: "%"
       icon: mdi:water-percent
 
     - name: terrarium_temperature
+      unique_id: terrarium_temperature
       state_topic: haplants/sensor/terrarium_temperature/state
       unit_of_measurement: "\u00b0F"
       device_class: temperature
 
     - name: west_hanging_nepenthes_conductivity
+      unique_id: west_hanging_nepenthes_conductivity
       state_topic: haplants/sensor/west_hanging_nepenthes_conductivity/state
       unit_of_measurement: "\u00b5S/cm"
       icon: mdi:flash-circle
 
     - name: west_hanging_nepenthes_light_intensity
+      unique_id: west_hanging_nepenthes_light_intensity
       state_topic: haplants/sensor/west_hanging_nepenthes_light_intensity/state
       unit_of_measurement: "lx"
       device_class: illuminance
       #icon:
 
     - name: west_hanging_nepenthes_moisture
+      unique_id: west_hanging_nepenthes_moisture
       state_topic: haplants/sensor/west_hanging_nepenthes_moisture/state
       unit_of_measurement: "%"
       #device_class: moisture
       icon: mdi:water-percent
 
     - name: west_hanging_nepenthes_temperature
+      unique_id: west_hanging_nepenthes_temperature
       state_topic: haplants/sensor/west_hanging_nepenthes_temperature/state
       unit_of_measurement: "\u00b0F"
       device_class: temperature

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -922,6 +922,7 @@ sensor: []
 template:
   - binary_sensor:
       - default_entity_id: binary_sensor.sensed_trip
+        unique_id: sensed_trip
         state: >-
           {% if is_state("input_boolean.trip", 'on') %}
             True
@@ -930,6 +931,7 @@ template:
           {% endif %}
         name: sensed_trip
       - default_entity_id: binary_sensor.planned_vacation_calendar
+        unique_id: planned_vacation_calendar
         state: >-
           {% set start = state_attr('sensor.ecobee_calendar_vacation_schedule', 'start') %}
           {% set end = state_attr('sensor.ecobee_calendar_vacation_schedule', 'end') %}
@@ -947,6 +949,7 @@ template:
           {% endif %}
         name: planned_vacation_calendar
       - default_entity_id: binary_sensor.planned_work_trip_calendar
+        unique_id: planned_work_trip_calendar
         state: >-
           {% if is_state("binary_sensor.work_trip_today", 'on') %}
             true
@@ -956,6 +959,7 @@ template:
         name: planned_work_trip_calendar
       - delay_off: "3:00:00"
         default_entity_id: binary_sensor.flying_home_today
+        unique_id: flying_home_today
         state: >-
           {% if is_state("binary_sensor.flight_to_msp_today", 'on') or is_state("binary_sensor.flight_to_rst_today",'on')  %}
             true
@@ -1489,6 +1493,7 @@ template:
   - sensor:
       - name: time_to_home
         default_entity_id: sensor.me_to_home
+        unique_id: me_to_home
         state: >-
           {% set to_home = states.sensor.me_to_home.state | int %}
           {% set minutes = ((to_home % 60) / 1) | int %}

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -699,6 +699,7 @@ switch: []
 template:
   - sensor:
       - name: house_electrical_meter
+        unique_id: house_electrical_meter
         device_class: energy
         unit_of_measurement: kWh
         availability: >

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -521,6 +521,7 @@ template:
   sensor:
     # Legacy NWS Dakota County alert sensors
     - name: nws_dakota_county_alerts_active_alerts
+      unique_id: nws_dakota_county_alerts_active_alerts
       ## You can add your county or city name to friendly_name for personalization
       ## For example: Weather Alerts for YourCountyName
       unit_of_measurement: Alerts
@@ -628,6 +629,7 @@ template:
           {{ test.count }}
 
     - name: nws_dakota_county_alerts_alert_1
+      unique_id: nws_dakota_county_alerts_alert_1
       icon: >-
         {% set mapper =  {
             '911 Telephone Outage Emergency' : 'hass:phone-alert',
@@ -926,6 +928,7 @@ template:
           {% endif %}
 
     - name: nws_dakota_county_alerts_alert_2
+      unique_id: nws_dakota_county_alerts_alert_2
       icon: >-
         {% set mapper =  {
             '911 Telephone Outage Emergency' : 'hass:phone-alert',
@@ -1224,6 +1227,7 @@ template:
           {% endif %}
 
     - name: nws_dakota_county_alerts_alert_3
+      unique_id: nws_dakota_county_alerts_alert_3
       icon: >-
         {% set mapper =  {
             '911 Telephone Outage Emergency' : 'hass:phone-alert',
@@ -1522,6 +1526,7 @@ template:
           {% endif %}
 
     - name: nws_dakota_county_alerts_alert_4
+      unique_id: nws_dakota_county_alerts_alert_4
       icon: >-
         {% set mapper =  {
             '911 Telephone Outage Emergency' : 'hass:phone-alert',
@@ -1820,6 +1825,7 @@ template:
           {% endif %}
 
     - name: nws_dakota_county_alerts_alert_5
+      unique_id: nws_dakota_county_alerts_alert_5
       icon: >-
         {% set mapper =  {
             '911 Telephone Outage Emergency' : 'hass:phone-alert',
@@ -2118,6 +2124,7 @@ template:
           {% endif %}
 
     - name: nws_dakota_county_alerts_alert_1_last_changed
+      unique_id: nws_dakota_county_alerts_alert_1_last_changed
       state: >-
         {% if states('sensor.nws_dakota_county_alerts_alert_1') == "on" %}
           {{ states.sensor.nws_dakota_county_alerts_alert_1.last_updated }}
@@ -2126,6 +2133,7 @@ template:
         {% endif %}
 
     - name: nws_dakota_county_alerts_alert_2_last_changed
+      unique_id: nws_dakota_county_alerts_alert_2_last_changed
       state: >-
         {% if states('sensor.nws_dakota_county_alerts_alert_2') == "on" %}
           {{ states.sensor.nws_dakota_county_alerts_alert_2.last_updated }}
@@ -2134,6 +2142,7 @@ template:
         {% endif %}
 
     - name: nws_dakota_county_alerts_alert_3_last_changed
+      unique_id: nws_dakota_county_alerts_alert_3_last_changed
       state: >-
         {% if states('sensor.nws_dakota_county_alerts_alert_3') == "on" %}
           {{ states.sensor.nws_dakota_county_alerts_alert_3.last_updated }}
@@ -2142,6 +2151,7 @@ template:
         {% endif %}
 
     - name: nws_dakota_county_alerts_alert_4_last_changed
+      unique_id: nws_dakota_county_alerts_alert_4_last_changed
       state: >-
         {% if states('sensor.nws_dakota_county_alerts_alert_4') == "on" %}
           {{ states.sensor.nws_dakota_county_alerts_alert_4.last_updated }}
@@ -2150,6 +2160,7 @@ template:
         {% endif %}
 
     - name: nws_dakota_county_alerts_alert_5_last_changed
+      unique_id: nws_dakota_county_alerts_alert_5_last_changed
       state: >-
         {% if states('sensor.nws_dakota_county_alerts_alert_5') == "on" %}
           {{ states.sensor.nws_dakota_county_alerts_alert_5.last_updated }}
@@ -2158,6 +2169,7 @@ template:
         {% endif %}
 
     - name: nws_dakota_county_alerts_alert_1_most_recent_active_alert
+      unique_id: nws_dakota_county_alerts_alert_1_most_recent_active_alert
       icon: >-
         {% set mapper =  {
             '911 Telephone Outage Emergency' : 'hass:phone-alert',
@@ -2343,6 +2355,7 @@ template:
           {% endif %}
 
     - name: nws_dakota_county_alerts_alert_2_most_recent_active_alert
+      unique_id: nws_dakota_county_alerts_alert_2_most_recent_active_alert
       icon: >-
         {% set mapper =  {
             '911 Telephone Outage Emergency' : 'hass:phone-alert',
@@ -2528,6 +2541,7 @@ template:
           {% endif %}
 
     - name: nws_dakota_county_alerts_alert_3_most_recent_active_alert
+      unique_id: nws_dakota_county_alerts_alert_3_most_recent_active_alert
       icon: >-
         {% set mapper =  {
             '911 Telephone Outage Emergency' : 'hass:phone-alert',
@@ -2713,6 +2727,7 @@ template:
           {% endif %}
 
     - name: nws_dakota_county_alerts_alert_4_most_recent_active_alert
+      unique_id: nws_dakota_county_alerts_alert_4_most_recent_active_alert
       icon: >-
         {% set mapper =  {
             '911 Telephone Outage Emergency' : 'hass:phone-alert',
@@ -2898,6 +2913,7 @@ template:
           {% endif %}
 
     - name: nws_dakota_county_alerts_alert_5_most_recent_active_alert
+      unique_id: nws_dakota_county_alerts_alert_5_most_recent_active_alert
       icon: >-
         {% set mapper =  {
             '911 Telephone Outage Emergency' : 'hass:phone-alert',
@@ -3083,6 +3099,7 @@ template:
           {% endif %}
 
     - name: nws_dakota_county_alerts_alerts_are_active
+      unique_id: nws_dakota_county_alerts_alerts_are_active
       icon: mdi:alert-rhombus
       state: >
         {% if (states('sensor.nws_dakota_county_alerts')|int(default=0) > 0) or ((states('sensor.nws_dakota_county_alerts') == 'unavailable') and (states('sensor.nws_dakota_county_alerts_alert_1') == 'on')) %}

--- a/packages/xiaomi_robot_vacuum.yaml
+++ b/packages/xiaomi_robot_vacuum.yaml
@@ -107,6 +107,7 @@ alarm_control_panel: []
 ########################
 automation:
   - alias: "Resume vacuum on error (den)"
+    id: resume_vacuum_on_error_den
     mode: single
     trigger:
       - trigger: state

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1536,6 +1536,7 @@ automation:
 binary_sensor:
   - platform: bayesian
     name: "Bayesian Bed Occupancy"
+    unique_id: bayesian_bed_occupancy
     prior: 0.40
     probability_threshold: 0.60
     observations:
@@ -2225,6 +2226,7 @@ sensor: []
 template:
   - binary_sensor:
       - name: master_bed_occupancy
+        unique_id: master_bed_occupancy
         delay_on: 00:00:30
         device_class: occupancy
         state: >-
@@ -2244,6 +2246,7 @@ template:
         #   {{ states('sensor.average_bed_load')| int(0) > 20 }}
 
       - name: z2m_failing
+        unique_id: z2m_failing_binary
         device_class: problem
         state: >-
           {% set total = states('sensor.z2m_router_total') | int(0) %}
@@ -2253,6 +2256,7 @@ template:
 
   - lock:
       - name: Front door lock
+        unique_id: front_door_lock_template
         optimistic: true
         lock:
           - target:
@@ -2441,6 +2445,7 @@ template:
         state: "{{ state_attr('sensor.z2m_router_offline_pct', 'total_router_count') | int(0) }}"
 
       - name: z2m_failing
+        unique_id: z2m_failing_count
         state: "{{ state_attr('sensor.z2m_router_offline_pct', 'offline_router_count') | int(0) }}"
         attributes:
           total_router_count: "{{ state_attr('sensor.z2m_router_offline_pct', 'total_router_count') | int(0) }}"

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -860,6 +860,7 @@ sensor: []
 template:
   - binary_sensor:
       - name: test_homeward
+        unique_id: test_homeward
         availability: >-
           {{ states.sensor.the_brewery_nearest_direction_of_travel.last_changed is defined }}
         state: >-
@@ -871,14 +872,17 @@ template:
           {% endif %}
   - sensor:
       - name: home_time
+        unique_id: home_time
         state: >-
           {{ (as_timestamp(now(), default=now()) - as_timestamp(states.sensor.the_brewery_nearest_direction_of_travel.last_changed, default=now())) | int //60 }}
         unit_of_measurement: "minutes"
       - name: zeke_speed
+        unique_id: zeke_speed
         unit_of_measurement: "mph"
         state: >-
           {{ state_attr('device_tracker.bayesian_zeke_home', 'speed') | int(-1) }}
       - name: zeke_direction
+        unique_id: zeke_direction
         state: >-
           {% if (state_attr('device_tracker.bayesian_zeke_home', 'course') | int(-1)) >=0 -%}
             {{ state_attr('device_tracker.bayesian_zeke_home', 'course') | int(-1) }}


### PR DESCRIPTION
## Summary
- add `unique_id` to YAML entities that Home Assistant can register and manage in the UI while still keeping the source in YAML
- add the two missing automation `id` fields so those automations can be edited from the automation editor
- leave unsupported YAML object types alone instead of adding non-functional IDs

## What Changed
- `template`: added `unique_id` values for eligible sensors, binary sensors, locks, and image entities
- `mqtt`: added `unique_id` values for eligible light and sensor entities
- `rest`: added `unique_id` values for eligible REST sensors
- `bayesian`: added `unique_id` to the active Bayesian occupancy sensor
- `light`: added `unique_id` to the eligible YAML light group
- `automation`: added missing `id` fields for `Tiki Room Animation Speed` and `Resume vacuum on error (den)`

## Not Included
- no script `id`/`unique_id` additions, because YAML scripts do not support them for UI editing
- no IDs added to classic YAML platforms that are not entity-registry backed in Home Assistant, such as `utility_meter`, `statistics`, `filter`, `trend`, `derivative`, `history_stats`, and `generic_thermostat`

## Validation
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `source .venv/bin/activate && yamllint configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `source .venv/bin/activate && python -m homeassistant --config /tmp/hass_config_check --script check_config`

## Validation Notes
- `check_config` exited successfully for the updated YAML, but still reported the repo's existing local dependency/custom-component warnings in this environment
- targeted `yamllint` on `packages/light.yaml` and `packages/xiaomi_robot_vacuum.yaml` still shows pre-existing line-length/style warnings in those files; the new `id` fields did not add new lint classes
