### PR TITLE
Document active YAML configuration files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Legacy Travis CI pipeline kept for historical validation reference.
+# It installs Home Assistant in CI and runs a config check using the sample secrets file.
+
 language: python
 python:
   - "3.9"

--- a/automations.yaml
+++ b/automations.yaml
@@ -1,0 +1,2 @@
+# Intentionally kept empty.
+# This repo stores automations inside domain packages so behavior stays grouped with the entities and helpers it depends on.

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,3 +1,7 @@
+# Main Home Assistant bootstrap file for this repo.
+# It defines instance-wide settings, loads package-based domain logic, and registers shared frontend, recorder, proxy, and cloud integrations.
+# Complex areas: trusted network auth, recorder/influx exclusions, and Lovelace/HACS resources all live here because they affect the whole system.
+
 homeassistant:
   name: The Brewery
   unit_system: us_customary

--- a/esphome/bedloadcell1.yaml
+++ b/esphome/bedloadcell1.yaml
@@ -1,3 +1,6 @@
+# ESPHome node for the first bed load-cell assembly.
+# It publishes raw and filtered weight readings that feed the bed occupancy logic used by bedroom lighting and sleep automations.
+
 #  the sensors for load cell one are on the eastern-most east half of the bed
 #  and the western most western half of the bed
 esphome:

--- a/esphome/bedloadcell2.yaml
+++ b/esphome/bedloadcell2.yaml
@@ -1,3 +1,6 @@
+# ESPHome node for the second bed load-cell assembly.
+# This companion sensor is combined with bedloadcell1 so Home Assistant can infer which side of the bed is occupied and when the bed is empty.
+
 esphome:
   name: bedloadcell2 # this is the west side of the bed sensor
   platform: ESP8266

--- a/esphome/bluetoothproxy1.yaml
+++ b/esphome/bluetoothproxy1.yaml
@@ -1,3 +1,6 @@
+# ESPHome Bluetooth proxy node that extends Bluetooth coverage for Home Assistant.
+# It improves BLE device discovery and room-level presence resolution away from the main coordinator host.
+
 esphome:
   name: denbluetoothproxy
   project: 

--- a/esphome/livingroombtproxy.yaml
+++ b/esphome/livingroombtproxy.yaml
@@ -1,3 +1,6 @@
+# ESPHome Bluetooth proxy for the living room.
+# This node improves BLE reach in the main living area so trackers and Bluetooth sensors remain visible from that part of the house.
+
 esphome:
   name: diningroom-bt-proxy
   project: 

--- a/esphome/office-bt-proxy.yaml
+++ b/esphome/office-bt-proxy.yaml
@@ -1,3 +1,6 @@
+# ESPHome Bluetooth proxy for the office with custom Apple Watch advertisement parsing.
+# Complex areas: besides proxying BLE traffic, this node inspects nearby Apple Watch packets and derives RSSI-based presence helpers for office automations.
+
 esphome:
   name: office-bt-proxy
   project: 

--- a/esphome/watersoftener.yaml
+++ b/esphome/watersoftener.yaml
@@ -1,3 +1,6 @@
+# ESPHome node attached to the water softener hardware.
+# It reports salt level and related sensors that the Home Assistant water softener package turns into inventory, reminder, and refill workflows.
+
 esphome:
   name: watersoftener
   platform: ESP8266

--- a/lovelace/speaker_group.yaml
+++ b/lovelace/speaker_group.yaml
@@ -1,3 +1,6 @@
+# Helper entity list for temporary speaker grouping controls.
+# Cards and scripts can include this list instead of repeating the same Sonos targets in multiple places.
+
 - entity_id: media_player.office_sonos_2
   name: Sonos Office
 - entity_id: media_player.bathroom_sonos_2

--- a/lovelace/tiles/tiles_average_house.yaml
+++ b/lovelace/tiles/tiles_average_house.yaml
@@ -1,3 +1,6 @@
+# Whole-home summary tile stack for the main dashboard.
+# This include is meant for top-level health and status cards that summarize the house before the room-specific sections below it.
+
 type: horizontal-stack
 cards:
   - type: custom:mini-graph-card

