### PR TITLE
Track vacuum leave and return behavior in zone package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 ########################################
 # Explicitly ignore sensitive files
 ########################################
+AGENTS.local.md
 secrets.yaml
 known_devices.yaml
 ip_bans.yaml

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -616,14 +616,39 @@ automation:
         to: "on"
     action:
       - action: vacuum.return_to_base
-        data:
-          entity_id: all
+        target:
+          entity_id:
+            - vacuum.valetudo_den
+            - vacuum.valetudo_mainlevel
+            - vacuum.valetudo_upstairs_vacuum
       - action: switch.turn_off
         target:
           entity_id: switch.living_room_camera
       - action: switch.turn_off
         target:
           entity_id: switch.basement_camera_power
+
+  - id: vacuum_leave_home
+    alias: vacuum_leave_home
+    description: Start the den, main level, and upstairs vacuums when Ryan leaves home.
+    trigger:
+      - trigger: state
+        entity_id: binary_sensor.bayesian_zeke_home
+        from: "on"
+        to: "off"
+    action:
+      - action: vacuum.start
+        target:
+          entity_id: vacuum.valetudo_mainlevel
+        continue_on_error: true
+      - action: vacuum.start
+        target:
+          entity_id: vacuum.valetudo_den
+        continue_on_error: true
+      - action: vacuum.start
+        target:
+          entity_id: vacuum.valetudo_upstairs_vacuum
+        continue_on_error: true
 
 ########################
 # Binary Sensors


### PR DESCRIPTION
## Summary
- add a package-backed leave-home automation to start the den, main level, and upstairs vacuums
- make the return-home automation dock those same three vacuums explicitly instead of targeting `all`
- add `AGENTS.local.md` to `.gitignore` so repo-local runtime memory stays untracked

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('packages/zone.yaml'); YAML.load_file('configuration.yaml'); puts 'YAML OK'"`

## Test Cases
- leave home with `binary_sensor.bayesian_zeke_home` transitioning from `on` to `off` and verify the three real vacuums are targeted
- return home with `binary_sensor.bayesian_zeke_home` transitioning to `on` and verify the same three vacuums are sent to dock
- confirm no package references remain to `vacuum.valetudo_yummyhurtfulhornet`

## Coverage
- configuration-only change; no automated code coverage suite is present in this repo