### PR TITLE
Add EV-specific TOU tariff for charger and Tesla planner

### DIFF
--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -1390,8 +1390,13 @@
                 },
                 {
                   "type": "markdown",
-                  "content": "{% if state_attr('sensor.nigori_charging_rate','time_left') > 0 %}\n  {{ states('sensor.charge_complete')|as_timestamp(default=now()) | timestamp_custom('%b %d at %H:%M %Z') }}\n{% else %}\n  Charging Complete\n{% endif %}\n\n{% if is_state('input_boolean.long_range_travel', 'on') %}\n  ### Max-range override is active\n  #### Charge limit pinned to 100% until you return to the daily plan\n{% elif is_state('binary_sensor.upcoming_trip_charging', 'on') %}\n  ### {{ state_attr('binary_sensor.upcoming_trip_charging', 'entry') }}\n  #### Start: {{ state_attr('binary_sensor.upcoming_trip_charging', 'start_time') }}\n  #### Distance: {{ state_attr(\"sensor.waze_next_trip_distance\", \"distance\")| int }} mi\n{% else %}\n  ### Daily planner is active\n  #### Charge limit and preconditioning follow tomorrow's trip, alarm, weather, and tariff inputs\n{% endif %}",
+                  "content": "{% if state_attr('sensor.nigori_charging_rate','time_left') > 0 %}\n  {{ states('sensor.charge_complete')|as_timestamp(default=now()) | timestamp_custom('%b %d at %H:%M %Z') }}\n{% else %}\n  Charging Complete\n{% endif %}\n\n{% if is_state('input_boolean.long_range_travel', 'on') %}\n  ### Max-range override is active\n  #### Charge limit pinned to 100% until you return to the daily plan\n{% elif is_state('binary_sensor.upcoming_trip_charging', 'on') %}\n  ### {{ state_attr('binary_sensor.upcoming_trip_charging', 'entry') }}\n  #### Start: {{ state_attr('binary_sensor.upcoming_trip_charging', 'start_time') }}\n  #### Distance: {{ state_attr('sensor.waze_next_trip_distance', 'distance')| int }} mi\n{% else %}\n  ### Daily planner is active\n  #### Charge limit and preconditioning follow tomorrow's trip, alarm, weather, and EV tariff inputs\n{% endif %}",
                   "title": "Status and Reason"
+                },
+                {
+                  "type": "markdown",
+                  "content": "{% set tariff = states('sensor.ev_charging_tariff') %}\n{% set rate = states('sensor.ev_charging_tariff_rate') | float(default=0) %}\n{% set charge_limit = states('number.nigori_charge_limit') | int(default=80) %}\n{% set alarm_enabled = is_state('input_boolean.weekday_alarm_on', 'on') or is_state('input_boolean.weekend_alarm_on', 'on') %}\n{% set cold_weather = states('sensor.outside_temperature') | float(default=999) <= 20 %}\n### {{ charge_limit }}% target\n{% if is_state('input_boolean.long_range_travel', 'on') %}\n  #### Manual override is forcing max range\n{% elif is_state('binary_sensor.upcoming_trip_charging', 'on') %}\n  #### Planner is following the next trip\n{% elif alarm_enabled and cold_weather %}\n  #### Planner is following tomorrow's alarm and cold-weather preconditioning\n{% elif alarm_enabled %}\n  #### Planner is following tomorrow's alarm and EV TOU pricing\n{% else %}\n  #### No next-day departure plan is active\n{% endif %}\n#### Current EV tariff: {{ tariff }} at ${{ '%.4f' | format(rate) }}/kWh",
+                  "title": "Planner Decision"
                 },
                 {
                   "type": "tile",
@@ -1430,6 +1435,30 @@
                 {
                   "type": "tile",
                   "entity": "number.nigori_charge_limit"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.ev_charging_tariff"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.ev_charging_tariff_rate"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.daily_ev_charging_energy"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.daily_ev_charging_cost"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.monthly_ev_charging_energy"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.monthly_ev_charging_cost"
                 }
               ]
             },
@@ -1458,6 +1487,82 @@
                   "type": "custom:mushroom-cover-card",
                   "entity": "cover.nigori_trunk",
                   "show_buttons_control": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Energy",
