### PR TITLE
Add earlier Tiki Room ESPHome registration tracing

### DIFF
--- a/esphome/tikiroom.yaml
+++ b/esphome/tikiroom.yaml
@@ -13,6 +13,65 @@ esphome:
   name: tikiroomlights
   includes:
     - tikiroom_effects.h
+  on_boot:
+    - priority: 800
+      then:
+        - logger.log:
+            level: INFO
+            tag: tikiroom.boot
+            format: "Boot stage=hardware priority=800"
+    - priority: 250
+      then:
+        - logger.log:
+            level: INFO
+            tag: tikiroom.boot
+            format: "Boot stage=wifi priority=250 wifi_status=%d"
+            args:
+              - WiFi.status()
+    - priority: 200
+      then:
+        - logger.log:
+            level: INFO
+            tag: tikiroom.boot
+            format: "Boot stage=api priority=200 wifi_status=%d api_any=%s api_state_sub=%s"
+            args:
+              - WiFi.status()
+              - 'id(tikiroom_api).is_connected() ? "yes" : "no"'
+              - 'id(tikiroom_api).is_connected(true) ? "yes" : "no"'
+    - priority: -100
+      then:
+        - logger.log:
+            level: INFO
+            tag: tikiroom.boot
+            format: "Boot stage=ready priority=-100 effect=%s speed=%.0f api_any=%s api_state_sub=%s"
+            args:
+              - id(tiki_room_strip).get_effect_name().c_str()
+              - id(tikiroom_effect_speed)
+              - 'id(tikiroom_api).is_connected() ? "yes" : "no"'
+              - 'id(tikiroom_api).is_connected(true) ? "yes" : "no"'
+        - logger.log:
+            level: INFO
+            tag: tikiroom.boot
+            format: "Waiting up to 30s for a state-subscribing API client so entities can register"
+        - wait_until:
+            condition:
+              api.connected:
+                state_subscription_only: true
+            timeout: 30s
+        - if:
+            condition:
+              api.connected:
+                state_subscription_only: true
+            then:
+              - logger.log:
+                  level: INFO
+                  tag: tikiroom.boot
+                  format: "State-subscribing API client connected; entity registration should now be active"
+            else:
+              - logger.log:
+                  level: WARN
+                  tag: tikiroom.boot
+                  format: "No state-subscribing API client connected within 30s; entities will remain unavailable"
 
 esp8266:
   board: esp01_1m
@@ -48,28 +107,73 @@ logger:
   esp8266_store_log_strings_in_flash: false
 
 api:
+  id: tikiroom_api
   on_client_connected:
     - logger.log:
         level: INFO
         tag: tikiroom.api
-        format: "API client %s connected from %s"
+        format: "API client %s connected from %s (state_subscriber=%s)"
         args:
           - client_info.c_str()
           - client_address.c_str()
+          - 'id(tikiroom_api).is_connected(true) ? "yes" : "no"'
+    - if:
+        condition:
+          lambda: |-
+            return id(tikiroom_api).is_connected(true);
+        then:
+          - logger.log:
+              level: INFO
+              tag: tikiroom.api
+              format: "State-subscribing API client connected; Home Assistant should be able to control entities"
+        else:
+          - logger.log:
+              level: WARN
+              tag: tikiroom.api
+              format: "API client connected without state subscription; entity registration is still pending"
   on_client_disconnected:
     - logger.log:
         level: WARN
         tag: tikiroom.api
-        format: "API client %s disconnected from %s"
+        format: "API client %s disconnected from %s (state_subscriber=%s)"
         args:
           - client_info.c_str()
           - client_address.c_str()
+          - 'id(tikiroom_api).is_connected(true) ? "yes" : "no"'
+    - if:
+        condition:
+          lambda: |-
+            return !id(tikiroom_api).is_connected(true);
+        then:
+          - logger.log:
+              level: WARN
+              tag: tikiroom.api
+              format: "No state-subscribing API clients remain; Home Assistant entities will go unavailable"
 
 ota:
   - platform: esphome
 
 debug:
   update_interval: 60s
