### PR TITLE
Create reusable house transition framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ docker run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:stable \
 
 ## Feature Docs
 
+- [House Transition Framework](docs/house_transition_framework.md)
 - [EV Charging Tariff](docs/ev_charging_tariff.md)
 - [Tesla Departure Planner](docs/tesla_departure_planner.md)
 

--- a/docs/house_transition_framework.md
+++ b/docs/house_transition_framework.md
@@ -1,0 +1,77 @@
+# House Transition Framework
+
+Issue: `#109`
+
+## Summary
+
+`script.house_transition` is the single entrypoint for shared house-mode changes.
+Existing automations now delegate to it instead of each one directly managing
+lights, locks, covers, climate, guest media grouping, or trip-mode vacation
+simulation.
+
+Base modes:
+
+- `home`
+- `away`
+- `night`
+
+Explicit overrides:
+
+- `input_boolean.guest_mode`
+- `input_boolean.trip`
+
+## Entrypoint
+
+```yaml
+- action: script.house_transition
+  data:
+    mode: away
+    reason: leave_home
+```
+
+Common optional fields:
+
+- `light_scene`
+- `light_transition`
+- `extra_scene`
+- `notify_message`
+- `guest_mode`
+- `trip_mode`
+- `apply_lights`
+- `apply_security`
+- `apply_climate`
+- `apply_media`
+- `apply_trip_policy`
+
+## Current Delegates
+
+- `packages/zone.yaml`
+  `cloudy_home_arrival`, `default_arrive_home`,
+  `turn_on_lights_at_night_when_i_get_home`,
+  `turn_on_bedroom_lights_at_night_when_i_get_home`,
+  `turn_off_lights_when_i_leave`
+- `packages/guest.yaml`
+  guest-mode enable/disable and guest climate refresh automations
+- `packages/trips.yaml`
+  trip-mode manager enable/disable paths
+
+## Manual Verification
+
+1. Trigger `script.house_transition` twice with the same `mode` and confirm no
+   unsafe repeat behavior occurs.
+2. Leave home with `input_boolean.guest_mode` off and confirm the lock, garage,
+   leave-home scene, camera scene, and light shutdown still run.
+3. Leave home with `input_boolean.guest_mode` on and confirm away tracking
+   updates without running the destructive leave-home actions.
+4. Arrive home during the day and confirm the normal arrival scene and Ecobee
+   program resume still run.
+5. Arrive home at night and confirm the night-arrival scene still runs; repeat
+   with the bedroom-prep automation path.
+6. Toggle `input_boolean.guest_mode` on and off and confirm Sonos grouping and
+   the Ecobee guest preset reapply without retriggering arrival/departure
+   lighting.
+7. Toggle `input_boolean.trip` on and off and confirm
+   `switch.vacation_simulation` and
+   `input_number.random_vacation_light_group` stay in sync.
+8. Temporarily make one target entity unavailable and confirm the script keeps
+   applying the remaining actions because service calls use `continue_on_error`.

--- a/packages/guest.yaml
+++ b/packages/guest.yaml
@@ -123,18 +123,22 @@ automation:
       - action: input_boolean.turn_off
         target:
           entity_id: input_boolean.guest_mode
+      - action: script.house_transition
+        data:
+          mode: >-
+            {% if is_state('binary_sensor.bayesian_zeke_home', 'off') %}
+              away
+            {% else %}
+              {{ states('input_select.house_mode') }}
+            {% endif %}
+          reason: guest_mode_disabled
+          apply_lights: false
+          apply_security: false
+          apply_media: true
+          apply_trip_policy: false
       - action: notify.all
         data:
           message: Guest Mode Deactivated
-      - action: media_player.join
-        target:
-          entity_id:
-            - media_player.bedroom_sonos_2
-        data:
-          group_members:
-            - media_player.bathroom_sonos_2
-            - media_player.office_sonos_2
-            - media_player.den_sonos_2
 
   - id: turn_on_guest_mode_when_guest_wifi_active
     alias: turn_on_guest_mode_when_guest_wifi_active
