### PR TITLE
Refactor battery monitoring to auto-discover sensors

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -79,10 +79,10 @@ frontend:
 logbook:
   exclude:
     entities:
-      - automation.battery_sensor_from_attributes
-      - automation.update_battery_status_group_members
-      - automation.battery_persistent_notification
-      - automation.battery_persistent_notification_clear
+      - automation.notify_battery_dying_20
+      - automation.notify_battery_dying_10
+      - sensor.battery_low_20
+      - sensor.battery_low_10
 
 tts:
   - platform: google_translate

--- a/packages/batteries.yaml
+++ b/packages/batteries.yaml
@@ -1,5 +1,5 @@
 # Home Assistant package for low-battery monitoring.
-# It groups battery status helpers and staged notifications so sensor maintenance shows up consistently across the house.
+# It dynamically scans battery sensors, keeps an explicit exclusion list, and stages notifications consistently across the house.
 
 ################################################################
 ## Packages / Batteries
@@ -29,13 +29,13 @@ homeassistant:
     ################################################
     automation.notify_battery_dying_20:
       <<: *customize
-      friendly_name: "Notify Sensor Battery at 20%"
-      icon: mdi:battery-charging-wireless-20
+      friendly_name: "Notify Battery Sensors Below 20%"
+      icon: mdi:battery-alert
 
     automation.notify_battery_dying_10:
       <<: *customize
-      friendly_name: "Notify Sensor Battery at 10%"
-      icon: mdi:battery-charging-wireless-10
+      friendly_name: "Notify Battery Sensors Below 10%"
+      icon: mdi:battery-alert
 
     ################################################
     ## Binary Sensors
@@ -60,10 +60,111 @@ homeassistant:
     ################################################
     ## Sensors
     ################################################
+    sensor.battery_low_20:
+      <<: *customize
+      friendly_name: "Battery Sensors Below 20%"
+      icon: mdi:battery-20
+
+    sensor.battery_low_10:
+      <<: *customize
+      friendly_name: "Battery Sensors Below 10%"
+      icon: mdi:battery-10
 
     ################################################
     ## Thermostats
     ################################################
+
+################################################
+## Template
+################################################
+template:
+  - sensor:
+      - name: battery_low_20
+        unique_id: battery_low_20
+        default_entity_id: sensor.battery_low_20
+        icon: mdi:battery-20
+        variables: &battery_monitor_exclusions
+          # Exact entity_ids that should never appear in the low-battery monitor.
+          # Leave this list empty for the default include-all behavior.
+          battery_exclude_entities: []
+        state: >-
+          {% set monitored_batteries = states.sensor
+            | selectattr('attributes.device_class', 'eq', 'battery')
+            | rejectattr('entity_id', 'in', battery_exclude_entities)
+            | sort(attribute='entity_id')
+            | list %}
+          {% set ns = namespace(low_count=0) %}
+          {% for battery in monitored_batteries %}
+            {% set value = battery.state | float(9999) %}
+            {% if value < 20 %}
+              {% set ns.low_count = ns.low_count + 1 %}
+            {% endif %}
+          {% endfor %}
+          {{ ns.low_count }}
+        attributes:
+          tracked_count: >-
+            {% set monitored_batteries = states.sensor
+              | selectattr('attributes.device_class', 'eq', 'battery')
+              | rejectattr('entity_id', 'in', battery_exclude_entities)
+              | sort(attribute='entity_id')
+              | list %}
+            {{ monitored_batteries | count }}
+          summary: >-
+            {% set monitored_batteries = states.sensor
+              | selectattr('attributes.device_class', 'eq', 'battery')
+              | rejectattr('entity_id', 'in', battery_exclude_entities)
+              | sort(attribute='entity_id')
+              | list %}
+            {% set ns = namespace(lines=[]) %}
+            {% for battery in monitored_batteries %}
+              {% set value = battery.state | float(9999) %}
+              {% if value < 20 %}
+                {% set ns.lines = ns.lines + ['- ' ~ (battery.name | default(battery.entity_id, true)) ~ ': ' ~ battery.state ~ '%'] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.lines | join('\n') }}
+
+      - name: battery_low_10
+        unique_id: battery_low_10
+        default_entity_id: sensor.battery_low_10
+        icon: mdi:battery-10
+        variables: *battery_monitor_exclusions
+        state: >-
+          {% set monitored_batteries = states.sensor
+            | selectattr('attributes.device_class', 'eq', 'battery')
+            | rejectattr('entity_id', 'in', battery_exclude_entities)
+            | sort(attribute='entity_id')
+            | list %}
+          {% set ns = namespace(low_count=0) %}
+          {% for battery in monitored_batteries %}
+            {% set value = battery.state | float(9999) %}
+            {% if value < 10 %}
+              {% set ns.low_count = ns.low_count + 1 %}
+            {% endif %}
+          {% endfor %}
+          {{ ns.low_count }}
+        attributes:
+          tracked_count: >-
+            {% set monitored_batteries = states.sensor
+              | selectattr('attributes.device_class', 'eq', 'battery')
+              | rejectattr('entity_id', 'in', battery_exclude_entities)
+              | sort(attribute='entity_id')
+              | list %}
+            {{ monitored_batteries | count }}
+          summary: >-
+            {% set monitored_batteries = states.sensor
+              | selectattr('attributes.device_class', 'eq', 'battery')
+              | rejectattr('entity_id', 'in', battery_exclude_entities)
+              | sort(attribute='entity_id')
+              | list %}
+            {% set ns = namespace(lines=[]) %}
+            {% for battery in monitored_batteries %}
+              {% set value = battery.state | float(9999) %}
+              {% if value < 10 %}
+                {% set ns.lines = ns.lines + ['- ' ~ (battery.name | default(battery.entity_id, true)) ~ ': ' ~ battery.state ~ '%'] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.lines | join('\n') }}
 
 ################################################
 ## Automation
