### PR TITLE
Fix Tesla daily plan dashboard toggle

### DIFF
--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -1709,7 +1709,7 @@
                 },
                 {
                   "type": "tile",
-                  "entity": "input_boolean.long_range_travel",
+                  "entity": "binary_sensor.tesla_daily_plan_active",
                   "tap_action": {
                     "action": "call-service",
                     "service": "input_boolean.turn_off",

--- a/lovelace/tiles/tiles_tesla_charging.yaml
+++ b/lovelace/tiles/tiles_tesla_charging.yaml
@@ -100,10 +100,11 @@ cards:
               service_data:
                 entity_id: input_boolean.long_range_travel
           - type: button
-            entity: input_boolean.long_range_travel
+            entity: binary_sensor.tesla_daily_plan_active
             name: "Use Daily Plan"
             icon: mdi:ev-station
             show_state: false
+            state_color: true
             tap_action:
               action: call-service
               service: input_boolean.turn_off

--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -993,6 +993,11 @@ template:
             {% endif %}
           {% endif %}
           {{ ns.eligible and (state_attr("sensor.waze_next_trip_distance", "distance") | int(0) > 45) }}
+      - default_entity_id: binary_sensor.tesla_daily_plan_active
+        unique_id: tesla_daily_plan_active
+        name: Tesla Daily Plan Active
+        state: >-
+          {{ is_state('input_boolean.long_range_travel', 'off') }}
   - sensor:
       - name: charge_complete
         unique_id: charge_complete

--- a/tests/test_tesla_charging_dashboard.py
+++ b/tests/test_tesla_charging_dashboard.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CAR_PACKAGE_PATH = ROOT / "packages" / "car.yaml"
+TESLA_TILE_PATH = ROOT / "lovelace" / "tiles" / "tiles_tesla_charging.yaml"
+DASHBOARD_PATH = ROOT / ".storage" / "lovelace.ryan_new_mushroom"
+
+
+def test_daily_plan_binary_sensor_tracks_inverse_of_max_range_override() -> None:
+    package_text = CAR_PACKAGE_PATH.read_text(encoding="utf-8")
+
+    assert "default_entity_id: binary_sensor.tesla_daily_plan_active" in package_text
+    assert "unique_id: tesla_daily_plan_active" in package_text
+    assert "name: Tesla Daily Plan Active" in package_text
+    assert "{{ is_state('input_boolean.long_range_travel', 'off') }}" in package_text
+
+
+def test_yaml_dashboard_uses_inverse_sensor_for_daily_plan_button() -> None:
+    tile_text = TESLA_TILE_PATH.read_text(encoding="utf-8")
+
+    assert 'entity: binary_sensor.tesla_daily_plan_active\n            name: "Use Daily Plan"' in tile_text
+    assert "state_color: true" in tile_text
+    assert "service: input_boolean.turn_off" in tile_text
+    assert "entity: input_boolean.long_range_travel\n            name: \"Use Daily Plan\"" not in tile_text
+
+
+def test_storage_dashboard_uses_inverse_sensor_for_daily_plan_tile() -> None:
+    dashboard_text = DASHBOARD_PATH.read_text(encoding="utf-8")
+
+    assert '"entity": "binary_sensor.tesla_daily_plan_active"' in dashboard_text
+    assert '"name": "Use Daily Plan"' in dashboard_text
+    assert '"service": "input_boolean.turn_off"' in dashboard_text
+    assert (
+        '"entity": "input_boolean.long_range_travel",\n'
+        '                  "tap_action": {\n'
+        '                    "action": "call-service",\n'
+        '                    "service": "input_boolean.turn_off"'
+    ) not in dashboard_text


### PR DESCRIPTION
## Summary
- add a dedicated `binary_sensor.tesla_daily_plan_active` template entity so the dashboard can represent the planner mode independently from the max-range override helper
- repoint the Tesla charging dashboard `Use Daily Plan` control in both the YAML tile include and tracked Lovelace storage dashboard to that inverse sensor
- add regression tests covering the new template sensor and both dashboard representations

## Testing
- `.venv/bin/pytest -q`
- `.venv/bin/yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`

Closes #160