### PR TITLE
Generalize Music Assistant item selection and add playlist builder UI

### DIFF
--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -1484,6 +1484,76 @@
                     "when_standby": true
                   },
                   "group": false
+                },
+                {
+                  "type": "vertical-stack",
+                  "cards": [
+                    {
+                      "type": "entities",
+                      "title": "Search Music Assistant",
+                      "show_header_toggle": false,
+                      "entities": [
+                        {
+                          "entity": "input_text.music_assistant_search_query",
+                          "name": "Query"
+                        },
+                        {
+                          "entity": "input_text.music_assistant_provider_filter",
+                          "name": "Provider filter"
+                        },
+                        {
+                          "entity": "input_select.music_assistant_search_media_type",
+                          "name": "Type"
+                        },
+                        {
+                          "entity": "input_select.music_assistant_search_results",
+                          "name": "Results"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "horizontal-stack",
+                      "cards": [
+                        {
+                          "type": "button",
+                          "name": "Search",
+                          "icon": "mdi:magnify",
+                          "tap_action": {
+                            "action": "call-service",
+                            "service": "script.music_assistant_search_music"
+                          }
+                        },
+                        {
+                          "type": "button",
+                          "name": "Play now",
+                          "icon": "mdi:play",
+                          "tap_action": {
+                            "action": "call-service",
+                            "service": "script.music_assistant_play_selected_search_result",
+                            "service_data": {
+                              "enqueue": "replace"
+                            }
+                          }
+                        },
+                        {
+                          "type": "button",
+                          "name": "Add to queue",
+                          "icon": "mdi:playlist-plus",
+                          "tap_action": {
+                            "action": "call-service",
+                            "service": "script.music_assistant_play_selected_search_result",
+                            "service_data": {
+                              "enqueue": "add"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "markdown",
+                      "content": "Search by name, then narrow results with a provider token like `spotify`, `tunein`, or `library`."
+                    }
+                  ]
                 }
               ]
             }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Music playback automations now target the Music Assistant-backed Sonos entities,
 
 The reusable media helpers live in `packages/media_player.yaml`:
 
-- `script.music_assistant_play_item`: accepts Spotify URIs/URLs or Music Assistant radio item names and converts them into the `music_assistant.play_media` payload.
+- `script.music_assistant_play_item`: thin wrapper around `music_assistant.play_media` for any Music Assistant URI, URL, or plain item name. Pass `media_type` explicitly when you need to disambiguate a track, album, artist, playlist, or radio item.
+- `script.music_assistant_search_music`: searches Music Assistant from the dashboard controls and populates the result picker.
+- `script.music_assistant_play_selected_search_result`: plays or queues the selected Music Assistant search result.
 - `script.music_assistant_prepare_bedroom_group`: regroup bedroom/bathroom and optionally office/den depending on guest mode.
 - `script.music_assistant_prepare_arrival_group`: regroup the arrival playback zone.
 - `script.music_assistant_prepare_house_party_group`: regroup all Sonos players for party modes.
@@ -41,7 +43,7 @@ The Siri/Homebridge entrypoint for the Tiki Time party mode is `script.tiki_time
 
 ### Adding Another Playlist
 
-If an existing script already picks from a list, the normal change is just to append one more Spotify URI or Music Assistant radio item to that script's `plists` array in `packages/media_player.yaml`.
+If an existing script already picks from a list, the normal change is just to append one more URI or plain Music Assistant item name to that script's `plists` array in `packages/media_player.yaml`.
 
 Examples:
 
@@ -59,7 +61,7 @@ Accepted playlist values:
 - `https://open.spotify.com/album/...`
 - `https://open.spotify.com/artist/...`
 - `https://open.spotify.com/track/...`
-- Music Assistant radio item names or URIs, for mixed lists that call `script.music_assistant_play_item`
+- Music Assistant URIs or plain item names, for mixed lists that call `script.music_assistant_play_item`
 
 If you are creating a brand new script, prefer calling the helper instead of using `media_player.play_media` directly:
 
@@ -72,8 +74,20 @@ If you are creating a brand new script, prefer calling the helper instead of usi
 
 Notes:
 
-- The helper currently builds provider URIs with the active Spotify provider id in Music Assistant. If Spotify is removed and re-added in Music Assistant, re-check `script.music_assistant_play_spotify_uri` in `packages/media_player.yaml`.
-- The helper determines `track` vs `album` vs `artist` vs `playlist` automatically from the URI.
+- The generic helper now passes Music Assistant URIs and plain item names through directly. Use `media_type` when a name is ambiguous.
+- `script.music_assistant_play_spotify_uri` remains as a compatibility wrapper for Spotify URLs and URIs.
+
+### Searching and Queuing Music Assistant Items
+
+The `Music Assistant` section on the dashboard includes a small search flow:
+
+1. Enter a plain-text query in `input_text.music_assistant_search_query`.
+2. Optionally enter a provider token such as `spotify`, `tunein`, or `library` in `input_text.music_assistant_provider_filter`.
+3. Choose the media type from `input_select.music_assistant_search_media_type`.
+4. Press `script.music_assistant_search_music` to populate `input_select.music_assistant_search_results`.
+5. Use `script.music_assistant_play_selected_search_result` to play the selected result now or add it to the current queue.
+
+This flow appends to the live Music Assistant queue on `media_player.bedroom_sonos_2`, which is the current "playlist" target in the dashboard.
 
 ### Adding Another Radio Station
 

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1,5 +1,5 @@
 # Home Assistant package for Music Assistant, Sonos, and whole-home media behavior.
-# Complex areas: it handles cube/button media controls, group preparation, wake-up and bedtime playback, and reusable scripts for Spotify and radio playback.
+# Complex areas: it handles cube/button media controls, group preparation, wake-up and bedtime playback, and reusable scripts for generic Music Assistant search/playback flows.
 
 ################################################################
 ## Packages / Media Players
@@ -532,9 +532,38 @@ input_boolean: {}
 input_number: {}
 
 ########################
+# Input Text
+########################
+input_text:
+  music_assistant_search_query:
+    name: "Music Assistant search query"
+    icon: mdi:magnify
+    max: 255
+  music_assistant_provider_filter:
+    name: "Music Assistant provider filter"
+    icon: mdi:database-search
+    max: 80
+
+########################
 # Input Select
 ########################
-input_select: {}
+input_select:
+  music_assistant_search_media_type:
+    name: "Music Assistant search type"
+    icon: mdi:music-note-search
+    options:
+      - track
+      - album
+      - artist
+      - playlist
+      - radio
+    initial: track
+  music_assistant_search_results:
+    name: "Music Assistant search results"
+    icon: mdi:playlist-music
+    options:
+      - "No results found"
+    initial: "No results found"
 
 ########################
 # iOS
@@ -706,60 +735,37 @@ script:
       entity_id:
         description: "Music Assistant media_player entity"
       media_item:
-        description: "Spotify URI, open.spotify.com URL, or Music Assistant radio item name"
+        description: "Music Assistant URI, open.spotify.com URL, or plain item name"
+      media_type:
+        description: "Optional Music Assistant media type"
       enqueue:
         description: "Music Assistant enqueue mode"
     variables:
       raw_item: "{{ media_item | trim }}"
-      normalized_uri: >-
-        {% if raw_item.startswith('https://open.spotify.com/') %}
-          {% set path = raw_item.split('open.spotify.com/')[1].split('?')[0] %}
-          {{ 'spotify:' ~ path.replace('/', ':') }}
-        {% else %}
-          {{ raw_item }}
-        {% endif %}
-      media_type: >-
-        {% if raw_item.startswith('spotify:') or raw_item.startswith('https://open.spotify.com/') %}
-          {% set parts = normalized_uri.split(':') %}
-          {% if 'track' in parts %}
-            track
-          {% elif 'album' in parts %}
-            album
-          {% elif 'artist' in parts %}
-            artist
-          {% else %}
-            playlist
-          {% endif %}
-        {% else %}
-          radio
-        {% endif %}
-      # NOTE: The `spotify--Tviw9k66` provider id is tied to the current
-      # Spotify provider in Music Assistant. If Spotify is removed and
-      # re-added, re-check the provider URI format below.
-      media_id: >-
-        {% if raw_item.startswith('spotify:') or raw_item.startswith('https://open.spotify.com/') %}
-          {% set parts = normalized_uri.split(':') %}
-          {% if 'track' in parts %}
-            spotify--Tviw9k66://track/{{ parts[-1] }}
-          {% elif 'album' in parts %}
-            spotify--Tviw9k66://album/{{ parts[-1] }}
-          {% elif 'artist' in parts %}
-            spotify--Tviw9k66://artist/{{ parts[-1] }}
-          {% else %}
-            spotify--Tviw9k66://playlist/{{ parts[-1] }}
-          {% endif %}
-        {% else %}
-          {{ raw_item }}
-        {% endif %}
+      raw_media_type: "{{ media_type | default('') | trim }}"
+      raw_enqueue: "{{ enqueue | default('replace') }}"
     sequence:
-      - action: music_assistant.play_media
-        continue_on_error: true
-        target:
-          entity_id: "{{ entity_id }}"
-        data:
-          media_id: "{{ media_id }}"
-          media_type: "{{ media_type }}"
-          enqueue: "{{ enqueue | default('replace') }}"
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ raw_media_type != '' }}"
+            sequence:
+              - action: music_assistant.play_media
+                continue_on_error: true
+                target:
+                  entity_id: "{{ entity_id }}"
+                data:
+                  media_id: "{{ raw_item }}"
+                  media_type: "{{ raw_media_type }}"
+                  enqueue: "{{ raw_enqueue }}"
+        default:
+          - action: music_assistant.play_media
+            continue_on_error: true
+            target:
+              entity_id: "{{ entity_id }}"
+            data:
+              media_id: "{{ raw_item }}"
+              enqueue: "{{ raw_enqueue }}"
 
   music_assistant_play_spotify_uri:
     alias: "Play Spotify item via Music Assistant"
@@ -770,12 +776,120 @@ script:
         description: "Spotify URI or open.spotify.com URL"
       enqueue:
         description: "Music Assistant enqueue mode"
+    variables:
+      raw_uri: "{{ spotify_uri | trim }}"
+      normalized_uri: >-
+        {% if raw_uri.startswith('https://open.spotify.com/') %}
+          {% set path = raw_uri.split('open.spotify.com/')[1].split('?')[0] %}
+          {{ 'spotify:' ~ path.replace('/', ':') }}
+        {% else %}
+          {{ raw_uri }}
+        {% endif %}
     sequence:
       - action: script.music_assistant_play_item
         data:
           entity_id: "{{ entity_id }}"
-          media_item: "{{ spotify_uri }}"
+          media_item: "{{ normalized_uri }}"
           enqueue: "{{ enqueue | default('replace') }}"
+
+  music_assistant_search_music:
+    alias: "Search Music Assistant"
+    sequence:
+      - variables:
+          query: "{{ states('input_text.music_assistant_search_query') | trim }}"
+          provider_filter: "{{ states('input_text.music_assistant_provider_filter') | trim | lower }}"
+          media_type: "{{ states('input_select.music_assistant_search_media_type') | trim }}"
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ query == '' }}"
+            sequence:
+              - action: input_select.set_options
+                target:
+                  entity_id: input_select.music_assistant_search_results
+                data:
+                  options:
+                    - "No results found"
+          - conditions:
+              - condition: template
+                value_template: "{{ query.startswith('spotify:') or query.startswith('http') or '://' in query }}"
+            sequence:
+              - variables:
+                  direct_options: >-
+                    {% if provider_filter == '' or provider_filter in (query | lower) %}
+                      {{ ['Direct URI || ' ~ query] }}
+                    {% else %}
+                      {{ ['No results found'] }}
+                    {% endif %}
+              - action: input_select.set_options
+                target:
+                  entity_id: input_select.music_assistant_search_results
+                data:
+                  options: "{{ direct_options }}"
+        default:
+          - action: music_assistant.search
+            continue_on_error: true
+            response_variable: search_results
+            data:
+              name: "{{ query }}"
+              media_type: "{{ media_type }}"
+              limit: 20
+          - variables:
+              search_options: >-
+                {% set search_response = search_results | default({}, true) %}
+                {% set ns = namespace(options=[], seen=[]) %}
+                {% for bucket in ['tracks', 'albums', 'artists', 'playlists', 'radio', 'items'] %}
+                  {% for item in search_response.get(bucket, []) %}
+                    {% set uri = item.uri | default(item.media_id | default('')) %}
+                    {% if uri and uri not in ns.seen %}
+                      {% set provider_token = uri.split('://')[0] | lower %}
+                      {% set provider_name = provider_token.split('--', 1)[0] %}
+                      {% set provider_blob = provider_token ~ ' ' ~ provider_name ~ ' ' ~ (item.name | default('') | lower) %}
+                      {% if provider_filter == '' or provider_filter in provider_blob %}
+                        {% set label = item.name | default(uri) %}
+                        {% if item.artists is defined and item.artists %}
+                          {% set label = (item.artists | map(attribute='name') | join(', ')) ~ ' - ' ~ label %}
+                        {% endif %}
+                        {% set ns.options = ns.options + ['[' ~ provider_name ~ '] ' ~ label ~ ' || ' ~ uri] %}
+                        {% set ns.seen = ns.seen + [uri] %}
+                      {% endif %}
+                    {% endif %}
+                  {% endfor %}
+                {% endfor %}
+                {{ ns.options if ns.options else ['No results found'] }}
+          - action: input_select.set_options
+            target:
+              entity_id: input_select.music_assistant_search_results
+            data:
+              options: "{{ search_options }}"
+
+  music_assistant_play_selected_search_result:
+    alias: "Play selected Music Assistant search result"
+    fields:
+      entity_id:
+        description: "Music Assistant media_player entity"
+      enqueue:
+        description: "Music Assistant enqueue mode"
+    variables:
+      target_entity: "{{ entity_id | default('media_player.bedroom_sonos_2') }}"
+      selected_option: "{{ states('input_select.music_assistant_search_results') | trim }}"
+      selected_uri: >-
+        {% if ' || ' in selected_option %}
+          {{ selected_option.split(' || ', 1)[1] | trim }}
+        {% else %}
+          {{ selected_option }}
+        {% endif %}
+    sequence:
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ selected_uri not in ['', 'No results found'] }}"
+            sequence:
+              - action: script.music_assistant_play_item
+                data:
+                  entity_id: "{{ target_entity }}"
+                  media_item: "{{ selected_uri }}"
+                  enqueue: "{{ enqueue | default('add') }}"
 
   music_assistant_radio_wake_up:
     alias: "Radio wake-up via Music Assistant"

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 
 MEDIA_PLAYER_PATH = Path(__file__).resolve().parents[1] / "packages" / "media_player.yaml"
