### PR TITLE
Sync battery notifications from current state on startup

### DIFF
--- a/packages/batteries.yaml
+++ b/packages/batteries.yaml
@@ -177,20 +177,30 @@ automation:
     max: 10
     trigger:
       - trigger: state
+        id: summary_change
         entity_id: sensor.battery_low_20
         attribute: summary
-    condition:
-      - condition: template
-        value_template: >-
-          {{ trigger.from_state is not none
-             and trigger.from_state.state not in ['unknown', 'unavailable']
-             and trigger.to_state.state not in ['unknown', 'unavailable'] }}
+      - trigger: homeassistant
+        id: startup_sync
+        event: start
+    variables:
+      battery_count: >-
+        {{ states('sensor.battery_low_20') | int(0) }}
+      battery_summary: >-
+        {{ state_attr('sensor.battery_low_20', 'summary') | default('', true) }}
+      count_increased: >-
+        {{ trigger.id == 'summary_change'
+           and trigger.from_state is not none
+           and trigger.to_state is not none
+           and trigger.from_state.state not in ['unknown', 'unavailable']
+           and trigger.to_state.state not in ['unknown', 'unavailable']
+           and trigger.to_state.state | int(0) > trigger.from_state.state | int(0) }}
     action:
       - choose:
           - conditions:
               - condition: template
                 value_template: >-
-                  {{ trigger.to_state.state | int(0) == 0 }}
+                  {{ battery_count == 0 }}
             sequence:
               - action: persistent_notification.dismiss
                 data:
@@ -199,22 +209,22 @@ automation:
           - action: persistent_notification.create
             data:
               title: >-
-                Battery Sensors Below 20% ({{ trigger.to_state.state | int(0) }})
+                Battery Sensors Below 20% ({{ battery_count }})
               message: >-
-                {{ trigger.to_state.attributes.summary }}
+                {{ battery_summary }}
               notification_id: low-battery-20
           - choose:
               - conditions:
                   - condition: template
                     value_template: >-
-                      {{ trigger.to_state.state | int(0) > trigger.from_state.state | int(0) }}
+                      {{ count_increased }}
                 sequence:
                   - action: notify.all
                     data:
                       title: >-
-                        Battery Sensors Below 20% ({{ trigger.to_state.state | int(0) }})
+                        Battery Sensors Below 20% ({{ battery_count }})
                       message: >-
-                        {{ trigger.to_state.attributes.summary }}
+                        {{ battery_summary }}
 
   - id: notify_battery_dying_10
     alias: notify_battery_dying_10
@@ -223,20 +233,30 @@ automation:
     max: 10
     trigger:
       - trigger: state
+        id: summary_change
         entity_id: sensor.battery_low_10
         attribute: summary
-    condition:
-      - condition: template
-        value_template: >-
-          {{ trigger.from_state is not none
-             and trigger.from_state.state not in ['unknown', 'unavailable']
-             and trigger.to_state.state not in ['unknown', 'unavailable'] }}
+      - trigger: homeassistant
+        id: startup_sync
+        event: start
+    variables:
+      battery_count: >-
+        {{ states('sensor.battery_low_10') | int(0) }}
+      battery_summary: >-
+        {{ state_attr('sensor.battery_low_10', 'summary') | default('', true) }}
+      count_increased: >-
+        {{ trigger.id == 'summary_change'
+           and trigger.from_state is not none
+           and trigger.to_state is not none
+           and trigger.from_state.state not in ['unknown', 'unavailable']
+           and trigger.to_state.state not in ['unknown', 'unavailable']
+           and trigger.to_state.state | int(0) > trigger.from_state.state | int(0) }}
     action:
       - choose:
           - conditions:
               - condition: template
                 value_template: >-
-                  {{ trigger.to_state.state | int(0) == 0 }}
+                  {{ battery_count == 0 }}
             sequence:
               - action: persistent_notification.dismiss
                 data:
@@ -245,22 +265,22 @@ automation:
           - action: persistent_notification.create
             data:
               title: >-
-                Battery Sensors Below 10% ({{ trigger.to_state.state | int(0) }})
+                Battery Sensors Below 10% ({{ battery_count }})
               message: >-
-                {{ trigger.to_state.attributes.summary }}
+                {{ battery_summary }}
               notification_id: low-battery-10
           - choose:
               - conditions:
                   - condition: template
                     value_template: >-
-                      {{ trigger.to_state.state | int(0) > trigger.from_state.state | int(0) }}
+                      {{ count_increased }}
                 sequence:
                   - action: notify.all
                     data:
                       title: >-
-                        Battery Sensors Below 10% ({{ trigger.to_state.state | int(0) }})
+                        Battery Sensors Below 10% ({{ battery_count }})
                       message: >-
-                        {{ trigger.to_state.attributes.summary }}
+                        {{ battery_summary }}
 
 ########################
 # Binary Sensors

--- a/tests/test_batteries_package.py
+++ b/tests/test_batteries_package.py
@@ -58,13 +58,21 @@ def test_battery_automations_update_notifications_from_dynamic_sensor_summaries(
         block = _automation_block(automation_id)
 
         assert "mode: queued" in block
+        assert "id: summary_change" in block
         assert "attribute: summary" in block
+        assert "trigger: homeassistant" in block
+        assert "id: startup_sync" in block
+        assert "event: start" in block
         assert "persistent_notification.create" in block
         assert "persistent_notification.dismiss" in block
         assert "notify.all" in block
+        assert f"states('sensor.battery_low_{threshold}')" in block
+        assert f"state_attr('sensor.battery_low_{threshold}', 'summary')" in block
+        assert "trigger.id == 'summary_change'" in block
+        assert "count_increased" in block
         assert f"notification_id: low-battery-{threshold}" in block
         assert f"Battery Sensors Below {threshold}%" in block
-        assert "trigger.from_state.state not in ['unknown', 'unavailable']" in block
+        assert "trigger.from_state is not none" in block
 
 
 def test_logbook_excludes_current_battery_monitor_entities_instead_of_stale_ones() -> None:


### PR DESCRIPTION
Related to #172.

Summary:
- sync low-battery persistent notifications from the current sensor state on Home Assistant startup
- keep push notifications limited to real worsening events instead of startup syncs
- strengthen the battery package tests to cover the startup-sync path

Validation:
- `pytest tests`
- `yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
