### PR TITLE
Add Energy panel support for EV tariff split

### DIFF
--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -1506,19 +1506,29 @@
                   "heading": "House Electricity"
                 },
                 {
+                  "type": "markdown",
+                  "title": "Built-in Energy Panel",
+                  "content": "### Use `sensor.house_electrical_meter_non_ev` for house consumption and `sensor.nigori_energy_added` for EV charging\n#### Keep `sensor.house_electrical_meter` out of the built-in Energy panel if you add EV separately"
+                },
+                {
                   "type": "tile",
                   "entity": "select.daily_electricity",
                   "name": "Current House Tariff"
                 },
                 {
                   "type": "tile",
-                  "entity": "input_number.electrical_rate",
+                  "entity": "sensor.house_electrical_rate",
                   "name": "Current House Rate"
                 },
                 {
                   "type": "tile",
                   "entity": "sensor.house_electrical_meter",
-                  "name": "House Meter"
+                  "name": "Whole House Meter"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.house_electrical_meter_non_ev",
+                  "name": "House Meter Without EV"
                 }
               ]
             },

--- a/docs/ev_charging_tariff.md
+++ b/docs/ev_charging_tariff.md
@@ -94,6 +94,27 @@ The Tesla dashboards now show:
 - monthly EV energy and cost
 - a planner-decision summary card
 
+## Built-in Energy Panel
+
+Home Assistant's built-in Energy panel can use the EV tariff, but it should be configured as two separate grid-consumption sources.
+
+Use these entities in `Settings > Dashboards > Energy`:
+
+- house without EV:
+  - energy: `sensor.house_electrical_meter_non_ev`
+  - current price: `sensor.house_electrical_rate`
+- EV charging:
+  - energy: `sensor.nigori_energy_added`
+  - current price: `sensor.ev_charging_tariff_rate`
+
+Important:
+
+- do not use `sensor.house_electrical_meter` for grid consumption if you add the EV source separately, or EV charging will be counted twice
+- `sensor.house_electrical_meter_non_ev` is derived as whole-house energy minus `sensor.nigori_energy_added`
+- this keeps the built-in Energy panel aligned with the EV tariff, but it still reflects battery-added EV energy rather than wall-side charging losses
+
+The built-in Energy panel preferences are not tracked in this repository, so the panel still needs to be updated manually in the Home Assistant UI after this config is deployed.
+
 ## Validation
 
 Recommended validation after EV tariff changes:

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -725,6 +725,7 @@ template:
       - name: house_electrical_meter
         unique_id: house_electrical_meter
         device_class: energy
+        state_class: total_increasing
         unit_of_measurement: kWh
         availability: >
           {% if is_state("sensor.filtered_raw_electrical_sensor", "unavailable") %}
@@ -738,6 +739,28 @@ template:
           {% else %}
             unavailable
           {% endif %}
+      - name: house_electrical_meter_non_ev
+        unique_id: house_electrical_meter_non_ev
+        device_class: energy
+        state_class: total_increasing
+        unit_of_measurement: kWh
+        availability: >
+          {{
+            states('sensor.house_electrical_meter') not in ['unavailable', 'unknown', 'Unavailable', 'Unknown']
+            and states('sensor.nigori_energy_added') not in ['unavailable', 'unknown', 'Unavailable', 'Unknown']
+          }}
+        state: >-
+          {% set house_kwh = states('sensor.house_electrical_meter') | float(default=0) %}
+          {% set ev_kwh = states('sensor.nigori_energy_added') | float(default=0) %}
+          {% set calculated = [house_kwh - ev_kwh, 0] | max %}
+          {% set previous = this.state | float(default=calculated) %}
+          {{ [calculated, previous] | max | round(3) }}
+      - name: house_electrical_rate
+        unique_id: house_electrical_rate
+        icon: mdi:currency-usd
+        state_class: measurement
+        unit_of_measurement: USD/kWh
+        state: "{{ states('input_number.electrical_rate') }}"
       - name: tariff_under_15k_water
         unique_id: tariff_under_15k_water
         icon: mdi:cash-minus
@@ -765,6 +788,7 @@ template:
       - name: ev_charging_tariff_rate
         unique_id: ev_charging_tariff_rate
         icon: mdi:currency-usd
+        state_class: measurement
         unit_of_measurement: USD/kWh
         state: "{{ states('input_number.ev_electrical_rate') }}"
       - name: daily_ev_charging_energy


### PR DESCRIPTION
## Summary
- add `sensor.house_electrical_meter_non_ev` so Home Assistant's built-in Energy panel can track house consumption without double-counting EV charging
- add `sensor.house_electrical_rate` for the house-side current price entity expected by the Energy panel
- update the storage `Energy` dashboard view to show the non-EV house meter and the intended built-in Energy-panel wiring
- document the manual built-in Energy-panel setup for separate house and EV grid-consumption sources

## Test Cases
- `sensor.house_electrical_meter_non_ev` remains non-negative and tracks whole-house energy minus EV charging energy
- the built-in Energy panel can be configured with `sensor.house_electrical_meter_non_ev` plus `sensor.house_electrical_rate` for house usage and `sensor.nigori_energy_added` plus `sensor.ev_charging_tariff_rate` for EV charging
- the storage `Energy` view shows both the whole-house meter and the non-EV house meter
- EV charging remains on the Dakota Electric TOU tariff without changing the earlier Tesla planner behavior

## Coverage
- split house-vs-EV energy sensor coverage: `packages/utilities.yaml`
- storage dashboard coverage: `.storage/lovelace.ryan_new_mushroom`
- documentation coverage: `docs/ev_charging_tariff.md`

## Validation
- `python -m json.tool .storage/lovelace.ryan_new_mushroom >/dev/null`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt lovelace docs`
- `uv run --python $(cat .python-version) --with homeassistant==2026.3.3 python -m homeassistant --config "$PWD" --script check_config`

## Notes
- the built-in Energy-panel preferences are still configured in Home Assistant UI, not from this repository
- EV energy still comes from `sensor.nigori_energy_added`, so billing reflects battery-added energy rather than wall-side charging losses
- `check_config` still reports the existing unrelated warning: `Platform error 'sensor' from integration 'weatheralerts' - No module named 'custom_components.weatheralerts.const'`