@@ -177,27 +181,19 @@ automation:
       - action: input_boolean.turn_on
         target:
           entity_id: input_boolean.guest_mode
-      - action: media_player.unjoin
-        target:
-          entity_id:
-            - media_player.bedroom_sonos_2
-            - media_player.bathroom_sonos_2
-            - media_player.office_sonos_2
-            - media_player.den_sonos_2
-      - action: media_player.join
-        target:
-          entity_id:
-            - media_player.bedroom_sonos_2
+      - action: script.house_transition
         data:
-          group_members:
-            - media_player.bathroom_sonos_2
-      # - action: media_player.join
-      #   target:
-      #     entity_id:
-      #       - media_player.office
-      #   data:
-      #     group_members:
-      #       - media_player.den
+          mode: >-
+            {% if is_state('binary_sensor.bayesian_zeke_home', 'off') %}
+              away
+            {% else %}
+              {{ states('input_select.house_mode') }}
+            {% endif %}
+          reason: guest_mode_enabled
+          apply_lights: false
+          apply_security: false
+          apply_media: true
+          apply_trip_policy: false
 
   - id: climate_guest_mode_day
     alias: climate_guest_mode_day
@@ -218,11 +214,19 @@ automation:
           - input_boolean.guest_mode
         state: "on"
     action:
-      - action: climate.set_preset_mode
+      - action: script.house_transition
         data:
-          preset_mode: "Guest Day"
-        target:
-          entity_id: climate.my_ecobee
+          mode: >-
+            {% if is_state('binary_sensor.bayesian_zeke_home', 'off') %}
+              away
+            {% else %}
+              {{ states('input_select.house_mode') }}
+            {% endif %}
+          reason: guest_climate_day_refresh
+          apply_lights: false
+          apply_security: false
+          apply_media: false
+          apply_trip_policy: false
 
   - id: climate_guest_mode_night
     alias: climate_guest_mode_night
@@ -243,11 +247,19 @@ automation:
           - input_boolean.guest_mode
         state: "on"
     action:
-      - action: climate.set_preset_mode
+      - action: script.house_transition
         data:
-          preset_mode: "Guest Sleep"
-        target:
-          entity_id: climate.my_ecobee
+          mode: >-
+            {% if is_state('binary_sensor.bayesian_zeke_home', 'off') %}
+              away
+            {% else %}
+              {{ states('input_select.house_mode') }}
+            {% endif %}
+          reason: guest_climate_night_refresh
+          apply_lights: false
+          apply_security: false
+          apply_media: false
+          apply_trip_policy: false
 
 ########################
 # Binary Sensors

