### PR TITLE
Migrate Tiki Room LED strip to ESPHome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 ########################################
 !*.yaml
 !*.yml
+!esphome/tikiroom_effects.h
 !.python-version
 !README.md
 !docs/

--- a/esphome/tikiroom.yaml
+++ b/esphome/tikiroom.yaml
@@ -1,0 +1,211 @@
+# ESPHome migration for the Tiki Room LED strip.
+# This keeps the existing GPIO14 wiring, exposes the light natively to Home Assistant,
+# and adds device-native effect/speed helpers so Lovelace and HomeKit can control them.
+
+esphome:
+  name: tikiroom
+  includes:
+    - tikiroom_effects.h
+
+esp8266:
+  board: esp01_1m
+  restore_from_flash: true
+
+wifi:
+  ssid: !secret wifi_ap
+  password: !secret wifi_password
+  min_auth_mode: WPA2
+
+  ap:
+    ssid: "Tikiroom Fallback Hotspot"
+    password: "change-me-please"
+
+captive_portal:
+
+logger:
+  level: INFO
+  esp8266_store_log_strings_in_flash: false
+
+api:
+
+ota:
+  - platform: esphome
+
+globals:
+  - id: tikiroom_effect_speed
+    type: float
+    restore_value: yes
+    initial_value: "150.0"
+
+number:
+  - platform: template
+    id: tikiroom_strip_animation_speed
+    name: "Tiki Room Strip Animation Speed"
+    icon: mdi:speedometer
+    min_value: 1
+    max_value: 150
+    step: 1
+    lambda: |-
+      return id(tikiroom_effect_speed);
+    update_interval: 1s
+    set_action:
+      - lambda: |-
+          id(tikiroom_effect_speed) = x;
+
+select:
+  - platform: template
+    id: tikiroom_strip_effect
+    name: "Tiki Room Strip Effect"
+    icon: mdi:creation
+    options:
+      - solid
+      - bpm
+      - candy cane
+      - christmas
+      - confetti
+      - cyclon rainbow
+      - dots
+      - fire
+      - glitter
+      - juggle
+      - lightning
+      - noise
+      - police all
+      - police one
+      - rainbow
+      - rainbow with glitter
+      - ripple
+      - sinelon
+      - twinkle
+    lambda: |-
+      const auto effect = id(tiki_room_strip).get_effect_name();
+      if (strcmp(effect.c_str(), "None") == 0) {
+        return std::string("solid");
+      }
+      return std::string(effect.c_str());
+    update_interval: 1s
+    set_action:
+      - lambda: |-
+          auto call = id(tiki_room_strip).turn_on();
+          call.set_effect(x.c_str());
+          call.perform();
+
+light:
+  - platform: neopixelbus
+    id: tiki_room_strip
+    name: "Tiki Room Strip"
+    type: BRG
+    variant: WS2811
+    pin: GPIO14
+    method:
+      type: bit_bang
+    num_leds: 579
+    restore_mode: RESTORE_DEFAULT_OFF
+    default_transition_length: 1s
+    flash_transition_length: 0s
+    on_turn_on:
+      then:
+        - if:
+            condition:
+              lambda: |-
+                return strcmp(id(tiki_room_strip).get_effect_name().c_str(), "None") == 0;
+            then:
+              - light.turn_on:
+                  id: tiki_room_strip
+                  effect: solid
+    effects:
+      - addressable_lambda:
+          name: solid
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_solid(it, current_color, initial_run);
+      - addressable_lambda:
+          name: bpm
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_bpm(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: candy cane
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_candy_cane(it, id(tikiroom_effect_speed), tikiroom::candy_cane_palette(), initial_run);
+      - addressable_lambda:
+          name: christmas
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_candy_cane(it, id(tikiroom_effect_speed), tikiroom::christmas_palette(), initial_run);
+      - addressable_lambda:
+          name: confetti
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_confetti(it, current_color, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: cyclon rainbow
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_cyclon_rainbow(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: dots
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_dots(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: fire
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_fire(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: glitter
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_glitter(it, current_color, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: juggle
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_juggle(it, current_color, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: lightning
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_lightning(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: noise
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_noise(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: police all
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_police_all(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: police one
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_police_one(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: rainbow
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_rainbow(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: rainbow with glitter
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_rainbow_with_glitter(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: ripple
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_ripple(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: sinelon
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_sinelon(it, current_color, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: twinkle
+          update_interval: 16ms
+          lambda: |-
+            tikiroom::apply_twinkle(it, id(tikiroom_effect_speed), initial_run);

--- a/esphome/tikiroom_effects.h
+++ b/esphome/tikiroom_effects.h
@@ -1,0 +1,684 @@
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+
+#include "esphome/components/light/addressable_light.h"
+#include "esphome/core/color.h"
+
+namespace tikiroom {
+
+using esphome::Color;
+using esphome::light::AddressableLight;
+
+constexpr uint16_t NUM_LEDS = 579;
+constexpr uint8_t DENSITY = 80;
+constexpr uint8_t MAX_RIPPLE_STEPS = 16;
+constexpr uint8_t COOLING = 55;
+constexpr uint8_t SPARKING = 120;
+constexpr float PI_F = 3.14159265f;
+
+struct RuntimeState {
+  std::array<Color, NUM_LEDS> leds{};
+  std::array<uint8_t, NUM_LEDS> heat{};
+  uint8_t rainbow_hue{0};
+  uint8_t g_hue{0};
+  uint16_t noise_dist{0};
+  std::array<Color, 4> current_palette{};
+  std::array<Color, 4> target_palette{};
+};
+
+inline RuntimeState &state() {
+  static RuntimeState instance{
+      {},
+      {},
+      0,
+      0,
+      0,
+      {Color(0, 0, 40), Color(0, 80, 120), Color(0, 160, 200), Color(0, 220, 255)},
+      {Color(0, 0, 40), Color(0, 80, 120), Color(0, 160, 200), Color(0, 220, 255)},
+  };
+  return instance;
+}
+
+inline uint32_t now_ms() { return millis(); }
+
+inline uint8_t random_u8() { return static_cast<uint8_t>(random(256)); }
+
+inline uint8_t random_u8(uint8_t max_value) { return max_value == 0 ? 0 : static_cast<uint8_t>(random(max_value)); }
+
+inline uint8_t random_u8(uint8_t min_value, uint8_t max_value) {
+  if (max_value <= min_value) {
+    return min_value;
+  }
+  return static_cast<uint8_t>(random(min_value, max_value));
+}
+
+inline uint16_t random_u16(uint16_t max_value) {
+  if (max_value == 0) {
+    return 0;
+  }
+  return static_cast<uint16_t>(random(max_value));
+}
+
+inline uint8_t clamp_u8(int value) {
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 255) {
+    return 255;
+  }
+  return static_cast<uint8_t>(value);
+}
+
+inline uint32_t clamp_interval(float speed, uint32_t slow_ms = 120, uint32_t fast_ms = 10) {
+  if (speed < 1.0f) {
+    speed = 1.0f;
+  } else if (speed > 150.0f) {
+    speed = 150.0f;
+  }
+  const float ratio = (speed - 1.0f) / 149.0f;
+  return static_cast<uint32_t>(slow_ms - ((slow_ms - fast_ms) * ratio));
+}
+
+inline bool due(uint32_t &last_update, uint32_t interval_ms) {
+  const auto now = now_ms();
+  if (last_update == 0 || (now - last_update) >= interval_ms) {
+    last_update = now;
+    return true;
+  }
+  return false;
+}
+
+inline Color blend(const Color &a, const Color &b, uint8_t amount) {
+  const auto inv = static_cast<uint8_t>(255 - amount);
+  return Color(
+      static_cast<uint8_t>((a.r * inv + b.r * amount) / 255),
+      static_cast<uint8_t>((a.g * inv + b.g * amount) / 255),
+      static_cast<uint8_t>((a.b * inv + b.b * amount) / 255));
+}
+
+inline void add_inplace(Color &base, const Color &added) {
+  base.r = clamp_u8(base.r + added.r);
+  base.g = clamp_u8(base.g + added.g);
+  base.b = clamp_u8(base.b + added.b);
+}
+
+inline Color scale_color(const Color &color, uint8_t scale) {
+  return Color(
+      static_cast<uint8_t>((color.r * scale) / 255),
+      static_cast<uint8_t>((color.g * scale) / 255),
+      static_cast<uint8_t>((color.b * scale) / 255));
+}
+
+inline Color hsv_to_rgb(uint8_t h, uint8_t s, uint8_t v) {
+  if (s == 0) {
+    return Color(v, v, v);
+  }
+
+  const uint8_t region = h / 43;
+  const uint8_t remainder = (h - (region * 43)) * 6;
+
+  const uint8_t p = (v * (255 - s)) >> 8;
+  const uint8_t q = (v * (255 - ((s * remainder) >> 8))) >> 8;
+  const uint8_t t = (v * (255 - ((s * (255 - remainder)) >> 8))) >> 8;
+
+  switch (region) {
+    case 0:
+      return Color(v, t, p);
+    case 1:
+      return Color(q, v, p);
+    case 2:
+      return Color(p, v, t);
+    case 3:
+      return Color(p, q, v);
+    case 4:
+      return Color(t, p, v);
+    default:
+      return Color(v, p, q);
+  }
+}
+
+inline uint8_t sin8_from_phase(float phase) {
+  return static_cast<uint8_t>(((std::sin(phase) + 1.0f) * 0.5f) * 255.0f);
+}
+
+inline uint8_t beatsin8(uint8_t bpm, uint8_t low, uint8_t high, float offset = 0.0f) {
+  const float phase = ((now_ms() / 1000.0f) * bpm / 60.0f * 2.0f * PI_F) + offset;
+  const float wave = (std::sin(phase) + 1.0f) * 0.5f;
+  return static_cast<uint8_t>(low + wave * (high - low));
+}
+
+inline uint16_t beatsin16(uint8_t bpm, uint16_t low, uint16_t high, float offset = 0.0f) {
+  const float phase = ((now_ms() / 1000.0f) * bpm / 60.0f * 2.0f * PI_F) + offset;
+  const float wave = (std::sin(phase) + 1.0f) * 0.5f;
+  return static_cast<uint16_t>(low + wave * (high - low));
+}
+
+inline float pseudo_noise(uint16_t x, uint16_t y) {
+  const float xf = static_cast<float>(x) * 0.11f;
+  const float yf = static_cast<float>(y) * 0.015f;
+  const float n =
+      std::sin(xf + yf) +
+      std::sin((xf * 0.31f) - (yf * 1.77f)) +
+      std::sin((xf * 1.13f) + (yf * 0.53f));
+  return (n + 3.0f) / 6.0f;
+}
+
+inline Color palette_color(const std::array<Color, 4> &palette, uint8_t index) {
+  const uint8_t segment = index / 64;
+  const uint8_t amount = (index % 64) * 4;
+  const auto &a = palette[segment];
+  const auto &b = palette[(segment + 1) % palette.size()];
+  return blend(a, b, amount);
+}
+
+inline const std::array<Color, 4> &candy_cane_palette() {
+  static const std::array<Color, 4> palette{
+      Color(255, 0, 0), Color(255, 0, 0), Color(255, 255, 255), Color(255, 255, 255)};
+  return palette;
+}
+
+inline const std::array<Color, 4> &christmas_palette() {
+  static const std::array<Color, 4> palette{
+      Color(255, 0, 0), Color(255, 0, 0), Color(0, 255, 0), Color(0, 255, 0)};
+  return palette;
+}
+
+inline const std::array<Color, 4> &party_palette() {
+  static const std::array<Color, 4> palette{
+      Color(140, 0, 255), Color(0, 96, 255), Color(0, 255, 220), Color(255, 0, 128)};
+  return palette;
+}
+
+inline Color heat_color(uint8_t heat) {
+  if (heat <= 85) {
+    return blend(Color(0, 0, 0), Color(255, 0, 0), heat * 3);
+  }
+  if (heat <= 170) {
+    return blend(Color(255, 0, 0), Color(255, 160, 0), (heat - 85) * 3);
+  }
+  return blend(Color(255, 160, 0), Color(255, 255, 255), (heat - 170) * 3);
+}
+
+inline void copy_to_output(AddressableLight &it) {
+  auto &rt = state();
+  for (uint16_t i = 0; i < NUM_LEDS; i++) {
+    it[i] = rt.leds[i];
+  }
+}
+
+inline void fill_all(const Color &color) {
+  state().leds.fill(color);
+}
+
+inline void clear_leds() { fill_all(Color(0, 0, 0)); }
+
+inline void fade_to_black(uint8_t amount) {
+  const uint8_t scale = 255 - amount;
+  for (auto &led : state().leds) {
+    led = scale_color(led, scale);
+  }
+}
+
+inline void nscale8(uint8_t scale) {
+  for (auto &led : state().leds) {
+    led = scale_color(led, scale);
+  }
+}
+
+inline void add_glitter(uint8_t chance, const Color &color) {
+  if (random_u8() < chance) {
+    add_inplace(state().leds[random_u16(NUM_LEDS)], color);
+  }
+}
+
+inline void fill_rainbow(uint8_t start_hue, uint8_t delta_hue) {
+  auto &rt = state();
+  uint8_t hue = start_hue;
+  for (auto &led : rt.leds) {
+    led = hsv_to_rgb(hue, 255, 255);
+    hue += delta_hue;
+  }
+}
+
+inline void fill_palette_stripes(const std::array<Color, 4> &palette, uint8_t start_index) {
+  auto &rt = state();
+  for (uint16_t i = 0; i < NUM_LEDS; i++) {
+    const uint8_t pos = static_cast<uint8_t>((start_index + (i * 16)) & 0xFF);
+    rt.leds[i] = palette_color(palette, pos);
+  }
+}
+
+inline void apply_solid(AddressableLight &it, const Color &current_color, bool initial_run) {
+  if (initial_run) {
+    clear_leds();
+  }
+  fill_all(current_color);
+  copy_to_output(it);
+}
+
+inline void apply_bpm(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  auto &rt = state();
+  if (initial_run) {
+    rt.g_hue = 0;
+  }
+  if (!due(last_update, clamp_interval(speed, 80, 12))) {
+    copy_to_output(it);
+    return;
+  }
+  const uint8_t beat = beatsin8(62, 64, 255);
+  const auto &palette = party_palette();
+  for (uint16_t i = 0; i < NUM_LEDS; i++) {
+    const uint8_t index = static_cast<uint8_t>(rt.g_hue + (i * 2));
+    const uint8_t brightness = static_cast<uint8_t>(beat - rt.g_hue + (i * 10));
+    rt.leds[i] = scale_color(palette_color(palette, index), brightness);
+  }
+  rt.g_hue++;
+  copy_to_output(it);
+}
+
+inline void apply_candy_cane(AddressableLight &it, float speed, const std::array<Color, 4> &palette, bool initial_run) {
+  static uint8_t start_index = 0;
+  static uint32_t last_update = 0;
+  if (initial_run) {
+    start_index = 0;
+  }
+  if (!due(last_update, clamp_interval(speed, 100, 16))) {
+    copy_to_output(it);
+    return;
+  }
+  fill_palette_stripes(palette, start_index);
+  start_index++;
+  copy_to_output(it);
+}
+
+inline void apply_confetti(AddressableLight &it, const Color &current_color, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  auto &rt = state();
+  if (initial_run) {
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 100, 12))) {
+    copy_to_output(it);
+    return;
+  }
+  fade_to_black(25);
+  auto burst = current_color;
+  burst.r = clamp_u8(burst.r + random_u8(64));
+  add_inplace(rt.leds[random_u16(NUM_LEDS)], burst);
+  copy_to_output(it);
+}
+
+inline void apply_cyclon_rainbow(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  static uint16_t position = 0;
+  static int8_t direction = 1;
+  static uint8_t hue = 0;
+  auto &rt = state();
+  if (initial_run) {
+    position = 0;
+    direction = 1;
+    hue = 0;
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 80, 8))) {
+    copy_to_output(it);
+    return;
+  }
+  nscale8(250);
+  rt.leds[position] = hsv_to_rgb(hue++, 255, 255);
+  if (direction > 0) {
+    if (position >= (NUM_LEDS - 1)) {
+      direction = -1;
+      position = NUM_LEDS - 1;
+    } else {
+      position++;
+    }
+  } else if (position == 0) {
+    direction = 1;
+  } else {
+    position--;
+  }
+  copy_to_output(it);
+}
+
+inline void apply_dots(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  auto &rt = state();
+  if (initial_run) {
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 70, 10))) {
+    copy_to_output(it);
+    return;
+  }
+  const uint16_t inner = beatsin16(30, NUM_LEDS / 4, (NUM_LEDS / 4) * 3);
+  const uint16_t outer = beatsin16(30, 0, NUM_LEDS - 1, 1.5f);
+  const uint16_t middle = beatsin16(30, NUM_LEDS / 3, (NUM_LEDS / 3) * 2, 3.0f);
+  rt.leds[middle] = Color(160, 0, 255);
+  rt.leds[inner] = Color(0, 80, 255);
+  rt.leds[outer] = Color(0, 220, 255);
+  nscale8(224);
+  copy_to_output(it);
+}
+
+inline void apply_fire(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  auto &rt = state();
+  if (initial_run) {
+    rt.heat.fill(0);
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 90, 16))) {
+    copy_to_output(it);
+    return;
+  }
+  for (uint16_t i = 0; i < NUM_LEDS; i++) {
+    const uint8_t cooldown = random_u8(0, ((COOLING * 10) / NUM_LEDS) + 2);
+    rt.heat[i] = rt.heat[i] > cooldown ? rt.heat[i] - cooldown : 0;
+  }
+  for (int k = NUM_LEDS - 1; k >= 2; k--) {
+    rt.heat[k] = static_cast<uint8_t>((rt.heat[k - 1] + rt.heat[k - 2] + rt.heat[k - 2]) / 3);
+  }
+  if (random_u8() < SPARKING) {
+    const uint8_t y = random_u8(7);
+    rt.heat[y] = clamp_u8(rt.heat[y] + random_u8(160, 255));
+  }
+  for (uint16_t j = 0; j < NUM_LEDS; j++) {
+    rt.leds[j] = heat_color(rt.heat[j]);
+  }
+  copy_to_output(it);
+}
+
+inline void apply_glitter(AddressableLight &it, const Color &current_color, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  if (initial_run) {
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 90, 12))) {
+    copy_to_output(it);
+    return;
+  }
+  fade_to_black(20);
+  add_glitter(80, current_color);
+  copy_to_output(it);
+}
+
+inline void apply_juggle(AddressableLight &it, const Color &current_color, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  auto &rt = state();
+  if (initial_run) {
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 90, 12))) {
+    copy_to_output(it);
+    return;
+  }
+  fade_to_black(20);
+  for (int i = 0; i < 8; i++) {
+    add_inplace(rt.leds[beatsin16(i + 7, 0, NUM_LEDS - 1, i)], current_color);
+  }
+  copy_to_output(it);
+}
+
+inline void apply_lightning(AddressableLight &it, float speed, bool initial_run) {
+  static bool active = false;
+  static uint8_t flashes_remaining = 0;
+  static uint8_t flash_index = 0;
+  static bool segment_on = false;
+  static uint32_t next_step_ms = 0;
+  static uint32_t next_strike_ms = 0;
+  static uint16_t led_start = 0;
+  static uint16_t led_len = 1;
+  auto &rt = state();
+  const auto now = now_ms();
+
+  if (initial_run) {
+    active = false;
+    flashes_remaining = 0;
+    flash_index = 0;
+    segment_on = false;
+    next_step_ms = 0;
+    next_strike_ms = now + 1000;
+    clear_leds();
+  }
+
+  if (!active && now >= next_strike_ms) {
+    active = true;
+    flashes_remaining = random_u8(3, 8);
+    flash_index = 0;
+    segment_on = true;
+    led_start = random_u16(NUM_LEDS);
+    const uint16_t remaining = NUM_LEDS - led_start;
+    led_len = remaining <= 1 ? 1 : static_cast<uint16_t>(1 + random_u16(remaining));
+    next_step_ms = now;
+  }
+
+  if (active && now >= next_step_ms) {
+    if (segment_on) {
+      const uint8_t dimmer = flash_index == 0 ? 5 : random_u8(1, 3);
+      clear_leds();
+      const Color flash_color(255 / dimmer, 255 / dimmer, 255 / dimmer);
+      for (uint16_t i = led_start; i < led_start + led_len && i < NUM_LEDS; i++) {
+        rt.leds[i] = flash_color;
+      }
+      segment_on = false;
+      next_step_ms = now + random_u8(4, 10);
+    } else {
+      clear_leds();
+      flash_index++;
+      if (flash_index >= flashes_remaining) {
+        active = false;
+        next_strike_ms = now + ((50U + random_u8(static_cast<uint8_t>(clamp_interval(speed, 180, 20)))) * 40U);
+      } else {
+        segment_on = true;
+        next_step_ms = now + (flash_index == 1 ? 130U : (50U + random_u8(100)));
+      }
+    }
+  }
+
+  copy_to_output(it);
+}
+
+inline void apply_noise(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  static uint32_t last_palette_refresh = 0;
+  auto &rt = state();
+  if (initial_run) {
+    rt.noise_dist = 0;
+    rt.current_palette = {Color(0, 0, 40), Color(0, 80, 120), Color(0, 160, 200), Color(0, 220, 255)};
+    rt.target_palette = rt.current_palette;
+    clear_leds();
+    last_palette_refresh = 0;
+  }
+  if (!due(last_update, clamp_interval(speed, 90, 10))) {
+    copy_to_output(it);
+    return;
+  }
+  if (last_palette_refresh == 0 || (now_ms() - last_palette_refresh) >= 5000) {
+    rt.target_palette = std::array<Color, 4>{
+        hsv_to_rgb(random_u8(), 255, random_u8(128, 255)),
+        hsv_to_rgb(random_u8(), 255, random_u8(128, 255)),
+        hsv_to_rgb(random_u8(), 192, random_u8(128, 255)),
+        hsv_to_rgb(random_u8(), 255, random_u8(128, 255)),
+    };
+    last_palette_refresh = now_ms();
+  }
+  for (size_t i = 0; i < rt.current_palette.size(); i++) {
+    rt.current_palette[i] = blend(rt.current_palette[i], rt.target_palette[i], 24);
+  }
+  for (uint16_t i = 0; i < NUM_LEDS; i++) {
+    const auto index = static_cast<uint8_t>(pseudo_noise(i * 30, rt.noise_dist + i * 30) * 255.0f);
+    rt.leds[i] = palette_color(rt.current_palette, index);
+  }
+  rt.noise_dist += 1 + (beatsin8(10, 1, 4) / 64);
+  copy_to_output(it);
+}
+
+inline void apply_police_all(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  static uint16_t index = 0;
+  auto &rt = state();
+  if (initial_run) {
+    index = 0;
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 80, 10))) {
+    copy_to_output(it);
+    return;
+  }
+  const uint16_t top_index = NUM_LEDS / 2;
+  const uint16_t other = index >= top_index ? (index + top_index) % NUM_LEDS : index + top_index;
+  rt.leds[index] = Color(255, 0, 0);
+  rt.leds[other] = Color(0, 0, 255);
+  index = (index + 1) % NUM_LEDS;
+  copy_to_output(it);
+}
+
+inline void apply_police_one(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  static uint16_t index = 0;
+  auto &rt = state();
+  if (initial_run) {
+    index = 0;
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 80, 10))) {
+    copy_to_output(it);
+    return;
+  }
+  clear_leds();
+  const uint16_t top_index = NUM_LEDS / 2;
+  const uint16_t other = index >= top_index ? (index + top_index) % NUM_LEDS : index + top_index;
+  rt.leds[index] = Color(255, 0, 0);
+  rt.leds[other] = Color(0, 0, 255);
+  index = (index + 1) % NUM_LEDS;
+  copy_to_output(it);
+}
+
+inline void apply_rainbow(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  auto &rt = state();
+  if (initial_run) {
+    rt.rainbow_hue = 0;
+  }
+  if (!due(last_update, clamp_interval(speed, 90, 12))) {
+    copy_to_output(it);
+    return;
+  }
+  fill_rainbow(rt.rainbow_hue++, 10);
+  copy_to_output(it);
+}
+
+inline void apply_rainbow_with_glitter(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  auto &rt = state();
+  if (initial_run) {
+    rt.rainbow_hue = 0;
+  }
+  if (!due(last_update, clamp_interval(speed, 90, 12))) {
+    copy_to_output(it);
+    return;
+  }
+  fill_rainbow(rt.rainbow_hue++, 10);
+  add_glitter(80, Color(255, 255, 255));
+  copy_to_output(it);
+}
+
+inline void apply_ripple(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  static int step = -1;
+  static uint16_t center = 0;
+  static uint8_t colour = 0;
+  static uint8_t bgcol = 0;
+  auto &rt = state();
+  if (initial_run) {
+    step = -1;
+    center = 0;
+    colour = 0;
+    bgcol = 0;
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 80, 10))) {
+    copy_to_output(it);
+    return;
+  }
+  for (uint16_t i = 0; i < NUM_LEDS; i++) {
+    rt.leds[i] = hsv_to_rgb(bgcol++, 255, 15);
+  }
+  switch (step) {
+    case -1:
+      center = random_u16(NUM_LEDS);
+      colour = random_u8();
+      step = 0;
+      break;
+    case 0:
+      rt.leds[center] = hsv_to_rgb(colour, 255, 255);
+      step++;
+      break;
+    case MAX_RIPPLE_STEPS:
+      step = -1;
+      break;
+    default: {
+      const auto ripple_color = hsv_to_rgb(colour, 255, static_cast<uint8_t>(255 / step * 2));
+      add_inplace(rt.leds[(center + step + NUM_LEDS) % NUM_LEDS], ripple_color);
+      add_inplace(rt.leds[(center - step + NUM_LEDS) % NUM_LEDS], ripple_color);
+      step++;
+      break;
+    }
+  }
+  copy_to_output(it);
+}
+
+inline void apply_sinelon(AddressableLight &it, const Color &current_color, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  auto &rt = state();
+  if (initial_run) {
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 80, 12))) {
+    copy_to_output(it);
+    return;
+  }
+  fade_to_black(20);
+  const auto pos = beatsin16(13, 0, NUM_LEDS - 1);
+  add_inplace(rt.leds[pos], current_color);
+  copy_to_output(it);
+}
+
+inline void apply_twinkle(AddressableLight &it, float speed, bool initial_run) {
+  static uint32_t last_update = 0;
+  auto &rt = state();
+  const Color light_color(8, 7, 1);
+  if (initial_run) {
+    clear_leds();
+  }
+  if (!due(last_update, clamp_interval(speed, 80, 10))) {
+    copy_to_output(it);
+    return;
+  }
+  for (auto &led : rt.leds) {
+    if (led.r == 0 && led.g == 0 && led.b == 0) {
+      continue;
+    }
+    if (led.r & 1) {
+      led.r = led.r > light_color.r ? led.r - light_color.r : 0;
+      led.g = led.g > light_color.g ? led.g - light_color.g : 0;
+      led.b = led.b > light_color.b ? led.b - light_color.b : 0;
+    } else {
+      add_inplace(led, light_color);
+    }
+  }
+  if (random_u8() < DENSITY) {
+    const auto j = random_u16(NUM_LEDS);
+    if (rt.leds[j].r == 0 && rt.leds[j].g == 0 && rt.leds[j].b == 0) {
+      rt.leds[j] = light_color;
+    }
+  }
+  copy_to_output(it);
+}
+
+}  // namespace tikiroom

