### PR TITLE
Fix Inovelli day mode timing

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1588,7 +1588,62 @@ automation:
             - switch.sleep_mode
       - action: script.turn_on
         target:
-          entity_id: script.day_mode_switches
+          entity_id: script.day_mode_switches_general
+      - if:
+          - condition: state
+            entity_id: input_boolean.guest_mode
+            state: "off"
+        then:
+          - action: script.turn_on
+            target:
+              entity_id: script.day_mode_switches_office_guest_room
+
+  - alias: enable_office_guest_room_switch_day_mode_for_guest_mode
+    id: enable_office_guest_room_switch_day_mode_for_guest_mode
+    description: Keep the office and guest room switch LEDs in night mode until noon while guest mode is active.
+    trigger:
+      - trigger: time
+        at: "12:00:00"
+    condition:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "on"
+    action:
+      - action: script.turn_on
+        target:
+          entity_id: script.day_mode_switches_office_guest_room
+
+  - alias: enable_owner_suite_bedroom_switch_day_mode_after_morning_activity
+    id: enable_owner_suite_bedroom_switch_day_mode_after_morning_activity
+    description: Apply owner suite bedroom switch day mode after 8 AM once bed occupancy clears and both the bathroom and hallway have seen motion.
+    trigger:
+      - trigger: time
+        at: "08:00:00"
+      - trigger: state
+        entity_id: binary_sensor.bayesian_bed_occupancy
+        to: "off"
+      - trigger: state
+        entity_id: binary_sensor.owner_suite_bathroom_room_occupancy
+        to: "on"
+      - trigger: state
+        entity_id: binary_sensor.hallway_motion
+        to: "on"
+    condition:
+      - condition: time
+        after: "07:59:59"
+      - condition: state
+        entity_id: binary_sensor.bayesian_bed_occupancy
+        state: "off"
+      - >-
+        {{ is_state('binary_sensor.owner_suite_bathroom_room_occupancy', 'on')
+           or states.binary_sensor.owner_suite_bathroom_room_occupancy.last_changed >= today_at('08:00') }}
+      - >-
+        {{ is_state('binary_sensor.hallway_motion', 'on')
+           or states.binary_sensor.hallway_motion.last_changed >= today_at('08:00') }}
+    action:
+      - action: script.turn_on
+        target:
+          entity_id: script.day_mode_switches_owner_suite_bedroom
 
   - alias: button_reset_basement
     id: button_reset_basement

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -639,10 +639,6 @@ script:
                 position: "{{ repeat.index * 2 }}"
             - delay:
                 seconds: "{{ (75/(log(repeat.index + 1, 5))) | round(0, 'ceil', 5) }}"
-      - alias: "Set light switches to day mode"
-        continue_on_error: true
-        action: script.turn_on
-        entity_id: script.day_mode_switches
       - alias: "Turn on Adaptive Brightness for bedroom"
         continue_on_error: true
         action: switch.turn_on

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1871,15 +1871,49 @@ script:
 
   day_mode_switches:
     icon: mdi:light-switch
+    sequence:
+      - action: script.turn_on
+        target:
+          entity_id:
+            - script.day_mode_switches_general
+            - script.day_mode_switches_owner_suite_bedroom
+            - script.day_mode_switches_office_guest_room
+
+  day_mode_switches_general:
+    icon: mdi:light-switch
     variables:
       all_off_led_switches: >