--- a/lovelace/tiles/tiles_bathroom.yaml
+++ b/lovelace/tiles/tiles_bathroom.yaml
@@ -1,3 +1,6 @@
+# Bathroom tile include for the main Lovelace dashboard.
+# It groups the bathroom-specific light and fan controls into a reusable room section.
+
 #####
 ## Tile Template
 ##

--- a/lovelace/tiles/tiles_guest_room.yaml
+++ b/lovelace/tiles/tiles_guest_room.yaml
@@ -1,3 +1,6 @@
+# Guest room tile include for the main Lovelace dashboard.
+# This section keeps the guest bedroom controls isolated so guest-facing updates do not clutter other room tiles.
+
 type: custom:vertical-stack-in-card
 title: Guest Bedroom
 cards:

--- a/lovelace/tiles/tiles_kitchen.yaml
+++ b/lovelace/tiles/tiles_kitchen.yaml
@@ -1,3 +1,6 @@
+# Kitchen tile include for the main Lovelace dashboard.
+# It contains the kitchen lighting controls that are rendered inside the Home view via !include.
+
 type: custom:vertical-stack-in-card
 title: Kitchen
 cards:

--- a/lovelace/tiles/tiles_living_room.yaml
+++ b/lovelace/tiles/tiles_living_room.yaml
@@ -1,3 +1,6 @@
+# Living room tile include for the main Lovelace dashboard.
+# Complex areas: this room mixes light controls, scenes, and graphs, so it is split into its own include to keep the main view maintainable.
+
 type: custom:vertical-stack-in-card
 title: Living Room
 cards:

--- a/lovelace/tiles/tiles_master_bedroom.yaml
+++ b/lovelace/tiles/tiles_master_bedroom.yaml
@@ -1,3 +1,6 @@
+# Owner suite / primary bedroom tile include for the main Lovelace dashboard.
+# It groups the bedroom lighting, climate, and occupancy-related controls into a dedicated section.
+
 type: custom:vertical-stack-in-card
 title: Master Bedroom
 cards:

--- a/lovelace/tiles/tiles_office.yaml
+++ b/lovelace/tiles/tiles_office.yaml
@@ -1,3 +1,6 @@
+# Office tile include for the main Lovelace dashboard.
+# Besides lights and fan controls, this section also surfaces standing-desk controls that belong with the office room context.
+
 type: custom:vertical-stack-in-card
 title: Office
 cards:

--- a/lovelace/tiles/tiles_other.yaml
+++ b/lovelace/tiles/tiles_other.yaml
@@ -1,3 +1,6 @@
+# Catch-all tile include for secondary indoor spaces.
+# Use this section for controls that do not justify a dedicated room tile but should still appear on the Home dashboard.
+
 type: custom:vertical-stack-in-card
 title: Other
 cards:

--- a/lovelace/tiles/tiles_outside.yaml
+++ b/lovelace/tiles/tiles_outside.yaml
@@ -1,3 +1,6 @@
+# Outdoor tile include for the main Lovelace dashboard.
+# It is intended for exterior lights, entry points, and other outside-facing controls that belong together operationally.
+
 type: custom:vertical-stack-in-card
 title: Outside
 cards:

--- a/lovelace/tiles/tiles_template.yaml
+++ b/lovelace/tiles/tiles_template.yaml
@@ -1,3 +1,6 @@
+# Reference template for building a new room tile include.
+# Use this as the starting point when adding another room section so layout, icon sizing, and card organization stay consistent.
+
 #####
 ## Tile Template
 ##

--- a/lovelace/tiles/tiles_tesla_charging.yaml
+++ b/lovelace/tiles/tiles_tesla_charging.yaml
@@ -1,3 +1,6 @@
+# Tesla charging status tile include.
+# It summarizes live charging state, estimates, and helper information that support the vehicle dashboard and departure-planning automations.
+
 #####
 ## Tile Template
 ##

