### PR TITLE
Fix Inovelli single-tap day mode regression

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1968,6 +1968,14 @@ script:
         {%- for device in states.number | select('match', '.*brightnesslevelfordoubletapup.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
       all_inovelli_switches_bindingofftoonsynclevel_mode: >
         {%- for device in states.select | select('match', '.*bindingofftoonsynclevel.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+      all_inovelli_switches_singletapbehavior_mode: >
+        {%- for device in states.select
+          | selectattr('entity_id', 'search', 'singletapbehavior')
+          | rejectattr('entity_id', 'search', 'exhaust')
+          | rejectattr('entity_id', 'search', 'fan_switch')
+          | rejectattr('entity_id', 'search', 'overhead_outlet') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
     sequence:
       - action: logbook.log
         data:
@@ -2004,6 +2012,12 @@ script:
           entity_id: >
             {{all_inovelli_switches_double_tap_up_brightness}}
           value: "254"
+      - delay: "{{ ha_write_delay }}"
+      - action: select.select_option
+        data:
+          entity_id: >
+            {{all_inovelli_switches_singletapbehavior_mode}}
+          option: "Old Behavior"
       - delay: "{{ ha_write_delay }}"
         enabled: false
       - action: select.select_option

--- a/tests/test_zigbee_zwave_inovelli_day_mode.py
+++ b/tests/test_zigbee_zwave_inovelli_day_mode.py
@@ -39,3 +39,10 @@ def test_day_mode_switches_keeps_full_brightness_defaults() -> None:
     assert "all_day_mode_defaultlevellocal_switches" in block
     assert "all_day_mode_defaultlevelremote_switches" in block
     assert block.count('value: "254"') >= 2
+
+
+def test_reset_inovelli_switches_restores_old_single_tap_behavior() -> None:
+    block = _script_block("reset_inovelli_switches")
+
+    assert "all_inovelli_switches_singletapbehavior_mode" in block
+    assert 'option: "Old Behavior"' in block


### PR DESCRIPTION
## Summary
- restore Inovelli light switches to `Old Behavior` during `script.day_mode_switches`
- keep the full-brightness default level reconciliation introduced for day mode
- add a regression test so the day-mode script cannot reintroduce `New Behavior`

## Root cause
Issue #185 matches the behavior documented by Zigbee2MQTT for Inovelli `singleTapBehavior = New Behavior`: single taps cycle through preset brightness levels instead of acting as direct on/off. This repo started forcing `New Behavior` in `script.day_mode_switches` on March 20, 2026, which is why switches began stepping through roughly 66% -> 33% -> off.

## Testing
- `pytest`
- `yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/zigbee_zwave.yaml`

Closes #185