--- a/lovelace/tiles/tiles_other.yaml
+++ b/lovelace/tiles/tiles_other.yaml
@@ -27,6 +27,17 @@ cards:
         tap_action:
           action: toggle
 
+  - type: entities
+    title: Tiki Room
+    show_header_toggle: false
+    entities:
+      - entity: light.tiki_room_strip
+        name: Strip
+      - entity: select.tiki_room_strip_effect
+        name: Effect
+      - entity: number.tiki_room_strip_animation_speed
+        name: Animation Speed
+
   - type: custom:mini-media-player
     entity: media_player.bedroom_sonos_2
     name: Music

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1884,18 +1884,6 @@ automation:
                 data:
                   entity_id: input_boolean.office_auto_on
 
-  - alias: "Tiki Room Animation Speed"
-    id: tiki_room_animation_speed
-    initial_state: True
-    trigger:
-      - trigger: state
-        entity_id: input_number.tikiroom_ani_speed
-    action:
-      - action: mqtt.publish
-        data:
-          topic: "leds/tikiroom/set"
-          payload: '{"transition":{{ trigger.to_state.state | int }}}'
-
 ########################
 # Binary Sensors
 ########################
@@ -1920,16 +1908,6 @@ input_boolean:
   basement_auto_on:
   office_auto_on:
   owner_suite_bedroom_auto_on:
