### PR TITLE
Address Codex review follow-ups for z2m watchdog and west-bed gating

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -481,10 +481,6 @@ automation:
     trigger:
       - trigger: state
         entity_id:
-          - media_player.bedroom_sonos
-          - media_player.bathroom_sonos
-          - media_player.office_sonos
-          - media_player.den_sonos
           - media_player.bedroom_sonos_2
           - media_player.bathroom_sonos_2
           - media_player.office_sonos_2

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -654,6 +654,9 @@ automation:
           - conditions:
               - condition: trigger
                 id: west_bed_left_bed
+              - condition: state
+                entity_id: input_boolean.west_bed_occupied
+                state: "on"
               - condition: or
                 conditions:
                   - condition: sun
@@ -1413,19 +1416,24 @@ automation:
         id: recovery_candidates_high
     variables:
       max_restart_attempts: 3
+      recovery_candidates_high: >-
+        {{
+          states('sensor.z2m_recovery_candidates') | int(0) > 20
+          and (as_timestamp(now()) - as_timestamp(states.sensor.z2m_recovery_candidates.last_changed, 0)) >= 300
+        }}
       issue_active: >-
         {{
           is_state('binary_sensor.zigbee2mqtt_running', 'off')
           or is_state('binary_sensor.z2m_failing', 'on')
-          or (states('sensor.z2m_recovery_candidates') | int(0) > 20)
+          or recovery_candidates_high
         }}
       issue_reason: >-
         {% if is_state('binary_sensor.zigbee2mqtt_running', 'off') %}
           Zigbee2MQTT add-on is not running
         {% elif is_state('binary_sensor.z2m_failing', 'on') %}
           Router offline threshold exceeded
-        {% elif states('sensor.z2m_recovery_candidates') | int(0) > 20 %}
-          Z2M recovery candidates exceeded threshold (20)
+        {% elif recovery_candidates_high %}
+          Z2M recovery candidates exceeded threshold (20) for at least 5 minutes
         {% else %}
           Unknown
         {% endif %}


### PR DESCRIPTION
Closes #233.

This follow-up addresses the remaining live review feedback in the zigbee2mqtt / Sonos / bedroom automation cluster:
- z2m watchdog now only treats recovery candidates as unhealthy after they have stayed above threshold for 5 minutes.
- `restart_sonos_unavailable` now watches only the active `_2` Sonos entities.
- west-bed auto-on now requires confirmed occupancy before turning the lamp on.

I re-audited the other comments in this cluster and left the ones that already matched current code untouched.
