### PR TITLE
Expand hard-coded window egress coverage

### DIFF
--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -164,12 +164,24 @@ automation:
     trigger:
       - trigger: state
         entity_id:
+          - binary_sensor.basement_window_contact
+          - binary_sensor.unfinished_basement_window_contact
           - binary_sensor.se_basement_window_contact
           - binary_sensor.sw_basement_window_contact
           - binary_sensor.deck_door_contact
           #        - binary_sensor.downstairs_motion
+          - binary_sensor.dining_room_north_window_contact
+          - binary_sensor.dining_room_south_window_contact
           - binary_sensor.ene_window_contact
           - binary_sensor.ese_window_contact
+          - binary_sensor.guest_bathroom_window_contact
+          - binary_sensor.guest_room_window_contact
+          - binary_sensor.hall_garage_entry_contact
+          - binary_sensor.kitchen_bay_middle_window_contact
+          - binary_sensor.kitchen_bay_north_window_contact
+          - binary_sensor.kitchen_bay_south_window_contact
+          - binary_sensor.kitchen_north_window_contact
+          - binary_sensor.kitchen_south_window_contact
           - binary_sensor.main_foyer_front_door_contact
           #        - binary_sensor.hallway_motion
           #        - binary_sensor.master_bedroom_motion
@@ -178,9 +190,18 @@ automation:
           - binary_sensor.north_master_bedroom_window_contact
           - binary_sensor.nw_basement_window_contact
           - binary_sensor.office_occupancy_2
+          - binary_sensor.office_window_contact
           - binary_sensor.office_north_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_north_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_south_window_contact
+          - binary_sensor.owner_suite_north_window_contact
+          - binary_sensor.owner_suite_south_window_contact
+          - binary_sensor.powder_room_window_contact
           #        - binary_sensor.motion_sensor_motion
           - binary_sensor.sse_window_contact
+          - binary_sensor.tiki_room_deck_contact
         from: "off"
         to: "on"
     condition:

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -238,6 +238,24 @@ automation:
       condition: or
       conditions:
         - condition: state
+          entity_id: binary_sensor.basement_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.unfinished_basement_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.dining_room_north_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.dining_room_south_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.guest_bathroom_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.guest_room_window_contact
+          state: open
+        - condition: state
           entity_id: binary_sensor.main_foyer_front_door_contact
           state: open
         - condition: state
@@ -246,10 +264,79 @@ automation:
         - condition: state
           entity_id: binary_sensor.hall_garage_entry_contact
           state: open
+        - condition: state
+          entity_id: binary_sensor.kitchen_bay_middle_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.kitchen_bay_north_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.kitchen_bay_south_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.kitchen_north_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.kitchen_south_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.office_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.owner_suite_bathroom_bay_north_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.owner_suite_bathroom_bay_south_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.owner_suite_north_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.owner_suite_south_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.powder_room_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.se_basement_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.sw_basement_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.ene_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.ese_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.nne_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.north_kitchen_sink_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.north_master_bedroom_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.nw_basement_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.office_north_window_contact
+          state: open
+        - condition: state
+          entity_id: binary_sensor.sse_window_contact
+          state: open
     action:
       - action: notify.all
         data:
-          message: Door left open!
+          message: Door or window left open!
 
   - id: garage_door_open_when_leaving_home
     alias: garage_door_open_when_leaving_home

