### PR TITLE
Simplify duplicated egress window logic

### DIFF
--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -163,47 +163,20 @@ automation:
     mode: restart
     trigger:
       - trigger: state
-        entity_id:
-          - binary_sensor.basement_window_contact
-          - binary_sensor.unfinished_basement_window_contact
-          - binary_sensor.se_basement_window_contact
-          - binary_sensor.sw_basement_window_contact
-          - binary_sensor.deck_door_contact
-          #        - binary_sensor.downstairs_motion
-          - binary_sensor.dining_room_north_window_contact
-          - binary_sensor.dining_room_south_window_contact
-          - binary_sensor.ene_window_contact
-          - binary_sensor.ese_window_contact
-          - binary_sensor.guest_bathroom_window_contact
-          - binary_sensor.guest_room_window_contact
-          - binary_sensor.hall_garage_entry_contact
-          - binary_sensor.kitchen_bay_middle_window_contact
-          - binary_sensor.kitchen_bay_north_window_contact
-          - binary_sensor.kitchen_bay_south_window_contact
-          - binary_sensor.kitchen_north_window_contact
-          - binary_sensor.kitchen_south_window_contact
-          - binary_sensor.main_foyer_front_door_contact
-          #        - binary_sensor.hallway_motion
-          #        - binary_sensor.master_bedroom_motion
-          - binary_sensor.nne_window_contact
-          - binary_sensor.north_kitchen_sink_window_contact
-          - binary_sensor.north_master_bedroom_window_contact
-          - binary_sensor.nw_basement_window_contact
-          - binary_sensor.office_occupancy_2
-          - binary_sensor.office_window_contact
-          - binary_sensor.office_north_window_contact
-          - binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
-          - binary_sensor.owner_suite_bathroom_bay_north_window_contact
-          - binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
-          - binary_sensor.owner_suite_bathroom_bay_south_window_contact
-          - binary_sensor.owner_suite_north_window_contact
-          - binary_sensor.owner_suite_south_window_contact
-          - binary_sensor.powder_room_window_contact
-          #        - binary_sensor.motion_sensor_motion
-          - binary_sensor.sse_window_contact
-          - binary_sensor.tiki_room_deck_contact
+        entity_id: group.egress_points
+      - trigger: state
+        entity_id: binary_sensor.office_occupancy_2
         from: "off"
         to: "on"
+    variables:
+      open_egress_points: >-
+        {{ expand('group.egress_points') | selectattr('state', 'eq', 'on') | map(attribute='name') | join(', ') }}
+      trigger_label: >-
+        {% if trigger.entity_id == 'group.egress_points' %}
+          {{ open_egress_points if open_egress_points else 'an egress point' }}
+        {% else %}
+          {{ trigger.to_state.attributes.friendly_name }}
+        {% endif %}
     condition:
       - condition: state
         entity_id: alarm_control_panel.home_alarm
@@ -215,7 +188,7 @@ automation:
       - action: notify.all
         data:
           message: >
-            Motion detected at {{ trigger.to_state.attributes.friendly_name }} while you're away!
+            Activity detected at {{ trigger_label }} while you're away!
       #    - action: tts.google_say
       #      data:
       #        message: "Intruder Alert! Intruder Alert! You are detected and recorded."

--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -1071,24 +1071,7 @@ template:
       - device_class: window
         default_entity_id: binary_sensor.fresh_air_open
         unique_id: fresh_air_open
-        state: >-
-          {% set excluded = states('input_text.any_window_open_exclude_entities').replace('\n', ',').split(',') | map('trim') | reject('equalto', '') | list %}
-          {% set matches = namespace(count=0) %}
-          {% for sensor in states.binary_sensor %}
-            {% set entity_id = sensor.entity_id %}
-            {% if entity_id not in ['binary_sensor.any_window_open', 'binary_sensor.fresh_air_open'] %}
-              {% set device_class = sensor.attributes.device_class | default('', true) | lower %}
-              {% set did = device_id(entity_id) %}
-              {% set model = '' %}
-              {% if did is not none and did != '' %}
-                {% set model = device_attr(did, 'model') | default('', true) | lower %}
-              {% endif %}
-              {% if sensor.state == 'on' and device_class in ['opening', 'window'] and 'parasoll' in model and entity_id not in excluded %}
-                {% set matches.count = matches.count + 1 %}
-              {% endif %}
-            {% endif %}
-          {% endfor %}
-          {{ matches.count > 0 }}
+        state: "{{ is_state('binary_sensor.any_window_open', 'on') }}"
         name: fresh_air_open
   - sensor:
       - name: HVAC Activity

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1669,12 +1669,40 @@ device_tracker: []
 group:
   egress_points:
     entities:
-      # Compatibility helper for older consumers. Windows are rolled up
-      # through the dynamic window sensor; doors remain explicit.
-      - binary_sensor.any_window_open
+      # Canonical egress inventory for security and leave-home automations.
+      - binary_sensor.basement_window_contact
+      - binary_sensor.unfinished_basement_window_contact
+      - binary_sensor.se_basement_window_contact
+      - binary_sensor.sw_basement_window_contact
       - binary_sensor.deck_door_contact
-      - binary_sensor.main_foyer_front_door_contact
+      - binary_sensor.dining_room_north_window_contact
+      - binary_sensor.dining_room_south_window_contact
+      - binary_sensor.ene_window_contact
+      - binary_sensor.ese_window_contact
+      - binary_sensor.guest_bathroom_window_contact
+      - binary_sensor.guest_room_window_contact
       - binary_sensor.hall_garage_entry_contact
+      - binary_sensor.kitchen_bay_middle_window_contact
+      - binary_sensor.kitchen_bay_north_window_contact
+      - binary_sensor.kitchen_bay_south_window_contact
+      - binary_sensor.kitchen_north_window_contact
+      - binary_sensor.kitchen_south_window_contact
+      - binary_sensor.main_foyer_front_door_contact
+      - binary_sensor.nne_window_contact
+      - binary_sensor.north_kitchen_sink_window_contact
+      - binary_sensor.north_master_bedroom_window_contact
+      - binary_sensor.nw_basement_window_contact
+      - binary_sensor.office_window_contact
+      - binary_sensor.office_north_window_contact
+      - binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
+      - binary_sensor.owner_suite_bathroom_bay_north_window_contact
+      - binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
+      - binary_sensor.owner_suite_bathroom_bay_south_window_contact
+      - binary_sensor.owner_suite_north_window_contact
+      - binary_sensor.owner_suite_south_window_contact
+      - binary_sensor.powder_room_window_contact
+      - binary_sensor.sse_window_contact
+      - binary_sensor.tiki_room_deck_contact
 
 ########################
 # Input Booleans

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -42,7 +42,7 @@ homeassistant:
       icon: mdi:weather-cloudy
     automation.doors_open_when_leaving_home:
       <<: *customize
-      friendly_name: Doors Left Open When Leaving
+      friendly_name: Egress Left Open When Leaving
       icon: mdi:door-open
     automation.garage_door_open_when_leaving_home:
       <<: *customize
@@ -234,109 +234,18 @@ automation:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
         to: "off"
+    variables:
+      open_egress_points: >-
+        {{ expand('group.egress_points') | selectattr('state', 'eq', 'on') | map(attribute='name') | join(', ') }}
     condition:
-      condition: or
-      conditions:
-        - condition: state
-          entity_id: binary_sensor.basement_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.unfinished_basement_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.dining_room_north_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.dining_room_south_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.guest_bathroom_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.guest_room_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.main_foyer_front_door_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.deck_door_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.hall_garage_entry_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.kitchen_bay_middle_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.kitchen_bay_north_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.kitchen_bay_south_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.kitchen_north_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.kitchen_south_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.office_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.owner_suite_bathroom_bay_north_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.owner_suite_bathroom_bay_south_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.owner_suite_north_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.owner_suite_south_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.powder_room_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.se_basement_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.sw_basement_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.ene_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.ese_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.nne_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.north_kitchen_sink_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.north_master_bedroom_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.nw_basement_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.office_north_window_contact
-          state: open
-        - condition: state
-          entity_id: binary_sensor.sse_window_contact
-          state: open
+      - condition: state
+        entity_id: group.egress_points
+        state: "on"
     action:
       - action: notify.all
         data:
-          message: Door or window left open!
+          message: >-
+            Door or window left open: {{ open_egress_points }}.
 
   - id: garage_door_open_when_leaving_home
     alias: garage_door_open_when_leaving_home

--- a/tests/test_window_egress_automation_coverage.py
+++ b/tests/test_window_egress_automation_coverage.py
@@ -2,7 +2,45 @@ from pathlib import Path
 
 
 ALERTS_PATH = Path(__file__).resolve().parents[1] / "packages" / "alerts.yaml"
+CLIMATE_PATH = Path(__file__).resolve().parents[1] / "packages" / "climate.yaml"
 ZONE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zone.yaml"
+ZIGBEE_ZWAVE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zigbee_zwave.yaml"
+
+EGRESS_ENTITY_IDS = (
+    "binary_sensor.basement_window_contact",
+    "binary_sensor.unfinished_basement_window_contact",
+    "binary_sensor.se_basement_window_contact",
+    "binary_sensor.sw_basement_window_contact",
+    "binary_sensor.deck_door_contact",
+    "binary_sensor.dining_room_north_window_contact",
+    "binary_sensor.dining_room_south_window_contact",
+    "binary_sensor.ene_window_contact",
+    "binary_sensor.ese_window_contact",
+    "binary_sensor.guest_bathroom_window_contact",
+    "binary_sensor.guest_room_window_contact",
+    "binary_sensor.hall_garage_entry_contact",
+    "binary_sensor.kitchen_bay_middle_window_contact",
+    "binary_sensor.kitchen_bay_north_window_contact",
+    "binary_sensor.kitchen_bay_south_window_contact",
+    "binary_sensor.kitchen_north_window_contact",
+    "binary_sensor.kitchen_south_window_contact",
+    "binary_sensor.main_foyer_front_door_contact",
+    "binary_sensor.nne_window_contact",
+    "binary_sensor.north_kitchen_sink_window_contact",
+    "binary_sensor.north_master_bedroom_window_contact",
+    "binary_sensor.nw_basement_window_contact",
+    "binary_sensor.office_window_contact",
+    "binary_sensor.office_north_window_contact",
+    "binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact",
+    "binary_sensor.owner_suite_bathroom_bay_north_window_contact",
+    "binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact",
+    "binary_sensor.owner_suite_bathroom_bay_south_window_contact",
+    "binary_sensor.owner_suite_north_window_contact",
+    "binary_sensor.owner_suite_south_window_contact",
+    "binary_sensor.powder_room_window_contact",
+    "binary_sensor.sse_window_contact",
+    "binary_sensor.tiki_room_deck_contact",
+)
 
 
 def _automation_block(path: Path, automation_id: str) -> str:
@@ -36,73 +74,31 @@ def _automation_block(path: Path, automation_id: str) -> str:
 def test_motion_detected_on_trip_watches_all_known_window_and_egress_contacts() -> None:
     block = _automation_block(ALERTS_PATH, "motion_detected_on_trip")
 
-    expected_entities = (
-        "binary_sensor.basement_window_contact",
-        "binary_sensor.unfinished_basement_window_contact",
-        "binary_sensor.dining_room_north_window_contact",
-        "binary_sensor.dining_room_south_window_contact",
-        "binary_sensor.guest_bathroom_window_contact",
-        "binary_sensor.guest_room_window_contact",
-        "binary_sensor.hall_garage_entry_contact",
-        "binary_sensor.kitchen_bay_middle_window_contact",
-        "binary_sensor.kitchen_bay_north_window_contact",
-        "binary_sensor.kitchen_bay_south_window_contact",
-        "binary_sensor.kitchen_north_window_contact",
-        "binary_sensor.kitchen_south_window_contact",
-        "binary_sensor.office_window_contact",
-        "binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact",
-        "binary_sensor.owner_suite_bathroom_bay_north_window_contact",
-        "binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact",
-        "binary_sensor.owner_suite_bathroom_bay_south_window_contact",
-        "binary_sensor.owner_suite_north_window_contact",
-        "binary_sensor.owner_suite_south_window_contact",
-        "binary_sensor.powder_room_window_contact",
-        "binary_sensor.tiki_room_deck_contact",
-    )
-
-    for entity_id in expected_entities:
-        assert entity_id in block
+    assert "entity_id: group.egress_points" in block
+    assert "entity_id: binary_sensor.office_occupancy_2" in block
+    assert "expand('group.egress_points')" in block
+    assert "trigger_label" in block
+    assert "Activity detected at {{ trigger_label }} while you're away!" in block
 
 
 def test_doors_open_when_leaving_home_checks_windows_and_doors() -> None:
     block = _automation_block(ZONE_PATH, "doors_open_when_leaving_home")
 