+DASHBOARD_PATH = Path(__file__).resolve().parents[1] / ".storage" / "lovelace.ryan_new_mushroom"
 
 
 def _script_block(script_id: str) -> str:
@@ -30,21 +31,54 @@ def _script_block(script_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
-def test_music_assistant_item_helper_handles_spotify_and_radio_items() -> None:
+def test_music_assistant_item_helper_is_generic_pass_through() -> None:
     block = _script_block("music_assistant_play_item")
 
-    assert "Spotify URI, open.spotify.com URL, or Music Assistant radio item name" in block
-    assert "raw_item.startswith('spotify:')" in block
-    assert "raw_item.startswith('https://open.spotify.com/')" in block
-    assert "spotify--Tviw9k66://" in block
-    assert "          radio" in block
+    assert "Music Assistant URI, open.spotify.com URL, or plain item name" in block
+    assert "raw_media_type" in block
+    assert "music_assistant.play_media" in block
+    assert "spotify--Tviw9k66://" not in block
+    assert "raw_item.startswith('spotify:')" not in block
+    assert "raw_item.startswith('https://open.spotify.com/')" not in block
+
+
+def test_music_assistant_search_helpers_populate_dashboard_results() -> None:
+    block = _script_block("music_assistant_search_music")
+
+    for token in (
+        "input_text.music_assistant_search_query",
+        "input_text.music_assistant_provider_filter",
+        "input_select.music_assistant_search_media_type",
+        "input_select.music_assistant_search_results",
+        "music_assistant.search",
+        "Direct URI ||",
+        "provider_blob",
+        "No results found",
+    ):
+        assert token in block
+
+
+def test_music_assistant_selected_result_can_be_queued_or_played() -> None:
+    block = _script_block("music_assistant_play_selected_search_result")
+
+    for token in (
+        "input_select.music_assistant_search_results",
+        "selected_option.split(' || ', 1)[1]",
+        "script.music_assistant_play_item",
+        "media_player.bedroom_sonos_2",
+    ):
+        assert token in block
+
+    assert "enqueue: \"{{ enqueue | default('add') }}\"" in block
 
 
 def test_spotify_wrapper_delegates_to_generic_music_assistant_helper() -> None:
     block = _script_block("music_assistant_play_spotify_uri")
 
     assert "action: script.music_assistant_play_item" in block
-    assert 'media_item: "{{ spotify_uri }}"' in block
+    assert "normalized_uri" in block
+    assert "open.spotify.com" in block
+    assert 'media_item: "{{ normalized_uri }}"' in block
 
 
 def test_house_party_helper_joins_every_sonos_zone() -> None:
@@ -76,3 +110,18 @@ def test_bedtime_playlist_includes_somafm_station_names() -> None:
     assert "range(0, (plists | length))" in block
     assert "action: script.music_assistant_play_item" in block
     assert 'media_item: "{{ playlist }}"' in block
+
+
+def test_music_assistant_dashboard_exposes_search_controls() -> None:
+    dashboard = DASHBOARD_PATH.read_text(encoding="utf-8")
+
+    for token in (
+        "Music Assistant",
+        "input_text.music_assistant_search_query",
+        "input_text.music_assistant_provider_filter",
+        "input_select.music_assistant_search_media_type",
+        "input_select.music_assistant_search_results",
+        "script.music_assistant_search_music",
+        "script.music_assistant_play_selected_search_result",
+    ):
+        assert token in dashboard


### PR DESCRIPTION
Closes #173.

Summary:
- Replaces the Spotify-specific MA item inference with a generic pass-through helper that accepts explicit media type when needed.
- Adds a dashboard search flow for Music Assistant with query, provider filter, media type selection, and result picker.
- Lets the selected search result be played now or added to the current Music Assistant queue.
- Keeps the Spotify URL wrapper for backward compatibility.

Verification:
- /tmp/codex-hass-config-venv/bin/pytest -q
- yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/media_player.yaml