### PR TITLE
Guard Uplift desk scripts when device is unavailable

### DIFF
--- a/packages/desk.yaml
+++ b/packages/desk.yaml
@@ -279,6 +279,16 @@ script:
       - condition: state
         entity_id: timer.uplift_desk_motion_window
         state: "idle"
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_max_height
+            state: "unavailable"
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_max_height
+            state: "unknown"
       - action: button.press
         target:
           entity_id: button.uplift_desk_75b205_move_to_max_height
@@ -296,6 +306,16 @@ script:
       - condition: state
         entity_id: timer.uplift_desk_motion_window
         state: "idle"
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_preset_1
+            state: "unavailable"
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_preset_1
+            state: "unknown"
       - action: button.press
         target:
           entity_id: button.uplift_desk_75b205_move_to_preset_1
@@ -313,6 +333,16 @@ script:
       - condition: state
         entity_id: timer.uplift_desk_motion_window
         state: "idle"
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_preset_2
+            state: "unavailable"
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_preset_2
+            state: "unknown"
       - action: button.press
         target:
           entity_id: button.uplift_desk_75b205_move_to_preset_2
@@ -329,6 +359,16 @@ script:
     mode: single
     icon: mdi:arrow-up-bold-box
     sequence:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_max_height
+            state: "unavailable"
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_max_height
+            state: "unknown"
       - action: button.press
         target:
           entity_id: button.uplift_desk_75b205_move_to_max_height
@@ -341,6 +381,16 @@ script:
     mode: single
     icon: mdi:numeric-1-box
     sequence:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_preset_1
+            state: "unavailable"
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_preset_1
+            state: "unknown"
       - action: button.press
         target:
           entity_id: button.uplift_desk_75b205_move_to_preset_1
@@ -353,6 +403,16 @@ script:
     mode: single
     icon: mdi:numeric-2-box
     sequence:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_preset_2
+            state: "unavailable"
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: button.uplift_desk_75b205_move_to_preset_2
+            state: "unknown"
       - action: button.press
         target:
           entity_id: button.uplift_desk_75b205_move_to_preset_2

--- a/tests/test_desk_package.py
+++ b/tests/test_desk_package.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+DESK_PATH = Path(__file__).resolve().parents[1] / "packages" / "desk.yaml"
+
+
+def _script_block(script_id: str) -> str:
+    lines = DESK_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r}")
+
+    end = len(lines)
+    next_script = re.compile(r"^  [A-Za-z0-9_]+:$")
+    for index in range(start + 1, len(lines)):
+        if next_script.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_automatic_desk_moves_skip_unavailable_buttons() -> None:
+    expectations = {
+        "uplift_desk_auto_move_max": "button.uplift_desk_75b205_move_to_max_height",
+        "uplift_desk_auto_move_preset_1": "button.uplift_desk_75b205_move_to_preset_1",
+        "uplift_desk_auto_move_preset_2": "button.uplift_desk_75b205_move_to_preset_2",
+    }
+
+    for script_id, button_id in expectations.items():
+        block = _script_block(script_id)
+
+        assert 'entity_id: timer.uplift_desk_motion_window' in block
+        assert 'state: "idle"' in block
+        assert block.count(f"entity_id: {button_id}") >= 3
+        assert 'state: "unavailable"' in block
+        assert 'state: "unknown"' in block
+        assert "action: timer.start" in block
+
+
+def test_manual_desk_moves_skip_unavailable_buttons() -> None:
+    expectations = {
+        "uplift_desk_manual_move_max": "button.uplift_desk_75b205_move_to_max_height",
+        "uplift_desk_manual_move_preset_1": "button.uplift_desk_75b205_move_to_preset_1",
+        "uplift_desk_manual_move_preset_2": "button.uplift_desk_75b205_move_to_preset_2",
+    }
+
+    for script_id, button_id in expectations.items():
+        block = _script_block(script_id)
+
+        assert block.count(f"entity_id: {button_id}") >= 3
+        assert 'state: "unavailable"' in block
+        assert 'state: "unknown"' in block
+        assert "action: button.press" in block


### PR DESCRIPTION
## Summary
- guard every Uplift desk button press behind native Home Assistant availability checks so automations and manual scripts no-op when the desk integration is not currently loaded
- add focused regression tests that lock the `unavailable`/`unknown` guard into the desk package
- keep the existing desk automation flow and motion-window timer unchanged when the desk entities are healthy

## Live HA evidence
- `uplift_desk` config entry is currently `setup_retry`
- Home Assistant reports: `Could not find Uplift Desk with address F0:AE:7D:75:B2:05`
- the desk button entities are restored as unavailable, so direct `button.press` calls are the repo-side source of avoidable runtime/action errors whenever desk automations fire

## Research
- Home Assistant button entities can become `unavailable`, so action paths should guard live service calls instead of assuming device reachability
- community BLE / Bluetooth-proxy debugging guidance consistently points to range, proxy coverage, or adapter reachability as the underlying cause of `device not found` errors, which makes a defensive script guard the right repo-side fix while the live BLE path is investigated separately

## Testing
- `pytest -q tests/test_desk_package.py`
- `pytest -q tests`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/desk.yaml`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`

Related to #182