### PR TITLE
Add EV vs gas daily cost comparison

### DIFF
--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -1751,6 +1751,26 @@
                 },
                 {
                   "type": "tile",
+                  "entity": "sensor.average_daily_ev_charging_cost"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.average_daily_vehicle_miles"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.weekly_regular_gas_price_55125"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.average_daily_gas_car_cost_30mpg"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.average_daily_ev_savings_vs_30mpg"
+                },
+                {
+                  "type": "tile",
                   "entity": "sensor.monthly_ev_charging_energy"
                 },
                 {

--- a/lovelace/tiles/tiles_tesla_charging.yaml
+++ b/lovelace/tiles/tiles_tesla_charging.yaml
@@ -184,6 +184,16 @@ cards:
                 name: Today's EV Energy
               - entity: sensor.daily_ev_charging_cost
                 name: Today's EV Cost
+              - entity: sensor.average_daily_ev_charging_cost
+                name: Avg EV Cost / Day
+              - entity: sensor.average_daily_vehicle_miles
+                name: Avg Miles / Day
+              - entity: sensor.weekly_regular_gas_price_55125
+                name: 55125 Gas Price / Gal
+              - entity: sensor.average_daily_gas_car_cost_30mpg
+                name: Avg Gas Cost / Day @ 30 MPG
+              - entity: sensor.average_daily_ev_savings_vs_30mpg
+                name: EV Savings / Day vs 30 MPG
               - entity: sensor.monthly_ev_charging_energy
                 name: This Month EV Energy
               - entity: sensor.monthly_ev_charging_cost

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -621,6 +621,17 @@ input_number:
     step: 0.00001
     mode: box
     unit_of_measurement: USD/kWh
+  # Seeded from the current Woodbury, MN regular "Week Ago Avg." value on
+  # https://www.way.com/gas/prices/minnesota/woodbury and used as a manual
+  # fallback if the live scrape ever fails. Woodbury is the city for ZIP 55125.
+  weekly_regular_gas_price_55125_fallback:
+    name: 55125 Weekly Gas Price Fallback
+    min: 0.50000
+    max: 8.00000
+    step: 0.01000
+    mode: box
+    unit_of_measurement: USD/gal
+    initial: 3.76
 
 ########################
 # Input Select
@@ -671,6 +682,29 @@ rest_command:
   trigger_flow_watermeter_light:
     url: http://watermeter.iot.rtclauss.org/flow_start
     method: GET
+
+########################
+# REST
+########################
+rest:
+  - resource: https://www.way.com/gas/prices/minnesota/woodbury
+    scan_interval: 43200
+    timeout: 30
+    headers:
+      Accept: text/html
+      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:146.0) Gecko/20100101 Firefox/146.0
+    sensor:
+      - name: Woodbury Weekly Regular Gas Price Live
+        unique_id: woodbury_weekly_regular_gas_price_live
+        icon: mdi:gas-station
+        unit_of_measurement: USD/gal
+        value_template: >-
+          {% set match = value | regex_findall_index('Week Ago Avg\\.\\s*\\$([0-9]+\\.[0-9]+)', 0) %}
+          {% if match not in [none, ''] %}
+            {{ match | float(default=0) | round(2) }}
+          {% else %}
+            {{ 'unknown' }}
+          {% endif %}
 
 ########################
 # Scenes
@@ -857,6 +891,84 @@ template:
               + (on_peak_kwh * 0.4420)
             ) | round(2)
           }}
