### PR TITLE
Remove Tiki Room ESPHome debug instrumentation

### DIFF
--- a/esphome/tikiroom.yaml
+++ b/esphome/tikiroom.yaml
@@ -13,65 +13,6 @@ esphome:
   name: tikiroomlights
   includes:
     - tikiroom_effects.h
-  on_boot:
-    - priority: 800
-      then:
-        - logger.log:
-            level: INFO
-            tag: tikiroom.boot
-            format: "Boot stage=hardware priority=800"
-    - priority: 250
-      then:
-        - logger.log:
-            level: INFO
-            tag: tikiroom.boot
-            format: "Boot stage=wifi priority=250 wifi_status=%d"
-            args:
-              - WiFi.status()
-    - priority: 200
-      then:
-        - logger.log:
-            level: INFO
-            tag: tikiroom.boot
-            format: "Boot stage=api priority=200 wifi_status=%d api_any=%s api_state_sub=%s"
-            args:
-              - WiFi.status()
-              - 'id(tikiroom_api).is_connected() ? "yes" : "no"'
-              - 'id(tikiroom_api).is_connected(true) ? "yes" : "no"'
-    - priority: -100
-      then:
-        - logger.log:
-            level: INFO
-            tag: tikiroom.boot
-            format: "Boot stage=ready priority=-100 effect=%s speed=%.0f api_any=%s api_state_sub=%s"
-            args:
-              - id(tiki_room_strip).get_effect_name().c_str()
-              - id(tikiroom_effect_speed)
-              - 'id(tikiroom_api).is_connected() ? "yes" : "no"'
-              - 'id(tikiroom_api).is_connected(true) ? "yes" : "no"'
-        - logger.log:
-            level: INFO
-            tag: tikiroom.boot
-            format: "Waiting up to 30s for a state-subscribing API client so entities can register"
-        - wait_until:
-            condition:
-              api.connected:
-                state_subscription_only: true
-            timeout: 30s
-        - if:
-            condition:
-              api.connected:
-                state_subscription_only: true
-            then:
-              - logger.log:
-                  level: INFO
-                  tag: tikiroom.boot
-                  format: "State-subscribing API client connected; entity registration should now be active"
-            else:
-              - logger.log:
-                  level: WARN
-                  tag: tikiroom.boot
-                  format: "No state-subscribing API client connected within 30s; entities will remain unavailable"
 
 esp8266:
   board: esp01_1m
@@ -81,20 +22,6 @@ wifi:
   ssid: !secret wifi_ap
   password: !secret wifi_password
   min_auth_mode: WPA2
-  on_connect:
-    - logger.log:
-        level: INFO
-        tag: tikiroom.net
-        format: "WiFi connected to %s"
-        args:
-          - WiFi.SSID().c_str()
-  on_disconnect:
-    - logger.log:
-        level: WARN
-        tag: tikiroom.net
-        format: "WiFi disconnected with status=%d"
-        args:
-          - WiFi.status()
 
   ap:
     ssid: "Tikiroom Fallback Hotspot"
@@ -104,118 +31,12 @@ captive_portal:
 
 logger:
   level: INFO
-  esp8266_store_log_strings_in_flash: false
 
 api:
-  id: tikiroom_api
-  on_client_connected:
-    - logger.log:
-        level: INFO
-        tag: tikiroom.api
-        format: "API client %s connected from %s (state_subscriber=%s)"
-        args:
-          - client_info.c_str()
-          - client_address.c_str()
-          - 'id(tikiroom_api).is_connected(true) ? "yes" : "no"'
-    - if:
-        condition:
-          lambda: |-
-            return id(tikiroom_api).is_connected(true);
-        then:
-          - logger.log:
-              level: INFO
-              tag: tikiroom.api
-              format: "State-subscribing API client connected; Home Assistant should be able to control entities"
-        else:
-          - logger.log:
-              level: WARN
-              tag: tikiroom.api
-              format: "API client connected without state subscription; entity registration is still pending"
-  on_client_disconnected:
-    - logger.log:
-        level: WARN
-        tag: tikiroom.api
-        format: "API client %s disconnected from %s (state_subscriber=%s)"
-        args:
-          - client_info.c_str()
-          - client_address.c_str()
-          - 'id(tikiroom_api).is_connected(true) ? "yes" : "no"'
-    - if:
-        condition:
-          lambda: |-
-            return !id(tikiroom_api).is_connected(true);
-        then:
-          - logger.log:
-              level: WARN
-              tag: tikiroom.api
-              format: "No state-subscribing API clients remain; Home Assistant entities will go unavailable"
+  reboot_timeout: 15min
 
 ota:
   - platform: esphome
