### PR TITLE
Add goodnight integrity bedtime sweep

### DIFF
--- a/packages/house_mode.yaml
+++ b/packages/house_mode.yaml
@@ -41,6 +41,11 @@ homeassistant:
       friendly_name: "House Transition"
       icon: mdi:home-switch
 
+    script.goodnight_integrity:
+      <<: *customize
+      friendly_name: "Goodnight Integrity"
+      icon: mdi:shield-moon
+
 ########################
 # Automation
 ########################
@@ -319,3 +324,211 @@ script:
             action: notify.all
             data:
               message: "{{ notify_message }}"
+
+  goodnight_integrity:
+    alias: goodnight_integrity
+    description: >-
+      Quietly verify the house is in a sleep-safe state by shutting down
+      straggler lights, fans, and common-area media, then checking the lock,
+      covers, and climate for exceptions.
+    mode: queued
+    max: 5
+    fields:
+      reason:
+        description: Optional reason for the bedtime integrity run.
+        example: bed_lamps_off
+    variables:
+      guest_mode_enabled: "{{ is_state('input_boolean.guest_mode', 'on') }}"
+      guest_room_occupied: "{{ is_state('binary_sensor.guest_room_occupancy_2', 'on') }}"
+      guest_context_enabled: "{{ guest_mode_enabled or guest_room_occupied }}"
+    sequence:
+      - parallel:
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ guest_mode_enabled }}"
+                sequence:
+                  - action: script.lights_off_except
+                    data:
+                      exclude_lights:
+                        - light.outside_front_hue
+                        - light.outside_north_west_garage
+                        - light.outside_south_west_garage
+                        - light.outside_front_door
+                        - light.office_all
+                        - light.den_all
+                        - light.guest_room_ceiling
+                      transition: 30
+              - conditions:
+                  - condition: template
+                    value_template: "{{ guest_room_occupied }}"
+                sequence:
+                  - action: script.lights_off_except
+                    data:
+                      exclude_lights:
+                        - light.outside_front_hue
+                        - light.outside_north_west_garage
+                        - light.outside_south_west_garage
+                        - light.outside_front_door
+                        - light.guest_room_ceiling
+                      transition: 30
+            default:
+              - action: script.lights_off_except
+                data:
+                  exclude_lights:
+                    - light.outside_front_hue
+                    - light.outside_north_west_garage
+                    - light.outside_south_west_garage
+                    - light.outside_front_door
+                  transition: 30
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ guest_mode_enabled }}"
+                sequence:
+                  - continue_on_error: true
+                    action: fan.turn_off
+                    target:
+                      entity_id:
+                        - fan.den_ceiling
+              - conditions:
+                  - condition: template
+                    value_template: "{{ guest_room_occupied }}"
+                sequence:
+                  - continue_on_error: true
+                    action: fan.turn_off
+                    target:
+                      entity_id:
+                        - fan.den_ceiling
+                        - fan.office_ceiling_fan
+            default:
+              - continue_on_error: true
+                action: fan.turn_off
+                target:
+                  entity_id:
+                    - fan.den_ceiling
+                    - fan.office_ceiling_fan
+                    - fan.guest_room
+          - continue_on_error: true
+            action: switch.turn_off
+            target:
+              entity_id:
+                - switch.office_red_lava_lamp
+                - switch.northern_light_lava_lamp
+          - continue_on_error: true
+            action: media_player.turn_off
+            target:
+              entity_id:
+                - media_player.lg_webos_smart_tv
+                - media_player.basement
+          - continue_on_error: true
+            action: script.turn_off_owner_suite_inovelli_switch_leds
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ not guest_context_enabled }}"
+                sequence:
+                  - variables:
+                      bedroom_audio_pause_targets: >-
+                        {%- set bedroom_entity = 'media_player.bedroom_sonos_2' -%}
+                        {%- set candidate_players = [
+                          'media_player.bathroom_sonos_2',
+                          'media_player.office_sonos_2',
+                          'media_player.den_sonos_2',
+                          'media_player.tiki_room_2'
+                        ] -%}
+                        {%- set ns = namespace(
+                          protected=[bedroom_entity],
+                          pause_targets=[]
+                        ) -%}
+                        {%- for member in state_attr(bedroom_entity, 'group_members') or [] -%}
+                          {%- if member not in ns.protected -%}
+                            {%- set ns.protected = ns.protected + [member] -%}
+                          {%- endif -%}
+                        {%- endfor -%}
+                        {%- for entity_id in candidate_players -%}
+                          {%- set members = state_attr(entity_id, 'group_members') or [] -%}
+                          {%- if bedroom_entity in members -%}
+                            {%- if entity_id not in ns.protected -%}
+                              {%- set ns.protected = ns.protected + [entity_id] -%}
+                            {%- endif -%}
+                            {%- for member in members -%}
+                              {%- if member not in ns.protected -%}
+                                {%- set ns.protected = ns.protected + [member] -%}
+                              {%- endif -%}
+                            {%- endfor -%}
+                          {%- endif -%}
+                        {%- endfor -%}
+                        {%- for entity_id in candidate_players -%}
+                          {%- if entity_id not in ns.protected -%}
+                            {%- set ns.pause_targets = ns.pause_targets + [entity_id] -%}
+                          {%- endif -%}
+                        {%- endfor -%}
+                        {{ ns.pause_targets | join(', ') }}
+                  - if:
+                      - condition: template
+                        value_template: "{{ bedroom_audio_pause_targets | trim != '' }}"
+                    then:
+                      - continue_on_error: true
+                        action: media_player.media_pause
+                        data:
+                          entity_id: "{{ bedroom_audio_pause_targets }}"
+          - continue_on_error: true
+            action: lock.lock
+            target:
+              entity_id: lock.front_door_lock
+          - continue_on_error: true
+            action: cover.close_cover
+            target:
+              entity_id:
+                - cover.garage_door
+                - cover.owner_suite_blinds_ha
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ guest_context_enabled }}"
+                sequence:
+                  - continue_on_error: true
+                    action: climate.set_preset_mode
+                    target:
+                      entity_id: climate.my_ecobee
+                    data:
+                      preset_mode: Guest Sleep
+            default:
+              - continue_on_error: true
+                action: ecobee.resume_program
+                data:
+                  resume_all: true
+                  entity_id: climate.my_ecobee
+      - delay:
+          seconds: 30
+      - variables:
+          goodnight_integrity_issues: >-
+            {%- set ns = namespace(issues=[]) -%}
+            {%- if states('lock.front_door_lock') != 'locked' -%}
+              {%- set ns.issues = ns.issues + ['Front door lock is still ' ~ states('lock.front_door_lock') ~ '.'] -%}
+            {%- endif -%}
+            {%- if states('cover.garage_door') not in ['closed', 'closing'] -%}
+              {%- set ns.issues = ns.issues + ['Garage door is still ' ~ states('cover.garage_door') ~ '.'] -%}
+            {%- endif -%}
+            {%- if states('cover.owner_suite_blinds_ha') not in ['closed', 'closing'] -%}
+              {%- set ns.issues = ns.issues + ['Owner suite blinds are still ' ~ states('cover.owner_suite_blinds_ha') ~ '.'] -%}
+            {%- endif -%}
+            {%- if states('climate.my_ecobee') in ['unknown', 'unavailable'] -%}
+              {%- set ns.issues = ns.issues + ['Ecobee is unavailable for bedtime verification.'] -%}
+            {%- elif guest_context_enabled and state_attr('climate.my_ecobee', 'preset_mode') != 'Guest Sleep' -%}
+              {%- set ns.issues = ns.issues + ['Ecobee preset is ' ~ (state_attr('climate.my_ecobee', 'preset_mode') | default('unknown', true)) ~ ' instead of Guest Sleep.'] -%}
+            {%- elif (not guest_context_enabled) and state_attr('climate.my_ecobee', 'preset_mode') in ['Away', 'away', 'away_indefinitely'] -%}
+              {%- set ns.issues = ns.issues + ['Ecobee is still in an away preset during bedtime.'] -%}
+            {%- endif -%}
+            {{ ns.issues | join('\n') }}
+      - if:
+          - condition: template
+            value_template: "{{ goodnight_integrity_issues | trim != '' }}"
+        then:
+          - action: notify.all
+            data:
+              message: >-
+                Goodnight integrity found exceptions{% if reason is defined and reason | string | trim %} ({{ reason }}){% endif %}:
+
+                {{ goodnight_integrity_issues }}

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1674,41 +1674,13 @@ automation:
             - input_boolean.guest_mode
           state: "off"
     action:
