### PR TITLE
Loop Tiki Time lights through tropical colors

### DIFF
--- a/packages/tiki_time.yaml
+++ b/packages/tiki_time.yaml
@@ -41,11 +41,267 @@ homeassistant:
 ########################
 
 script:
+  tiki_time_tropical_color_cycle:
+    alias: "Tiki Time Tropical Color Cycle"
+    description: >-
+      Continuously rotate Tiki Time-capable lights through a tropical palette
+      while the Tiki Time station is still playing.
+    icon: mdi:palette
+    mode: restart
+    sequence:
+      - if:
+          - condition: not
+            conditions:
+              - condition: or
+                conditions:
+                  - condition: state
+                    entity_id: media_player.den_sonos_2
+                    state: "playing"
+                  - condition: state
+                    entity_id: media_player.den_sonos_2
+                    state: "buffering"
+        then:
+          - wait_for_trigger:
+              - trigger: state
+                entity_id: media_player.den_sonos_2
+                to: "playing"
+              - trigger: state
+                entity_id: media_player.den_sonos_2
+                to: "buffering"
+            timeout: "00:00:10"
+            continue_on_timeout: true
+      - repeat:
+          while:
+            - condition: or
+              conditions:
+                - condition: state
+                  entity_id: media_player.den_sonos_2
+                  state: "playing"
+                - condition: state
+                  entity_id: media_player.den_sonos_2
+                  state: "buffering"
+          sequence:
+            - variables:
+                cycle_index: "{{ repeat.index0 }}"
+                tropical_palette:
+                  - [18, 86]
+                  - [34, 90]
+                  - [52, 82]
+                  - [108, 70]
+                  - [166, 74]
+                  - [196, 76]
+                  - [286, 62]
+                  - [338, 68]
+            - parallel:
+                - sequence:
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.basement_great_room_east_1
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 0) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 0) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 55
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.basement_great_east_room_2
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 1) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 1) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 55
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.basement_great_room_middle_1
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 2) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 2) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 55
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.basement_great_room_middle_2
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 3) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 3) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 55
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.basement_great_room_west_1
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 4) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 4) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 55
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.basement_great_room_west_2
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 5) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 5) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 55
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.basement_great_room_west_3
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 6) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 6) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 55
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.basement_tv_bias
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 7) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 7) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 35
+                        transition: 18
+                - sequence:
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.kitchen_overhead_1
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 1) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 1) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 45
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.kitchen_overhead_2
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 2) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 2) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 45
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.kitchen_overhead_3
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 3) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 3) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 45
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.kitchen_overhead_4
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 4) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 4) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 45
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.kitchen_overhead_5
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 5) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 5) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 45
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.kitchen_overhead_6
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 6) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 6) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 45
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.kitchen_overhead_7
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 7) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 7) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 45
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.kitchen_sink_overhead
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 0) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 0) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 55
+                        transition: 18
+                - sequence:
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.east_table_lamp
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 2) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 2) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 65
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.west_table_lamp
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 6) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 6) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 65
+                        transition: 18
+                - sequence:
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.tiki_room_floor_lamp
+                      data:
+                        hs_color:
+                          - "{{ tropical_palette[(cycle_index + 3) % (tropical_palette | count)][0] }}"
+                          - "{{ tropical_palette[(cycle_index + 3) % (tropical_palette | count)][1] }}"
+                        brightness_pct: 70
+                        transition: 18
+                    - action: light.turn_on
+                      continue_on_error: true
+                      target:
+                        entity_id: light.tiki_room_strip
+                      data:
+                        effect: rainbow
+                        brightness_pct: 80
+            - delay:
+                seconds: 20
   tiki_time:
     alias: "Tiki Time"
     description: >-
       Start the Tiki Time party mode: flash the lights, start SomaFM Tiki Time
-      on the Sonos group, and move the basement display into Photos.
+      on the Sonos group, move the basement display into Photos, and start the
+      tropical light rotation.
     icon: mdi:palm-tree
     mode: restart
     sequence:
@@ -55,6 +311,9 @@ script:
           entity_id: script.tiki_time
           domain: script
           message: "Starting the Tiki Time party mode."
+      - action: script.turn_off
+        target:
+          entity_id: script.tiki_time_tropical_color_cycle
       - parallel:
           - sequence:
               - repeat:
@@ -116,32 +375,6 @@ script:
           brightness_pct: 25
           color_temp_kelvin: 2000
           transition: 45
-      - parallel:
-          - action: light.turn_on
-            continue_on_error: true
-            target:
-              entity_id:
-                - light.basement_great_room
-                - light.kitchen_all
-            data:
-              effect: colorloop
-              brightness_pct: 60
-          - action: light.turn_on
-            continue_on_error: true
-            target:
-              entity_id: light.tiki_room_strip
-            data:
-              effect: rainbow
-              brightness_pct: 80
-          - action: light.turn_on
-            continue_on_error: true
-            target:
-              entity_id:
-                - light.office_all
-                - light.basement_tv_bias
-            data:
-              hs_color:
-                - 178
-                - 72
-              brightness_pct: 40
-              transition: 30
+      - action: script.turn_on
+        target:
+          entity_id: script.tiki_time_tropical_color_cycle

--- a/tests/test_tiki_time.py
+++ b/tests/test_tiki_time.py
@@ -41,6 +41,46 @@ def test_tiki_time_uses_shared_music_assistant_helpers() -> None:
     assert "media_player.basement" in block
     assert "source: Photos" in block
     assert "flash: short" in block
+    assert "script.tiki_time_tropical_color_cycle" in block
+
+
+def test_tiki_time_color_cycle_loops_while_party_music_is_active() -> None:
+    block = _script_block("tiki_time_tropical_color_cycle")
+
+    assert "Continuously rotate Tiki Time-capable lights" in block
+    assert "wait_for_trigger:" in block
+    assert "repeat:" in block
+    assert "while:" in block
+    assert 'state: "playing"' in block
+    assert 'state: "buffering"' in block
+    assert "tropical_palette:" in block
+    assert "seconds: 20" in block
+
+
+def test_tiki_time_color_cycle_targets_individual_color_lights() -> None:
+    block = _script_block("tiki_time_tropical_color_cycle")
+
+    for entity_id in (
+        "light.basement_great_room_east_1",
+        "light.basement_great_east_room_2",
+        "light.basement_great_room_middle_1",
+        "light.basement_great_room_middle_2",
+        "light.basement_great_room_west_1",
+        "light.basement_great_room_west_2",
+        "light.basement_great_room_west_3",
+        "light.basement_tv_bias",
+        "light.kitchen_overhead_1",
+        "light.kitchen_overhead_7",
+        "light.kitchen_sink_overhead",
+        "light.east_table_lamp",
+        "light.west_table_lamp",
+        "light.tiki_room_floor_lamp",
+    ):
+        assert entity_id in block
+
+    assert "effect: rainbow" in block
+    assert "entity_id: light.kitchen_all" not in block
+    assert "entity_id: light.office_all" not in block
 
 
 def test_tiki_time_is_exposed_to_voice_assistants() -> None:


### PR DESCRIPTION
## Summary
- add a dedicated Tiki Time helper script that rotates individual color-capable lights through a tropical palette while the station is playing
- replace the old grouped accent-light scene with a handoff from `script.tiki_time` to the new background color loop
- expand Tiki Time tests to cover the looping helper and individual light targeting

## Testing
- pytest -q
- pytest tests/test_tiki_time.py -q
- yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/tiki_time.yaml

Fixes #181