@@ -71,88 +172,95 @@ homeassistant:
 automation:
   - id: notify_battery_dying_20
     alias: notify_battery_dying_20
+    description: Keep the 20 percent battery notification current and send a push message when the situation gets worse.
+    mode: queued
+    max: 10
     trigger:
-      - trigger: numeric_state
-        entity_id:
-          - sensor.arrival_sensor_battery
-          - sensor.basement_door_battery
-          - sensor.bathroom_battery
-          - sensor.deck_door_battery
-          - sensor.downstairs_motion_battery
-          - sensor.ene_window_battery
-          - sensor.ese_window_battery
-          - sensor.front_door_battery
-          - sensor.guest_room_button_battery
-          - sensor.guest_room_battery
-          - sensor.kitchen_battery
-          - sensor.kitchen_button_battery
-          - sensor.living_room_battery
-          - sensor.living_room_button_battery
-          - sensor.master_bedroom_battery
-          - sensor.master_bedroom_motion_battery
-          - sensor.motion_sensor_battery
-          - sensor.north_kitchen_sink_window_battery
-          - sensor.north_master_bedroom_window_battery
-          - sensor.nne_window_battery
-          - sensor.nw_basement_window_battery
-          - sensor.office_button_battery
-          - sensor.office_motion_battery
-          - sensor.office_north_window_battery
-          - sensor.se_basement_window_battery
-          - sensor.sw_basement_window_battery
-        below: 20
-        above: 10
+      - trigger: state
+        entity_id: sensor.battery_low_20
+        attribute: summary
+    condition:
+      - condition: template
+        value_template: >-
+          {{ trigger.from_state is not none
+             and trigger.from_state.state not in ['unknown', 'unavailable']
+             and trigger.to_state.state not in ['unknown', 'unavailable'] }}
     action:
-      - action: persistent_notification.create
-        data:
-          title: Low Battery
-          message: "Battery {{  trigger.from_state.attributes.friendly_name }} is below 20%"
-          notification_id: low-battery-alert
-      - action: notify.all
-        data:
-          message: >-
-            Battery '{{ trigger.from_state.attributes.friendly_name }}' is below 20%.
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: >-
+                  {{ trigger.to_state.state | int(0) == 0 }}
+            sequence:
+              - action: persistent_notification.dismiss
+                data:
+                  notification_id: low-battery-20
+        default:
+          - action: persistent_notification.create
+            data:
+              title: >-
+                Battery Sensors Below 20% ({{ trigger.to_state.state | int(0) }})
+              message: >-
+                {{ trigger.to_state.attributes.summary }}
+              notification_id: low-battery-20
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: >-
+                      {{ trigger.to_state.state | int(0) > trigger.from_state.state | int(0) }}
+                sequence:
+                  - action: notify.all
+                    data:
+                      title: >-
+                        Battery Sensors Below 20% ({{ trigger.to_state.state | int(0) }})
+                      message: >-
+                        {{ trigger.to_state.attributes.summary }}
 
   - id: notify_battery_dying_10
     alias: notify_battery_dying_10
+    description: Keep the 10 percent battery notification current and send a push message when the situation gets worse.
+    mode: queued
+    max: 10
     trigger:
-      - trigger: numeric_state
-        entity_id:
-          - sensor.arrival_sensor_battery
-          - sensor.basement_door_battery
-          - sensor.bathroom_battery
-          - sensor.deck_door_battery
-          - sensor.downstairs_motion_battery
-          - sensor.ene_window_battery
-          - sensor.ese_window_battery
-          - sensor.front_door_battery
-          - sensor.guest_room_button_battery
-          - sensor.guest_room_battery
-          - sensor.kitchen_battery
-          - sensor.living_room_battery
-          - sensor.living_room_button_battery
-          - sensor.master_bedroom_battery
-          - sensor.master_bedroom_motion_battery
-          - sensor.motion_sensor_battery
-          - sensor.north_kitchen_sink_window_battery
-          - sensor.north_master_bedroom_window_battery
-          - sensor.nne_window_battery
-          - sensor.nw_basement_window_battery
-          - sensor.office_motion_battery
-          - sensor.office_north_window_battery
-          - sensor.se_basement_window_battery
-          - sensor.sw_basement_window_battery
-        below: 10
+      - trigger: state
+        entity_id: sensor.battery_low_10
+        attribute: summary
+    condition:
+      - condition: template
+        value_template: >-
+          {{ trigger.from_state is not none
+             and trigger.from_state.state not in ['unknown', 'unavailable']
+             and trigger.to_state.state not in ['unknown', 'unavailable'] }}
     action:
-      - action: persistent_notification.create
-        data:
-          title: Low Battery
-          message: "Battery {{  trigger.from_state.attributes.friendly_name }} is below 10%"
-          notification_id: low-battery-alert
-      - action: notify.all
-        data:
-          message: >-
-            Battery '{{ trigger.from_state.attributes.friendly_name }}' is below 10%.
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: >-
+                  {{ trigger.to_state.state | int(0) == 0 }}
+            sequence:
+              - action: persistent_notification.dismiss
+                data:
+                  notification_id: low-battery-10
+        default:
+          - action: persistent_notification.create
+            data:
+              title: >-
+                Battery Sensors Below 10% ({{ trigger.to_state.state | int(0) }})
+              message: >-
+                {{ trigger.to_state.attributes.summary }}
+              notification_id: low-battery-10
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: >-
+                      {{ trigger.to_state.state | int(0) > trigger.from_state.state | int(0) }}
+                sequence:
+                  - action: notify.all
+                    data:
+                      title: >-
+                        Battery Sensors Below 10% ({{ trigger.to_state.state | int(0) }})
+                      message: >-
+                        {{ trigger.to_state.attributes.summary }}
 
 ########################
 # Binary Sensors
@@ -174,34 +282,6 @@ input_number: {}
 ########################
 group:
   {}
