### PR TITLE
Fix Apple TV media card source overflow

### DIFF
--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -1080,6 +1080,9 @@
                   "type": "custom:mini-media-player",
                   "entity": "media_player.lg_webos_smart_tv",
                   "name": "TV",
+                  "hide": {
+                    "source": true
+                  },
                   "artwork": "material",
                   "idle_view": {
                     "when_idle": true,
@@ -1722,6 +1725,9 @@
                   "type": "custom:mini-media-player",
                   "entity": "media_player.lg_webos_smart_tv",
                   "toggle_power": true,
+                  "hide": {
+                    "source": true
+                  },
                   "artwork": "material",
                   "idle_view": {
                     "when_idle": true

--- a/lovelace/tiles/tiles_living_room.yaml
+++ b/lovelace/tiles/tiles_living_room.yaml
@@ -98,3 +98,5 @@ cards:
       volume: true
   - type: custom:mini-media-player
     entity: media_player.lg_webos_smart_tv
+    hide:
+      source: true

--- a/lovelace/tiles/tiles_template.yaml
+++ b/lovelace/tiles/tiles_template.yaml
@@ -108,3 +108,5 @@ cards:
           volume: true
       - type: custom:mini-media-player
         entity: media_player.lg_webos_smart_tv
+        hide:
+          source: true


### PR DESCRIPTION
## Summary
- hide the inline `source` menu on the Apple TV `mini-media-player` cards in the active storage dashboard
- apply the same `source` suppression to the legacy living room tile configs for consistency
- keep the rest of the Apple TV card controls unchanged

## Validation
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `python3` JSON parse of `.storage/lovelace.ryan_new_mushroom`
- `yamllint` on `lovelace/tiles/tiles_living_room.yaml` and `lovelace/tiles/tiles_template.yaml`
- Docker-based Home Assistant `check_config` could not be run locally because `docker` is not installed in this environment

## Test Cases
- verify the Basement Apple TV card no longer renders the source/app list outside the card row
- verify the Dining Room Apple TV card no longer renders the source/app list outside the card row
- verify normal transport/power controls still render on the Apple TV cards

## Coverage
- no code coverage change; this is a dashboard configuration fix