--- a/packages/house_mode.yaml
+++ b/packages/house_mode.yaml
@@ -1,0 +1,316 @@
+# Home Assistant package for shared house mode transitions.
+# It centralizes arrival, departure, night, guest, and trip side effects so
+# existing automations can delegate to one script entrypoint.
+
+################################################################
+## Packages / House Mode
+################################################################
+
+################################################
+## Customize
+################################################
+
+homeassistant:
+  customize:
+    ################################################
+    ## Node Anchors
+    ################################################
+
+    package.node_anchors:
+      customize: &customize
+        package: "house_mode"
+
+    ################################################
+    ## Input Select
+    ################################################
+    input_select.house_mode:
+      <<: *customize
+      friendly_name: "House Mode"
+      icon: mdi:home-switch-outline
+
+    ################################################
+    ## Scripts
+    ################################################
+    script.house_transition:
+      <<: *customize
+      friendly_name: "House Transition"
+      icon: mdi:home-switch
+
+########################
+# Automation
+########################
+automation: []
+
+########################
+# Input Select
+########################
+input_select:
+  house_mode:
+    options:
+      - home
+      - away
+      - night
+    initial: home
+
+########################
+# Scripts
+########################
+script:
+  house_transition:
+    alias: house_transition
+    description: >-
+      Shared entrypoint for house mode transitions. Base arrival/departure
+      automations can reapply lights, security, and climate, while guest/trip
+      callers can selectively reapply only media, climate, or travel policy.
+    mode: queued
+    max: 10
+    fields:
+      mode:
+        description: "Base house mode to apply: home, away, or night."
+        example: away
+      reason:
+        description: Optional logbook reason for the transition request.
+        example: departure
+      light_scene:
+        description: Optional scene override for home or night lighting.
+        example: scene.cloudy_arrive_home
+      light_transition:
+        description: Transition seconds for the requested light scene.
+        example: 30
+      extra_scene:
+        description: Optional extra scene to apply after the primary mode scene.
+        example: scene.bedroom_prep
+      notify_message:
+        description: Optional notify.all message for the transition.
+        example: Welcome home
+      guest_mode:
+        description: Explicit guest override state. Defaults to input_boolean.guest_mode.
+        example: "on"
+      trip_mode:
+        description: Explicit trip override state. Defaults to input_boolean.trip.
+        example: "off"
+      apply_lights:
+        description: Apply light scenes and light shutdown behavior.
+        example: true
+      apply_security:
+        description: Apply locks, covers, and camera policy.
+        example: false
+      apply_climate:
+        description: Apply climate presets or resume the Ecobee program.
+        example: true
+      apply_media:
+        description: Apply guest-aware Sonos grouping policy.
+        example: true
+      apply_trip_policy:
+        description: Apply trip-mode vacation simulation state.
+        example: true
+    variables:
+      requested_mode: >-
+        {% set normalized = (mode | default(states('input_select.house_mode'), true) | string | lower | trim) %}
+        {% if normalized in ['away', 'night'] %}
+          {{ normalized }}
+        {% else %}
+          home
+        {% endif %}
+      guest_mode_enabled: >-
+        {% set normalized = (guest_mode if guest_mode is defined else states('input_boolean.guest_mode')) | string | lower | trim %}
+        {{ normalized in ['on', 'true', '1', 'yes'] }}
+      trip_mode_enabled: >-
+        {% set normalized = (trip_mode if trip_mode is defined else states('input_boolean.trip')) | string | lower | trim %}
+        {{ normalized in ['on', 'true', '1', 'yes'] }}
+      should_apply_lights: >-
+        {% set normalized = (apply_lights if apply_lights is defined else true) | string | lower | trim %}
+        {{ normalized not in ['off', 'false', '0', 'no'] }}
+      should_apply_security: >-
+        {% set normalized = (apply_security if apply_security is defined else true) | string | lower | trim %}
+        {{ normalized not in ['off', 'false', '0', 'no'] }}
+      should_apply_climate: >-
+        {% set normalized = (apply_climate if apply_climate is defined else true) | string | lower | trim %}
+        {{ normalized not in ['off', 'false', '0', 'no'] }}
+      should_apply_media: >-
+        {% set normalized = (apply_media if apply_media is defined else false) | string | lower | trim %}
+        {{ normalized not in ['off', 'false', '0', 'no'] }}
+      should_apply_trip_policy: >-
+        {% set normalized = (apply_trip_policy if apply_trip_policy is defined else false) | string | lower | trim %}
+        {{ normalized not in ['off', 'false', '0', 'no'] }}
+      resolved_light_scene: >-
+        {% if light_scene is defined and light_scene | string | trim %}
+          {{ light_scene }}
+        {% elif requested_mode == 'home' %}
+          scene.arrive_home
+        {% elif requested_mode == 'night' %}
+          scene.night_arrive_home
+        {% else %}
+          none
+        {% endif %}
+      resolved_extra_scene: >-
+        {% if extra_scene is defined and extra_scene | string | trim %}
+          {{ extra_scene }}
+        {% else %}
+          none
+        {% endif %}
+      resolved_light_transition: "{{ light_transition | default(30, true) | int(30) }}"
+      guest_climate_preset: >-
+        {% if now().hour < 7 %}
+          Guest Sleep
+        {% else %}
+          Guest Day
+        {% endif %}
+    sequence:
+      - action: logbook.log
+        data:
+          name: House Transition
+          entity_id: script.house_transition
+          message: >-
+            Applying {{ requested_mode }} mode
+            (guest={{ guest_mode_enabled }}, trip={{ trip_mode_enabled }},
+            reason={{ reason | default('unspecified', true) }}).
+          domain: script
+      - continue_on_error: true
+        action: input_select.select_option
+        target:
+          entity_id: input_select.house_mode
+        data:
+          option: "{{ requested_mode }}"
+      - parallel:
+          - choose:
+              - conditions:
+                  - "{{ should_apply_lights and requested_mode in ['home', 'night'] and resolved_light_scene != 'none' }}"
+                sequence:
+                  - continue_on_error: true
+                    action: scene.turn_on
+                    data:
+                      entity_id: "{{ resolved_light_scene }}"
+                      transition: "{{ resolved_light_transition }}"
+              - conditions:
+                  - "{{ should_apply_lights and requested_mode == 'away' and not guest_mode_enabled }}"
+                sequence:
+                  - continue_on_error: true
+                    action: scene.turn_on
+                    target:
+                      entity_id: scene.leave_home
+                  - continue_on_error: true
+                    action: script.lights_off_except
+                    data:
+                      exclude_lights:
+                        - light.outside_front_hue
+                        - light.outside_north_west_garage
+                        - light.outside_south_west_garage
+                        - light.outside_front_door
+                      transition: 240
+          - choose:
+              - conditions:
+                  - "{{ should_apply_lights and resolved_extra_scene != 'none' }}"
+                sequence:
+                  - continue_on_error: true
+                    action: scene.turn_on
+                    data:
+                      entity_id: "{{ resolved_extra_scene }}"
+          - choose:
+              - conditions:
+                  - "{{ should_apply_security and requested_mode == 'away' and not guest_mode_enabled }}"
+                sequence:
+                  - continue_on_error: true
+                    action: lock.lock
+                    target:
+                      entity_id: lock.front_door_lock
+                  - continue_on_error: true
+                    action: cover.close_cover
+                    target:
+                      entity_id: cover.garage_door
+                  - continue_on_error: true
+                    action: fan.turn_off
+                    target:
+                      entity_id: all
+                  - continue_on_error: true
+                    action: scene.turn_on
+                    target:
+                      entity_id: scene.turn_on_cameras
+              - conditions:
+                  - "{{ should_apply_security and requested_mode in ['home', 'night'] }}"
+                sequence:
+                  - continue_on_error: true
+                    action: switch.turn_off
+                    target:
+                      entity_id:
+                        - switch.living_room_camera
+                        - switch.basement_camera_power
+          - choose:
+              - conditions:
+                  - "{{ should_apply_climate and guest_mode_enabled }}"
+                sequence:
+                  - continue_on_error: true
+                    action: climate.set_preset_mode
+                    target:
+                      entity_id: climate.my_ecobee
+                    data:
+                      preset_mode: "{{ guest_climate_preset }}"
+              - conditions:
+                  - "{{ should_apply_climate and requested_mode in ['home', 'night'] }}"
+                sequence:
+                  - continue_on_error: true
+                    action: ecobee.resume_program
+                    data:
+                      resume_all: true
+                      entity_id: climate.my_ecobee
+          - choose:
+              - conditions:
+                  - "{{ should_apply_media and guest_mode_enabled }}"
+                sequence:
+                  - continue_on_error: true
+                    action: media_player.unjoin
+                    target:
+                      entity_id:
+                        - media_player.bedroom_sonos_2
+                        - media_player.bathroom_sonos_2
+                        - media_player.office_sonos_2
+                        - media_player.den_sonos_2
+                  - continue_on_error: true
+                    action: media_player.join
+                    target:
+                      entity_id:
+                        - media_player.bedroom_sonos_2
+                    data:
+                      group_members:
+                        - media_player.bathroom_sonos_2
+              - conditions:
+                  - "{{ should_apply_media and not guest_mode_enabled }}"
+                sequence:
+                  - continue_on_error: true
+                    action: media_player.join
+                    target:
+                      entity_id:
+                        - media_player.bedroom_sonos_2
+                    data:
+                      group_members:
+                        - media_player.bathroom_sonos_2
+                        - media_player.office_sonos_2
+                        - media_player.den_sonos_2
+          - choose:
+              - conditions:
+                  - "{{ should_apply_trip_policy and trip_mode_enabled }}"
+                sequence:
+                  - continue_on_error: true
+                    action: switch.turn_on
+                    target:
+                      entity_id: switch.vacation_simulation
+              - conditions:
+                  - "{{ should_apply_trip_policy and not trip_mode_enabled }}"
+                sequence:
+                  - continue_on_error: true
+                    action: switch.turn_off
+                    target:
+                      entity_id: switch.vacation_simulation
+                  - continue_on_error: true
+                    action: input_number.set_value
+                    data:
+                      entity_id: input_number.random_vacation_light_group
+                      value: 0
+      - if:
+          - condition: template
+            value_template: "{{ notify_message is defined and notify_message | string | trim != '' }}"
+        then:
+          - continue_on_error: true
+            action: notify.all
+            data:
+              message: "{{ notify_message }}"

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -372,9 +372,15 @@ automation:
               - action: input_boolean.turn_on
                 target:
                   entity_id: input_boolean.trip