-      - parallel:
-          # - action: scene.turn_on
-          #   entity_id: scene.good_night
-          - action: script.lights_off_except
-            data:
-              exclude_lights:
-                - light.outside_front_hue
-                - light.outside_north_west_garage
-                - light.outside_south_west_garage
-                - light.outside_front_door
-              transition: 30
-          # - action: light.turn_off
-          #   entity_id: "all"
-          - action: fan.turn_off
-            target:
-              entity_id:
-                - fan.den_ceiling
-          - action: switch.turn_on
-            data:
-              entity_id:
-                - switch.sleep_mode
-          - action: switch.turn_off
-            target:
-              entity_id:
-                - switch.office_red_lava_lamp
-          - action: switch.turn_off
-            target:
-              entity_id:
-                - switch.northern_light_lava_lamp
-          - action: media_player.turn_off
-            target:
-              entity_id:
-                - media_player.lg_webos_smart_tv
-                - media_player.basement
-          - action: script.turn_off_owner_suite_inovelli_switch_leds
+      - action: switch.turn_on
+        data:
+          entity_id:
+            - switch.sleep_mode
+      - action: script.goodnight_integrity
+        data:
+          reason: bed_lamps_off
         # Only turn on the humidifier when it's winter
         # Not used with whole-home humidifier
         # - condition: and

