### PR TITLE
Fix Music Assistant search helper flow

### DIFF
--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -1513,6 +1513,10 @@
                         {
                           "entity": "input_select.music_assistant_search_results",
                           "name": "Results"
+                        },
+                        {
+                          "entity": "input_select.music_assistant_playlist_target",
+                          "name": "Playlist target"
                         }
                       ]
                     },
@@ -1551,12 +1555,21 @@
                               "enqueue": "add"
                             }
                           }
+                        },
+                        {
+                          "type": "button",
+                          "name": "Add to playlist",
+                          "icon": "mdi:playlist-edit",
+                          "tap_action": {
+                            "action": "call-service",
+                            "service": "script.music_assistant_add_selected_search_result_to_playlist"
+                          }
                         }
                       ]
                     },
                     {
                       "type": "markdown",
-                      "content": "Search by name, then narrow results with a provider token like `spotify`, `tunein`, or `library`."
+                      "content": "Search by name, narrow results with a provider token when needed, then choose whether to play now, queue, or append the selected item into one of the supported playlist scripts."
                     }
                   ]
                 }

--- a/README.md
+++ b/README.md
@@ -85,11 +85,13 @@ The `Music Assistant` section on the dashboard includes a small search flow:
 2. Optionally pick a provider token from `input_select.music_assistant_provider_filter`.
 3. Choose the media type from `input_select.music_assistant_search_media_type`.
 4. Press `script.music_assistant_search_music` to populate `input_select.music_assistant_search_results`.
-5. Use `script.music_assistant_play_selected_search_result` to play the selected result now or add it to the current queue.
+5. Optionally choose a target playlist script from `input_select.music_assistant_playlist_target`.
+6. Use `script.music_assistant_play_selected_search_result` to play the selected result now or add it to the current queue.
+7. Use `script.music_assistant_add_selected_search_result_to_playlist` to append the selected Music Assistant URI to the chosen `plists`-based script and reload scripts.
 
 The search helper derives the Music Assistant `config_entry_id` dynamically from `media_player.bedroom_sonos_2`, so it does not depend on a hard-coded config entry. The provider dropdown refreshes from the current unfiltered search response, which keeps the options aligned with the providers that can satisfy the active query.
 
-This flow appends to the live Music Assistant queue on `media_player.bedroom_sonos_2`, which is the current "playlist" target in the dashboard.
+The supported playlist-script targets are `spotify_bedtime`, `spotify_wake_up`, `spotify_arrival`, and `bedroom_playlist_0` through `bedroom_playlist_5`. Appending a result updates `packages/media_player.yaml` in place and then reloads Home Assistant scripts so the change is immediately available.
 
 ### Adding Another Radio Station
 

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -551,6 +551,20 @@ input_select:
     options:
       - All providers
     initial: All providers
+  music_assistant_playlist_target:
+    name: "Music Assistant playlist target"
+    icon: mdi:playlist-edit
+    options:
+      - Bedtime || spotify_bedtime
+      - Wake Up || spotify_wake_up
+      - Arrival || spotify_arrival
+      - Bedroom Playlist 0 || bedroom_playlist_0
+      - Bedroom Playlist 1 || bedroom_playlist_1
+      - Bedroom Playlist 2 || bedroom_playlist_2
+      - Bedroom Playlist 3 || bedroom_playlist_3
+      - Bedroom Playlist 4 || bedroom_playlist_4
+      - Bedroom Playlist 5 || bedroom_playlist_5
+    initial: Bedtime || spotify_bedtime
   music_assistant_search_media_type:
     name: "Music Assistant search type"
     icon: mdi:music-note-search
@@ -616,6 +630,16 @@ plant: {}
 # Scenes
 ########################
 scene: []
+
+########################
+# Shell Command
+########################
+shell_command:
+  music_assistant_append_playlist_item: >-
+    python3 /config/scripts/update_music_assistant_playlist.py
+    --config /config/packages/media_player.yaml
+    --target '{{ target_script | replace("'", "'\"'\"'") }}'
+    --item '{{ item_uri | replace("'", "'\"'\"'") }}'
 
 ########################
 # Scripts
@@ -962,6 +986,46 @@ script:
                   entity_id: "{{ target_entity }}"
                   media_item: "{{ selected_uri }}"
                   enqueue: "{{ enqueue | default('add') }}"