-########################
-# Input Numbers
-########################
-input_number:
-  tikiroom_ani_speed:
-    name: Tiki Room Animation Speed
-    initial: 150
-    min: 1
-    max: 150
-    step: 10
 ########################
 # Light
 ########################
@@ -1988,47 +1966,6 @@ light:
   #   rgb: true
   #   optimistic: false
   #   qos: 0
-
-########################
-# MQTT
-########################
-mqtt:
-  light:
-    - name: "Tiki Room Strip"
-      unique_id: tiki_room_strip
-      schema: json
-      state_topic: "leds/tikiroom"
-      command_topic: "leds/tikiroom/set"
-      # command_off_template: '{"state": "OFF"}'
-      # command_on_template: '{"state": "ON"}'
-      # effect: true
-      brightness: true
-      effect: true
-      effect_list:
-        - bpm
-        - candy cane
-        - confetti
-        - cyclon rainbow
-        - dots
-        - fire
-        - glitter
-        - juggle
-        - lightning
-        - noise
-        - police all
-        - police one
-        - rainbow
-        - rainbow with glitter
-        - ripple
-        - sinelon
-        - solid
-        - twinkle
-      #brightness: true
-      #flash: true
-      # color_mode: true
-      supported_color_modes: ["rgb", "color_temp"]
-      optimistic: false
-      qos: 0
 
 ########################
 # Scenes
