### PR TITLE
Add Tiki Room ESPHome diagnostics

### DIFF
--- a/esphome/tikiroom.yaml
+++ b/esphome/tikiroom.yaml
@@ -15,6 +15,20 @@ wifi:
   ssid: !secret wifi_ap
   password: !secret wifi_password
   min_auth_mode: WPA2
+  on_connect:
+    - logger.log:
+        level: INFO
+        tag: tikiroom.net
+        format: "WiFi connected to %s"
+        args:
+          - WiFi.SSID().c_str()
+  on_disconnect:
+    - logger.log:
+        level: WARN
+        tag: tikiroom.net
+        format: "WiFi disconnected with status=%d"
+        args:
+          - WiFi.status()
 
   ap:
     ssid: "Tikiroom Fallback Hotspot"
@@ -27,9 +41,70 @@ logger:
   esp8266_store_log_strings_in_flash: false
 
 api:
+  on_client_connected:
+    - logger.log:
+        level: INFO
+        tag: tikiroom.api
+        format: "API client %s connected from %s"
+        args:
+          - client_info.c_str()
+          - client_address.c_str()
+  on_client_disconnected:
+    - logger.log:
+        level: WARN
+        tag: tikiroom.api
+        format: "API client %s disconnected from %s"
+        args:
+          - client_info.c_str()
+          - client_address.c_str()
 
 ota:
   - platform: esphome
+
+debug:
+  update_interval: 60s
+
+binary_sensor:
+  - platform: status
+    name: "Tiki Room Strip Status"
+    entity_category: diagnostic
+
+sensor:
+  - platform: wifi_signal
+    name: "Tiki Room Strip WiFi Signal"
+    update_interval: 60s
+    entity_category: diagnostic
+
+  - platform: debug
+    free:
+      name: "Tiki Room Strip Heap Free"
+      entity_category: diagnostic
+    block:
+      name: "Tiki Room Strip Heap Max Block"
+      entity_category: diagnostic
+    fragmentation:
+      name: "Tiki Room Strip Heap Fragmentation"
+      entity_category: diagnostic
+    loop_time:
+      name: "Tiki Room Strip Loop Time"
+      entity_category: diagnostic
+
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "Tiki Room Strip IP Address"
+      entity_category: diagnostic
+    ssid:
+      name: "Tiki Room Strip Connected SSID"
+      entity_category: diagnostic
+    bssid:
+      name: "Tiki Room Strip Connected BSSID"
+      entity_category: diagnostic
+
+  - platform: debug
+    reset_reason:
+      name: "Tiki Room Strip Reset Reason"
+      entity_category: diagnostic
 
 globals:
   - id: tikiroom_effect_speed
@@ -49,6 +124,12 @@ number:
       return id(tikiroom_effect_speed);
     update_interval: 1s
     set_action:
+      - logger.log:
+          level: INFO
+          tag: tikiroom.light
+          format: "Animation speed changed to %.0f"
+          args:
+            - x
       - lambda: |-
           id(tikiroom_effect_speed) = x;
 
@@ -85,6 +166,12 @@ select:
       return std::string(effect.c_str());
     update_interval: 1s
     set_action:
+      - logger.log:
+          level: INFO
+          tag: tikiroom.light
+          format: "Effect changed to %s"
+          args:
+            - x.c_str()
       - lambda: |-
           auto call = id(tiki_room_strip).turn_on();
           call.set_effect(x.c_str());
@@ -113,6 +200,24 @@ light:
               - light.turn_on:
                   id: tiki_room_strip
                   effect: solid
+        - logger.log:
+            level: INFO
+            tag: tikiroom.light
+            format: "Light turned on with effect %s"
+            args:
+              - id(tiki_room_strip).get_effect_name().c_str()
+    on_turn_off:
+      - logger.log:
+          level: INFO
+          tag: tikiroom.light
+          format: "Light turned off"
+    on_state:
+      - logger.log:
+          level: INFO
+          tag: tikiroom.light
+          format: "Light state updated; active effect %s"
+          args:
+            - id(tiki_room_strip).get_effect_name().c_str()
     effects:
       - addressable_lambda:
           name: solid

--- a/tests/test_tikiroom_esphome.py
+++ b/tests/test_tikiroom_esphome.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+
+TIKIROOM_ESPHOME_PATH = Path(__file__).resolve().parents[1] / "esphome" / "tikiroom.yaml"
+
+
+def test_tikiroom_esphome_logs_connectivity_lifecycle() -> None:
+    text = TIKIROOM_ESPHOME_PATH.read_text(encoding="utf-8")
+
+    assert "tag: tikiroom.net" in text
+    assert 'format: "WiFi connected to %s"' in text
+    assert 'format: "WiFi disconnected with status=%d"' in text
+    assert "tag: tikiroom.api" in text
+    assert 'format: "API client %s connected from %s"' in text
+    assert 'format: "API client %s disconnected from %s"' in text
+
+
+def test_tikiroom_esphome_exposes_diagnostic_entities() -> None:
+    text = TIKIROOM_ESPHOME_PATH.read_text(encoding="utf-8")
+
+    assert "debug:\n  update_interval: 60s" in text
+    assert "- platform: status" in text
+    assert '- platform: wifi_signal' in text
+    assert '- platform: debug' in text
+    assert '- platform: wifi_info' in text
+
+    for entity_name in (
+        "Tiki Room Strip Status",
+        "Tiki Room Strip WiFi Signal",
+        "Tiki Room Strip Heap Free",
+        "Tiki Room Strip Heap Max Block",
+        "Tiki Room Strip Heap Fragmentation",
+        "Tiki Room Strip Loop Time",
+        "Tiki Room Strip IP Address",
+        "Tiki Room Strip Connected SSID",
+        "Tiki Room Strip Connected BSSID",
+        "Tiki Room Strip Reset Reason",
+    ):
+        assert f'name: "{entity_name}"' in text
+
+
+def test_tikiroom_esphome_logs_light_commands() -> None:
+    text = TIKIROOM_ESPHOME_PATH.read_text(encoding="utf-8")
+
+    assert 'format: "Animation speed changed to %.0f"' in text
+    assert 'format: "Effect changed to %s"' in text
+    assert 'format: "Light turned on with effect %s"' in text
+    assert 'format: "Light turned off"' in text
+    assert 'format: "Light state updated; active effect %s"' in text


### PR DESCRIPTION
## Summary
- add Wi-Fi and ESPHome API lifecycle logging for the Tiki Room LED strip node
- expose diagnostic entities for Wi-Fi signal, heap health, loop time, IP/SSID/BSSID, and reset reason
- log light control changes and cover the new diagnostics with a focused pytest file

## Testing
- `/tmp/codex-issue-184-venv/bin/pytest tests/test_tikiroom_esphome.py tests/test_tiki_time.py tests/test_batteries_package.py tests/test_media_player_music_assistant.py tests/test_trips_flight_classification.py tests/test_zigbee_zwave_garage_overhead_switch.py`
- `/tmp/codex-issue-184-venv/bin/yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" esphome/tikiroom.yaml`
- `/tmp/codex-issue-184-venv/bin/esphome config esphome/tikiroom.yaml`

Closes #184.