### PR TITLE
Fix Home Assistant repair regressions

### DIFF
--- a/packages/camera.yaml
+++ b/packages/camera.yaml
@@ -235,33 +235,32 @@ group:
 
   basement_camera_status:
     entities:
-      - switch.basement_motion_detection
-      - switch.basement_motion_tracking
-      - switch.basement_night_mode
-      - switch.basement_night_mode_auto
-      - switch.basement_ir_filter
-      - switch.basement_ir_led
-      - switch.basement_mjpeg_rtsp_server
-      - switch.basement_h264_rtsp_server
-      - switch.basement_blue_led
-      - switch.basement_yellow_led
-      - cover.basement_move_leftright
-      - cover.basement_move_updown
+      - switch.tiki_room_camera
+      - switch.tikiroomcam_tikiroom_motion_detection
+      - switch.tikiroomcam_tikiroom_motion_tracking
+      - switch.tikiroomcam_tikiroom_night_mode
+      - switch.tikiroomcam_tikiroom_night_mode_auto
+      - switch.tikiroomcam_tikiroom_ir_filter
+      - switch.tikiroomcam_tikiroom_ir_led
+      - switch.tikiroomcam_tikiroom_rtsp_server
+      - switch.tikiroomcam_tikiroom_blue_led
+      - switch.tikiroomcam_tikiroom_yellow_led
+      - cover.tikiroomcam_tikiroom_move_left_right
+      - cover.tikiroomcam_tikiroom_move_up_down
 
   livingroom_camera_status:
     entities:
       - switch.livingroom_motion_detection
       - switch.livingroom_motion_tracking
       - switch.livingroom_night_mode
-      - switch.livingroom_night_mode_auto
+      - switch.livingroom_auto_night_detection
       - switch.livingroom_ir_filter
       - switch.livingroom_ir_led
-      - switch.livingroom_mjpeg_rtsp_server
-      - switch.livingroom_h264_rtsp_server
+      - switch.livingroom_rtsp_server
       - switch.livingroom_blue_led
       - switch.livingroom_yellow_led
-      - cover.livingroom_move_leftright
-      - cover.livingroom_move_updown
+      - cover.livingroom_move_left_right
+      - cover.livingroom_move_up_down
 
 ########################
 # Input Booleans

--- a/packages/curling.yaml
+++ b/packages/curling.yaml
@@ -263,14 +263,18 @@ group:
 script:
   toggle_curling_automation_on_curling_season:
     sequence:
-      - action: >-
-          {% if is_state("binary_sensor.curling_season", 'on') %}
-            automation.turn_on
-          {% else %}
-            automation.turn_off
-          {% endif %}
-        data_template:
-          entity_id: "{{ entity_id }}"
+      - if:
+          - condition: state
+            entity_id: binary_sensor.curling_season
+            state: "on"
+        then:
+          - action: automation.turn_on
+            target:
+              entity_id: "{{ entity_id }}"
+        else:
+          - action: automation.turn_off
+            target:
+              entity_id: "{{ entity_id }}"
 
 ########################
 # Sensors

--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -551,14 +551,18 @@ scene:
 script:
   toggle_christmas_automation_during_christmas_season:
     sequence:
-      - action: >-
-          {% if is_state("binary_sensor.christmas_season", 'on') %}
-            automation.turn_on
-          {% else %}
-            automation.turn_off
-          {% endif %}
-        data_template:
-          entity_id: "{{ entity_id }}"
+      - if:
+          - condition: state
+            entity_id: binary_sensor.christmas_season
+            state: "on"
+        then:
+          - action: automation.turn_on
+            target:
+              entity_id: "{{ entity_id }}"
+        else:
+          - action: automation.turn_off
+            target:
+              entity_id: "{{ entity_id }}"
 
 ########################
 # Template

--- a/packages/house_mode.yaml
+++ b/packages/house_mode.yaml
@@ -243,8 +243,8 @@ script:
                     action: switch.turn_off
                     target:
                       entity_id:
-                        - switch.living_room_camera
-                        - switch.basement_camera_power
+                        - switch.livingroom_motion_detection
+                        - switch.tiki_room_camera
           - choose:
               - conditions:
                   - "{{ should_apply_climate and guest_mode_enabled }}"

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1618,7 +1618,7 @@ automation:
         entity_id: binary_sensor.owner_suite_bathroom_room_occupancy
         to: "on"
       - trigger: state
-        entity_id: binary_sensor.hallway_motion
+        entity_id: binary_sensor.hall_upstairs_motion_occupancy
         to: "on"
     condition:
       - condition: time