-
-debug:
-  update_interval: 60s
-
-interval:
-  - interval: 30s
-    startup_delay: 45s
-    then:
-      - if:
-          condition:
-            lambda: |-
-              return !id(tikiroom_api).is_connected(true);
-          then:
-            - logger.log:
-                level: WARN
-                tag: tikiroom.boot
-                format: "Runtime registration check missing state-subscribing API client; wifi_status=%d api_any=%s effect=%s speed=%.0f"
-                args:
-                  - WiFi.status()
-                  - 'id(tikiroom_api).is_connected() ? "yes" : "no"'
-                  - id(tiki_room_strip).get_effect_name().c_str()
-                  - id(tikiroom_effect_speed)
-
-binary_sensor:
-  - platform: status
-    name: "Tiki Room Strip Status"
-    entity_category: diagnostic
-
-sensor:
-  - platform: wifi_signal
-    name: "Tiki Room Strip WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: debug
-    free:
-      name: "Tiki Room Strip Heap Free"
-      entity_category: diagnostic
-    block:
-      name: "Tiki Room Strip Heap Max Block"
-      entity_category: diagnostic
-    fragmentation:
-      name: "Tiki Room Strip Heap Fragmentation"
-      entity_category: diagnostic
-    loop_time:
-      name: "Tiki Room Strip Loop Time"
-      entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "Tiki Room Strip IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Tiki Room Strip Connected SSID"
-      entity_category: diagnostic
-    bssid:
-      name: "Tiki Room Strip Connected BSSID"
-      entity_category: diagnostic
-
-  - platform: debug
-    reset_reason:
-      name: "Tiki Room Strip Reset Reason"
-      entity_category: diagnostic
 
 globals:
   - id: tikiroom_effect_speed
@@ -235,12 +56,6 @@ number:
       return id(tikiroom_effect_speed);
     update_interval: 1s
     set_action:
-      - logger.log:
-          level: INFO
-          tag: tikiroom.light
-          format: "Animation speed changed to %.0f"
-          args:
-            - x
       - lambda: |-
           id(tikiroom_effect_speed) = x;
 
@@ -281,12 +96,6 @@ select:
       return std::string(effect.c_str());
     update_interval: 1s
     set_action:
-      - logger.log:
-          level: INFO
-          tag: tikiroom.light
-          format: "Effect changed to %s"
-          args:
-            - x.c_str()
       - lambda: |-
           auto call = id(tiki_room_strip).turn_on();
           call.set_effect(x.c_str());
@@ -315,24 +124,6 @@ light:
               - light.turn_on:
                   id: tiki_room_strip
                   effect: solid
-        - logger.log:
-            level: INFO
-            tag: tikiroom.light
-            format: "Light turned on with effect %s"
-            args:
-              - id(tiki_room_strip).get_effect_name().c_str()
-    on_turn_off:
-      - logger.log:
-          level: INFO
-          tag: tikiroom.light
-          format: "Light turned off"
-    on_state:
-      - logger.log:
-          level: INFO
-          tag: tikiroom.light
-          format: "Light state updated; active effect %s"
-          args:
-            - id(tiki_room_strip).get_effect_name().c_str()
     effects:
       - addressable_lambda:
           name: solid

--- a/packages/logger.yaml
+++ b/packages/logger.yaml
@@ -30,11 +30,6 @@ homeassistant:
       friendly_name: "Log Level"
       icon: mdi:bug
 
-    input_boolean.esphome_debug_logging:
-      <<: *customize
-      friendly_name: "ESPHome Debug Logging"
-      icon: mdi:lan-connect
-
   customize_glob:
     "input_select.log_*":
       icon: mdi:bug
@@ -57,11 +52,6 @@ input_select:
       - notset
     initial: warn
 
