### PR TITLE
Fix office false vacancy handling

### DIFF
--- a/docs/room_confidence_occupancy.md
+++ b/docs/room_confidence_occupancy.md
@@ -47,6 +47,12 @@ That mismatch penalty is intentional. It prevents stale motion/occupancy
 booleans from winning outright when both Bermuda devices agree that Ryan is in
 another room.
 
+For the office specifically, that disagreement penalty is suppressed once two
+local office signals agree (`binary_sensor.office_occupancy_2`,
+`binary_sensor.office_motion_occupancy`, or `binary_sensor.ryan_office_presence`).
+That keeps a bad phone/watch room hint from forcing a false vacancy while the
+office sensors still corroborate each other.
+
 That also means a watch left on a charger or nightstand should not keep a room
 in the `likely` band by itself.
 
@@ -62,10 +68,13 @@ Binary sensors such as `binary_sensor.office_confident_occupancy` switch on at
 
 ## Downstream Usage
 
-`automation.office_lights_morning_on_vacancy_off` now keys off
-`binary_sensor.office_confident_occupancy` instead of raw office occupancy
-signals. That lets Bermuda disagreement suppress obvious false positives while
-still allowing BLE-only and motion-only occupancy to count.
+`automation.office_lights_morning_on_vacancy_off` uses
+`binary_sensor.office_confident_occupancy` to decide when morning auto-on is
+allowed, but the vacancy-off path now also requires
+`binary_sensor.office_occupancy_2` and `binary_sensor.office_motion_occupancy`
+to be clear. That keeps the confidence model useful for avoiding false auto-on
+events without letting a stale Bermuda room hint shut the lights off while the
+office sensors still see occupancy.
 
 ## Manual Validation
 
@@ -82,6 +91,9 @@ still allowing BLE-only and motion-only occupancy to count.
    to `0`.
 6. Signal loss: mark one Bermuda room sensor unavailable and confirm the score
    drops but does not collapse to `0` when another positive signal remains.
+7. Office false-vacancy guard: leave the office occupancy sensors on while BLE
+   room hints disagree, then confirm the office light auto-off path does not
+   fire until both office occupancy sensors are also clear.
 
 ## Notification Guidance
 

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1814,7 +1814,7 @@ automation:
 
   - id: office_lights_morning_on_vacancy_off
     alias: office_lights_morning_on_vacancy_off
-    description: Turn office lights on with morning occupancy (when not in guest/trip mode), then turn them off after vacancy if auto-on was used.
+    description: Turn office lights on with morning occupancy (when not in guest/trip mode), then turn them off only after the confidence model and local office sensors all show vacancy.
     mode: restart
     trigger:
       - trigger: state
@@ -1826,7 +1826,19 @@ automation:
         to: "off"
         for:
           minutes: 10
-        id: office-unoccupied
+        id: office-unoccupied-confidence
+      - trigger: state
+        entity_id: binary_sensor.office_occupancy_2
+        to: "off"
+        for:
+          minutes: 10
+        id: office-unoccupied-mmwave
+      - trigger: state
+        entity_id: binary_sensor.office_motion_occupancy
+        to: "off"
+        for:
+          minutes: 10
+        id: office-unoccupied-motion
     action:
       - choose:
           # Morning auto-on path.
@@ -1857,7 +1869,10 @@ automation:
           # Auto-off path: only lights that this automation turned on.
           - conditions:
               - condition: trigger
-                id: office-unoccupied
+                id:
+                  - office-unoccupied-confidence
+                  - office-unoccupied-mmwave
+                  - office-unoccupied-motion
               - condition: state
                 entity_id: input_boolean.office_auto_on
                 state: "on"
@@ -1867,6 +1882,12 @@ automation:
                 state: "off"
               - condition: state
                 entity_id: binary_sensor.office_confident_occupancy
+                state: "off"
+              - condition: state
+                entity_id: binary_sensor.office_occupancy_2
+                state: "off"
+              - condition: state
+                entity_id: binary_sensor.office_motion_occupancy
                 state: "off"
             sequence:
               - action: light.turn_off

