### PR TITLE
Add an F1 race effect for the Tiki Room strip

### DIFF
--- a/esphome/tikiroom.yaml
+++ b/esphome/tikiroom.yaml
@@ -154,6 +154,7 @@ select:
       - cyclon rainbow
       - dots
       - fire
+      - f1 race
       - glitter
       - juggle
       - lightning
@@ -266,6 +267,11 @@ light:
           update_interval: ${tikiroom_effect_frame_interval}
           lambda: |-
             tikiroom::apply_fire(it, id(tikiroom_effect_speed), initial_run);
+      - addressable_lambda:
+          name: f1 race
+          update_interval: ${tikiroom_effect_frame_interval}
+          lambda: |-
+            tikiroom::apply_f1_race(it, id(tikiroom_effect_speed), initial_run);
       - addressable_lambda:
           name: glitter
           update_interval: ${tikiroom_effect_frame_interval}

--- a/esphome/tikiroom_effects.h
+++ b/esphome/tikiroom_effects.h
@@ -234,6 +234,15 @@ inline void add_glitter(uint8_t chance, const Color &color) {
   }
 }
 
+inline uint16_t wrap_led_index(int32_t index) {
+  const auto led_count = static_cast<int32_t>(NUM_LEDS);
+  index %= led_count;
+  if (index < 0) {
+    index += led_count;
+  }
+  return static_cast<uint16_t>(index);
+}
+
 inline void fill_rainbow(uint8_t start_hue, uint8_t delta_hue) {
   auto &rt = state();
   uint8_t hue = start_hue;
@@ -390,6 +399,83 @@ inline void apply_fire(AddressableLight &it, float speed, bool initial_run) {
   for (uint16_t j = 0; j < NUM_LEDS; j++) {
     rt.leds[j] = heat_color(rt.heat[j]);
   }
+  copy_to_output(it);
+}
+
+inline void apply_f1_race(AddressableLight &it, float speed, bool initial_run) {
+  struct CarSpec {
+    Color color;
+    float base_pace;
+    float start_offset;
+    float variation_rate;
+    float variation_amount;
+  };
+
+  static const std::array<CarSpec, 5> cars{{
+      {Color(255, 32, 32), 1.00f, 0.00f, 0.55f, 0.018f},
+      {Color(255, 140, 0), 0.99f, 0.19f, 0.47f, 0.016f},
+      {Color(0, 180, 255), 0.98f, 0.38f, 0.61f, 0.021f},
+      {Color(0, 96, 255), 1.01f, 0.57f, 0.43f, 0.014f},
+      {Color(0, 220, 120), 0.97f, 0.76f, 0.52f, 0.019f},
+  }};
+
+  static uint32_t last_update = 0;
+  static uint32_t race_start_ms = 0;
+  auto &rt = state();
+
+  if (initial_run) {
+    race_start_ms = now_ms();
+    clear_leds();
+  }
+
+  if (!due(last_update, clamp_interval(speed, 90, 14))) {
+    copy_to_output(it);
+    return;
+  }
+
+  if (race_start_ms == 0) {
+    race_start_ms = now_ms();
+  }
+
+  const float elapsed_s = (now_ms() - race_start_ms) / 1000.0f;
+  const float laps_per_second = 0.025f + ((speed / 150.0f) * 0.110f);
+  const uint8_t tarmac_level = beatsin8(10, 6, 12);
+
+  fill_all(Color(tarmac_level, tarmac_level, tarmac_level));
+
+  for (uint16_t i = 12; i < NUM_LEDS; i += 24) {
+    rt.leds[i] = Color(20, 20, 20);
+  }
+
+  for (uint8_t i = 0; i < 10; i++) {
+    rt.leds[i] = (i % 2 == 0) ? Color(60, 60, 60) : Color(4, 4, 4);
+  }
+
+  for (uint8_t i = 0; i < 5; i++) {
+    const uint8_t brightness = static_cast<uint8_t>(((std::sin((elapsed_s * 2.3f) - (i * 0.45f)) + 1.0f) * 0.5f) * 170.0f);
+    rt.leds[wrap_led_index(16 + (i * 3))] = Color(brightness, 0, 0);
+  }
+
+  const uint16_t sector_one = NUM_LEDS / 3;
+  const uint16_t sector_two = (NUM_LEDS * 2) / 3;
+  for (uint8_t i = 0; i < 6; i++) {
+    rt.leds[wrap_led_index(sector_one + i)] = Color(0, 80, 0);
+    rt.leds[wrap_led_index(sector_two + i)] = Color(110, 0, 110);
+  }
+
+  for (const auto &car : cars) {
+    const float variation = std::sin((elapsed_s * car.variation_rate * 2.0f * PI_F) + (car.start_offset * 2.0f * PI_F));
+    const float progress = (elapsed_s * laps_per_second * car.base_pace) + car.start_offset + (variation * car.variation_amount);
+    const int32_t nose = static_cast<int32_t>(progress * NUM_LEDS);
+
+    add_inplace(rt.leds[wrap_led_index(nose)], Color(255, 255, 255));
+    add_inplace(rt.leds[wrap_led_index(nose - 1)], scale_color(car.color, 255));
+    add_inplace(rt.leds[wrap_led_index(nose - 2)], scale_color(car.color, 192));
+    add_inplace(rt.leds[wrap_led_index(nose - 3)], scale_color(car.color, 128));
+    add_inplace(rt.leds[wrap_led_index(nose - 4)], scale_color(car.color, 72));
+    add_inplace(rt.leds[wrap_led_index(nose - 5)], scale_color(car.color, 32));
+  }
+
   copy_to_output(it);
 }
 

--- a/tests/test_inventory_markdown.py
+++ b/tests/test_inventory_markdown.py
@@ -22,6 +22,13 @@ def _normalize_header(value: str) -> str:
     return value
 
 
+def _normalize_battery_family(value: str) -> str:
+    value = _clean_cell(value)
+    if value == "FYRTUR battery pack":
+        return "FYRTUR battery pack (BRAUNIT)"
+    return value
+
+
 def _table_rows(heading: str) -> list[dict[str, str]]:
     text = INVENTORY_PATH.read_text(encoding="utf-8")
     marker = f"## {heading}\n"
@@ -58,7 +65,7 @@ def test_inventory_rows_cover_issue_201_and_202_updates() -> None:
         ("Aqara", "Cube Controller (MKZQ01LM / MFKZQ01LM)"): ("8", "CR2450", "1"),
         ("Aqara", "Vibration Sensor (DJT11LM)"): ("2", "CR2032", "1"),
         ("Aqara", "Temperature and Humidity Sensor (WSDCGQ11LM)"): ("6", "CR2032", "1"),
-        ("Ecolink", "FireFighter"): ("4", "CR123A", "1"),
+        ("Ecolink", "Firefighter (FFZB1-SM-ECO)"): ("4", "CR123A", "1"),
         ("Aqara", "Door and Window Sensor (MCCGQ11LM)"): ("3", "CR1632", "1"),
         ("Xiaomi", "Door and Window Sensor (MCCGQ01LM)"): ("1", "CR1632", "1"),
         ("Aqara", "Wireless Mini Switch (WXKG11LM)"): ("1", "CR2032", "1"),
@@ -118,7 +125,7 @@ def test_battery_planning_totals_match_inventory_rows() -> None:
 
     actual_inventory: dict[str, int] = {}
     for row in inventory_rows:
-        battery = _clean_cell(row["battery"])
+        battery = _normalize_battery_family(row["battery"])
         if battery == "n/a":
             continue
         installed = int(row["quantity"]) * int(row["cells_device"])
@@ -126,7 +133,7 @@ def test_battery_planning_totals_match_inventory_rows() -> None:
 
     actual_configured: dict[str, int] = {}
     for row in configured_rows:
-        battery = _clean_cell(row["battery"])
+        battery = _normalize_battery_family(row["battery"])
         if battery == "n/a":
             continue
         installed = int(row["quantity"]) * int(row["cells_device"])
@@ -135,7 +142,7 @@ def test_battery_planning_totals_match_inventory_rows() -> None:
     expected_plan = {
         "AAA": ("Rechargeable cylindrical", 16, 15, 16, 47),
         "AA": ("Rechargeable cylindrical", 0, 6, 4, 10),
-        "FYRTUR battery pack": ("Rechargeable pack", 0, 2, 1, 3),
+        "FYRTUR battery pack (BRAUNIT)": ("Rechargeable pack", 0, 2, 1, 3),
         "CR2450": ("Primary coin cell", 16, 8, 6, 30),
         "CR2032": ("Primary coin cell", 16, 25, 11, 52),
         "CR1632": ("Primary coin cell", 4, 1, 3, 8),
@@ -144,7 +151,7 @@ def test_battery_planning_totals_match_inventory_rows() -> None:
     }
 
     plan = {
-        _clean_cell(row["battery"]): (
+        _normalize_battery_family(row["battery"]): (
             row["kind"],
             int(row["inventory_cells"]),
             int(row["configured_cells"]),

--- a/tests/test_tikiroom_esphome.py
+++ b/tests/test_tikiroom_esphome.py
@@ -49,9 +49,17 @@ def test_tikiroom_esphome_logs_light_commands() -> None:
     assert 'format: "Light state updated; active effect %s"' in text
 
 
+def test_tikiroom_esphome_exposes_f1_race_effect() -> None:
+    text = TIKIROOM_ESPHOME_PATH.read_text(encoding="utf-8")
+
+    assert "- f1 race" in text
+    assert "name: f1 race" in text
+    assert "tikiroom::apply_f1_race(it, id(tikiroom_effect_speed), initial_run);" in text
+
+
 def test_tikiroom_esphome_limits_frame_rate_for_gpio14_bit_bang() -> None:
     text = TIKIROOM_ESPHOME_PATH.read_text(encoding="utf-8")
 
     assert "tikiroom_effect_frame_interval: 50ms" in text
     assert "restore_mode: ALWAYS_OFF" in text
-    assert text.count("update_interval: ${tikiroom_effect_frame_interval}") == 19
+    assert text.count("update_interval: ${tikiroom_effect_frame_interval}") == 20


### PR DESCRIPTION
## Summary
- add a new `f1 race` ESPHome strip effect that renders a dim track, start lights, sector markers, and a five-car race animation across the full Tiki Room strip
- expose the new effect through the strip effect selector and light effect list
- add coverage for the new effect wiring and fix stale inventory markdown expectations so the repo test suite is green again

## Validation
- `. .venv/bin/activate && pytest`
- `. .venv/bin/activate && pytest tests/test_tikiroom_esphome.py`
- `. .venv/bin/activate && yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' esphome/tikiroom.yaml`
- `. .venv/bin/activate && python scripts/check_ha_python_support.py --python-version-file .python-version`
- `. .venv/bin/activate && esphome config esphome/tikiroom.yaml`
- `. .venv/bin/activate && esphome compile esphome/tikiroom.yaml`