-input_boolean:
-  esphome_debug_logging:
-    name: ESPHome Debug Logging
-    initial: off
-
 ###################################
 ##  Dynamically set the log levels without having to restart HASS or edit configuration.yaml
 #- Thanks @VDRainer
@@ -78,62 +68,3 @@ automation:
       - action: logger.set_level
         data:
           homeassistant.components: "{{ states.input_select.log_level.state }}"
-
-  - id: esphome_debug_logging
-    alias: esphome_debug_logging
-    mode: single
-    trigger:
-      - trigger: homeassistant
-        event: start
-      - trigger: state
-        entity_id:
-          - input_boolean.esphome_debug_logging
-    variables:
-      esphome_debug_level: >-
-        {{ 'debug' if is_state('input_boolean.esphome_debug_logging', 'on') else 'error' }}
-    action:
-      - action: logger.set_level
-        data:
-          # Subscribe to logs from the ESPHome device in the integration options to
-          # surface device-side logs here under homeassistant.components.esphome.
-          homeassistant.components.esphome: "{{ esphome_debug_level }}"
-          homeassistant.components.zeroconf: "{{ esphome_debug_level }}"
-          homeassistant.config_entries: "{{ esphome_debug_level }}"
-          homeassistant.helpers.device_registry: "{{ esphome_debug_level }}"
-          homeassistant.helpers.entity_registry: "{{ esphome_debug_level }}"
-          aioesphomeapi: "{{ esphome_debug_level }}"
-          zeroconf: "{{ esphome_debug_level }}"
-
-  - id: tikiroom_esphome_availability_trace
-    alias: tikiroom_esphome_availability_trace
-    mode: queued
-    trigger:
-      - trigger: homeassistant
-        event: start
-        id: startup
-      - trigger: state
-        entity_id:
-          - light.tiki_room_lights_tiki_room_strip
-          - select.tiki_room_lights_tiki_room_strip_effect
-          - number.tiki_room_lights_tiki_room_strip_animation_speed
-          - update.tikiroomlights_firmware
-        id: entity_state_change
-    condition:
-      - condition: state
-        entity_id: input_boolean.esphome_debug_logging
-        state: "on"
-    action:
-      - action: system_log.write
-        data:
-          level: info
-          logger: packages.logger.tikiroom_esphome
-          message: >-
-            Tiki Room ESPHome trace trigger={{ trigger.id }}
-            changed={{ trigger.entity_id | default('homeassistant.start') }}
-            from={{ trigger.from_state.state if trigger.from_state is not none else 'n/a' }}
-            to={{ trigger.to_state.state if trigger.to_state is not none else 'n/a' }}
-            light={{ states('light.tiki_room_lights_tiki_room_strip') }}
-            effect={{ states('select.tiki_room_lights_tiki_room_strip_effect') }}
-            speed={{ states('number.tiki_room_lights_tiki_room_strip_animation_speed') }}
-            firmware={{ states('update.tikiroomlights_firmware') }}
-            wifi_client={{ states('device_tracker.tikiroom_esp8266_led_string') }}

--- a/tests/test_logger_package.py
+++ b/tests/test_logger_package.py
@@ -2,51 +2,22 @@ from pathlib import Path
 
 
 LOGGER_PACKAGE_PATH = Path(__file__).resolve().parents[1] / "packages" / "logger.yaml"
-CONFIG_PATH = Path(__file__).resolve().parents[1] / "configuration.yaml"
 
 
-def test_logger_package_exposes_runtime_esphome_debug_toggle() -> None:
+def test_logger_package_exposes_runtime_log_level_control() -> None:
     text = LOGGER_PACKAGE_PATH.read_text(encoding="utf-8")
 