-    expected_entities = (
-        "binary_sensor.basement_window_contact",
-        "binary_sensor.unfinished_basement_window_contact",
-        "binary_sensor.dining_room_north_window_contact",
-        "binary_sensor.dining_room_south_window_contact",
-        "binary_sensor.guest_bathroom_window_contact",
-        "binary_sensor.guest_room_window_contact",
-        "binary_sensor.kitchen_bay_middle_window_contact",
-        "binary_sensor.kitchen_bay_north_window_contact",
-        "binary_sensor.kitchen_bay_south_window_contact",
-        "binary_sensor.kitchen_north_window_contact",
-        "binary_sensor.kitchen_south_window_contact",
-        "binary_sensor.office_window_contact",
-        "binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact",
-        "binary_sensor.owner_suite_bathroom_bay_north_window_contact",
-        "binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact",
-        "binary_sensor.owner_suite_bathroom_bay_south_window_contact",
-        "binary_sensor.owner_suite_north_window_contact",
-        "binary_sensor.owner_suite_south_window_contact",
-        "binary_sensor.powder_room_window_contact",
-        "binary_sensor.se_basement_window_contact",
-        "binary_sensor.sw_basement_window_contact",
-        "binary_sensor.ene_window_contact",
-        "binary_sensor.ese_window_contact",
-        "binary_sensor.main_foyer_front_door_contact",
-        "binary_sensor.deck_door_contact",
-        "binary_sensor.hall_garage_entry_contact",
-        "binary_sensor.nne_window_contact",
-        "binary_sensor.north_kitchen_sink_window_contact",
-        "binary_sensor.north_master_bedroom_window_contact",
-        "binary_sensor.nw_basement_window_contact",
-        "binary_sensor.office_north_window_contact",
-        "binary_sensor.sse_window_contact",
-    )
+    assert "entity_id: group.egress_points" in block
+    assert 'state: "on"' in block
+    assert "expand('group.egress_points')" in block
+    assert "Door or window left open: {{ open_egress_points }}." in block
 
-    for entity_id in expected_entities:
-        assert entity_id in block
 
-    assert "Door or window left open!" in block
+def test_egress_group_centralizes_all_window_and_door_contacts() -> None:
+    text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
+
+    for entity_id in EGRESS_ENTITY_IDS:
+        assert entity_id in text
+
+
+def test_fresh_air_open_reuses_any_window_open_state() -> None:
+    text = CLIMATE_PATH.read_text(encoding="utf-8")
+
+    assert 'default_entity_id: binary_sensor.fresh_air_open' in text
+    assert 'state: "{{ is_state(\'binary_sensor.any_window_open\', \'on\') }}"' in text


### PR DESCRIPTION
## Summary
- centralize the egress inventory in `group.egress_points` instead of repeating the same window/door entity list across multiple automations
- update the away alarm and leave-home notification automations to consume that canonical group and summarize currently open egress points
- simplify `binary_sensor.fresh_air_open` so it mirrors `binary_sensor.any_window_open` instead of re-running the same template logic
- rename the leave-home automation's friendly name to match its expanded egress scope

## Validation
- `pytest -q`
- `pytest -q tests/test_window_egress_automation_coverage.py`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/alerts.yaml packages/zone.yaml packages/zigbee_zwave.yaml packages/climate.yaml`

## Stack
- this PR is stacked on #229 and should be reviewed after or alongside that coverage fix
- once #229 merges, this PR can be retargeted to `master`