+
+interval:
+  - interval: 30s
+    startup_delay: 45s
+    then:
+      - if:
+          condition:
+            lambda: |-
+              return !id(tikiroom_api).is_connected(true);
+          then:
+            - logger.log:
+                level: WARN
+                tag: tikiroom.boot
+                format: "Runtime registration check missing state-subscribing API client; wifi_status=%d api_any=%s effect=%s speed=%.0f"
+                args:
+                  - WiFi.status()
+                  - 'id(tikiroom_api).is_connected() ? "yes" : "no"'
+                  - id(tiki_room_strip).get_effect_name().c_str()
+                  - id(tikiroom_effect_speed)
 
 binary_sensor:
   - platform: status

--- a/tests/test_tikiroom_esphome.py
+++ b/tests/test_tikiroom_esphome.py
@@ -10,9 +10,31 @@ def test_tikiroom_esphome_logs_connectivity_lifecycle() -> None:
     assert "tag: tikiroom.net" in text
     assert 'format: "WiFi connected to %s"' in text
     assert 'format: "WiFi disconnected with status=%d"' in text
+    assert "id: tikiroom_api" in text
     assert "tag: tikiroom.api" in text
-    assert 'format: "API client %s connected from %s"' in text
-    assert 'format: "API client %s disconnected from %s"' in text
+    assert 'format: "API client %s connected from %s (state_subscriber=%s)"' in text
+    assert 'format: "State-subscribing API client connected; Home Assistant should be able to control entities"' in text
+    assert 'format: "API client connected without state subscription; entity registration is still pending"' in text
+    assert 'format: "API client %s disconnected from %s (state_subscriber=%s)"' in text
+    assert 'format: "No state-subscribing API clients remain; Home Assistant entities will go unavailable"' in text
+
+
+def test_tikiroom_esphome_logs_boot_and_registration_stages() -> None:
+    text = TIKIROOM_ESPHOME_PATH.read_text(encoding="utf-8")
+
+    assert "tag: tikiroom.boot" in text
+    assert 'format: "Boot stage=hardware priority=800"' in text
+    assert 'format: "Boot stage=wifi priority=250 wifi_status=%d"' in text
+    assert 'format: "Boot stage=api priority=200 wifi_status=%d api_any=%s api_state_sub=%s"' in text
+    assert 'format: "Boot stage=ready priority=-100 effect=%s speed=%.0f api_any=%s api_state_sub=%s"' in text
+    assert 'format: "Waiting up to 30s for a state-subscribing API client so entities can register"' in text
+    assert "wait_until:" in text
+    assert "state_subscription_only: true" in text
+    assert "timeout: 30s" in text
+    assert 'format: "State-subscribing API client connected; entity registration should now be active"' in text
+    assert 'format: "No state-subscribing API client connected within 30s; entities will remain unavailable"' in text
+    assert "startup_delay: 45s" in text
+    assert 'format: "Runtime registration check missing state-subscribing API client; wifi_status=%d api_any=%s effect=%s speed=%.0f"' in text
 
 
 def test_tikiroom_esphome_exposes_diagnostic_entities() -> None:


### PR DESCRIPTION
## Summary
- add early boot-stage logging around hardware, Wi-Fi, API startup, and post-init readiness in `esphome/tikiroom.yaml`
- distinguish logger-only API connections from state-subscribing Home Assistant connections and warn when entities will remain unavailable
- add test coverage for the new boot and API registration tracing

## Validation
- `pytest`
- `python scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt esphome/tikiroom.yaml`
- `esphome config esphome/tikiroom.yaml` with temporary placeholder Wi-Fi secrets

## Context
Follow-up instrumentation for issue #205 so the Tiki Room node logs whether Home Assistant ever reaches the state-subscribing API phase where entities become controllable.