-              - action: switch.turn_on
-                target:
-                  entity_id: switch.vacation_simulation
+              - action: script.house_transition
+                data:
+                  mode: "{{ states('input_select.house_mode') }}"
+                  reason: startup_reconcile_enable
+                  apply_lights: false
+                  apply_security: false
+                  apply_climate: false
+                  apply_media: false
+                  apply_trip_policy: true
               - action: notify.all
                 data:
                   message: "Trip mode enabled."
@@ -382,16 +388,18 @@ automation:
               - condition: trigger
                 id: startup_reconcile_disable
             sequence:
-              - action: switch.turn_off
-                target:
-                  entity_id: switch.vacation_simulation
               - action: input_boolean.turn_off
                 target:
                   entity_id: input_boolean.trip
-              - action: input_number.set_value
+              - action: script.house_transition
                 data:
-                  entity_id: input_number.random_vacation_light_group
-                  value: "{{ (0|int) }}"
+                  mode: "{{ states('input_select.house_mode') }}"
+                  reason: startup_reconcile_disable
+                  apply_lights: false
+                  apply_security: false
+                  apply_climate: false
+                  apply_media: false
+                  apply_trip_policy: true
               - action: notify.all
                 data:
                   message: "Back from trip. \U0001F4BA"
@@ -412,9 +420,15 @@ automation:
               - action: input_boolean.turn_on
                 target:
                   entity_id: input_boolean.trip