-  # battery_status:
-  #   name: Battery Status
-  #   entities:
-  #     - sensor.arrival_sensor_battery
-  #     - sensor.basement_door_battery
-  #     - sensor.bathroom_battery
-  #     - sensor.deck_door_battery
-  #     - sensor.downstairs_motion_battery
-  #     - sensor.ene_window_battery
-  #     - sensor.ese_window_battery
-  #     - sensor.front_door_battery
-  #     - sensor.guest_room_button_battery
-  #     - sensor.guest_room_battery
-  #     - sensor.hallway_motion_battery
-  #     - sensor.kitchen_battery
-  #     - sensor.living_room_battery
-  #     - sensor.living_room_button_battery
-  #     - sensor.master_bedroom_battery
-  #     - sensor.master_bedroom_motion_battery
-  #     - sensor.motion_sensor_battery
-  #     - sensor.north_kitchen_sink_window_battery
-  #     - sensor.north_master_bedroom_window_battery
-  #     - sensor.nne_window_battery
-  #     - sensor.nw_basement_window_battery
-  #     - sensor.office_motion_battery
-  #     - sensor.office_north_window_battery
-  #     - sensor.se_basement_window_battery
-  #     - sensor.sw_basement_window_battery
 
 ########################
 # Scenes

--- a/tests/test_batteries_package.py
+++ b/tests/test_batteries_package.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BATTERIES_PATH = ROOT / "packages" / "batteries.yaml"
+CONFIG_PATH = ROOT / "configuration.yaml"
+
+
+def _sensor_block(sensor_name: str) -> str:
+    text = BATTERIES_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^      - name: {re.escape(sensor_name)}\n(.*?)(?=^      - name: |^automation:)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find template sensor block {sensor_name!r}")
+    return match.group(0)
+
+
+def _automation_block(automation_id: str) -> str:
+    text = BATTERIES_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^  - id: {re.escape(automation_id)}\n(.*?)(?=^  - id: |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+    return match.group(0)
+
+
+def test_battery_template_sensors_scan_all_battery_device_class_entities() -> None:
+    block_20 = _sensor_block("battery_low_20")
+    block_10 = _sensor_block("battery_low_10")
+
+    assert "battery_exclude_entities: []" in block_20
+    assert "variables: *battery_monitor_exclusions" in block_10
+
+    for block, threshold in ((block_20, "20"), (block_10, "10")):
+        assert f"default_entity_id: sensor.battery_low_{threshold}" in block
+        assert "selectattr('attributes.device_class', 'eq', 'battery')" in block
+        assert "rejectattr('entity_id', 'in', battery_exclude_entities)" in block
+        assert f"if value < {threshold}" in block
+        assert "tracked_count:" in block
+        assert "summary: >-" in block
+        assert "battery.state ~ '%'" in block
+
+
+def test_battery_automations_update_notifications_from_dynamic_sensor_summaries() -> None:
+    for automation_id, threshold in (
+        ("notify_battery_dying_20", "20"),
+        ("notify_battery_dying_10", "10"),
+    ):
+        block = _automation_block(automation_id)
+
+        assert "mode: queued" in block
+        assert "attribute: summary" in block
+        assert "persistent_notification.create" in block
+        assert "persistent_notification.dismiss" in block
+        assert "notify.all" in block
+        assert f"notification_id: low-battery-{threshold}" in block
+        assert f"Battery Sensors Below {threshold}%" in block
+        assert "trigger.from_state.state not in ['unknown', 'unavailable']" in block
+
+
+def test_logbook_excludes_current_battery_monitor_entities_instead_of_stale_ones() -> None:
+    text = CONFIG_PATH.read_text(encoding="utf-8")
+
+    for entity_id in (
+        "automation.notify_battery_dying_20",
+        "automation.notify_battery_dying_10",
+        "sensor.battery_low_20",
+        "sensor.battery_low_10",
+    ):
+        assert entity_id in text
+
+    for stale_entity_id in (
+        "automation.battery_sensor_from_attributes",
+        "automation.update_battery_status_group_members",
+        "automation.battery_persistent_notification",
+        "automation.battery_persistent_notification_clear",
+    ):
+        assert stale_entity_id not in text


### PR DESCRIPTION
Closes #169.

Summary:
- Replace hard-coded battery entity lists with dynamic template sensors that scan all `sensor` entities with `device_class: battery`.
- Add an explicit exclusion list for battery sensors that should not be monitored.
- Keep 20% and 10% notifications current with persistent notifications and push updates.
- Add tests for the new battery monitor behavior and update stale logbook exclusions.

Validation:
- `pytest tests`
- `yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
