### PR TITLE
Fix Den Sonos Zigbee controller reliability

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -253,6 +253,11 @@ automation:
       - trigger: state
         entity_id:
           - sensor.den_sonos_controls_action
+        to: "play_pause"
+        id: play_pause
+      - trigger: state
+        entity_id:
+          - sensor.den_sonos_controls_action
         to: "track_next"
         id: track_next
       - trigger: state
@@ -265,27 +270,31 @@ automation:
           - sensor.den_sonos_controls_action
         to: "volume_up"
         id: volume_up
-      # - platform: state
-      #   entity_id:
-      #     - sensor.den_sonos_controls_action
-      #   to: "volume_up_hold"
-      #   id: volume_up_hold
+      - trigger: state
+        entity_id:
+          - sensor.den_sonos_controls_action
+        to: "volume_up_hold"
+        id: volume_up_hold
       - trigger: state
         entity_id:
           - sensor.den_sonos_controls_action
         to: "volume_down"
         id: volume_down
-      # - platform: state
-      #   entity_id:
-      #     - sensor.den_sonos_controls_action
-      #   to: "volume_down_hold"
-      #   id: volume_down_hold
+      - trigger: state
+        entity_id:
+          - sensor.den_sonos_controls_action
+        to: "volume_down_hold"
+        id: volume_down_hold
       # TODO Use Dots for shuffle and repeat
     action:
       - choose:
           - conditions:
-              - condition: trigger
-                id: toggle_play_pause
+              - condition: or
+                conditions:
+                  - condition: trigger
+                    id: toggle_play_pause
+                  - condition: trigger
+                    id: play_pause
             sequence:
               - action: media_player.media_play_pause
                 target:
@@ -305,15 +314,23 @@ automation:
                 target:
                   entity_id: media_player.den_sonos_2
           - conditions:
-              - condition: trigger
-                id: volume_up
+              - condition: or
+                conditions:
+                  - condition: trigger
+                    id: volume_up
+                  - condition: trigger
+                    id: volume_up_hold
             sequence:
               - action: media_player.volume_up
                 target:
                   entity_id: media_player.den_sonos_2
           - conditions:
-              - condition: trigger
-                id: volume_down
+              - condition: or
+                conditions:
+                  - condition: trigger
+                    id: volume_down
+                  - condition: trigger
+                    id: volume_down_hold
             sequence:
               - action: media_player.volume_down
                 target:

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1680,6 +1680,19 @@ script:
             {{ devices
               | selectattr('friendly_name', 'defined')
               | rejectattr('friendly_name', 'equalto', 'Coordinator')
+              | rejectattr('disabled', 'eq', true)
+              | rejectattr('type', 'eq', 'EndDevice')
+              | map(attribute='friendly_name')
+              | unique
+              | list }}
+          z2m_skipped_end_devices: >
+            {% set payload = wait.trigger.payload_json %}
+            {% set devices = payload.data if payload and payload.data is defined else [] %}
+            {{ devices
+              | selectattr('friendly_name', 'defined')
+              | rejectattr('friendly_name', 'equalto', 'Coordinator')
+              | rejectattr('disabled', 'eq', true)
+              | selectattr('type', 'eq', 'EndDevice')
               | map(attribute='friendly_name')
               | unique
               | list }}
@@ -1688,7 +1701,17 @@ script:
         data:
           name: Zigbee2MQTT Reset
           message: >
-            Resetting {{ z2m_devices | count }} devices: {{ z2m_devices | join(', ') }}
+            Resetting {{ z2m_devices | count }} mains-powered devices: {{ z2m_devices | join(', ') }}
+      - if:
+          - condition: template
+            value_template: "{{ z2m_skipped_end_devices | count > 0 }}"
+        then:
+          - alias: Log skipped sleepy end devices
+            service: logbook.log
+            data:
+              name: Zigbee2MQTT Reset
+              message: >
+                Skipped {{ z2m_skipped_end_devices | count }} Zigbee end devices because sleeping remotes can miss unbind/rebind requests: {{ z2m_skipped_end_devices | join(', ') }}
       - condition: template
         value_template: "{{ z2m_devices | count > 0 }}"
       - repeat:


### PR DESCRIPTION
## Summary
- accept the current IKEA SYMFONISK Gen 2 play/pause action and volume hold actions in `den_sonos_control_actions`
- stop the bulk Zigbee2MQTT binding reset script from unbinding sleeping `EndDevice` remotes that can miss the rebind request
- log which sleepy end devices were skipped so manual wake-and-repair is explicit instead of silent

## Root Cause
The live Den Sonos controller path showed two problems:
- `automation.den_sonos_control_actions` was still keyed to the older `toggle` play action and ignored hold-based volume actions
- the controller has not emitted any usable `sensor.den_sonos_controls_action` events since February 27, 2026 even though it still reports battery, which strongly suggests a Zigbee binding loss on the sleeping IKEA remote

The historical playback state confirms the Music Assistant player target (`media_player.den_sonos_2`) did change volume correctly on February 27, 2026, so the player target itself was not the regression.

## Validation
- `python scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `python -m homeassistant --config . --script check_config`
  - completed without new invalid-config errors
  - existing partial warning remains: `weatheralerts` custom component import warning
