### PR TITLE
Document current Tesla departure planner behavior

### DIFF
--- a/docs/tesla_departure_planner.md
+++ b/docs/tesla_departure_planner.md
@@ -38,7 +38,7 @@ The trip-selection template now only considers future departures inside the next
 
 These drive non-trip next-morning departure planning.
 
-When an alarm-based departure is active, the planner now schedules cabin preconditioning regardless of outdoor temperature.
+Alarm-only plans affect charge-limit planning, but they do not create Tesla scheduled-departure or cabin-preconditioning overrides on their own. Cabin preconditioning only runs when there is a real upcoming calendar departure.
 
 ### Weather inputs
 
@@ -88,7 +88,7 @@ The schedule helper preserves the Tesla app's own charging schedule when the car
 - `OCC`
 - `SPCC`
 
-At `home`, Home Assistant can still set charge limit and schedule departure preconditioning, but it omits the Tesla off-peak charging fields so the Tesla-app charging defaults remain authoritative.
+At `home`, Home Assistant can still set charge limit and, for real calendar departures, write a Tesla scheduled-departure/preconditioning entry. It omits the Tesla off-peak charging fields there, so the Tesla app's charging defaults remain authoritative even though Tesla scheduled departure can still be updated.
 
 At `parents`, `OCC`, and `SPCC`, the planner is currently hands-off. Those locations are protected so Tesla-app charging defaults remain authoritative there, and Home Assistant does not actively create departure plans there.
 
@@ -125,13 +125,14 @@ Script:
 
 Behavior:
 
-- enables Tesla scheduled departure for any planned calendar departure or enabled alarm when a departure time exists
+- enables Tesla scheduled departure only for real calendar departures that still have a valid future departure time
+- does not enable Tesla scheduled departure for alarm-only plans; those only influence charge-limit planning and planner messaging
 - disables Tesla scheduled departure when the planner no longer has a Home Assistant-managed preconditioning plan to keep
 - refuses to schedule preconditioning when the computed departure window is already in the past
 - stores the last Home Assistant-managed Tesla departure in `input_text.tesla_managed_departure_time`
 - clears that Home Assistant-managed Tesla schedule as soon as the stored departure time passes, even if the car is no longer at home
 - skips scheduled departure for all-day calendar events
-- preserves Tesla-app charging schedules at `home` by omitting the off-peak charging parameters from the Tesla API call there
+- preserves Tesla-app charging schedules at `home` by omitting the off-peak charging parameters from the Tesla API call there, even though calendar-departure plans can still update Tesla scheduled departure/preconditioning
 - preserves Tesla-app charging schedules at protected locations during cleanup by only clearing Tesla when the live scheduled-departure state still matches the stored HA-managed departure and Tesla is not advertising scheduled charging or off-peak charging
 
 ### Notifications
@@ -190,7 +191,8 @@ Manual regression cases worth checking in Template Developer Tools or against li
 - Tesla `sensor.nigori_charging_rate` `time_left` as `HH:MM:SS` or ISO8601 still produces a valid `charge_complete` timestamp.
 - A just-finished calendar departure disappears from `binary_sensor.upcoming_trip_charging` and clears Tesla scheduled departure on the next planner recompute.
 - A calendar event that is still upcoming but already inside the departure buffer skips scheduled preconditioning instead of creating a stale past-due Tesla schedule.
-- At `home`, enabling a planner-managed departure only changes Tesla preconditioning and does not create or rewrite Tesla charging schedules.
+- At `home`, a real calendar departure can still create or update Tesla scheduled departure/preconditioning while leaving Tesla app charging defaults in place because the off-peak charging fields are omitted.
+- Alarm-only plans adjust charge limit and planner messaging but do not create Tesla scheduled departure or cabin-preconditioning overrides.
 - At `parents`, `OCC`, and `SPCC`, Tesla dashboard text reflects that Home Assistant is preserving Tesla-app defaults and not actively planning departures there.
 - When there is no stored `input_text.tesla_managed_departure_time`, the planner does not send a redundant Tesla disable call.
 - At protected locations, cleanup/no-plan disables only call the Tesla API when the live Tesla scheduled-departure state still matches the stored HA-managed departure and Tesla is not advertising scheduled charging or off-peak charging.


### PR DESCRIPTION
## Summary
- update Tesla departure planner documentation to match the current mainline behavior
- clarify that alarm-only plans affect charge-limit planning but do not create Tesla scheduled-departure/preconditioning overrides
- clarify that Home can still update Tesla scheduled departure for real calendar departures while omitting off-peak charging fields

## Validation
- not run (documentation-only change)

Addresses the documentation review finding for the Tesla planner.