--- a/lovelace/tiles/tiles_tesla_location.yaml
+++ b/lovelace/tiles/tiles_tesla_location.yaml
@@ -1,3 +1,6 @@
+# Tesla location tile include.
+# This is the simple map card used by the Tesla dashboard to show the vehicle’s current reported location.
+
 #####
 ## Tile Template
 ##

--- a/lovelace/tiles/tiles_weekday_alarm.yaml
+++ b/lovelace/tiles/tiles_weekday_alarm.yaml
@@ -1,3 +1,6 @@
+# Weekday alarm helper tile include.
+# It is kept separate from the weekend tile so workday alarm settings can differ without conditional card logic.
+
 type: entities
 entities:
   - input_datetime.weekday_alarm

--- a/lovelace/tiles/tiles_weekend_alarm.yaml
+++ b/lovelace/tiles/tiles_weekend_alarm.yaml
@@ -1,3 +1,6 @@
+# Weekend alarm helper tile include.
+# This companion to the weekday tile keeps weekend scheduling simple and avoids mixing different wake-up assumptions in one card.
+
 type: entities
 entities:
   - input_datetime.weekend_alarm

--- a/lovelace/views/view_alarm.yaml
+++ b/lovelace/views/view_alarm.yaml
@@ -1,3 +1,6 @@
+# Lovelace view for alarm scheduling helpers.
+# It pulls together the weekday and weekend alarm tiles so the user can manage wake-up times from one focused screen.
+
 title: Alarms
 icon: mdi:alarm-multiple
 path: alarms

--- a/lovelace/views/view_home.yaml
+++ b/lovelace/views/view_home.yaml
@@ -1,3 +1,6 @@
+# Primary daily-use Lovelace view.
+# The view is intentionally composed from per-room tile includes so the main dashboard stays readable and each room can evolve independently.
+
 title: Home
 path: home
 icon: mdi:beer

--- a/lovelace/views/view_tesla.yaml
+++ b/lovelace/views/view_tesla.yaml
@@ -1,3 +1,6 @@
+# Lovelace view dedicated to Tesla status and controls.
+# It is a thin wrapper that assembles the charging and location tile includes into a single vehicle-focused page.
+
 #####
 ## Views Template
 ##

--- a/lovelace/views/views_template.yaml
+++ b/lovelace/views/views_template.yaml
@@ -1,3 +1,6 @@
+# Reference template for creating new YAML-mode Lovelace views.
+# Keep this as a copyable example: it shows the project’s preferred structure for a view plus a realistic sample card stack.
+
 #####
 ## Views Template
 ##

--- a/packages/airplanes.yaml
+++ b/packages/airplanes.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for nearby aircraft tracking and ADS-B enrichment.
+# Complex areas: it collects raw aircraft data, looks up photos and route metadata, and turns those responses into dashboard-friendly sensors about the closest aircraft overhead.
+
 ################################################################
 ## Packages / TEMPLATE
 ################################################################

--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for security and household alerts.
+# It keeps alarm helpers, triggered-state notifications, and high-priority alert responses together so warning behavior is centralized.
+
 ################################################################
 ## Packages / Alerts
 ################################################################

--- a/packages/batteries.yaml
+++ b/packages/batteries.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for low-battery monitoring.
+# It groups battery status helpers and staged notifications so sensor maintenance shows up consistently across the house.
+
 ################################################################
 ## Packages / Batteries
 ################################################################

--- a/packages/birds.yaml
+++ b/packages/birds.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for bird-detection integrations and dashboards.
+# It exposes latest sightings, top-species summaries, and photo helpers so garden bird activity can be shown in cards and notifications.
+
 ################################################################
 ## Packages / TEMPLATE
 ################################################################