@@ -2139,6 +2076,215 @@ script:
           entity_id: scene.scene_reset_basement
         data:
           transition: 15
+
+  tiki_room_solid:
+    alias: "Tiki Room Solid"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: solid
+
+  tiki_room_bpm:
+    alias: "Tiki Room BPM"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: bpm
+
+  tiki_room_candy_cane:
+    alias: "Tiki Room Candy Cane"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: candy cane
+
+  tiki_room_christmas:
+    alias: "Tiki Room Christmas"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: christmas
+
+  tiki_room_confetti:
+    alias: "Tiki Room Confetti"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: confetti
+
+  tiki_room_cyclon_rainbow:
+    alias: "Tiki Room Cyclon Rainbow"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: cyclon rainbow
+
+  tiki_room_dots:
+    alias: "Tiki Room Dots"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: dots
+
+  tiki_room_fire:
+    alias: "Tiki Room Fire"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: fire
+
+  tiki_room_glitter:
+    alias: "Tiki Room Glitter"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: glitter
+
+  tiki_room_juggle:
+    alias: "Tiki Room Juggle"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: juggle
+
+  tiki_room_lightning:
+    alias: "Tiki Room Lightning"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: lightning
+
+  tiki_room_noise:
+    alias: "Tiki Room Noise"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: noise
+
+  tiki_room_police_all:
+    alias: "Tiki Room Police All"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: police all
+
+  tiki_room_police_one:
+    alias: "Tiki Room Police One"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: police one
+
+  tiki_room_rainbow:
+    alias: "Tiki Room Rainbow"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: rainbow
+
+  tiki_room_rainbow_with_glitter:
+    alias: "Tiki Room Rainbow With Glitter"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: rainbow with glitter
+
+  tiki_room_ripple:
+    alias: "Tiki Room Ripple"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: ripple
+
+  tiki_room_sinelon:
+    alias: "Tiki Room Sinelon"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: sinelon
+
+  tiki_room_twinkle:
+    alias: "Tiki Room Twinkle"
+    icon: mdi:led-strip-variant
+    mode: single
+    sequence:
+      - action: light.turn_on
+        target:
+          entity_id: light.tiki_room_strip
+        data:
+          effect: twinkle
 
   lights_off_except:
     icon: mdi:home-lightbulb


### PR DESCRIPTION
## Summary
- migrate the Tiki Room strip from the custom MQTT/FastLED sketch to a native ESPHome node while keeping the existing GPIO14 data pin
- port the non-native strip effects into custom `addressable_lambda` implementations and expose both effect selection and animation speed as native Home Assistant entities
- replace the old MQTT wrapper with native Home Assistant controls, add a Lovelace card for the strip, and add Siri-friendly script shims for effect-by-name activation

## Testing
- `ruby -e 'require "yaml"; YAML.load_file("packages/light.yaml"); puts "packages/light.yaml ok"'`
- `ruby -e 'require "yaml"; YAML.load_file("lovelace/tiles/tiles_other.yaml"); puts "lovelace/tiles/tiles_other.yaml ok"'`
- `uvx esphome compile <temp tikiroom.yaml with stub secrets>`
