### PR TITLE
Soften owner suite bed-exit light transition

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1222,6 +1222,9 @@ automation:
 
   - id: owner_suite_light_auto_on
     alias: owner_suite_light_auto_on
+    description: >
+      Turn on the owner suite lights to the current adaptive lighting target
+      with a soft transition after bed occupancy clears.
     trace:
       stored_traces: 20
     trigger:
@@ -1251,6 +1254,11 @@ automation:
           entity_id:
             - light.owner_suite_lamps
             - light.bed_lightstrip
+          brightness_pct: >-
+            {{ state_attr('switch.adaptive_lighting_owner_suite', 'brightness_pct') | int(100) }}
+          color_temp_kelvin: >-
+            {{ state_attr('switch.adaptive_lighting_owner_suite', 'color_temp_kelvin') | int(4000) }}
+          transition: 45
       - action: input_boolean.turn_on
         data:
           entity_id: input_boolean.owner_suite_bedroom_auto_on


### PR DESCRIPTION
## Summary
- analyzed the Home Assistant runs from Saturday, March 21, 2026 to isolate the bedroom light jump
- confirmed the wake-up alarm automation fired at 08:15 CDT and 08:25 CDT but did not run any wake-up scripts because its branch conditions failed
- confirmed `automation.owner_suite_light_auto_on` triggered at 10:17:09 CDT from `binary_sensor.bedroom_occupancy` and turned on `light.owner_suite_lamps` and `light.bed_lightstrip`
- changed that automation to turn on those lights using the current `switch.adaptive_lighting_owner_suite` brightness/color target with a 45 second transition

## Why
At the time of the 10:17 CDT bedroom auto-on, Owner Suite Adaptive Lighting was advertising `brightness_pct: 100` and the automation called a bare `light.turn_on` with no explicit transition. That made the bed-exit path jump straight to the daytime adaptive target instead of easing into it.

## Validation
- `ha_get_automation_traces(automation.alarm_wake_up)` for 2026-03-21: branches evaluated but no wake-up script ran
- `ha_get_logbook(automation.owner_suite_light_auto_on)` and trace `2e0a83998956341f5f734cdcb165c6c4`: bedroom occupancy triggered the abrupt light-on at 10:17:09 CDT
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/light.yaml`

## Local limits
- the repo's Docker-based `homeassistant --script check_config` step could not be run here because `docker` is not installed in this environment

## Follow-up
- `owner_suite_light_auto_on` is now aligned with the current adaptive target, but it is still a special-case path. If you want less duplication later, the next cleanup would be to centralize owner-suite adaptive turn-on behavior behind a shared script so this automation and the other owner-suite motion paths use one implementation.