--- a/tests/test_window_egress_automation_coverage.py
+++ b/tests/test_window_egress_automation_coverage.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+
+ALERTS_PATH = Path(__file__).resolve().parents[1] / "packages" / "alerts.yaml"
+ZONE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zone.yaml"
+
+
+def _automation_block(path: Path, automation_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    id_line = f"  - id: {automation_id}"
+    start = None
+
+    for index, line in enumerate(lines):
+        if line != id_line:
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_motion_detected_on_trip_watches_all_known_window_and_egress_contacts() -> None:
+    block = _automation_block(ALERTS_PATH, "motion_detected_on_trip")
+
+    expected_entities = (
+        "binary_sensor.basement_window_contact",
+        "binary_sensor.unfinished_basement_window_contact",
+        "binary_sensor.dining_room_north_window_contact",
+        "binary_sensor.dining_room_south_window_contact",
+        "binary_sensor.guest_bathroom_window_contact",
+        "binary_sensor.guest_room_window_contact",
+        "binary_sensor.hall_garage_entry_contact",
+        "binary_sensor.kitchen_bay_middle_window_contact",
+        "binary_sensor.kitchen_bay_north_window_contact",
+        "binary_sensor.kitchen_bay_south_window_contact",
+        "binary_sensor.kitchen_north_window_contact",
+        "binary_sensor.kitchen_south_window_contact",
+        "binary_sensor.office_window_contact",
+        "binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact",
+        "binary_sensor.owner_suite_bathroom_bay_north_window_contact",
+        "binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact",
+        "binary_sensor.owner_suite_bathroom_bay_south_window_contact",
+        "binary_sensor.owner_suite_north_window_contact",
+        "binary_sensor.owner_suite_south_window_contact",
+        "binary_sensor.powder_room_window_contact",
+        "binary_sensor.tiki_room_deck_contact",
+    )
+
+    for entity_id in expected_entities:
+        assert entity_id in block
+
+
+def test_doors_open_when_leaving_home_checks_windows_and_doors() -> None:
+    block = _automation_block(ZONE_PATH, "doors_open_when_leaving_home")
+
+    expected_entities = (
+        "binary_sensor.basement_window_contact",
+        "binary_sensor.unfinished_basement_window_contact",
+        "binary_sensor.dining_room_north_window_contact",
+        "binary_sensor.dining_room_south_window_contact",
+        "binary_sensor.guest_bathroom_window_contact",
+        "binary_sensor.guest_room_window_contact",
+        "binary_sensor.kitchen_bay_middle_window_contact",
+        "binary_sensor.kitchen_bay_north_window_contact",
+        "binary_sensor.kitchen_bay_south_window_contact",
+        "binary_sensor.kitchen_north_window_contact",
+        "binary_sensor.kitchen_south_window_contact",
+        "binary_sensor.office_window_contact",
+        "binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact",
+        "binary_sensor.owner_suite_bathroom_bay_north_window_contact",
+        "binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact",
+        "binary_sensor.owner_suite_bathroom_bay_south_window_contact",
+        "binary_sensor.owner_suite_north_window_contact",
+        "binary_sensor.owner_suite_south_window_contact",
+        "binary_sensor.powder_room_window_contact",
+        "binary_sensor.se_basement_window_contact",
+        "binary_sensor.sw_basement_window_contact",
+        "binary_sensor.ene_window_contact",
+        "binary_sensor.ese_window_contact",
+        "binary_sensor.main_foyer_front_door_contact",
+        "binary_sensor.deck_door_contact",
+        "binary_sensor.hall_garage_entry_contact",
+        "binary_sensor.nne_window_contact",
+        "binary_sensor.north_kitchen_sink_window_contact",
+        "binary_sensor.north_master_bedroom_window_contact",
+        "binary_sensor.nw_basement_window_contact",
+        "binary_sensor.office_north_window_contact",
+        "binary_sensor.sse_window_contact",
+    )
+
+    for entity_id in expected_entities:
+        assert entity_id in block
+
+    assert "Door or window left open!" in block


### PR DESCRIPTION
## Summary
- add the currently known PARASOLL window contacts to the away alarm automation's hard-coded trigger list
- add the same window contacts to the leave-home egress notification automation so it catches windows as well as doors
- add regression tests covering both automation blocks

## Validation
- `pytest -q`
- `pytest -q tests/test_window_egress_automation_coverage.py`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/alerts.yaml packages/zone.yaml`

## Follow-up
- a second stacked PR will simplify the duplicated egress/window logic after this coverage fix is in review