-              - action: switch.turn_on
-                target:
-                  entity_id: switch.vacation_simulation
+              - action: script.house_transition
+                data:
+                  mode: away
+                  reason: automatic_trip_enable
+                  apply_lights: false
+                  apply_security: false
+                  apply_climate: false
+                  apply_media: false
+                  apply_trip_policy: true
               - action: notify.all
                 data:
                   message: "You're on a trip! \U0001F6EC"
@@ -445,9 +459,15 @@ automation:
               - action: input_boolean.turn_on
                 target:
                   entity_id: input_boolean.trip
-              - action: switch.turn_on
-                target:
-                  entity_id: switch.vacation_simulation
+              - action: script.house_transition
+                data:
+                  mode: away
+                  reason: calendar_trip_enable
+                  apply_lights: false
+                  apply_security: false
+                  apply_climate: false
+                  apply_media: false
+                  apply_trip_policy: true
               - action: notify.all
                 data:
                   message: "You're on a trip! \U0001F6EC"
@@ -455,9 +475,15 @@ automation:
               - condition: trigger
                 id: manual_trip_on
             sequence:
-              - action: switch.turn_on
-                target:
-                  entity_id: switch.vacation_simulation
+              - action: script.house_transition
+                data:
+                  mode: "{{ states('input_select.house_mode') }}"
+                  reason: manual_trip_enable
+                  apply_lights: false
+                  apply_security: false
+                  apply_climate: false
+                  apply_media: false
+                  apply_trip_policy: true
               - action: notify.all
                 data:
                   message: "Trip mode enabled."
