### PR TITLE
Fix owner suite bedside lamp auto toggles

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1,6 +1,3 @@
-<<<<<<< HEAD
-[]
-=======
 # Intentionally kept empty.
 # This repo stores automations inside domain packages so behavior stays grouped with the entities and helpers it depends on.
->>>>>>> f6ccd90511733b2c657550d408083273e7f94782
+[]

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -518,14 +518,15 @@ automation:
         to: "on"
         for:
           seconds: 30
-        id: "west_bed_light_on"
-      - trigger: state
-        # entity_id: binary_sensor.bayesian_bed_occupancy
-        entity_id: binary_sensor.bed_presence_2d0670_bed_occupied_left
-        to: "on"
-        for:
-          seconds: 30
         id: "west_bed_on"
+      - trigger: state
+        # Turn on the west bedside lamp after leaving bed for a bit.
+        # Keep this delay/window easy to tune if the sensor still feels jumpy.
+        entity_id: binary_sensor.bed_presence_2d0670_bed_occupied_left
+        to: "off"
+        for:
+          seconds: 10
+        id: "west_bed_left_bed"
       - trigger: state
         # entity_id: binary_sensor.bayesian_bed_occupancy
         entity_id: binary_sensor.bed_presence_2d0670_bed_occupied_right
@@ -539,14 +540,15 @@ automation:
         to: "off"
         for:
           seconds: 30
-        id: "west_bed_light_off"
-      - trigger: state
-        # entity_id: binary_sensor.bayesian_bed_occupancy
-        entity_id: binary_sensor.bed_presence_2d0670_bed_occupied_left
-        to: "off"
-        for:
-          seconds: 30
         id: "west_bed_off"
+      - trigger: state
+        # Turn the west bedside lamp back off after settling into bed.
+        # Adjust this delay alongside west_bed_left_bed if nighttime behavior needs refinement.
+        entity_id: binary_sensor.bed_presence_2d0670_bed_occupied_left
+        to: "on"
+        for:
+          seconds: 10
+        id: "west_bed_back_in_bed"
       - trigger: state
         # entity_id: binary_sensor.bayesian_bed_occupancy
         entity_id: binary_sensor.bed_presence_2d0670_bed_occupied_right
@@ -630,6 +632,32 @@ automation:
               - action: input_boolean.turn_off
                 data:
                   entity_id: input_boolean.west_bed_occupied
+          - conditions:
+              - condition: trigger
+                id: west_bed_left_bed
+              - condition: or
+                conditions:
+                  - condition: sun
+                    after: sunset
+                  - condition: time
+                    before: "12:00:00"
+            sequence:
+              - action: light.turn_on
+                data:
+                  entity_id: light.owner_suite_lamp_bulb_1
+          - conditions:
+              - condition: trigger
+                id: west_bed_back_in_bed
+              - condition: or
+                conditions:
+                  - condition: sun
+                    after: sunset
+                  - condition: time
+                    before: "12:00:00"
+            sequence:
+              - action: light.turn_off
+                data:
+                  entity_id: light.owner_suite_lamp_bulb_1
           # control the lights
           - conditions:
               - condition: trigger


### PR DESCRIPTION
## Summary
- stop `side_of_bed_toggles` from turning the west bedside lamp on from a stale in-bed retrigger
- restore the intended automatic bedside behavior so the west lamp turns on after leaving bed and back off after settling into bed
- shorten that automatic bedside delay to 10 seconds and document that the delay/window can be tuned later
- resolve the existing merge markers in `automations.yaml` so YAML lint can run

## Validation
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `/tmp/ha-validate-venv/bin/yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' configuration.yaml automations.yaml blueprints packages zigbee2mqtt`

## Notes
- I could not run the repo's Docker-based Home Assistant `check_config` step locally because `docker` is not installed in this environment.