-        {%- for device in states.number | select('match', '.*ledcolorwhenoff.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
+          | rejectattr('entity_id', 'search', 'office_fan_switch')
+          | rejectattr('entity_id', 'search', 'guest_room_fan_switch') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_on_led_switches: >
-        {%- for device in states.number | select('match', '.*ledcolorwhenon.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
+          | rejectattr('entity_id', 'search', 'office_fan_switch')
+          | rejectattr('entity_id', 'search', 'guest_room_fan_switch') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_switches_led_intensity_on: >
-        {%- for device in states.number | select('match', '.*ledintensitywhenon.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
+          | rejectattr('entity_id', 'search', 'office_fan_switch')
+          | rejectattr('entity_id', 'search', 'guest_room_fan_switch') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_switches_led_intensity_off: >
-        {%- for device in states.number | select('match', '.*ledintensitywhenoff.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
+          | rejectattr('entity_id', 'search', 'office_fan_switch')
+          | rejectattr('entity_id', 'search', 'guest_room_fan_switch') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_day_mode_singletapbehavior_switches: >
         {%- for device in states.select
           | selectattr('entity_id', 'search', 'singletapbehavior')
@@ -1907,7 +1941,7 @@ script:
     sequence:
       - action: logbook.log
         data:
-          entity_id: script.day_mode_switches
+          entity_id: script.day_mode_switches_general
           name: Exclude log
           message: "Setting light switch day mode colors and full-brightness single tap"
           domain: script
@@ -1946,6 +1980,116 @@ script:
           entity_id: >
             {{all_day_mode_defaultlevelremote_switches}}
           value: "254"
+
+  day_mode_switches_owner_suite_bedroom:
+    icon: mdi:light-switch
+    variables:
+      owner_suite_bedroom_off_led_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | selectattr('entity_id', 'search', 'owner_suite_fan_switch') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      owner_suite_bedroom_on_led_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | selectattr('entity_id', 'search', 'owner_suite_fan_switch') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      owner_suite_bedroom_led_intensity_on_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | selectattr('entity_id', 'search', 'owner_suite_fan_switch') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      owner_suite_bedroom_led_intensity_off_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | selectattr('entity_id', 'search', 'owner_suite_fan_switch') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+    sequence:
+      - action: logbook.log
+        data:
+          entity_id: script.day_mode_switches_owner_suite_bedroom
+          name: Exclude log
+          message: "Setting owner suite bedroom switch day mode colors"
+          domain: script
+      - action: number.set_value
+        data:
+          entity_id: >
+            {{owner_suite_bedroom_off_led_switches}}
+          value: "170"
+      - action: number.set_value
+        data:
+          entity_id: >
+            {{owner_suite_bedroom_led_intensity_off_switches}}
+          value: "1"
+      - action: number.set_value
+        data:
+          entity_id: >
+            {{owner_suite_bedroom_led_intensity_on_switches}}
+          value: "75"
+      - action: number.set_value
+        data:
+          entity_id: >
+            {{owner_suite_bedroom_on_led_switches}}
+          value: "170"
+
+  day_mode_switches_office_guest_room:
+    icon: mdi:light-switch
+    variables:
+      office_guest_room_off_led_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      office_guest_room_on_led_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      office_guest_room_led_intensity_on_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      office_guest_room_led_intensity_off_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+    sequence:
+      - action: logbook.log
+        data:
+          entity_id: script.day_mode_switches_office_guest_room
+          name: Exclude log
+          message: "Setting office and guest room switch day mode colors"
+          domain: script
+      - action: number.set_value
+        data:
+          entity_id: >
+            {{office_guest_room_off_led_switches}}
+          value: "170"
+      - action: number.set_value
+        data:
+          entity_id: >
+            {{office_guest_room_led_intensity_off_switches}}
+          value: "1"
+      - action: number.set_value
+        data:
+          entity_id: >
+            {{office_guest_room_led_intensity_on_switches}}
+          value: "75"
+      - action: number.set_value
+        data:
+          entity_id: >
+            {{office_guest_room_on_led_switches}}
+          value: "170"
 
   reset_inovelli_switches:
     icon: mdi:light-switch

--- a/tests/test_inovelli_day_mode_switches.py
+++ b/tests/test_inovelli_day_mode_switches.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ZIGBEE_ZWAVE_PATH = ROOT / "packages" / "zigbee_zwave.yaml"
+LIGHT_PATH = ROOT / "packages" / "light.yaml"
+WORKDAY_PATH = ROOT / "packages" / "workday.yaml"
+
+
+def _script_block(path: Path, script_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r} in {path.name}")
+
+    end = len(lines)
+    next_script = re.compile(r"^  [A-Za-z0-9_]+:$")
+    for index in range(start + 1, len(lines)):
+        if next_script.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _automation_block(path: Path, automation_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    id_line = f"    id: {automation_id}"
+    start = None
+
+    for index, line in enumerate(lines):
+        if line != id_line:
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_day_mode_wrapper_runs_general_bedroom_and_office_guest_scripts() -> None:
+    block = _script_block(ZIGBEE_ZWAVE_PATH, "day_mode_switches")
+
+    for script_entity in (
+        "script.day_mode_switches_general",
+        "script.day_mode_switches_owner_suite_bedroom",
+        "script.day_mode_switches_office_guest_room",
+    ):
+        assert script_entity in block
+
+
+def test_general_day_mode_script_excludes_delayed_owner_suite_office_and_guest_switches() -> None:
+    block = _script_block(ZIGBEE_ZWAVE_PATH, "day_mode_switches_general")
+
+    for delayed_switch in (
+        "owner_suite_fan_switch",
+        "office_fan_switch",
+        "guest_room_fan_switch",
+    ):
+        assert f"rejectattr('entity_id', 'search', '{delayed_switch}')" in block
+
+    for token in (
+        "all_day_mode_singletapbehavior_switches",
+        "all_day_mode_defaultlevellocal_switches",
+        "all_day_mode_defaultlevelremote_switches",
+        'message: "Setting light switch day mode colors and full-brightness single tap"',
+    ):
+        assert token in block
+
+
+def test_turn_off_sleep_mode_uses_general_day_mode_and_early_office_guest_when_no_guests() -> None:
+    block = _automation_block(LIGHT_PATH, "turn_off_sleep_mode")
+
+    assert 'at: "08:00:00"' in block
+    assert "script.day_mode_switches_general" in block
+    assert "entity_id: input_boolean.guest_mode" in block
+    assert 'state: "off"' in block
+    assert "script.day_mode_switches_office_guest_room" in block
+    assert "script.day_mode_switches\n" not in block
+
+
+def test_guest_mode_keeps_office_and_guest_room_switches_delayed_until_noon() -> None:
+    block = _automation_block(LIGHT_PATH, "enable_office_guest_room_switch_day_mode_for_guest_mode")
+
+    assert 'at: "12:00:00"' in block
+    assert "entity_id: input_boolean.guest_mode" in block
+    assert 'state: "on"' in block
+    assert "script.day_mode_switches_office_guest_room" in block
+
+
+def test_owner_suite_bedroom_day_mode_waits_for_bed_bathroom_and_hallway_activity() -> None:
+    block = _automation_block(LIGHT_PATH, "enable_owner_suite_bedroom_switch_day_mode_after_morning_activity")
+
+    for entity_id in (
+        "binary_sensor.bayesian_bed_occupancy",
+        "binary_sensor.owner_suite_bathroom_room_occupancy",
+        "binary_sensor.hallway_motion",
+    ):
+        assert entity_id in block
+
+    assert 'after: "07:59:59"' in block
+    assert "today_at('08:00')" in block
+    assert "script.day_mode_switches_owner_suite_bedroom" in block
+
+
+def test_wake_up_script_no_longer_forces_day_mode_before_eight_am() -> None:
+    block = _script_block(WORKDAY_PATH, "wake_up_script")
+
+    assert "switch.sleep_mode" in block
+    assert "script.day_mode_switches" not in block


### PR DESCRIPTION
Closes #142

## Summary
- split Inovelli day mode into general, owner suite bedroom, and office/guest room scripts
- keep the owner suite bedroom in night mode until bed occupancy clears and both bathroom and hallway motion have happened after 8 AM
- keep office and guest room in night mode until noon when guest mode is on, otherwise enable them at 8 AM
- add regression coverage for the new switch timing behavior

## Validation
- python3 scripts/check_ha_python_support.py --python-version-file .python-version
- /tmp/codex-issue-142-venv/bin/pytest -q
- /tmp/codex-issue-142-venv/bin/yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt

## Notes
- Home Assistant check_config was not run locally because Docker is not installed in this environment.