-    assert "input_boolean.esphome_debug_logging" in text
-    assert "name: ESPHome Debug Logging" in text
-    assert "id: esphome_debug_logging" in text
-    assert "trigger: homeassistant" in text
-    assert "entity_id:\n          - input_boolean.esphome_debug_logging" in text
-
-    for logger_name in (
-        "homeassistant.components.esphome",
-        "homeassistant.components.zeroconf",
-        "homeassistant.config_entries",
-        "homeassistant.helpers.device_registry",
-        "homeassistant.helpers.entity_registry",
-        "aioesphomeapi",
-        "zeroconf",
-    ):
-        assert f'{logger_name}: "{{{{ esphome_debug_level }}}}"' in text
+    assert "automation.log_level" in text
+    assert "input_select:\n  log_level:" in text
+    assert "id: log_level" in text
+    assert "entity_id:\n          - input_select.log_level" in text
+    assert 'homeassistant.components: "{{ states.input_select.log_level.state }}"' in text
 
 
-def test_logger_package_traces_tikiroom_entity_availability_changes() -> None:
+def test_logger_package_does_not_keep_tikiroom_esphome_debug_helpers() -> None:
     text = LOGGER_PACKAGE_PATH.read_text(encoding="utf-8")
 
-    assert "id: tikiroom_esphome_availability_trace" in text
-    assert "mode: queued" in text
-    assert "entity_id: input_boolean.esphome_debug_logging" in text
-    assert 'state: "on"' in text
-    assert "action: system_log.write" in text
-    assert "logger: packages.logger.tikiroom_esphome" in text
-
-    for entity_id in (
-        "light.tiki_room_lights_tiki_room_strip",
-        "select.tiki_room_lights_tiki_room_strip_effect",
-        "number.tiki_room_lights_tiki_room_strip_animation_speed",
-        "update.tikiroomlights_firmware",
-        "device_tracker.tikiroom_esp8266_led_string",
-    ):
-        assert entity_id in text
-
-
-def test_logger_package_enables_system_log_for_tikiroom_trace() -> None:
-    config_text = CONFIG_PATH.read_text(encoding="utf-8")
-
-    assert "\nsystem_log:\n" in config_text
+    assert "input_boolean.esphome_debug_logging" not in text
+    assert "id: esphome_debug_logging" not in text
+    assert "id: tikiroom_esphome_availability_trace" not in text
+    assert "packages.logger.tikiroom_esphome" not in text

--- a/tests/test_tikiroom_esphome.py
+++ b/tests/test_tikiroom_esphome.py
@@ -4,71 +4,44 @@ from pathlib import Path
 TIKIROOM_ESPHOME_PATH = Path(__file__).resolve().parents[1] / "esphome" / "tikiroom.yaml"
 
 
-def test_tikiroom_esphome_logs_connectivity_lifecycle() -> None:
+def test_tikiroom_esphome_uses_native_api_without_extra_trace_hooks() -> None:
     text = TIKIROOM_ESPHOME_PATH.read_text(encoding="utf-8")
 
-    assert "tag: tikiroom.net" in text
-    assert 'format: "WiFi connected to %s"' in text
-    assert 'format: "WiFi disconnected with status=%d"' in text
-    assert "id: tikiroom_api" in text
-    assert "tag: tikiroom.api" in text
-    assert 'format: "API client %s connected from %s (state_subscriber=%s)"' in text
-    assert 'format: "State-subscribing API client connected; Home Assistant should be able to control entities"' in text
-    assert 'format: "API client connected without state subscription; entity registration is still pending"' in text
-    assert 'format: "API client %s disconnected from %s (state_subscriber=%s)"' in text
-    assert 'format: "No state-subscribing API clients remain; Home Assistant entities will go unavailable"' in text
+    assert "\napi:\n  reboot_timeout: 15min\n" in text
+    assert "tikiroom_api" not in text
+    assert "tag: tikiroom.api" not in text
+    assert "tag: tikiroom.net" not in text
+    assert "logger.log:" not in text
 
 
-def test_tikiroom_esphome_logs_boot_and_registration_stages() -> None:
+def test_tikiroom_esphome_removes_boot_and_runtime_debug_instrumentation() -> None:
     text = TIKIROOM_ESPHOME_PATH.read_text(encoding="utf-8")
 