--- a/packages/camera.yaml
+++ b/packages/camera.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for camera motion and health workflows.
+# It ties together camera entities, motion-triggered snapshots, and camera status groupings used for notifications and dashboard cards.
+
 ################################################################
 ## Packages / Camera
 ################################################################

--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for Tesla, charging, and garage-adjacent car automations.
+# Complex areas: it blends trip timing, charging policy, location, and garage device recovery so the car behaves correctly before departures and after arrivals.
+
 ################################################################
 ## Packages / Car
 ################################################################

--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for cleaning appliances and housekeeping state.
+# It infers washer, dryer, dishwasher, and vacuum-related status from sensors so chores can drive reminders and dashboard indicators.
+
 ################################################################
 ## Packages / Cleaning
 ################################################################

--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for HVAC control and environmental guardrails.
+# Complex areas: it mixes thermostat control, open-window protection, and weather-derived pressure sensors that are reused by other packages.
+
 ################################################################
 ## Packages / Climate
 ################################################################

--- a/packages/curling.yaml
+++ b/packages/curling.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for curling-season travel and UI behavior.
+# It turns seasonal schedules and venue-specific travel into helper states, notifications, and dashboard visibility rules.
+
 ################################################################
 ## Packages / Curling
 ################################################################

--- a/packages/desk.yaml
+++ b/packages/desk.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for the Uplift standing desk.
+# It coordinates desk presets with guest mode, trip mode, work-camera setup, and timed reset logic so the office returns to a known state automatically.
+
 ################################################################
 ## Packages / Desk
 ################################################################

--- a/packages/domain_name.yaml
+++ b/packages/domain_name.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for domain-expiration monitoring.
+# It keeps the alerting for external home-service domains isolated from the rest of the system so expiry checks are easy to maintain.
+
 ################################################################
 ## Packages / Domain Name
 ################################################################

--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for ceiling and room fan automation.
+# It combines occupancy and manual-control helpers to run bedroom, den, and office fans without duplicating room-specific logic.
+
 ################################################################
 ## Packages / TEMPLATE
 ################################################################

--- a/packages/guest.yaml
+++ b/packages/guest.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for guest mode.
+# It turns guest Wi-Fi presence into a house-wide guest state and then adjusts climate and UI behavior while visitors are around.
+
 ################################################################
 ## Packages / Guest
 ################################################################

--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for holiday and seasonal scenes.
+# It manages when seasonal lights, tabs, and reset scenes appear so holiday behavior can be enabled without touching everyday automations.
+
 ################################################################
 ## Packages / Holidays
 ################################################################

--- a/packages/ios_wakeup.yaml
+++ b/packages/ios_wakeup.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package that mirrors an iPhone wake-up alarm into Home Assistant helpers.
+# The webhook data from iOS Shortcuts lands here and becomes the canonical alarm state used by workday and wake-up automations.
+
 ################################################################
 ## Packages / iOS Wakeup
 ################################################################

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for the house lighting model.
+# Complex areas: this file owns most light entities, helper booleans, and occupancy/time-based lighting automations, so it acts as the central lighting policy for the house.
+
 ################################################################
 ## Packages / Light
 ################################################################

--- a/packages/logger.yaml
+++ b/packages/logger.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for runtime log-level control.
+# It exposes logger settings in the UI so debugging verbosity can be raised or lowered without editing configuration.yaml and restarting Home Assistant.
+
 ---
 #-------------------------------------------
 #  Realtime Debugging Related Packages

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for Music Assistant, Sonos, and whole-home media behavior.
+# Complex areas: it handles cube/button media controls, group preparation, wake-up and bedtime playback, and reusable scripts for Spotify and radio playback.
+
 ################################################################
 ## Packages / Media Players
 ################################################################

--- a/packages/octoprint.yaml
+++ b/packages/octoprint.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for OctoPrint integration.
+# It keeps printer status sensors and print-finished notifications together so 3D-printer behavior stays isolated from unrelated automation domains.
+
 ################################################################
 ## Packages / OctoPrint
 ################################################################

