### PR TITLE
Address remaining Codex review follow-ups

### DIFF
--- a/packages/house_mode.yaml
+++ b/packages/house_mode.yaml
@@ -72,7 +72,7 @@ script:
       Shared entrypoint for house mode transitions. Base arrival/departure
       automations can reapply lights, security, and climate, while guest/trip
       callers can selectively reapply only media, climate, or travel policy.
-    mode: queued
+    mode: restart
     max: 10
     fields:
       mode:

--- a/packages/tiki_time.yaml
+++ b/packages/tiki_time.yaml
@@ -349,9 +349,25 @@ script:
                   media_item: "somafm://radio/tikitime"
                   enqueue: replace
               - action: media_player.turn_on
-                continue_on_error: true
                 target:
                   entity_id: media_player.basement
+              - if:
+                  - condition: state
+                    entity_id: media_player.basement
+                    state: "off"
+                then:
+                  - wait_for_trigger:
+                      - trigger: state
+                        entity_id: media_player.basement
+                        from: "off"
+                    timeout: "00:00:05"
+                    continue_on_timeout: true
+                  - if:
+                      - condition: state
+                        entity_id: media_player.basement
+                        state: "off"
+                    then:
+                      - stop: Basement player failed to turn on
               - action: script.wait_for_basement_media_player_ready
               - action: media_player.volume_set
                 continue_on_error: true

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -459,9 +459,10 @@ automation:
                     {% set origin_code = summary.split('→', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
                     {% set destination_code = summary.split('→', 1)[1].split('•', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
                   {% elif summary_lower.startswith('flight to ') %}
-                    {% set destination_code = summary.split('Flight to ', 1)[1].split(' (', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
+                    {% set destination_code = summary_lower[10:].split(' (', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
                   {% elif summary_lower.startswith('flight: ') and ' to ' in summary_lower %}
-                    {% set destination_code = summary.split('Flight: ', 1)[1].split(' to ', 1)[1].split(' (', 1)[0].split(' •', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
+                    {% set flight_tail_lower = summary_lower[8:] %}
+                    {% set destination_code = flight_tail_lower.split(' to ', 1)[1].split(' (', 1)[0].split(' •', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
                   {% endif %}
                   {% set is_msp_departure = (
                     origin_code == "MSP"

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -759,7 +759,7 @@ template:
       - name: house_electrical_meter
         unique_id: house_electrical_meter
         device_class: energy
-        state_class: total_increasing
+        state_class: measurement
         unit_of_measurement: kWh
         availability: >
           {% if is_state("sensor.filtered_raw_electrical_sensor", "unavailable") %}
@@ -781,12 +781,17 @@ template:
         availability: >
           {{
             states('sensor.house_electrical_meter') not in ['unavailable', 'unknown', 'Unavailable', 'Unknown']
-            and states('sensor.nigori_energy_added') not in ['unavailable', 'unknown', 'Unavailable', 'Unknown']
+            and (
+              states('device_tracker.nigori_location_tracker') | default('', true) | lower != 'home'
+              or states('sensor.nigori_energy_added') not in ['unavailable', 'unknown', 'Unavailable', 'Unknown']
+            )
           }}
         state: >-
           {% set house_kwh = states('sensor.house_electrical_meter') | float(default=0) %}
           {% set ev_kwh = states('sensor.nigori_energy_added') | float(default=0) %}
-          {% set calculated = [house_kwh - ev_kwh, 0] | max %}
+          {% set home_charging = (states('device_tracker.nigori_location_tracker') | default('', true) | lower) == 'home' %}
+          {% set calculated = house_kwh - ev_kwh if home_charging else house_kwh %}
+          {% set calculated = [calculated, 0] | max %}
           {% set previous = this.state | float(default=calculated) %}
           {{ [calculated, previous] | max | round(3) }}
       - name: house_electrical_rate

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -178,18 +178,21 @@ automation:
           - condition: state
             entity_id: sensor.season
             state: "winter"
-      - alias: "Check if we already notified within the last hour"
-        condition: template
-        value_template: >-
-          {{ (as_timestamp(now()) - as_timestamp(state_attr('automation.alert_car_windows_open_pressure_dropping', 'last_triggered'), 0)) > 3600 }}
     action:
-      - action: notify.mobile_app_wethop
-        data:
-          title: "Tesla Windows"
-          message: >-
-            Rain is expected near the parked Tesla within the next two hours. Home
-            Assistant is closing the open windows using the vehicle's current location
-            forecast.
+      - choose:
+          - conditions:
+              - alias: "Check if we already notified within the last hour"
+                condition: template
+                value_template: >-
+                  {{ (as_timestamp(now()) - as_timestamp(state_attr('automation.alert_car_windows_open_pressure_dropping', 'last_triggered'), 0)) > 3600 }}
+            sequence:
+              - action: notify.mobile_app_wethop
+                data:
+                  title: "Tesla Windows"
+                  message: >-
+                    Rain is expected near the parked Tesla within the next two hours. Home
+                    Assistant is closing the open windows using the vehicle's current location
+                    forecast.
       - action: cover.close_cover
         target:
           entity_id: cover.nigori_windows
@@ -706,7 +709,11 @@ sensor:
       {% if latitude is number and longitude is number %}
         https://api.open-meteo.com/v1/forecast?latitude={{ '%.4f' | format(latitude) }}&longitude={{ '%.4f' | format(longitude) }}&hourly=precipitation_probability&forecast_hours=2&timezone=auto
       {% else %}
-        https://api.open-meteo.com/v1/forecast?latitude=0&longitude=0&hourly=precipitation_probability&forecast_hours=2&timezone=UTC
+        {% set home_lat = state_attr('zone.home', 'latitude') | float(default=none) %}
+        {% set home_lon = state_attr('zone.home', 'longitude') | float(default=none) %}
+        {% if home_lat is number and home_lon is number %}
+          https://api.open-meteo.com/v1/forecast?latitude={{ '%.4f' | format(home_lat) }}&longitude={{ '%.4f' | format(home_lon) }}&hourly=precipitation_probability&forecast_hours=2&timezone=auto
+        {% endif %}
       {% endif %}
     scan_interval: 900
     unit_of_measurement: "%"

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -485,17 +485,18 @@ automation:
         state: "Automotive"
         # Todo add biking here?
     action:
-      - action: script.house_transition
-        data:
-          mode: away
-          reason: leave_home
-      # Vacuum request payload is identical for both paths, so keep one action.
-      - action: mqtt.publish
-        data:
-          topic: valetudo/upstairs-vacuum/MapSegmentationCapability/clean/set
-          payload: >-
-            {% set segment_id = now().weekday() + 1 %}
-            {"segment_ids": ["{{segment_id}}"],"iterations": 4,"customOrder": true}
+      - parallel:
+          - action: script.house_transition
+            data:
+              mode: away
+              reason: leave_home
+          # Vacuum request payload is identical for both paths, so keep one action.
+          - action: mqtt.publish
+            data:
+              topic: valetudo/upstairs-vacuum/MapSegmentationCapability/clean/set
+              payload: >-
+                {% set segment_id = now().weekday() + 1 %}
+                {"segment_ids": ["{{segment_id}}"],"iterations": 4,"customOrder": true}
           # - action: notify.all
           #   data:
           #     title: "Auf wiedersehen"

--- a/tests/test_ev_cost_comparison.py
+++ b/tests/test_ev_cost_comparison.py
@@ -56,3 +56,14 @@ def test_storage_dashboard_exposes_ev_vs_gas_comparison_tiles() -> None:
         '"entity": "sensor.average_daily_ev_savings_vs_30mpg"',
     ):
         assert token in text
+
+
+def test_utilities_package_keeps_the_raw_meter_as_measurement_only() -> None:
+    text = UTILITIES_PATH.read_text(encoding="utf-8")
+
+    assert "name: house_electrical_meter" in text
+    assert "state_class: measurement" in text
+    assert "name: house_electrical_meter_non_ev" in text
+    assert "state_class: total_increasing" in text
+    assert "states('device_tracker.nigori_location_tracker') | default('', true) | lower != 'home'" in text
+    assert "home_charging = (states('device_tracker.nigori_location_tracker') | default('', true) | lower) == 'home'" in text

--- a/tests/test_house_mode_zone.py
+++ b/tests/test_house_mode_zone.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+HOUSE_MODE_PATH = Path(__file__).resolve().parents[1] / "packages" / "house_mode.yaml"
+ZONE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zone.yaml"
+
+
+def _script_block(script_id: str) -> str:
+    lines = HOUSE_MODE_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r}")
+
+    end = len(lines)
+    next_script = re.compile(r"^  [A-Za-z0-9_]+:$")
+    for index in range(start + 1, len(lines)):
+        if next_script.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_house_transition_no_longer_queues_later_mode_changes() -> None:
+    text = _script_block("house_transition")
+
+    assert "house_transition:" in text
+    assert "mode: restart" in text
+    assert "script.lights_off_except" in text
+
+
+def test_departure_vacuum_publish_runs_in_parallel_with_house_transition() -> None:
+    text = ZONE_PATH.read_text(encoding="utf-8")
+
+    assert "parallel:" in text
+    assert "action: script.house_transition" in text
+    assert "action: mqtt.publish" in text

--- a/tests/test_tiki_time.py
+++ b/tests/test_tiki_time.py
@@ -42,6 +42,13 @@ def test_tiki_time_uses_shared_music_assistant_helpers() -> None:
     assert "source: Photos" in block
     assert "flash: short" in block
     assert "script.tiki_time_tropical_color_cycle" in block
+    assert "Basement player failed to turn on" in block
+    assert "wait_for_trigger:" in block
+    turn_on_section = block.split("      - action: media_player.turn_on", 1)[1].split(
+        "      - action: script.wait_for_basement_media_player_ready",
+        1,
+    )[0]
+    assert "continue_on_error: true" not in turn_on_section
 
 
 def test_tiki_time_color_cycle_loops_while_party_music_is_active() -> None:

--- a/tests/test_trips_flight_classification.py
+++ b/tests/test_trips_flight_classification.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 
 CENTRAL = ZoneInfo("America/Chicago")
 HOME_CODES = {"MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "ROCHESTER"}
+TRIPS_PATH = Path(__file__).resolve().parents[1] / "packages" / "trips.yaml"
 
 
 @dataclass(frozen=True)
@@ -180,6 +182,14 @@ def test_named_flights_extract_clean_destination_codes() -> None:
     assert direct.destination_code == "CLT"
     assert verbose.destination_name == "CLT"
     assert verbose.destination_code == "CLT"
+
+
+def test_trips_package_avoids_case_sensitive_named_flight_splits() -> None:
+    text = TRIPS_PATH.read_text(encoding="utf-8")
+
+    assert "summary.split('Flight to ', 1)" not in text
+    assert "summary.split('Flight: ', 1)" not in text
+    assert "flight_tail_lower = summary_lower[8:]" in text
 
 
 def test_vacation_plan_ignores_barber_and_pairs_real_outbound_with_return() -> None:

--- a/tests/test_weather_package.py
+++ b/tests/test_weather_package.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WEATHER_PATH = Path(__file__).resolve().parents[1] / "packages" / "weather.yaml"
+
+
+def test_car_window_alert_closes_windows_even_when_notification_is_throttled() -> None:
+    text = WEATHER_PATH.read_text(encoding="utf-8")
+
+    assert "alert_car_windows_open_pressure_dropping" in text
+    assert "choose:" in text
+    assert "action: cover.close_cover" in text
+    assert "resource_template: >-" in text
+    assert "state_attr('zone.home', 'latitude')" in text
+    assert "state_attr('zone.home', 'longitude')" in text
+    assert "latitude=0&longitude=0" not in text
+    assert "Check if we already notified within the last hour" in text
+    assert "action: notify.mobile_app_wethop" in text


### PR DESCRIPTION
Closes #235.

This follow-on addresses the remaining live Codex review feedback that was still present after #234 and the merge of #226:
- keep `house_electrical_meter` as a measurement sensor and only subtract EV energy when the Tesla is home charging
- let the Tesla rain-window alert retry window closure every time while throttling only the notification, and stop using `0,0` coordinates as the location fallback
- stop queueing later house transitions behind the away fade and start the upstairs vacuum in parallel with the departure transition
- remove the last case-sensitive named-flight parser branch in `packages/trips.yaml`
- fail fast in Tiki Time if the basement player never leaves `off` before the readiness wait

Original review sources:
- PR #130 / #131
- PR #132
- PR #136
- PR #147
- PR #167

## Testing
- `uv run --with pytest pytest`