### PR TITLE
Adjust basement TV automation transitions

### DIFF
--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -27,10 +27,12 @@ automation:
         target:
           entity_id: scene.scene_reset_basement
         data:
-          transition: 1.5
+          transition: 4
       - action: light.turn_off
         target:
           entity_id: light.basement_tv_bias
+        data:
+          transition: 4
 
   - id: tv_on
     alias: tv_on
@@ -153,7 +155,7 @@ automation:
         target:
           entity_id: scene.tv_paused
         data:
-          transition: 5
+          transition: 4
 
   - id: tv_watching_scotland
     alias: tv_watching_scotland
@@ -200,19 +202,17 @@ automation:
         entity_id: media_player.lg_webos_smart_tv
         to: "playing"
         for:
-          minutes: 2
+          seconds: 10
       - trigger: state
         entity_id: media_player.basement
-        from: "paused"
         to: "playing"
         for:
-          minutes: 2
+          seconds: 5
       - trigger: state
         entity_id: media_player.plex_basement_apple_tv
-        from: "paused"
         to: "playing"
         for:
-          minutes: 2
+          seconds: 5
     condition:
       condition: and
       conditions:
@@ -236,7 +236,7 @@ automation:
             - light.outside_south_west_garage
             - light.outside_front_door
             - light.basement_tv_bias
-          transition: 20
+          transition: 15
       - action: script.turn_on
         target:
           entity_id: script.night_tv_mode_switches


### PR DESCRIPTION
## Summary
- shorten basement TV pause and stop transitions to 4 seconds
- start the basement media fade-down on actual playback instead of waiting 2 minutes
- reduce the basement playback fade-down from 20 seconds to 15 seconds

## Linked issues
Refs #104
Refs #98
Refs #100
Refs #101

## Validation / coverage
- Local YAML validation via `yamllint` across `configuration.yaml`, `automations.yaml`, `blueprints`, `packages`, and `zigbee2mqtt`
- Local Home Assistant config validation via `python -m homeassistant --script check_config`
- Existing unrelated warning still present during config validation: `weatheralerts` custom component is missing `custom_components.weatheralerts.const`

## Test cases
- Start basement playback and confirm the lighting fade-down begins within 5-10 seconds and uses a 15 second transition.
- Pause basement playback and confirm the paused scene restores over 4 seconds.
- Turn the TV off and confirm the basement reset scene and TV bias light both complete over 4 seconds.