-    assert "tag: tikiroom.boot" in text
-    assert 'format: "Boot stage=hardware priority=800"' in text
-    assert 'format: "Boot stage=wifi priority=250 wifi_status=%d"' in text
-    assert 'format: "Boot stage=api priority=200 wifi_status=%d api_any=%s api_state_sub=%s"' in text
-    assert 'format: "Boot stage=ready priority=-100 effect=%s speed=%.0f api_any=%s api_state_sub=%s"' in text
-    assert 'format: "Waiting up to 30s for a state-subscribing API client so entities can register"' in text
-    assert "wait_until:" in text
-    assert "state_subscription_only: true" in text
-    assert "timeout: 30s" in text
-    assert 'format: "State-subscribing API client connected; entity registration should now be active"' in text
-    assert 'format: "No state-subscribing API client connected within 30s; entities will remain unavailable"' in text
-    assert "startup_delay: 45s" in text
-    assert 'format: "Runtime registration check missing state-subscribing API client; wifi_status=%d api_any=%s effect=%s speed=%.0f"' in text
+    assert "on_boot:" not in text
+    assert "\ninterval:\n" not in text
+    assert "tag: tikiroom.boot" not in text
+    assert "state_subscription_only: true" not in text
 
 
-def test_tikiroom_esphome_exposes_diagnostic_entities() -> None:
+def test_tikiroom_esphome_does_not_expose_tikiroom_debug_entities() -> None:
     text = TIKIROOM_ESPHOME_PATH.read_text(encoding="utf-8")
 
-    assert "debug:\n  update_interval: 60s" in text
-    assert "- platform: status" in text
-    assert '- platform: wifi_signal' in text
-    assert '- platform: debug' in text
-    assert '- platform: wifi_info' in text
-
-    for entity_name in (
-        "Tiki Room Strip Status",
-        "Tiki Room Strip WiFi Signal",
-        "Tiki Room Strip Heap Free",
-        "Tiki Room Strip Heap Max Block",
-        "Tiki Room Strip Heap Fragmentation",
-        "Tiki Room Strip Loop Time",
-        "Tiki Room Strip IP Address",
-        "Tiki Room Strip Connected SSID",
-        "Tiki Room Strip Connected BSSID",
-        "Tiki Room Strip Reset Reason",
-    ):
-        assert f'name: "{entity_name}"' in text
+    assert "\ndebug:\n" not in text
+    assert "\nbinary_sensor:\n" not in text
+    assert '- platform: wifi_signal' not in text
+    assert '- platform: debug' not in text
+    assert '- platform: wifi_info' not in text
 
 
-def test_tikiroom_esphome_logs_light_commands() -> None:
+def test_tikiroom_esphome_keeps_user_controls_without_log_side_effects() -> None:
     text = TIKIROOM_ESPHOME_PATH.read_text(encoding="utf-8")
 
-    assert 'format: "Animation speed changed to %.0f"' in text
-    assert 'format: "Effect changed to %s"' in text
-    assert 'format: "Light turned on with effect %s"' in text
-    assert 'format: "Light turned off"' in text
-    assert 'format: "Light state updated; active effect %s"' in text
+    assert 'name: "Tiki Room Strip Animation Speed"' in text
+    assert 'name: "Tiki Room Strip Effect"' in text
+    assert 'name: "Tiki Room Strip"' in text
+    assert 'format: "Animation speed changed to %.0f"' not in text
+    assert 'format: "Effect changed to %s"' not in text
+    assert 'format: "Light turned on with effect %s"' not in text
 
 
 def test_tikiroom_esphome_exposes_f1_race_effect() -> None:


### PR DESCRIPTION
## Summary
- remove the temporary Home Assistant logger toggle and Tiki Room availability trace automation that were added for issue 205 debugging
- strip the ESPHome-side boot, API, Wi-Fi, diagnostic-entity, and light-command instrumentation while keeping the stable frame-rate cap, effect controls, and current effect set intact
- update the logger and Tiki Room ESPHome tests to verify the cleaned baseline instead of the removed debug hooks

## Validation
- `. .venv/bin/activate && pytest`
- `. .venv/bin/activate && pytest tests/test_logger_package.py tests/test_tikiroom_esphome.py`
- `. .venv/bin/activate && yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' esphome/tikiroom.yaml packages/logger.yaml`
- `. .venv/bin/activate && python scripts/check_ha_python_support.py --python-version-file .python-version`
- `. .venv/bin/activate && esphome config esphome/tikiroom.yaml`
- `. .venv/bin/activate && esphome compile esphome/tikiroom.yaml`