--- a/packages/plants.yaml
+++ b/packages/plants.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for plant monitoring.
+# It collects moisture, light, conductivity, and battery data into plant-centric helpers that are easier to surface in dashboards and reminders.
+
 ################################################################
 ## Packages / Plants
 ################################################################

--- a/packages/template.yaml
+++ b/packages/template.yaml
@@ -1,3 +1,6 @@
+# Template package scaffold for creating new domain packages.
+# This file is mostly a structured starting point rather than active house logic; copy it when adding a new package and replace the placeholders.
+
 ################################################################
 ## Packages / TEMPLATE
 ################################################################

--- a/packages/themes.yaml
+++ b/packages/themes.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for frontend theme automation.
+# It owns the helper logic that switches between light and dark themes so UI appearance changes are handled in one predictable place.
+
 ################################################################
 ## Packages / Themes
 ################################################################

--- a/packages/todoist.yaml
+++ b/packages/todoist.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for Todoist/task visibility inside the house dashboards.
+# It turns task and due-date data into helper sensors that can be reused by cards and reminder automations.
+
 ################################################################
 ## Packages / Todoist
 ################################################################

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for trip and vacation orchestration.
+# Complex areas: it combines presence, calendars, lighting simulation, and Ecobee vacation sync so long trips flip the house into the correct away-mode behavior.
+
 ################################################################
 ## Packages / Trips
 ################################################################

--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for TV activity scenes and playback state handling.
+# It wraps on, off, pause, and resume behaviors so other automations can react to TV usage without embedding low-level media-player logic everywhere.
+
 ################################################################
 ## Packages / TV
 ################################################################

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for utility and infrastructure monitoring.
+# Complex areas: it covers electrical and water tariff switching, water-meter recovery, sump-pump alerts, garbage reminders, and a few small device watchdog automations.
+
 ################################################################
 ## Packages / utilities
 ################################################################

--- a/packages/water_softener.yaml
+++ b/packages/water_softener.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for the water softener.
+# It turns ESPHome salt-level readings into low-salt alerts, bag inventory tracking, and refill workflows tied to household supply reminders.
+
 ################################################################
 ## Packages / TEMPLATE
 ################################################################

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for forecast data, weather alerts, and rain-driven notifications.
+# Complex areas: it combines forecast precipitation, falling-pressure sensors, and NWS alert feeds to decide when to warn about open windows, storms, or the Tesla.
+
 ################################################################
 ## Packages / Weather
 ################################################################

--- a/packages/windows.yaml
+++ b/packages/windows.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for blinds and window-covering routines.
+# It isolates the time-based and state-based logic that manages when shades should close or reset.
+
 ################################################################
 ## Packages / TEMPLATE
 ################################################################

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for workday-specific routines.
+# Complex areas: it ties together wake-up timing, office-lighting behavior, work-presence helpers, and automation branches that should only run on workdays.
+
 ################################################################
 ## Packages / Workday
 ################################################################

--- a/packages/xiaomi_robot_vacuum.yaml
+++ b/packages/xiaomi_robot_vacuum.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for the Xiaomi/Valetudo vacuum.
+# It wraps room-cleaning scripts, schedule helpers, and error recovery so the vacuum can be controlled by name instead of raw segment commands.
+
 ################################################################
 ## Packages / Xiaomi Vacuum
 ################################################################

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for Zigbee and legacy Z-Wave device normalization.
+# Complex areas: it gives contact, motion, and battery entities stable names and keeps the button, group, and device-health logic that many other packages rely on.
+
 ################################################################
 ## Packages / Zigbee
 ################################################################

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -1,3 +1,6 @@
+# Home Assistant package for core presence and arrival/departure behavior.
+# Complex areas: it builds the canonical home-state sensors and then uses them to drive ETA updates, arrival lighting, open-door reminders, and vacuum-return logic.
+
 ################################################################
 ## Packages / Zone
 ################################################################