+      - name: weekly_ev_charging_cost
+        unique_id: weekly_ev_charging_cost
+        icon: mdi:cash-clock
+        unit_of_measurement: USD
+        state: >-
+          {% set season = states('select.daily_electricity') %}
+          {% if season in ['unknown', 'unavailable', 'none', 'None', ''] %}
+            {% set season = 'summer' if now().month in [6, 7, 8, 9] else 'non-summer' %}
+          {% endif %}
+          {% set off_peak_kwh = states('sensor.weekly_ev_charging_off_peak') | float(default=0) %}
+          {% set mid_peak_kwh = states('sensor.weekly_ev_charging_mid_peak') | float(default=0) %}
+          {% set on_peak_kwh = states('sensor.weekly_ev_charging_on_peak') | float(default=0) %}
+          {% set mid_peak_rate = 0.1377 if season == 'summer' else 0.1238 %}
+          {{
+            (
+              (off_peak_kwh * 0.0755)
+              + (mid_peak_kwh * mid_peak_rate)
+              + (on_peak_kwh * 0.4420)
+            ) | round(2)
+          }}
+      - name: average_daily_ev_charging_cost
+        unique_id: average_daily_ev_charging_cost
+        icon: mdi:cash-fast
+        state_class: measurement
+        unit_of_measurement: USD/day
+        state: >-
+          {% set elapsed_days = [now().weekday() + 1, 1] | max %}
+          {% set weekly_cost = states('sensor.weekly_ev_charging_cost') | float(default=0) %}
+          {{ (weekly_cost / elapsed_days) | round(2) }}
+      - name: weekly_regular_gas_price_55125
+        unique_id: weekly_regular_gas_price_55125
+        icon: mdi:gas-station
+        state_class: measurement
+        unit_of_measurement: USD/gal
+        attributes:
+          source: >-
+            {% set live = states('sensor.woodbury_weekly_regular_gas_price_live') %}
+            {% if live not in ['unknown', 'unavailable', 'none', 'None', ''] %}
+              live
+            {% else %}
+              fallback
+            {% endif %}
+          source_url: https://www.way.com/gas/prices/minnesota/woodbury
+          coverage_area: Woodbury, Minnesota (ZIP 55125 local market)
+        state: >-
+          {% set live = states('sensor.woodbury_weekly_regular_gas_price_live') %}
+          {% if live not in ['unknown', 'unavailable', 'none', 'None', ''] %}
+            {{ live | float(default=0) | round(2) }}
+          {% else %}
+            {{ states('input_number.weekly_regular_gas_price_55125_fallback') | float(default=0) | round(2) }}
+          {% endif %}
+      - name: average_daily_vehicle_miles
+        unique_id: average_daily_vehicle_miles
+        icon: mdi:map-marker-distance
+        state_class: measurement
+        unit_of_measurement: mi/day
+        state: >-
+          {% set elapsed_days = [now().weekday() + 1, 1] | max %}
+          {% set weekly_miles = states('sensor.weekly_vehicle_mileage') | float(default=0) %}
+          {{ (weekly_miles / elapsed_days) | round(1) }}
+      - name: average_daily_gas_car_cost_30mpg
+        unique_id: average_daily_gas_car_cost_30mpg
+        icon: mdi:gas-station-outline
+        state_class: measurement
+        unit_of_measurement: USD/day
+        state: >-
+          {% set daily_miles = states('sensor.average_daily_vehicle_miles') | float(default=0) %}
+          {% set gas_price = states('sensor.weekly_regular_gas_price_55125') | float(default=0) %}
+          {{ ((daily_miles / 30) * gas_price) | round(2) }}
+      - name: average_daily_ev_savings_vs_30mpg
+        unique_id: average_daily_ev_savings_vs_30mpg
+        icon: mdi:piggy-bank
+        state_class: measurement
+        unit_of_measurement: USD/day
+        state: >-
+          {% set gas_cost = states('sensor.average_daily_gas_car_cost_30mpg') | float(default=0) %}
+          {% set ev_cost = states('sensor.average_daily_ev_charging_cost') | float(default=0) %}
+          {{ (gas_cost - ev_cost) | round(2) }}
 
 ########################
 # Utility Meter
@@ -898,6 +1010,13 @@ utility_meter:
       - off_peak
       - mid_peak
       - on_peak
+  weekly_ev_charging:
+    source: sensor.nigori_energy_added
+    cycle: weekly
+    tariffs:
+      - off_peak
+      - mid_peak
+      - on_peak
   monthly_ev_charging:
     source: sensor.nigori_energy_added
     cycle: monthly