@@ -1630,8 +1630,8 @@ automation:
         {{ is_state('binary_sensor.owner_suite_bathroom_room_occupancy', 'on')
            or states.binary_sensor.owner_suite_bathroom_room_occupancy.last_changed >= today_at('08:00') }}
       - >-
-        {{ is_state('binary_sensor.hallway_motion', 'on')
-           or states.binary_sensor.hallway_motion.last_changed >= today_at('08:00') }}
+        {{ is_state('binary_sensor.hall_upstairs_motion_occupancy', 'on')
+           or states.binary_sensor.hall_upstairs_motion_occupancy.last_changed >= today_at('08:00') }}
     action:
       - action: script.turn_on
         target:

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -640,15 +640,19 @@ script:
       - action: persistent_notification.dismiss
         data:
           notification_id: "nws_dakota_county_alerts_alert"
-        ## Create a new persistant notification in the UI for a new alert
-      - action: >
-          {% if states.sensor.nws_dakota_county_alerts.state != '0' %}
-            persistent_notification.create
-          {% endif %}
-        data_template:
-          notification_id: "nws_dakota_county_alerts_alert"
-          message: "{{ message }}"
-          title: "{{ title }}"
+      ## Create a new persistent notification only while at least one alert is active.
+      - if:
+          - condition: not
+            conditions:
+              - condition: state
+                entity_id: sensor.nws_dakota_county_alerts
+                state: "0"
+        then:
+          - action: persistent_notification.create
+            data:
+              notification_id: "nws_dakota_county_alerts_alert"
+              message: "{{ message }}"
+              title: "{{ title }}"
 
 ################################################
 ## Sensors

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -66,7 +66,7 @@ homeassistant:
       device_class: opening
       friendly_name: "Front Door"
 
-    binary_sensor.hallway_motion:
+    binary_sensor.hall_upstairs_motion_occupancy:
       <<: *customize
       device_class: motion
       friendly_name: "Hallway Motion"

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -594,10 +594,10 @@ automation:
             - vacuum.valetudo_upstairs_vacuum
       - action: switch.turn_off
         target:
-          entity_id: switch.living_room_camera
+          entity_id: switch.livingroom_motion_detection
       - action: switch.turn_off
         target:
-          entity_id: switch.basement_camera_power
+          entity_id: switch.tiki_room_camera
 
   - id: vacuum_leave_home
     alias: vacuum_leave_home
@@ -766,16 +766,16 @@ scene:
         state: "on"
       light.den_all:
         state: "on"
-      switch.living_room_camera:
+      switch.livingroom_motion_detection:
         state: "off"
-      switch.basement_camera_power:
+      switch.tiki_room_camera:
         state: "off"
 
   - name: turn_on_cameras
     entities:
-      switch.living_room_camera:
+      switch.livingroom_motion_detection:
         state: "on"
-      switch.basement_camera_power:
+      switch.tiki_room_camera:
         state: "on"
 
   - name: goodnight

--- a/tests/test_inovelli_day_mode_switches.py
+++ b/tests/test_inovelli_day_mode_switches.py
@@ -117,7 +117,7 @@ def test_owner_suite_bedroom_day_mode_waits_for_bed_bathroom_and_hallway_activit
     for entity_id in (
         "binary_sensor.bayesian_bed_occupancy",
         "binary_sensor.owner_suite_bathroom_room_occupancy",
-        "binary_sensor.hallway_motion",
+        "binary_sensor.hall_upstairs_motion_occupancy",
     ):
         assert entity_id in block
 

