### PR TITLE
Fix owner suite blinds scene reference

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -133,7 +133,7 @@ influxdb:
 cloud:
   alexa:
     entity_config:
-      cover.owner_suite_blinds:
+      cover.owner_suite_blinds_ha:
         display_categories: INTERIOR_BLIND
       cover.owner_suite_north_blind:
         display_categories: INTERIOR_BLIND

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -2067,7 +2067,7 @@ scene:
       light.bed_lightstrip:
         state: "on"
         brightness_pct: 25
-      cover.owner_suite_blinds:
+      cover.owner_suite_blinds_ha:
         state: "closed"
       fan.owner_suite:
         state: "on"


### PR DESCRIPTION
## Summary
- update the bedroom prep scene to use the current grouped owner suite blinds entity
- align the Alexa entity config with the same grouped blinds entity

## Validation
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `/tmp/hass-pytest-venv/bin/python -m pytest -q`
- `/tmp/hass-ha-venv/bin/python -m homeassistant --config . --script check_config` (passed with existing environment/dependency warnings unrelated to this change)

## Notes
- Home Assistant live reload still appears to be using a different local checkout, so this PR fixes the canonical repo state but may still require deploy/update on the active host config path.