@@ -468,13 +494,15 @@ automation:
                 entity_id: input_boolean.trip
                 state: "off"
             sequence:
-              - action: switch.turn_off
-                target:
-                  entity_id: switch.vacation_simulation
-              - action: input_number.set_value
+              - action: script.house_transition
                 data:
-                  entity_id: input_number.random_vacation_light_group
-                  value: "{{ (0|int) }}"
+                  mode: "{{ states('input_select.house_mode') }}"
+                  reason: manual_trip_disable
+                  apply_lights: false
+                  apply_security: false
+                  apply_climate: false
+                  apply_media: false
+                  apply_trip_policy: true
               - action: notify.all
                 data:
                   message: "Back from trip. \U0001F4BA"
@@ -485,16 +513,18 @@ automation:
             entity_id: input_boolean.trip
             state: "on"
         then:
-          - action: switch.turn_off
-            target:
-              entity_id: switch.vacation_simulation
           - action: input_boolean.turn_off
             target:
               entity_id: input_boolean.trip
-          - action: input_number.set_value
+          - action: script.house_transition
             data:
-              entity_id: input_number.random_vacation_light_group
-              value: "{{ (0|int) }}"
+              mode: "{{ states('input_select.house_mode') }}"
+              reason: return_home_trip_disable
+              apply_lights: false
+              apply_security: false
+              apply_climate: false
+              apply_media: false
+              apply_trip_policy: true
           - action: notify.all
             data:
               message: "Back from trip. \U0001F4BA"

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -185,14 +185,13 @@ automation:
           state: "off"
           # enabled: false
     action:
-      - service: scene.turn_on
-        target:
-          entity_id: scene.cloudy_arrive_home
+      - action: script.house_transition
         data:
-          transition: 30
-      - service: notify.all
-        data:
-          message: Cloudy day arrival.
+          mode: home
+          reason: cloudy_home_arrival
+          light_scene: scene.cloudy_arrive_home
+          light_transition: 30
+          notify_message: Cloudy day arrival.
 
   - id: default_arrive_home
     alias: default_arrive_home
@@ -215,9 +214,10 @@ automation:
           entity_id: sensor.wethop_activity
           state: "Automotive"
     action:
-      - action: scene.turn_on
-        target:
-          entity_id: scene.arrive_home
+      - action: script.house_transition
+        data:
+          mode: home
+          reason: default_arrive_home
       # - alias: "Notify action"
       #   action: notify.mobile_app_wethop
       #   data:
@@ -357,11 +357,11 @@ automation:
             - condition: sun
               before: sunrise
     action:
-      - action: scene.turn_on
-        target:
-          entity_id: scene.night_arrive_home
+      - action: script.house_transition
         data:
-          transition: 30
+          mode: night
+          reason: night_arrival
+          light_transition: 30
       - action: vacuum.return_to_base
         data:
           entity_id: all
@@ -394,16 +394,18 @@ automation:
             - condition: sun
               before: sunrise
     action:
-      - action: scene.turn_on
-        target:
-          entity_id: scene.bedroom_prep
+      - action: script.house_transition
+        data:
+          mode: night
+          reason: bedroom_prep_arrival
+          extra_scene: scene.bedroom_prep
       - action: notify.all
         data:
           data:
             url: "/ryan-new-mushroom/owner-suite"
           message: "Bedroom Prep Activated"
 
-          # Use Ecobee Vacation mode now.
+  # Use Ecobee Vacation mode now.
   # - id: return_from_road_trip
   #   alias: return_from_road_trip
   #   trigger:
@@ -490,56 +492,29 @@ automation:
         state: "Automotive"
         # Todo add biking here?
     action:
-      parallel:
-        - action: lock.lock
-          target:
-            entity_id: lock.front_door_lock
-        - action: cover.close_cover
-          target:
-            entity_id: cover.garage_door
-        - action: scene.turn_on
-          target:
-            entity_id: scene.leave_home
-        - action: script.lights_off_except
-          data:
-            exclude_lights:
-              - light.outside_front_hue
-              - light.outside_north_west_garage
-              - light.outside_south_west_garage
-              - light.outside_front_door
-            transition: 240
-        # - action: light.turn_off
-        #   entity_id: "all"
-        - action: fan.turn_off
-          target:
-            entity_id: "all"
-        # - alias: "Notify action"
-        #   action: notify.mobile_app_wethop
-        #   data:
-        #     message: >-
-        #       Leaving home with wethop activity {{ states('sensor.wethop_activity') }}
-        - action: scene.turn_on
-          target:
-            entity_id: scene.turn_on_cameras
-        # Vacuum request payload is identical for both paths, so keep one action.
-        - action: mqtt.publish
-          data:
-            topic: valetudo/upstairs-vacuum/MapSegmentationCapability/clean/set
-            payload: >-
-              {% set segment_id = now().weekday() + 1 %}
-              {"segment_ids": ["{{segment_id}}"],"iterations": 4,"customOrder": true}
-            # - action: notify.all
-            #   data:
-            #     title: "Auf wiedersehen"
-            #     message: "Vacuum the house?"
-            #     data:
-            #       actions:
-            #         - action: "VACUUM_HOUSE"
-            #           title: "Vacuum House"
-            #           activationMode: background
-            #           authenticationRequired: false
-            #           destructive: false
-            #           behavior: default
+      - action: script.house_transition
+        data:
+          mode: away
+          reason: leave_home
+      # Vacuum request payload is identical for both paths, so keep one action.
+      - action: mqtt.publish
+        data:
+          topic: valetudo/upstairs-vacuum/MapSegmentationCapability/clean/set
+          payload: >-
+            {% set segment_id = now().weekday() + 1 %}
+            {"segment_ids": ["{{segment_id}}"],"iterations": 4,"customOrder": true}
+          # - action: notify.all
+          #   data:
+          #     title: "Auf wiedersehen"
+          #     message: "Vacuum the house?"
+          #     data:
+          #       actions:
+          #         - action: "VACUUM_HOUSE"
+          #           title: "Vacuum House"
+          #           activationMode: background
+          #           authenticationRequired: false
+          #           destructive: false
+          #           behavior: default
 
   - alias: Update Bayesian Device tracker on start
     description: When HA starts up, update bayesian device tracker GPS items


### PR DESCRIPTION
Closes #109

## Summary
- add a dedicated `packages/house_mode.yaml` package with `script.house_transition` as the single entrypoint for shared house mode changes
- track the current base mode in `input_select.house_mode` and centralize light, security, climate, guest media, and trip-policy side effects behind per-domain apply flags
- rewire existing zone, guest, and trip automations to delegate to the shared transition script instead of mutating the same house-wide behaviors in multiple places
- document the framework and the manual verification matrix in `docs/house_transition_framework.md`

## Guest Mode / Travel Interaction
- guest mode remains explicit via `input_boolean.guest_mode`; Wi-Fi automation still toggles it, but the transition framework now consumes that boolean as the override input
- trip detection still lives in `packages/trips.yaml`; the new script only centralizes trip side effects like `switch.vacation_simulation` sync so trip enable/disable no longer has duplicated write paths
- trip-only reapplication calls disable light/security/climate/media domains so travel state changes do not accidentally retrigger arrival or departure scenes

## Validation
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- Home Assistant API `check_config`: `Configuration is valid`

## Coverage / Test Cases
- automated coverage is limited here because this repo is YAML-driven HA config rather than an application test suite
- manual verification cases are documented in `docs/house_transition_framework.md`, covering idempotent reruns, guest/trip overrides, day/night arrival, away transitions, and unavailable-entity safety