@@ -905,6 +1024,9 @@ utility_meter:
       - off_peak
       - mid_peak
       - on_peak
+  weekly_vehicle_mileage:
+    source: sensor.nigori_odometer
+    cycle: weekly
   # hourly_water:
   #   source: sensor.watermeter_value
   #   name: Hourly Water Usage

--- a/tests/test_ev_cost_comparison.py
+++ b/tests/test_ev_cost_comparison.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UTILITIES_PATH = ROOT / "packages" / "utilities.yaml"
+TESLA_TILE_PATH = ROOT / "lovelace" / "tiles" / "tiles_tesla_charging.yaml"
+DASHBOARD_PATH = ROOT / ".storage" / "lovelace.ryan_new_mushroom"
+
+
+def test_utilities_package_defines_weekly_gas_price_and_ev_comparison_sensors() -> None:
+    text = UTILITIES_PATH.read_text(encoding="utf-8")
+
+    for token in (
+        "weekly_regular_gas_price_55125_fallback:",
+        "initial: 3.76",
+        "resource: https://www.way.com/gas/prices/minnesota/woodbury",
+        "woodbury_weekly_regular_gas_price_live",
+        "Week Ago Avg.",
+        "weekly_regular_gas_price_55125",
+        "average_daily_ev_charging_cost",
+        "average_daily_vehicle_miles",
+        "average_daily_gas_car_cost_30mpg",
+        "average_daily_ev_savings_vs_30mpg",
+        "weekly_ev_charging:",
+        "weekly_vehicle_mileage:",
+        "source: sensor.nigori_odometer",
+    ):
+        assert token in text
+
+
+def test_tesla_yaml_tile_exposes_ev_vs_gas_comparison_entities() -> None:
+    text = TESLA_TILE_PATH.read_text(encoding="utf-8")
+
+    for token in (
+        "sensor.average_daily_ev_charging_cost",
+        "sensor.average_daily_vehicle_miles",
+        "sensor.weekly_regular_gas_price_55125",
+        "sensor.average_daily_gas_car_cost_30mpg",
+        "sensor.average_daily_ev_savings_vs_30mpg",
+        "Avg Gas Cost / Day @ 30 MPG",
+        "EV Savings / Day vs 30 MPG",
+    ):
+        assert token in text
+
+
+def test_storage_dashboard_exposes_ev_vs_gas_comparison_tiles() -> None:
+    text = DASHBOARD_PATH.read_text(encoding="utf-8")
+
+    for token in (
+        '"entity": "sensor.average_daily_ev_charging_cost"',
+        '"entity": "sensor.average_daily_vehicle_miles"',
+        '"entity": "sensor.weekly_regular_gas_price_55125"',
+        '"entity": "sensor.average_daily_gas_car_cost_30mpg"',
+        '"entity": "sensor.average_daily_ev_savings_vs_30mpg"',
+    ):
+        assert token in text


### PR DESCRIPTION
## Summary
- add weekly EV charging cost and weekly odometer mileage rollups, then derive average daily EV charging cost, average daily miles, equivalent 30 MPG gas cost, and daily EV savings
- add a live Woodbury weekly regular-gas scrape with a manual 55125 fallback helper so the comparison keeps working if the source page changes
- surface the new EV-vs-gas comparison sensors in the Tesla charging dashboard and cover them with regression tests

## Testing
- `.venv/bin/pytest -q tests/test_ev_cost_comparison.py`
- `.venv/bin/pytest -q`
- `.venv/bin/yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`

## Notes
- the live gas feed uses Woodbury, Minnesota's weekly regular average from [Way](https://www.way.com/gas/prices/minnesota/woodbury) as the local market proxy for ZIP 55125
- the fallback helper is seeded to `$3.76/gal`, matching the current `Week Ago Avg.` value visible on March 28, 2026

Closes #187