### PR TITLE
Fix battery notification wording for issue 200

### DIFF
--- a/packages/batteries.yaml
+++ b/packages/batteries.yaml
@@ -188,6 +188,12 @@ automation:
         {{ states('sensor.battery_low_20') | int(0) }}
       battery_summary: >-
         {{ state_attr('sensor.battery_low_20', 'summary') | default('', true) }}
+      battery_label: >-
+        {{ 'battery sensor' if battery_count == 1 else 'battery sensors' }}
+      battery_title: >-
+        {{ battery_count }} {{ battery_label }} below 20%
+      battery_message: >-
+        {{ ('Affected sensor' if battery_count == 1 else 'Affected sensors') ~ ':\n' ~ battery_summary }}
       count_increased: >-
         {{ trigger.id == 'summary_change'
            and trigger.from_state is not none
@@ -208,10 +214,8 @@ automation:
         default:
           - action: persistent_notification.create
             data:
-              title: >-
-                Battery Sensors Below 20% ({{ battery_count }})
-              message: >-
-                {{ battery_summary }}
+              title: "{{ battery_title }}"
+              message: "{{ battery_message }}"
               notification_id: low-battery-20
           - choose:
               - conditions:
@@ -221,10 +225,8 @@ automation:
                 sequence:
                   - action: notify.all
                     data:
-                      title: >-
-                        Battery Sensors Below 20% ({{ battery_count }})
-                      message: >-
-                        {{ battery_summary }}
+                      title: "{{ battery_title }}"
+                      message: "{{ battery_message }}"
 
   - id: notify_battery_dying_10
     alias: notify_battery_dying_10
@@ -244,6 +246,12 @@ automation:
         {{ states('sensor.battery_low_10') | int(0) }}
       battery_summary: >-
         {{ state_attr('sensor.battery_low_10', 'summary') | default('', true) }}
+      battery_label: >-
+        {{ 'battery sensor' if battery_count == 1 else 'battery sensors' }}
+      battery_title: >-
+        {{ battery_count }} {{ battery_label }} below 10%
+      battery_message: >-
+        {{ ('Affected sensor' if battery_count == 1 else 'Affected sensors') ~ ':\n' ~ battery_summary }}
       count_increased: >-
         {{ trigger.id == 'summary_change'
            and trigger.from_state is not none
@@ -264,10 +272,8 @@ automation:
         default:
           - action: persistent_notification.create
             data:
-              title: >-
-                Battery Sensors Below 10% ({{ battery_count }})
-              message: >-
-                {{ battery_summary }}
+              title: "{{ battery_title }}"
+              message: "{{ battery_message }}"
               notification_id: low-battery-10
           - choose:
               - conditions:
@@ -277,10 +283,8 @@ automation:
                 sequence:
                   - action: notify.all
                     data:
-                      title: >-
-                        Battery Sensors Below 10% ({{ battery_count }})
-                      message: >-
-                        {{ battery_summary }}
+                      title: "{{ battery_title }}"
+                      message: "{{ battery_message }}"
 
 ########################
 # Binary Sensors

--- a/tests/test_batteries_package.py
+++ b/tests/test_batteries_package.py
@@ -68,11 +68,17 @@ def test_battery_automations_update_notifications_from_dynamic_sensor_summaries(
         assert "notify.all" in block
         assert f"states('sensor.battery_low_{threshold}')" in block
         assert f"state_attr('sensor.battery_low_{threshold}', 'summary')" in block
+        assert "battery_label" in block
+        assert "battery_title" in block
+        assert "battery_message" in block
+        assert "battery sensor' if battery_count == 1 else 'battery sensors" in block
+        assert "Affected sensor' if battery_count == 1 else 'Affected sensors" in block
         assert "trigger.id == 'summary_change'" in block
         assert "count_increased" in block
         assert f"notification_id: low-battery-{threshold}" in block
-        assert f"Battery Sensors Below {threshold}%" in block
+        assert f"below {threshold}%" in block
         assert "trigger.from_state is not none" in block
+        assert f"Battery Sensors Below {threshold}% (" not in block
 
 
 def test_logbook_excludes_current_battery_monitor_entities_instead_of_stale_ones() -> None:

--- a/tests/test_inovelli_day_mode_switches.py
+++ b/tests/test_inovelli_day_mode_switches.py
@@ -86,7 +86,7 @@ def test_general_day_mode_script_excludes_delayed_owner_suite_office_and_guest_s
         "all_day_mode_singletapbehavior_switches",
         "all_day_mode_defaultlevellocal_switches",
         "all_day_mode_defaultlevelremote_switches",
-        'message: "Setting light switch day mode colors and full-brightness single tap"',
+        'message: "Setting light switch day mode colors and full-brightness defaults"',
     ):
         assert token in block
 

--- a/tests/test_zigbee_zwave_inovelli_day_mode.py
+++ b/tests/test_zigbee_zwave_inovelli_day_mode.py
@@ -26,7 +26,7 @@ def _script_block(name: str) -> str:
 
 
 def test_day_mode_switches_restores_old_single_tap_behavior() -> None:
-    block = _script_block("day_mode_switches")
+    block = _script_block("day_mode_switches_general")
 
     assert "all_day_mode_singletapbehavior_switches" in block
     assert 'option: "Old Behavior"' in block
@@ -34,7 +34,7 @@ def test_day_mode_switches_restores_old_single_tap_behavior() -> None:
 
 
 def test_day_mode_switches_keeps_full_brightness_defaults() -> None:
-    block = _script_block("day_mode_switches")
+    block = _script_block("day_mode_switches_general")
 
     assert "all_day_mode_defaultlevellocal_switches" in block
     assert "all_day_mode_defaultlevelremote_switches" in block


### PR DESCRIPTION
Closes #200.

## Summary
- replace ambiguous battery notification titles like `Battery Sensors Below 10% (1)` with explicit count-based titles such as `1 battery sensor below 10%`
- prefix battery notification bodies with `Affected sensor(s):` so the per-device list reads clearly in persistent and push notifications
- refresh stale Inovelli day-mode tests so the existing suite matches the current script split and logbook wording

## Validation
- `.venv/bin/python -m pytest tests`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`