### PR TITLE
Add new smart-bulb Inovelli switch mappings

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -508,6 +508,34 @@ automation:
                   kelvin: >-
                     {{state_attr("light.dining_room","color_temp_kelvin")-200}}
 
+  - alias: dining_room_table_switch_actions
+    id: dining_room_table_switch_actions
+    trigger:
+      - trigger: state
+        entity_id: sensor.dining_room_table_switch_action
+        to: "up_double"
+        id: up-double
+      - trigger: state
+        entity_id: sensor.dining_room_table_switch_action
+        to: "down_double"
+        id: down-double
+    action:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: up-double
+            sequence:
+              - action: light.turn_on
+                data:
+                  entity_id: light.kitchen_all
+          - conditions:
+              - condition: trigger
+                id: down-double
+            sequence:
+              - action: light.turn_off
+                data:
+                  entity_id: light.kitchen_all
+
   - alias: side_of_bed_toggles
     id: side_of_bed_toggles
     mode: queued
@@ -1993,7 +2021,9 @@ script:
             - select.basement_north_hallway_switch_switchtype
             - select.basement_overhead_outlet_switchtype
             - select.deck_flood_lights_switchtype
+            - select.den_flood_switch_switchtype
             - select.dining_room_wall_switch_switchtype
+            - select.dining_room_table_switch_switchtype
             - select.garage_overhead_switch_switchtype
             - select.kitchen_bay_switch_switchtype
             - select.kitchen_sink_overhead_switch_switchtype
@@ -2101,10 +2131,40 @@ script:
       - delay: 10 # seconds
       - action: mqtt.publish
         data:
+          topic: zigbee2mqtt/bridge/request/group/members/add
+          payload: >-
+            {"group":"Dining Room/Over Table",
+              "device":"Dining Room/Table Switch",
+              "endpoint":2}
+      - delay: 10 # seconds
+      - action: mqtt.publish
+        data:
+          topic: zigbee2mqtt/bridge/request/device/bind
+          payload: >-
+            {"clusters":["genGroups","genLevelCtrl","genOnOff"],
+              "from":"Dining Room/Table Switch/2","to":"Dining Room/Over Table"}
+      - delay: 10 # seconds
+      - action: mqtt.publish
+        data:
           topic: zigbee2mqtt/bridge/request/device/bind
           payload: >-
             {"clusters":["genGroups","genLevelCtrl","genOnOff"],
               "from":"Dining Room/Overhead/2","to":"Dining Room/Over Table"}
+      - delay: 10 # seconds
+      - action: mqtt.publish
+        data:
+          topic: zigbee2mqtt/bridge/request/group/members/add
+          payload: >-
+            {"group":"Den/Floods",
+              "device":"Den/Flood Switch",
+              "endpoint":2}
+      - delay: 10 # seconds
+      - action: mqtt.publish
+        data:
+          topic: zigbee2mqtt/bridge/request/device/bind
+          payload: >-
+            {"clusters":["genGroups","genLevelCtrl","genOnOff"],
+              "from":"Den/Flood Switch/2","to":"Den/Floods"}
       - delay: 10 # seconds
       - action: mqtt.publish
         data:

--- a/zigbee2mqtt/configuration.yaml
+++ b/zigbee2mqtt/configuration.yaml
@@ -366,6 +366,10 @@ devices:
     friendly_name: Kitchen/Bay Switch
   '0xf044d3fffe6d977b':
     friendly_name: Kitchen/Switch
+  '0xf044d3fffe6d7e4e':
+    friendly_name: Den/Flood Switch
+  '0xf044d3fffe6d0785':
+    friendly_name: Dining Room/Table Switch
 groups:
   '1':
     friendly_name: Owner Suite/Lamps


### PR DESCRIPTION
## Summary
- add Den/Flood Switch and Dining Room/Table Switch to the checked-in Zigbee2MQTT device map
- reset both switches as smart-bulb dimmers with Single Pole switchtype and reapply their group membership/binds
- add Dining Room/Table Switch double-tap actions to turn the Kitchen/All light group on and off

## Validation
- python3 scripts/check_ha_python_support.py --python-version-file .python-version
- yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/zigbee_zwave.yaml zigbee2mqtt/configuration.yaml
- ruby -e 'require "yaml"; YAML.load_file("packages/zigbee_zwave.yaml"); YAML.load_file("zigbee2mqtt/configuration.yaml"); puts "yaml-ok"'
- git diff --check
- ha_check_config