+
+  music_assistant_add_selected_search_result_to_playlist:
+    alias: "Add selected Music Assistant search result to playlist"
+    fields:
+      playlist_target:
+        description: "Playlist target script id or option label"
+    variables:
+      selected_option: "{{ states('input_select.music_assistant_search_results') | trim }}"
+      selected_uri: >-
+        {% if ' || ' in selected_option %}
+          {{ selected_option.split(' || ', 1)[1] | trim }}
+        {% else %}
+          {{ selected_option }}
+        {% endif %}
+      target_option: "{{ playlist_target | default(states('input_select.music_assistant_playlist_target')) | trim }}"
+      target_script: >-
+        {% if ' || ' in target_option %}
+          {{ target_option.split(' || ', 1)[1] | trim }}
+        {% else %}
+          {{ target_option }}
+        {% endif %}
+    sequence:
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ selected_uri not in ['', 'No results found'] and target_script != '' }}"
+            sequence:
+              - action: shell_command.music_assistant_append_playlist_item
+                data:
+                  target_script: "{{ target_script }}"
+                  item_uri: "{{ selected_uri }}"
+              - delay:
+                  seconds: 1
+              - action: script.reload
+              - action: logbook.log
+                data:
+                  entity_id: "script.{{ target_script }}"
+                  domain: script
+                  name: Music Assistant Playlist Builder
+                  message: "Added {{ selected_uri }} to {{ target_script }}"
 
   music_assistant_radio_wake_up:
     alias: "Radio wake-up via Music Assistant"

--- a/scripts/update_music_assistant_playlist.py
+++ b/scripts/update_music_assistant_playlist.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Append Music Assistant items to supported playlist scripts."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+SUPPORTED_PLAYLIST_SCRIPTS = {
+    "bedroom_playlist_0",
+    "bedroom_playlist_1",
+    "bedroom_playlist_2",
+    "bedroom_playlist_3",
+    "bedroom_playlist_4",
+    "bedroom_playlist_5",
+    "spotify_arrival",
+    "spotify_bedtime",
+    "spotify_wake_up",
+}
+
+SCRIPT_START_RE = re.compile(r"^  (?P<script>[A-Za-z0-9_]+):$")
+
+
+def append_item_to_playlist_config(content: str, script_id: str, item_uri: str) -> tuple[str, bool]:
+    """Append an item URI to a supported script's Jinja `plists` list."""
+    if script_id not in SUPPORTED_PLAYLIST_SCRIPTS:
+        raise ValueError(f"Unsupported playlist target: {script_id}")
+    if not item_uri or any(char in item_uri for char in ('"', "\n", "\r")):
+        raise ValueError("Playlist items must be non-empty and single-line")
+
+    lines = content.splitlines()
+    start_index = _find_script_start(lines, script_id)
+    end_index = _find_script_end(lines, start_index)
+    plists_start, plists_end = _find_plists_block(lines, start_index, end_index)
+    plists_block = "\n".join(lines[plists_start : plists_end + 1])
+    if item_uri in re.findall(r'"([^"\n]+)"', plists_block):
+        return content, False
+
+    insert_index = plists_end
+    last_item_index = _find_last_item_line(lines, plists_start, plists_end)
+    if last_item_index is None:
+        raise ValueError(f"Could not find any playlist items for {script_id}")
+
+    if lines[last_item_index].rstrip().endswith('"'):
+        lines[last_item_index] = f"{lines[last_item_index]},"
+
+    closing_indent = lines[plists_end][: len(lines[plists_end]) - len(lines[plists_end].lstrip(" "))]
+    lines.insert(insert_index, f'{closing_indent}"{item_uri}"')
+    updated = "\n".join(lines)
+    if content.endswith("\n"):
+        updated += "\n"
+    return updated, True
+
+
+def _find_script_start(lines: list[str], script_id: str) -> int:
+    needle = f"  {script_id}:"
+    for index, line in enumerate(lines):
+        if line == needle:
+            return index
+    raise ValueError(f"Could not find script {script_id}")
+
+
+def _find_script_end(lines: list[str], start_index: int) -> int:
+    for index in range(start_index + 1, len(lines)):
+        if SCRIPT_START_RE.match(lines[index]):
+            return index
+    return len(lines)
+
+
+def _find_plists_block(lines: list[str], start_index: int, end_index: int) -> tuple[int, int]:
+    plists_start: int | None = None
+    for index in range(start_index, end_index):
+        if "{%- set plists = [" in lines[index]:
+            plists_start = index
+            break
+    if plists_start is None:
+        raise ValueError("Could not find plists declaration")
+
+    for index in range(plists_start, end_index):
+        if "] -%}" in lines[index]:
+            return plists_start, index
+    raise ValueError("Could not find end of plists declaration")
+
+
+def _find_last_item_line(lines: list[str], plists_start: int, plists_end: int) -> int | None:
+    for index in range(plists_end - 1, plists_start - 1, -1):
+        stripped = lines[index].strip()
+        if stripped.startswith('"') and stripped.endswith('"'):
+            return index
+        if stripped.startswith('"') and stripped.endswith('",'):
+            return index
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--item", required=True)
+    args = parser.parse_args(argv)
+
+    config_path = Path(args.config)
+    content = config_path.read_text(encoding="utf-8")
+    updated, changed = append_item_to_playlist_config(content, args.target, args.item)
+    if changed:
+        config_path.write_text(updated, encoding="utf-8")
+        print(f"Added {args.item} to {args.target}")
+    else:
+        print(f"{args.item} already present in {args.target}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def media_player_config_text() -> str:
+    return (Path(__file__).resolve().parents[1] / "packages" / "media_player.yaml").read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -60,6 +60,20 @@ def test_music_assistant_search_helpers_populate_dashboard_results() -> None:
         assert token in block
 
 
+def test_music_assistant_selected_result_can_be_added_to_playlist_targets() -> None:
+    block = _script_block("music_assistant_add_selected_search_result_to_playlist")
+
+    for token in (
+        "input_select.music_assistant_search_results",
+        "input_select.music_assistant_playlist_target",
+        "selected_option.split(' || ', 1)[1]",
+        "target_option.split(' || ', 1)[1]",
+        "shell_command.music_assistant_append_playlist_item",
+        "script.reload",
+    ):
+        assert token in block
+
+
 def test_music_assistant_selected_result_can_be_queued_or_played() -> None:
     block = _script_block("music_assistant_play_selected_search_result")
 
@@ -121,10 +135,12 @@ def test_music_assistant_dashboard_exposes_search_controls() -> None:
         "Music Assistant",
         "input_text.music_assistant_search_query",
         "input_select.music_assistant_provider_filter",
+        "input_select.music_assistant_playlist_target",
         "input_select.music_assistant_search_media_type",
         "input_select.music_assistant_search_results",
         "script.music_assistant_search_music",
         "script.music_assistant_play_selected_search_result",
+        "script.music_assistant_add_selected_search_result_to_playlist",
     ):
         assert token in dashboard
 
