### PR TITLE
Fix garage door control to use the garage overhead switch

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -982,15 +982,15 @@ automation:
                 data:
                   entity_id: fan.guest_room
 
-  - alias: hall_garage_laundry_switch_actions
-    id: hall_garage_laundry_switch_actions
+  - alias: garage_overhead_switch_actions
+    id: garage_overhead_switch_actions
     trigger:
       - trigger: state
-        entity_id: sensor.hall_garage_laundry_switch_action
+        entity_id: sensor.garage_overhead_switch_action
         to: "up_double"
         id: up-double
       - trigger: state
-        entity_id: sensor.hall_garage_laundry_switch_action
+        entity_id: sensor.garage_overhead_switch_action
         to: "down_double"
         id: down-double
     action:

--- a/tests/test_zigbee_zwave_garage_overhead_switch.py
+++ b/tests/test_zigbee_zwave_garage_overhead_switch.py
@@ -25,11 +25,11 @@ def _automation_block(alias: str) -> str:
     return "\n".join(lines[start:end])
 
 
-def test_hall_garage_laundry_switch_double_taps_control_garage_door() -> None:
-    block = _automation_block("hall_garage_laundry_switch_actions")
+def test_garage_overhead_switch_double_taps_control_garage_door() -> None:
+    block = _automation_block("garage_overhead_switch_actions")
 
-    assert "id: hall_garage_laundry_switch_actions" in block
-    assert block.count("entity_id: sensor.hall_garage_laundry_switch_action") == 2
+    assert "id: garage_overhead_switch_actions" in block
+    assert block.count("entity_id: sensor.garage_overhead_switch_action") == 2
     assert 'to: "up_double"' in block
     assert 'to: "down_double"' in block
     assert "id: up-double" in block


### PR DESCRIPTION
## Summary
- correct the garage door double-tap automation to listen to `sensor.garage_overhead_switch_action`
- rename the automation from `hall_garage_laundry_switch_actions` to `garage_overhead_switch_actions`
- rename the regression test so it validates the correct switch entity
- supersedes the garage-door switch mapping introduced in #152

## Testing
- `python3 -m venv .venv-codex && .venv-codex/bin/python -m pip install --upgrade pip pytest yamllint`
- `.venv-codex/bin/python -m pytest`
- `.venv-codex/bin/python scripts/check_ha_python_support.py --python-version-file .python-version`
- `.venv-codex/bin/yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`

## Coverage
- Updated regression coverage in `tests/test_zigbee_zwave_garage_overhead_switch.py`
- Docker is not installed in this workspace, so Home Assistant `check_config` could not be run locally; CI will run that workflow step.