--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -127,13 +127,6 @@ automation:
           entity_id: binary_sensor.bayesian_bed_occupancy
           state: "off"
     action:
-      - action: cover.close_cover
-        target:
-          entity_id:
-            - cover.garage_door
-      - action: media_player.turn_off
-        data:
-          entity_id: media_player.lg_webos_smart_tv
       - action: media_player.volume_set
         data:
           entity_id:
@@ -148,6 +141,9 @@ automation:
       - action: script.turn_on
         target:
           entity_id: script.spotify_bedtime
+      - action: script.goodnight_integrity
+        data:
+          reason: tv_bed_prep
       - delay: "00:20:00"
       - action: switch.turn_off
         target:

--- a/tests/test_goodnight_integrity.py
+++ b/tests/test_goodnight_integrity.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOUSE_MODE_PATH = ROOT / "packages" / "house_mode.yaml"
+LIGHT_PATH = ROOT / "packages" / "light.yaml"
+TV_PATH = ROOT / "packages" / "tv.yaml"
+
+
+def _script_block(path: Path, script_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r} in {path.name}")
+
+    end = len(lines)
+    next_script = re.compile(r"^  [A-Za-z0-9_]+:$")
+    for index in range(start + 1, len(lines)):
+        if next_script.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _automation_block(path: Path, automation_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_goodnight_integrity_script_coordinates_house_shutdown_and_verification() -> None:
+    block = _script_block(HOUSE_MODE_PATH, "goodnight_integrity")
+
+    for token in (
+        "sleep-safe state",
+        "script.lights_off_except",
+        "switch.office_red_lava_lamp",
+        "switch.northern_light_lava_lamp",
+        "media_player.lg_webos_smart_tv",
+        "media_player.basement",
+        "script.turn_off_owner_suite_inovelli_switch_leds",
+        "lock.front_door_lock",
+        "cover.garage_door",
+        "cover.owner_suite_blinds_ha",
+        "climate.my_ecobee",
+    ):
+        assert token in block
+
+
+def test_goodnight_integrity_respects_guest_mode_and_guest_room_occupancy() -> None:
+    block = _script_block(HOUSE_MODE_PATH, "goodnight_integrity")
+
+    for token in (
+        "input_boolean.guest_mode",
+        "binary_sensor.guest_room_occupancy_2",
+        "light.office_all",
+        "light.den_all",
+        "light.guest_room_ceiling",
+        "fan.office_ceiling_fan",
+        "fan.guest_room",
+        "preset_mode: Guest Sleep",
+    ):
+        assert token in block
+
+
+def test_goodnight_integrity_only_notifies_on_verification_exceptions() -> None:
+    block = _script_block(HOUSE_MODE_PATH, "goodnight_integrity")
+
+    assert "goodnight_integrity_issues" in block
+    assert 'value_template: "{{ goodnight_integrity_issues | trim != \'\' }}"' in block
+    assert "notify.all" in block
+
+    for token in (
+        "Front door lock is still",
+        "Garage door is still",
+        "Owner suite blinds are still",
+        "Ecobee is unavailable for bedtime verification.",
+    ):
+        assert token in block
+
+
+def test_bed_lamps_off_delegates_to_goodnight_integrity() -> None:
+    block = _automation_block(LIGHT_PATH, "turn_off_all_lights_when_bed_off")
+
+    assert "script.goodnight_integrity" in block
+    assert "reason: bed_lamps_off" in block
+
+    for token in (
+        "script.lights_off_except",
+        "switch.office_red_lava_lamp",
+        "media_player.lg_webos_smart_tv",
+        "media_player.basement",
+    ):
+        assert token not in block
+
+
+def test_tv_bed_prep_delegates_to_goodnight_integrity() -> None:
+    block = _automation_block(TV_PATH, "tv_off_at_night_bed_prep")
+
+    assert "script.goodnight_integrity" in block
+    assert "reason: tv_bed_prep" in block
+    assert "script.spotify_bedtime" in block
+
+    for token in (
+        "cover.garage_door",
+        "action: media_player.turn_off",
+    ):
+        assert token not in block


### PR DESCRIPTION
## Summary
- add a shared `script.goodnight_integrity` bedtime sweep that shuts down stray lights, fans, and common-area media while preserving intentionally active bedroom audio
- verify the front door lock, garage door, owner suite blinds, and Ecobee bedtime state, notifying only when exceptions remain
- route the existing bed-lamps-off and TV bedtime prep automations through the shared script and add regression tests for the new behavior

## Testing
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/house_mode.yaml packages/light.yaml packages/tv.yaml`
- `.venv/bin/python -m pytest tests`
- `uvx --from homeassistant python -m homeassistant --config "$PWD" --script check_config` *(reports pre-existing unrelated config problems in `packages/climate.yaml` and a missing `custom_components.weatheralerts.const`; no new errors from this change)*

## Issue
- Closes #112