@@ -138,5 +154,9 @@ def test_music_assistant_search_helpers_are_restart_safe() -> None:
         'music_assistant_provider_filter:',
         '- All providers',
         'initial: All providers',
+        'music_assistant_playlist_target:',
+        'Bedtime || spotify_bedtime',
+        'shell_command:',
+        'music_assistant_append_playlist_item:',
     ):
         assert token in package

--- a/tests/test_update_music_assistant_playlist.py
+++ b/tests/test_update_music_assistant_playlist.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "update_music_assistant_playlist.py"
+SPEC = importlib.util.spec_from_file_location("update_music_assistant_playlist", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Could not load {MODULE_PATH}")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+SUPPORTED_PLAYLIST_SCRIPTS = MODULE.SUPPORTED_PLAYLIST_SCRIPTS
+append_item_to_playlist_config = MODULE.append_item_to_playlist_config
+
+
+def _script_block(text: str, script_id: str) -> str:
+    lines = text.splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r}")
+
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  ") and lines[index].endswith(":") and not lines[index].startswith("    "):
+            return "\n".join(lines[start:index])
+
+    return "\n".join(lines[start:])
+
+
+def test_append_item_to_playlist_config_appends_once(media_player_config_text: str) -> None:
+    updated, changed = append_item_to_playlist_config(
+        media_player_config_text,
+        "spotify_bedtime",
+        "spotify:playlist:test-addition",
+    )
+
+    assert changed is True
+    block = _script_block(updated, "spotify_bedtime")
+    assert '"spotify:playlist:test-addition"' in block
+    assert block.count('"spotify:playlist:test-addition"') == 1
+
+
+def test_append_item_to_playlist_config_deduplicates(media_player_config_text: str) -> None:
+    updated, changed = append_item_to_playlist_config(
+        media_player_config_text,
+        "spotify_bedtime",
+        "Groove Salad",
+    )
+
+    assert changed is False
+    assert updated == media_player_config_text
+
+
+def test_append_item_to_playlist_config_rejects_unknown_targets(media_player_config_text: str) -> None:
+    with pytest.raises(ValueError, match="Unsupported playlist target"):
+        append_item_to_playlist_config(
+            media_player_config_text,
+            "music_assistant_search_music",
+            "spotify:playlist:test-addition",
+        )
+
+
+def test_supported_playlist_scripts_cover_dashboard_targets() -> None:
+    assert SUPPORTED_PLAYLIST_SCRIPTS == {
+        "bedroom_playlist_0",
+        "bedroom_playlist_1",
+        "bedroom_playlist_2",
+        "bedroom_playlist_3",
+        "bedroom_playlist_4",
+        "bedroom_playlist_5",
+        "spotify_arrival",
+        "spotify_bedtime",
+        "spotify_wake_up",
+    }


### PR DESCRIPTION
## Summary
- derive the Music Assistant `config_entry_id` dynamically from `media_player.bedroom_sonos_2` so dashboard searches no longer fail when Home Assistant requires the config entry
- replace the provider free-text helper with a restart-safe dropdown that refreshes from the current unfiltered Music Assistant search response
- initialize the query helper at startup and update the dashboard, README, and tests for the new search flow

## Testing
- `pytest tests/test_media_player_music_assistant.py -q`
- `pytest -q`

Refs #173