### PR TITLE
Add garage door actions to the hall/garage laundry switch

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -982,6 +982,34 @@ automation:
                 data:
                   entity_id: fan.guest_room
 
+  - alias: hall_garage_laundry_switch_actions
+    id: hall_garage_laundry_switch_actions
+    trigger:
+      - trigger: state
+        entity_id: sensor.hall_garage_laundry_switch_action
+        to: "up_double"
+        id: up-double
+      - trigger: state
+        entity_id: sensor.hall_garage_laundry_switch_action
+        to: "down_double"
+        id: down-double
+    action:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: up-double
+            sequence:
+              - action: cover.open_cover
+                target:
+                  entity_id: cover.garage_door
+          - conditions:
+              - condition: trigger
+                id: down-double
+            sequence:
+              - action: cover.close_cover
+                target:
+                  entity_id: cover.garage_door
+
   - alias: kitchen_overhead_switch_actions
     id: kitchen_overhead_switch_actions
     mode: restart

--- a/tests/test_zigbee_zwave_hall_garage_laundry_switch.py
+++ b/tests/test_zigbee_zwave_hall_garage_laundry_switch.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+
+ZIGBEE_ZWAVE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zigbee_zwave.yaml"
+
+
+def _automation_block(alias: str) -> str:
+    lines = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line == f"  - alias: {alias}":
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation alias {alias!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - alias: "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_hall_garage_laundry_switch_double_taps_control_garage_door() -> None:
+    block = _automation_block("hall_garage_laundry_switch_actions")
+
+    assert "id: hall_garage_laundry_switch_actions" in block
+    assert block.count("entity_id: sensor.hall_garage_laundry_switch_action") == 2
+    assert 'to: "up_double"' in block
+    assert 'to: "down_double"' in block
+    assert "id: up-double" in block
+    assert "id: down-double" in block
+    assert "- action: cover.open_cover" in block
+    assert "- action: cover.close_cover" in block
+    assert "entity_id: cover.garage_door" in block


### PR DESCRIPTION
## Summary
- add a Home Assistant automation for `sensor.hall_garage_laundry_switch_action`
- map `up_double` to `cover.open_cover` and `down_double` to `cover.close_cover` for `cover.garage_door`
- add a pytest regression test that verifies the trigger and service mapping in `packages/zigbee_zwave.yaml`

## Testing
- `python3 -m venv .venv-codex && .venv-codex/bin/python -m pip install --upgrade pip pytest yamllint`
- `.venv-codex/bin/python -m pytest`
- `.venv-codex/bin/python scripts/check_ha_python_support.py --python-version-file .python-version`
- `.venv-codex/bin/yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`

## Coverage
- Added regression coverage via `tests/test_zigbee_zwave_hall_garage_laundry_switch.py`
- Docker is not installed in this workspace, so Home Assistant `check_config` could not be run locally; CI will run that workflow step.