--- a/packages/room_confidence.yaml
+++ b/packages/room_confidence.yaml
@@ -135,27 +135,31 @@ template:
           {% set unknown_states = ['unknown', 'unavailable', 'none', ''] %}
           {% set phone_area = states('sensor.iphone_17_pro_area') | lower %}
           {% set watch_area = states('sensor.apple_watch_ultra_2_area') | lower %}
+          {% set local_signal_count = namespace(value=0) %}
           {% set score = namespace(value=0) %}
           {% if not home_present %}
             0
           {% else %}
             {% if is_state('binary_sensor.office_occupancy_2', 'on') %}
+              {% set local_signal_count.value = local_signal_count.value + 1 %}
               {% set score.value = score.value + 55 %}
             {% endif %}
             {% if is_state('binary_sensor.office_motion_occupancy', 'on') %}
+              {% set local_signal_count.value = local_signal_count.value + 1 %}
               {% set score.value = score.value + 20 %}
             {% endif %}
             {% if is_state('binary_sensor.ryan_office_presence', 'on') %}
+              {% set local_signal_count.value = local_signal_count.value + 1 %}
               {% set score.value = score.value + 30 %}
             {% endif %}
             {% if phone_area == 'office' %}
               {% set score.value = score.value + 45 %}
-            {% elif phone_area not in unknown_states %}
+            {% elif phone_area not in unknown_states and local_signal_count.value < 2 %}
               {% set score.value = score.value - 25 %}
             {% endif %}
             {% if watch_area == 'office' %}
               {% set score.value = score.value + 10 %}
-            {% elif watch_area not in unknown_states %}
+            {% elif watch_area not in unknown_states and local_signal_count.value < 2 %}
               {% set score.value = score.value - 5 %}
             {% endif %}
             {% if phone_area == 'office' and watch_area == 'office' %}
@@ -174,6 +178,18 @@ template:
           phone_area: "{{ states('sensor.iphone_17_pro_area') }}"
           watch_area: "{{ states('sensor.apple_watch_ultra_2_area') }}"
           office_proxy_presence: "{{ states('binary_sensor.ryan_office_presence') }}"
+          local_signal_count: >-
+            {% set count = 0 %}
+            {% if is_state('binary_sensor.office_occupancy_2', 'on') %}
+              {% set count = count + 1 %}
+            {% endif %}
+            {% if is_state('binary_sensor.office_motion_occupancy', 'on') %}
+              {% set count = count + 1 %}
+            {% endif %}
+            {% if is_state('binary_sensor.ryan_office_presence', 'on') %}
+              {% set count = count + 1 %}
+            {% endif %}
+            {{ count }}
 
       - name: den_room_confidence
         unique_id: den_room_confidence


### PR DESCRIPTION
## Summary
- require all office vacancy signals to be clear before the office morning auto-off path runs
- keep office room confidence from dropping on stale Bermuda room hints when two local office signals corroborate occupancy
- document the office false-vacancy guard and validation path

## Validation
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- Home Assistant `check_config` via the connected HA instance (`ha_check_config`), because Docker is not installed in this workspace and the repo CI uses Docker for the same validation step

## Coverage
- N/A: this repository is Home Assistant YAML/configuration, and it does not have a code-coverage harness

## Test Cases
1. With `binary_sensor.office_occupancy_2` and `binary_sensor.office_motion_occupancy` both `on`, and Bermuda room hints stale or wrong, `sensor.office_room_confidence` stays at or above the confident threshold instead of collapsing below `50`.
2. The office morning auto-off path does not turn `light.office_all` off unless `binary_sensor.office_confident_occupancy`, `binary_sensor.office_occupancy_2`, and `binary_sensor.office_motion_occupancy` have all been clear for 10 minutes.
3. The office morning auto-on behavior still works once local office occupancy drives `binary_sensor.office_confident_occupancy` back on.