+          "path": "energy",
+          "icon": "mdi:transmission-tower",
+          "type": "sections",
+          "sections": [
+            {
+              "type": "grid",
+              "cards": [
+                {
+                  "type": "heading",
+                  "heading": "House Electricity"
+                },
+                {
+                  "type": "tile",
+                  "entity": "select.daily_electricity",
+                  "name": "Current House Tariff"
+                },
+                {
+                  "type": "tile",
+                  "entity": "input_number.electrical_rate",
+                  "name": "Current House Rate"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.house_electrical_meter",
+                  "name": "House Meter"
+                }
+              ]
+            },
+            {
+              "type": "grid",
+              "cards": [
+                {
+                  "type": "heading",
+                  "heading": "EV Charging"
+                },
+                {
+                  "type": "markdown",
+                  "title": "Dakota Electric EV TOU",
+                  "content": "### Off-peak before 08:00 and after 21:00\n#### Weekends and Minnesota holidays stay off-peak all day"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.ev_charging_tariff",
+                  "name": "Current EV Tariff"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.ev_charging_tariff_rate",
+                  "name": "Current EV Rate"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.daily_ev_charging_energy",
+                  "name": "Today's EV Energy"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.daily_ev_charging_cost",
+                  "name": "Today's EV Cost"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.monthly_ev_charging_energy",
+                  "name": "This Month EV Energy"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.monthly_ev_charging_cost",
+                  "name": "This Month EV Cost"
                 }
               ]
             }

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ docker run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:stable \
 
 ## Feature Docs
 
+- [EV Charging Tariff](docs/ev_charging_tariff.md)
 - [Tesla Departure Planner](docs/tesla_departure_planner.md)
 
 I have Home Assistant running on an [Intel NUC]().  This has been a work in progress since Nov 2015 (HA v0.7 or earlier).

--- a/docs/ev_charging_tariff.md
+++ b/docs/ev_charging_tariff.md
@@ -1,0 +1,107 @@
+# EV Charging Tariff
+
+This document describes the EV-specific charging tariff added in `packages/utilities.yaml`.
+
+## Purpose
+
+The rest of the house stays on the existing seasonal energy rate model.
+
+The Tesla charger now has its own Dakota Electric time-of-use model so:
+
+- EV charging costs are tracked separately from whole-home electricity usage
+- the Tesla departure planner can react to the EV tariff instead of the house tariff
+- the Tesla dashboards can show the current EV rate and EV charging cost totals
+
+## Source Data
+
+### Rate schedule
+
+This implementation follows the Dakota Electric EV time-of-use schedule from the packet provided by the user:
+
+- off-peak: `$0.0755/kWh`
+- mid-peak non-summer: `$0.1238/kWh`
+- mid-peak summer: `$0.1377/kWh`
+- on-peak: `$0.4420/kWh`
+
+Schedule:
+
+- weekdays before `08:00` and from `21:00` onward: off-peak
+- weekdays `08:00` to `16:00`: mid-peak
+- weekdays `16:00` to `21:00`: on-peak
+- weekends and Minnesota holidays: off-peak all day
+
+Summer is treated as June 1 through September 30, matching the existing seasonal house tariff split.
+
+### Energy source
+
+EV usage is measured from:
+
+- `sensor.nigori_energy_added`
+
+That Tesla entity reports `kWh`, `device_class: energy`, and `state_class: total_increasing`, so it can back `utility_meter` helpers.
+
+Important limitation:
+
+- this measures energy added to the car battery, not wall-side charger losses
+
+If a dedicated EVSE energy meter is added later, the EV utility meters should switch to that meter instead.
+
+## Entities
+
+### Current tariff state
+
+- `select.hourly_ev_charging`
+- `select.daily_ev_charging`
+- `select.monthly_ev_charging`
+- `input_number.ev_electrical_rate`
+- `sensor.ev_charging_tariff`
+- `sensor.ev_charging_tariff_rate`
+
+The `switch_ev_charging_tariff` automation keeps those entities aligned to the schedule.
+
+### EV charging utility meters
+
+- `sensor.hourly_ev_charging_*`
+- `sensor.daily_ev_charging_*`
+- `sensor.monthly_ev_charging_*`
+
+Tariffs:
+
+- `off_peak`
+- `mid_peak`
+- `on_peak`
+
+### Derived EV totals
+
+- `sensor.daily_ev_charging_energy`
+- `sensor.monthly_ev_charging_energy`
+- `sensor.daily_ev_charging_cost`
+- `sensor.monthly_ev_charging_cost`
+
+## UI
+
+The EV tariff is surfaced on both Tesla dashboard paths:
+
+- storage mode: `.storage/lovelace.ryan_new_mushroom`, view path `tesla-v2`
+- YAML mode: `lovelace/tiles/tiles_tesla_charging.yaml`
+- storage mode energy view: `.storage/lovelace.ryan_new_mushroom`, view path `energy`
+
+The Tesla dashboards now show:
+
+- current EV tariff
+- current EV rate
+- daily EV energy and cost
+- monthly EV energy and cost
+- a planner-decision summary card
+
+## Validation
+
+Recommended validation after EV tariff changes:
+
+```bash
+yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" \
+  configuration.yaml automations.yaml blueprints packages zigbee2mqtt lovelace
+
+uv run --python 3.14.2 --with homeassistant==2026.3.3 \
+  python -m homeassistant --config "$PWD" --script check_config
+```

--- a/docs/tesla_departure_planner.md
+++ b/docs/tesla_departure_planner.md
@@ -9,7 +9,7 @@ The planner sets the Tesla charge limit and scheduled departure behavior based o
 - upcoming trips
 - weekday/weekend alarm settings
 - weather
-- electricity tariff/rate
+- EV charging tariff/rate
 - a manual max-range override
 
 ## Inputs
@@ -30,22 +30,6 @@ If an upcoming trip exists, the planner uses trip start time plus Waze duration 
 
 These drive non-trip next-morning departure planning.
 
-### `special_meeting`
-
-`special_meeting` is a UI helper, not a calendar entity.
-
-- Entity: `input_boolean.special_meeting`
-- Defined in `packages/workday.yaml`
-- Exposed in the weekday alarm UI tile at `lovelace/tiles/tiles_weekday_alarm.yaml`
-
-When `special_meeting` is on, the planner treats the next alarm like a higher-priority morning:
-
-- adds extra prep time before departure
-- allows a higher charge target
-- enables preconditioning even if the weather is not cold
-
-The workday alarm flow also uses it as a dedicated `meeting-alarm` path and turns it back off after that alarm runs.
-
 ### Weather inputs
 
 - `sensor.outside_temperature`
@@ -54,19 +38,34 @@ Cold weather currently means `<= 20F`.
 
 Cold weather increases departure buffer time and can justify preconditioning or a higher charge target.
 
-### Tariff inputs
+### EV tariff inputs
 
-- `select.daily_electricity`
-- `select.hourly_electricity`
-- `input_number.electrical_rate`
+- `select.daily_ev_charging`
+- `select.hourly_ev_charging`
+- `input_number.ev_electrical_rate`
+- `sensor.ev_charging_tariff`
+- `sensor.ev_charging_tariff_rate`
+
+The EV charging tariff is separate from the rest of the house. It follows the Dakota Electric time-of-use schedule from the EV packet provided by the user:
+
+- off-peak: `$0.0755/kWh`
+- mid-peak non-summer: `$0.1238/kWh`
+- mid-peak summer: `$0.1377/kWh`
+- on-peak: `$0.4420/kWh`
+
+Schedule:
+
+- weekdays before `08:00` and from `21:00` onward: off-peak
+- weekdays `08:00` to `16:00`: mid-peak
+- weekdays `16:00` to `21:00`: on-peak
+- weekends and Minnesota holidays: off-peak all day
 
 The planner treats the tariff as "higher" when:
 
-- the tariff name includes `summer`
-- the tariff name is `peak`, `on-peak`, or `onpeak`
+- the EV tariff is `on_peak`
 - the numeric electrical rate is `>= 0.13`
 
-This only affects the non-trip alarm top-off case. Trip charging and cold-weather/special-meeting cases still take priority.
+This only affects the non-trip alarm top-off case. Trip charging and cold-weather cases still take priority.
 
 ### Manual override
 
@@ -86,9 +85,9 @@ Decision summary:
 
 - long trip (`>= 90 mi`): `100%`
 - other trip: `90%`
-- alarm + cold weather or `special_meeting`: `90%`
-- alarm + lower tariff: `85%`
-- alarm + higher tariff: `80%`
+- alarm + cold weather: `90%`
+- alarm + lower EV tariff: `85%`
+- alarm + higher EV tariff: `80%`
 - no plan: `80%`
 - manual max-range override: `100%`
 
@@ -117,11 +116,17 @@ Storage-mode dashboard:
 
 - `.storage/lovelace.ryan_new_mushroom`
 - view path: `tesla-v2`
+- companion storage energy view path: `energy`
 
 Controls:
 
 - `Max Range Override`
 - `Use Daily Plan`
+- `Planner Decision`
+- `sensor.ev_charging_tariff`
+- `sensor.ev_charging_tariff_rate`
+- `sensor.daily_ev_charging_energy`
+- `sensor.daily_ev_charging_cost`
 
 ### Alarm dashboard
 
@@ -130,7 +135,8 @@ The weekday alarm tile includes:
 - `input_datetime.weekday_alarm`
 - `input_boolean.weekday_alarm_on`
 - `input_datetime.next_work_meeting`
-- `input_boolean.special_meeting`
+
+`input_boolean.special_meeting` still exists for the workday alarm flow, but the Tesla planner does not use it.
 
 ## Validation
 

--- a/lovelace/tiles/tiles_tesla_charging.yaml
+++ b/lovelace/tiles/tiles_tesla_charging.yaml
@@ -122,5 +122,47 @@ cards:
                 #### Distance: {{ state_attr("sensor.waze_next_trip_distance", "distance")| int }} mi
               {% else %}
                 ### Daily planner is active
-                #### Charge limit and preconditioning follow tomorrow's trip, alarm, weather, and tariff inputs
+                #### Charge limit and preconditioning follow tomorrow's trip, alarm, weather, and EV tariff inputs
               {% endif %}
+
+      - type: horizontal-stack
+        title:
+        show_header_toggle: false
+        cards:
+          - type: markdown
+            title: "Planner Decision"
+            content: >-
+              {% set tariff = states('sensor.ev_charging_tariff') %}
+              {% set rate = states('sensor.ev_charging_tariff_rate') | float(default=0) %}
+              {% set charge_limit = states('number.nigori_charge_limit') | int(default=80) %}
+              {% set alarm_enabled = is_state('input_boolean.weekday_alarm_on', 'on') or is_state('input_boolean.weekend_alarm_on', 'on') %}
+              {% set cold_weather = states('sensor.outside_temperature') | float(default=999) <= 20 %}
+              ### {{ charge_limit }}% target
+              {% if is_state('input_boolean.long_range_travel', 'on') %}
+                #### Manual override is forcing max range
+              {% elif is_state('binary_sensor.upcoming_trip_charging', 'on') %}
+                #### Planner is following the next trip
+              {% elif alarm_enabled and cold_weather %}
+                #### Planner is following tomorrow's alarm and cold-weather preconditioning
+              {% elif alarm_enabled %}
+                #### Planner is following tomorrow's alarm and EV TOU pricing
+              {% else %}
+                #### No next-day departure plan is active
+              {% endif %}
+              #### Current EV tariff: {{ tariff }} at ${{ '%.4f' | format(rate) }}/kWh
+          - type: entities
+            title: "EV TOU"
+            show_header_toggle: false
+            entities:
+              - entity: sensor.ev_charging_tariff
+                name: Current Tariff
+              - entity: sensor.ev_charging_tariff_rate
+                name: Current Rate
+              - entity: sensor.daily_ev_charging_energy
+                name: Today's EV Energy
+              - entity: sensor.daily_ev_charging_cost
+                name: Today's EV Cost
+              - entity: sensor.monthly_ev_charging_energy
+                name: This Month EV Energy
+              - entity: sensor.monthly_ev_charging_cost
+                name: This Month EV Cost

--- a/lovelace/views/views_template.yaml
+++ b/lovelace/views/views_template.yaml
@@ -5,7 +5,7 @@
 ## Views Template
 ##
 ## Check out https://github.com/akmolina28/HomeAssistantConfig/tree/master/lovelace/views
-## or 
+## or
 ## https://github.com/search?q=views+lovelace+include&type=Code
 #####
 

--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -129,13 +129,12 @@ automation:
         entity_id:
           - input_boolean.weekday_alarm_on
           - input_boolean.weekend_alarm_on
-          - input_boolean.special_meeting
           - input_boolean.long_range_travel
           - input_datetime.weekday_alarm
           - input_datetime.weekend_alarm
-          - select.daily_electricity
-          - select.hourly_electricity
-          - input_number.electrical_rate
+          - select.daily_ev_charging
+          - select.hourly_ev_charging
+          - input_number.ev_electrical_rate
         id: planner_input
       - trigger: state
         entity_id: binary_sensor.nigori_parking_brake
@@ -164,7 +163,6 @@ automation:
             {% set manual_override = is_state('input_boolean.long_range_travel', 'on') %}
             {% set weekday_alarm_enabled = is_state('input_boolean.weekday_alarm_on', 'on') %}
             {% set weekend_alarm_enabled = is_state('input_boolean.weekend_alarm_on', 'on') %}
-            {% set special_meeting = is_state('input_boolean.special_meeting', 'on') %}
             {% if weekday_alarm_enabled %}
               {% set alarm_time_raw = states('input_datetime.weekday_alarm') %}
               {% set alarm_source = 'weekday alarm' %}
@@ -184,14 +182,15 @@ automation:
             {% set trip_start_raw = state_attr('binary_sensor.upcoming_trip_charging', 'start_time') %}
             {% set trip_all_day = state_attr('binary_sensor.upcoming_trip_charging', 'all_day') in [true, 'true', 'True', 'on'] %}
             {% set has_upcoming_trip = is_state('binary_sensor.upcoming_trip_charging', 'on') and trip_start_raw not in [none, '', 'None'] %}
-            {% if states('select.daily_electricity') not in ['unknown', 'unavailable'] %}
-              {% set tariff = states('select.daily_electricity') %}
+            {% if states('select.daily_ev_charging') not in ['unknown', 'unavailable'] %}
+              {% set tariff = states('select.daily_ev_charging') %}
             {% else %}
-              {% set tariff = states('select.hourly_electricity') %}
+              {% set tariff = states('select.hourly_ev_charging') %}
             {% endif %}
-            {% set electrical_rate = states('input_number.electrical_rate') | float(default=0) %}
+            {% set electrical_rate = states('input_number.ev_electrical_rate') | float(default=0) %}
             {% set tariff_name = tariff | lower %}
-            {% set high_tariff = 'summer' in tariff_name or tariff_name in ['peak', 'on-peak', 'onpeak'] or electrical_rate >= 0.13 %}
+            {% set tariff_display = tariff | replace('_', '-') | title %}
+            {% set high_tariff = tariff_name in ['on_peak', 'on-peak', 'onpeak'] or electrical_rate >= 0.13 %}
             {% set departure_dt = none %}
             {% if has_upcoming_trip %}
               {% set trip_start_dt = trip_start_raw | as_datetime | as_local %}
@@ -199,7 +198,7 @@ automation:
               {% set departure_dt = trip_start_dt - timedelta(minutes=trip_duration_min + trip_buffer_min) %}
             {% elif alarm_enabled %}
               {% set alarm_base_dt = today_at(alarm_time_raw[:5]) %}
-              {% set prep_buffer_min = 45 + (15 if special_meeting else 0) + (10 if cold_weather else 0) %}
+              {% set prep_buffer_min = 45 + (10 if cold_weather else 0) %}
               {% set candidate_departure = alarm_base_dt + timedelta(minutes=prep_buffer_min) %}
               {% if candidate_departure < now() + timedelta(minutes=15) %}
                 {% set departure_dt = candidate_departure + timedelta(days=1) %}
@@ -211,7 +210,7 @@ automation:
               {% set charge_limit = 100 %}
             {% elif has_upcoming_trip %}
               {% set charge_limit = 90 %}
-            {% elif alarm_enabled and (cold_weather or special_meeting) %}
+            {% elif alarm_enabled and cold_weather %}
               {% set charge_limit = 90 %}
             {% elif alarm_enabled and not high_tariff %}
               {% set charge_limit = 85 %}
@@ -223,7 +222,7 @@ automation:
             {% if manual_override %}
               {% set charge_limit = 100 %}
             {% endif %}
-            {% set precondition = has_upcoming_trip or (alarm_enabled and (cold_weather or special_meeting)) %}
+            {% set precondition = has_upcoming_trip or (alarm_enabled and cold_weather) %}
             {% if trip_all_day %}
               {% set precondition = false %}
             {% endif %}
@@ -247,14 +246,14 @@ automation:
             {% if manual_override and not has_upcoming_trip and not alarm_enabled %}
               {% set summary = 'Manual max-range override is on. Keep the Tesla at 100% charge.' %}
             {% elif has_upcoming_trip %}
-              {% set summary = 'Plan Tesla for ' ~ (trip_entry if trip_entry else 'upcoming trip') ~ '. Set charge limit to ' ~ charge_limit ~ '% and ' ~ ('enable' if precondition else 'skip') ~ ' preconditioning for ' ~ departure_label ~ '. Distance ' ~ (trip_distance_mi | round(0)) ~ ' mi. Tariff ' ~ tariff ~ ' at $' ~ ('%.4f' | format(electrical_rate)) ~ '/kWh.' %}
+              {% set summary = 'Plan Tesla for ' ~ (trip_entry if trip_entry else 'upcoming trip') ~ '. Set charge limit to ' ~ charge_limit ~ '% and ' ~ ('enable' if precondition else 'skip') ~ ' preconditioning for ' ~ departure_label ~ '. Distance ' ~ (trip_distance_mi | round(0)) ~ ' mi. EV tariff ' ~ tariff_display ~ ' at $' ~ ('%.4f' | format(electrical_rate)) ~ '/kWh.' %}
             {% elif alarm_enabled %}
-              {% if charge_limit == 80 and high_tariff and not (cold_weather or special_meeting) %}
-                {% set charge_limit_phrase = 'Keep the default 80% charge limit because the current tariff is higher' %}
+              {% if charge_limit == 80 and high_tariff and not cold_weather %}
+                {% set charge_limit_phrase = 'Keep the default 80% charge limit because the current EV tariff is higher' %}
               {% else %}
                 {% set charge_limit_phrase = 'Set charge limit to ' ~ charge_limit ~ '%' %}
               {% endif %}
-              {% set summary = 'Plan Tesla for ' ~ source ~ '. ' ~ charge_limit_phrase ~ ' and ' ~ ('enable' if precondition else 'skip') ~ ' preconditioning for ' ~ departure_label ~ '. Outside ' ~ (outside_temp_f | round(0)) ~ 'F. Tariff ' ~ tariff ~ ' at $' ~ ('%.4f' | format(electrical_rate)) ~ '/kWh.' %}
+              {% set summary = 'Plan Tesla for ' ~ source ~ '. ' ~ charge_limit_phrase ~ ' and ' ~ ('enable' if precondition else 'skip') ~ ' preconditioning for ' ~ departure_label ~ '. Outside ' ~ (outside_temp_f | round(0)) ~ 'F. EV tariff ' ~ tariff_display ~ ' at $' ~ ('%.4f' | format(electrical_rate)) ~ '/kWh.' %}
             {% else %}
               {% set summary = 'No next-day departure plan detected. Restore the Tesla default charge limit to 80%.' %}
             {% endif %}

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -260,6 +260,76 @@ automation:
               .1258
             {% endif %}
 
+  - id: switch_ev_charging_tariff
+    alias: switch_ev_charging_tariff
+    description: >
+      Keep the EV charging utility meters on Dakota Electric's time-of-use
+      schedule. Weekends and holidays stay off-peak all day.
+    trigger:
+      - trigger: homeassistant
+        event: start
+      - trigger: state
+        entity_id: binary_sensor.workday_sensor
+      - trigger: time
+        at: "00:05:00"
+      - trigger: time
+        at: "08:00:00"
+      - trigger: time
+        at: "16:00:00"
+      - trigger: time
+        at: "21:00:00"
+    variables:
+      ev_season: >-
+        {% set seasonal_tariff = states('select.daily_electricity') %}
+        {% if seasonal_tariff in ['summer', 'non-summer'] %}
+          {{ seasonal_tariff }}
+        {% elif now().month in [6, 7, 8, 9] %}
+          summer
+        {% else %}
+          non-summer
+        {% endif %}
+      ev_tariff: >-
+        {% if is_state('binary_sensor.workday_sensor', 'off') %}
+          off_peak
+        {% elif now().hour < 8 or now().hour >= 21 %}
+          off_peak
+        {% elif now().hour < 16 %}
+          mid_peak
+        {% else %}
+          on_peak
+        {% endif %}
+      ev_rate: >-
+        {% if ev_tariff == 'off_peak' %}
+          0.0755
+        {% elif ev_tariff == 'on_peak' %}
+          0.4420
+        {% elif ev_season == 'summer' %}
+          0.1377
+        {% else %}
+          0.1238
+        {% endif %}
+    action:
+      - action: select.select_option
+        target:
+          entity_id: select.hourly_ev_charging
+        data:
+          option: "{{ ev_tariff }}"
+      - action: select.select_option
+        target:
+          entity_id: select.daily_ev_charging
+        data:
+          option: "{{ ev_tariff }}"
+      - action: select.select_option
+        target:
+          entity_id: select.monthly_ev_charging
+        data:
+          option: "{{ ev_tariff }}"
+      - action: input_number.set_value
+        target:
+          entity_id: input_number.ev_electrical_rate
+        data:
+          value: "{{ ev_rate }}"
+
   - id: switch_water_tariff
     alias: switch_water_tariff
     trigger:
@@ -544,6 +614,13 @@ input_number:
     mode: box
     # TODO update the unit of measure
     unit_of_measurement: USD/kWh
+  ev_electrical_rate:
+    name: EV Electrical Rate
+    min: .00001
+    max: 1.00000
+    step: 0.00001
+    mode: box
+    unit_of_measurement: USD/kWh
 
 ########################
 # Input Select
@@ -671,6 +748,91 @@ template:
         icon: mdi:cash-minus
         unit_of_measurement: $/gal
         state: "0.00497"
+      - name: ev_charging_tariff
+        unique_id: ev_charging_tariff
+        icon: mdi:cash-clock
+        state: >-
+          {% set tariff = states('select.daily_ev_charging') %}
+          {% if tariff in ['unknown', 'unavailable', 'none', 'None', ''] %}
+            {% set tariff = states('select.hourly_ev_charging') %}
+          {% endif %}
+          {% set labels = {
+            'off_peak': 'Off-Peak',
+            'mid_peak': 'Mid-Peak',
+            'on_peak': 'On-Peak'
+          } %}
+          {{ labels.get(tariff, 'Unknown') }}
+      - name: ev_charging_tariff_rate
+        unique_id: ev_charging_tariff_rate
+        icon: mdi:currency-usd
+        unit_of_measurement: USD/kWh
+        state: "{{ states('input_number.ev_electrical_rate') }}"
+      - name: daily_ev_charging_energy
+        unique_id: daily_ev_charging_energy
+        icon: mdi:car-electric
+        device_class: energy
+        unit_of_measurement: kWh
+        state: >-
+          {{
+            (
+              states('sensor.daily_ev_charging_off_peak') | float(default=0)
+              + states('sensor.daily_ev_charging_mid_peak') | float(default=0)
+              + states('sensor.daily_ev_charging_on_peak') | float(default=0)
+            ) | round(2)
+          }}
+      - name: monthly_ev_charging_energy
+        unique_id: monthly_ev_charging_energy
+        icon: mdi:car-electric
+        device_class: energy
+        unit_of_measurement: kWh
+        state: >-
+          {{
+            (
+              states('sensor.monthly_ev_charging_off_peak') | float(default=0)
+              + states('sensor.monthly_ev_charging_mid_peak') | float(default=0)
+              + states('sensor.monthly_ev_charging_on_peak') | float(default=0)
+            ) | round(2)
+          }}
+      - name: daily_ev_charging_cost
+        unique_id: daily_ev_charging_cost
+        icon: mdi:cash
+        unit_of_measurement: USD
+        state: >-
+          {% set season = states('select.daily_electricity') %}
+          {% if season in ['unknown', 'unavailable', 'none', 'None', ''] %}
+            {% set season = 'summer' if now().month in [6, 7, 8, 9] else 'non-summer' %}
+          {% endif %}
+          {% set off_peak_kwh = states('sensor.daily_ev_charging_off_peak') | float(default=0) %}
+          {% set mid_peak_kwh = states('sensor.daily_ev_charging_mid_peak') | float(default=0) %}
+          {% set on_peak_kwh = states('sensor.daily_ev_charging_on_peak') | float(default=0) %}
+          {% set mid_peak_rate = 0.1377 if season == 'summer' else 0.1238 %}
+          {{
+            (
+              (off_peak_kwh * 0.0755)
+              + (mid_peak_kwh * mid_peak_rate)
+              + (on_peak_kwh * 0.4420)
+            ) | round(2)
+          }}
+      - name: monthly_ev_charging_cost
+        unique_id: monthly_ev_charging_cost
+        icon: mdi:cash-multiple
+        unit_of_measurement: USD
+        state: >-
+          {% set season = states('select.daily_electricity') %}
+          {% if season in ['unknown', 'unavailable', 'none', 'None', ''] %}
+            {% set season = 'summer' if now().month in [6, 7, 8, 9] else 'non-summer' %}
+          {% endif %}
+          {% set off_peak_kwh = states('sensor.monthly_ev_charging_off_peak') | float(default=0) %}
+          {% set mid_peak_kwh = states('sensor.monthly_ev_charging_mid_peak') | float(default=0) %}
+          {% set on_peak_kwh = states('sensor.monthly_ev_charging_on_peak') | float(default=0) %}
+          {% set mid_peak_rate = 0.1377 if season == 'summer' else 0.1238 %}
+          {{
+            (
+              (off_peak_kwh * 0.0755)
+              + (mid_peak_kwh * mid_peak_rate)
+              + (on_peak_kwh * 0.4420)
+            ) | round(2)
+          }}
 
 ########################
 # Utility Meter
@@ -694,6 +856,31 @@ utility_meter:
     tariffs:
       - non-summer
       - summer
+  # Dakota Electric EV TOU is modeled from the Tesla integration's cumulative
+  # energy-added sensor. This tracks energy added to the car battery, not
+  # utility-side wall losses, but it is the best EV-specific counter available
+  # in the current configuration.
+  hourly_ev_charging:
+    source: sensor.nigori_energy_added
+    cycle: hourly
+    tariffs:
+      - off_peak
+      - mid_peak
+      - on_peak
+  daily_ev_charging:
+    source: sensor.nigori_energy_added
+    cycle: daily
+    tariffs:
+      - off_peak
+      - mid_peak
+      - on_peak
+  monthly_ev_charging:
+    source: sensor.nigori_energy_added
+    cycle: monthly
+    tariffs:
+      - off_peak
+      - mid_peak
+      - on_peak
   # hourly_water:
   #   source: sensor.watermeter_value
   #   name: Hourly Water Usage


### PR DESCRIPTION
## Summary
- add a dedicated Dakota Electric EV time-of-use tariff model in `packages/utilities.yaml`
- back EV utility meters with `sensor.nigori_energy_added` and derive EV tariff/rate, daily EV energy, and daily/monthly EV cost sensors
- add `sensor.house_electrical_meter_non_ev` and `sensor.house_electrical_rate` so the built-in Energy panel can model house and EV charging as separate grid-consumption sources
- switch the Tesla departure planner in `packages/car.yaml` to the EV tariff entities instead of the house-wide electricity rate
- remove `special_meeting` from the Tesla planner so charge decisions follow trips, alarms, weather, and the EV rate
- update the storage Tesla dashboard, add a storage `Energy` view, and document the built-in Energy-panel setup

## Test Cases
- weekday before 08:00 and after 21:00 selects `off_peak` and sets the EV rate to `$0.0755/kWh`
- weekday from 08:00 to 16:00 selects `mid_peak` and sets the EV rate to `$0.1238/kWh` in non-summer and `$0.1377/kWh` in summer
- weekday from 16:00 to 21:00 selects `on_peak` and sets the EV rate to `$0.4420/kWh`
- weekends and Minnesota holidays keep EV charging in `off_peak` all day
- Tesla planner notifications and charge-limit decisions now reference EV tariff state instead of house tariff state
- storage dashboard `tesla-v2` shows the EV tariff/rate cards and planner-decision card
- storage dashboard `energy` shows the whole-house meter, the non-EV house meter, and the EV TOU section
- built-in Energy panel can be configured with `sensor.house_electrical_meter_non_ev` + `sensor.house_electrical_rate` for house consumption and `sensor.nigori_energy_added` + `sensor.ev_charging_tariff_rate` for EV charging without double counting

## Coverage
- utility tariff automation and helper coverage: `packages/utilities.yaml`
- Tesla planner coverage: `packages/car.yaml`
- storage dashboard coverage: `.storage/lovelace.ryan_new_mushroom`
- feature documentation coverage: `docs/ev_charging_tariff.md`, `docs/tesla_departure_planner.md`, `README.md`

## Validation
- `python -m json.tool .storage/lovelace.ryan_new_mushroom >/dev/null`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt lovelace docs`
- `uv run --python $(cat .python-version) --with homeassistant==2026.3.3 python -m homeassistant --config "$PWD" --script check_config`

## Notes
- EV cost tracking uses `sensor.nigori_energy_added`, which measures energy added to the vehicle battery rather than wall-side charger losses.
- `sensor.house_electrical_meter_non_ev` is derived as whole-house energy minus `sensor.nigori_energy_added` and clamps against temporary backwards movement so it remains usable for the built-in Energy panel.
- The built-in Energy-panel preferences themselves are not stored in this repository, so the final panel wiring still needs to be done once in the Home Assistant UI after deploy.
- `check_config` still reports the existing unrelated warning: `Platform error 'sensor' from integration 'weatheralerts' - No module named 'custom_components.weatheralerts.const'`