--- a/travis_secrets.yaml
+++ b/travis_secrets.yaml
@@ -1,3 +1,6 @@
+# Sample secret values used by CI and local validation when the real secrets file is unavailable.
+# These are placeholders only; production credentials stay in the private secrets.yaml file outside version control.
+
 adb_server_ip: 192.0.2.1
 alarm_code: 0000
 tikiroom_cam_ffmpeg_command: -rtsp_transport tcp -i rtsp://10.0.0.5:8554/unicast

--- a/ui-guest.yaml
+++ b/ui-guest.yaml
@@ -1,3 +1,6 @@
+# Guest-facing Lovelace dashboard used for the kiosk/tablet view.
+# It exposes only simple room, media, and household controls so visitors can operate the house without opening the full admin dashboard.
+
 title: The Brewery
 
 # custom_header:

--- a/zigbee2mqtt/configuration.yaml
+++ b/zigbee2mqtt/configuration.yaml
@@ -1,3 +1,6 @@
+# Live Zigbee2MQTT coordinator configuration.
+# It defines the MQTT/serial/frontend settings and the per-device options or friendly-name overrides that feed Home Assistant entity creation.
+
 homeassistant:
   enabled: true
   legacy_action_sensor: true

--- a/zigbee2mqtt/configuration_backup_v1.yaml
+++ b/zigbee2mqtt/configuration_backup_v1.yaml
@@ -1,3 +1,6 @@
+# Historical Zigbee2MQTT configuration snapshot kept for rollback and diffing.
+# This is not the active config; edit zigbee2mqtt/configuration.yaml unless intentionally restoring an older setup.
+
 homeassistant: true
 external_converters: []
 mqtt:

--- a/zigbee2mqtt/configuration_backup_v2.yaml
+++ b/zigbee2mqtt/configuration_backup_v2.yaml
@@ -1,3 +1,6 @@
+# Historical Zigbee2MQTT configuration snapshot kept for rollback and diffing.
+# This is not the active config; edit zigbee2mqtt/configuration.yaml unless intentionally restoring an older setup.
+
 homeassistant: true
 mqtt:
   server: mqtt://core-mosquitto:1883

--- a/zigbee2mqtt/configuration_backup_v3.yaml
+++ b/zigbee2mqtt/configuration_backup_v3.yaml
@@ -1,3 +1,6 @@
+# Historical Zigbee2MQTT configuration snapshot kept for rollback and diffing.
+# This is not the active config; edit zigbee2mqtt/configuration.yaml unless intentionally restoring an older setup.
+
 homeassistant:
   enabled: true
 mqtt:

--- a/zigbee2mqtt/configuration_backup_v4.yaml
+++ b/zigbee2mqtt/configuration_backup_v4.yaml
@@ -1,3 +1,6 @@
+# Historical Zigbee2MQTT configuration snapshot kept for rollback and diffing.
+# This is not the active config; edit zigbee2mqtt/configuration.yaml unless intentionally restoring an older setup.
+
 homeassistant:
   enabled: true
   legacy_action_sensor: true

--- a/zigbee2mqtt/secret.yaml
+++ b/zigbee2mqtt/secret.yaml
@@ -1,3 +1,6 @@
+# Local secret material consumed by the Zigbee2MQTT configuration.
+# Keep this file private and treat it as runtime-only data rather than project documentation or shared config.
+
 network_key: [1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53]
 
 mqtt_password: "XQydytH7WDez"


### PR DESCRIPTION
## Summary
- add inline header comments to the active Home Assistant YAML config files
- document Lovelace, ESPHome, package, Zigbee2MQTT, and top-level YAMLs with short purpose/overview notes
- leave archived AppDaemon files and blueprints untouched

## Validation
- `.venv-ci/bin/python scripts/check_ha_python_support.py --python-version-file .python-version`
- `.venv-ci/bin/yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `.venv-ci/bin/python -m homeassistant --config . --script check_config` (completed with existing environment-specific dependency warnings, no `Failed config` / invalid-config errors)
