### PR TITLE
Add Music Assistant Spotify provider caveat

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -733,6 +733,9 @@ script:
         {% else %}
           radio
         {% endif %}
+      # NOTE: The `spotify--Tviw9k66` provider id is tied to the current
+      # Spotify provider in Music Assistant. If Spotify is removed and
+      # re-added, re-check the provider URI format below.
       media_id: >-
         {% if raw_item.startswith('spotify:') or raw_item.startswith('https://open.spotify.com/') %}
           {% set parts = normalized_uri.split(':') %}


### PR DESCRIPTION
Add a YAML comment near the hard-coded Spotify provider URI to note that the Music Assistant provider id is environment-specific and should be rechecked if Spotify is removed and re-added.