--- a/tests/test_repair_regressions.py
+++ b/tests/test_repair_regressions.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CAMERA_PATH = ROOT / "packages" / "camera.yaml"
+CURLING_PATH = ROOT / "packages" / "curling.yaml"
+HOLIDAYS_PATH = ROOT / "packages" / "holidays.yaml"
+HOUSE_MODE_PATH = ROOT / "packages" / "house_mode.yaml"
+LIGHT_PATH = ROOT / "packages" / "light.yaml"
+WEATHER_PATH = ROOT / "packages" / "weather.yaml"
+ZONE_PATH = ROOT / "packages" / "zone.yaml"
+ZIGBEE_ZWAVE_PATH = ROOT / "packages" / "zigbee_zwave.yaml"
+
+
+def _script_block(path: Path, script_name: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^  {re.escape(script_name)}:\n(.*?)(?=^  [A-Za-z0-9_]+:|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find script block {script_name!r} in {path.name}")
+    return match.group(0)
+
+
+def _group_block(path: Path, group_name: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^  {re.escape(group_name)}:\n(.*?)(?=^  [A-Za-z0-9_]+:|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find group block {group_name!r} in {path.name}")
+    return match.group(0)
+
+
+def _scene_block(scene_name: str) -> str:
+    text = ZONE_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^  - name: {re.escape(scene_name)}\n(.*?)(?=^  - name: |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find scene block {scene_name!r}")
+    return match.group(0)
+
+
+def test_dynamic_action_scripts_use_explicit_native_actions() -> None:
+    for path, script_name, action_name in (
+        (CURLING_PATH, "toggle_curling_automation_on_curling_season", "automation.turn_on"),
+        (HOLIDAYS_PATH, "toggle_christmas_automation_during_christmas_season", "automation.turn_on"),
+        (WEATHER_PATH, "nws_dakota_county_alerts_popup_on_wx_alert", "persistent_notification.create"),
+    ):
+        block = _script_block(path, script_name)
+
+        assert "action: >" not in block
+        assert action_name in block
+
+    weather_block = _script_block(WEATHER_PATH, "nws_dakota_county_alerts_popup_on_wx_alert")
+    assert "persistent_notification.dismiss" in weather_block
+    assert "condition: not" in weather_block
+    assert 'state: "0"' in weather_block
+
+
+def test_camera_security_references_use_current_entities() -> None:
+    zone_text = ZONE_PATH.read_text(encoding="utf-8")
+    house_mode_text = HOUSE_MODE_PATH.read_text(encoding="utf-8")
+
+    for text in (zone_text, house_mode_text):
+        assert "switch.living_room_camera" not in text
+        assert "switch.basement_camera_power" not in text
+
+    assert "switch.livingroom_motion_detection" in zone_text
+    assert "switch.tiki_room_camera" in zone_text
+    assert "switch.livingroom_motion_detection" in house_mode_text
+    assert "switch.tiki_room_camera" in house_mode_text
+
+
+def test_camera_scenes_toggle_current_camera_controls() -> None:
+    arrive_home = _scene_block("arrive_home")
+    turn_on_cameras = _scene_block("turn_on_cameras")
+
+    for block, state in ((arrive_home, '"off"'), (turn_on_cameras, '"on"')):
+        assert "switch.livingroom_motion_detection" in block
+        assert "switch.tiki_room_camera" in block
+        assert f"state: {state}" in block
+
+
+def test_camera_status_groups_track_current_living_room_and_tiki_room_entities() -> None:
+    livingroom_group = _group_block(CAMERA_PATH, "livingroom_camera_status")
+    basement_group = _group_block(CAMERA_PATH, "basement_camera_status")
+
+    for stale_entity_id in (
+        "switch.livingroom_night_mode_auto",
+        "switch.livingroom_mjpeg_rtsp_server",
+        "switch.livingroom_h264_rtsp_server",
+        "cover.livingroom_move_leftright",
+        "cover.livingroom_move_updown",
+        "switch.basement_motion_detection",
+        "switch.basement_camera_power",
+    ):
+        assert stale_entity_id not in livingroom_group + basement_group
+
+    for current_entity_id in (
+        "switch.livingroom_auto_night_detection",
+        "switch.livingroom_rtsp_server",
+        "cover.livingroom_move_left_right",
+        "cover.livingroom_move_up_down",
+        "switch.tiki_room_camera",
+        "switch.tikiroomcam_tikiroom_motion_detection",
+        "switch.tikiroomcam_tikiroom_rtsp_server",
+        "cover.tikiroomcam_tikiroom_move_left_right",
+        "cover.tikiroomcam_tikiroom_move_up_down",
+    ):
+        assert current_entity_id in livingroom_group + basement_group
+
+
+def test_stale_hallway_motion_entity_is_fully_replaced() -> None:
+    light_text = LIGHT_PATH.read_text(encoding="utf-8")
+    zigbee_zwave_text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
+
+    assert "binary_sensor.hallway_motion" not in light_text + zigbee_zwave_text
+    assert "binary_sensor.hall_upstairs_motion_occupancy" in light_text
+    assert "binary_sensor.hall_upstairs_motion_occupancy" in zigbee_zwave_text


### PR DESCRIPTION
## Summary
- replace stale hallway and camera entity references with the current Home Assistant entity ids
- rewrite dynamic Home Assistant `action:` templates to explicit native branches for weather, curling, and holiday scripts
- add regression coverage for these repair classes and update the owner suite day-mode test

## Testing
- `pytest -q`
