### PR TITLE
[codex] Add room intent context and guest-mode cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 ########################################
 !*.yaml
 !*.yml
+!AGENTS.md
 !esphome/tikiroom_effects.h
 !.python-version
 !README.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md
+
+## Room Intent
+- Use `docs/room_intent.yaml` as the source of truth for room purpose, guest privacy, and room-sensitive automation behavior.
+- Read it before changing guest mode, occupancy, lighting, media, vacuum, climate, dashboards, or other room-targeted logic.
+- If convenience behavior conflicts with room intent, preserve privacy-first behavior.
+
+## Local Runtime Targets
+- Keep machine-local runtime verification targets in `AGENTS.local.md`.
+- Do not commit `AGENTS.local.md` unless explicitly asked.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ docker run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:stable \
 ## Feature Docs
 
 - [House Transition Framework](docs/house_transition_framework.md)
+- [Room Intent Policy](docs/room_intent.yaml)
 - [EV Charging Tariff](docs/ev_charging_tariff.md)
 - [Tesla Departure Planner](docs/tesla_departure_planner.md)
 
@@ -149,7 +150,6 @@ I use the new dashboards in 0.107 to create a [dashboard for guests](https://git
 Software on the NUC:
 * [Home Assistant](https://home-assistant.io/) via [Hass.io](https://www.home-assistant.io/hassio/)
 * Running in Hass.io
-  * ~~[ADB](https://github.com/hassio-addons/addon-adb)~~ Removed FireTVs
   * [AppDaemon](https://github.com/hassio-addons/addon-appdaemon)
   * [VSCode](https://github.com/hassio-addons/addon-vscode)
   * [Mosquitto Broker](https://home-assistant.io/addons/mosquitto/)
@@ -171,7 +171,6 @@ Software on the NUC:
 * [Ecobee Premium](https://www.ecobee.com/en-us/smart-thermostats/smart-thermostat-premium/) Love those remote sensors!
 * [Amazon Echo](http://amzn.to/2i6mShX)
 * [Amazon Echo Dot Gen 2](http://amzn.to/2hvCexj)
-* ~~[Amazon Fire TV](http://amzn.to/2iD9uPx)~~
 * Sonos One Speakers
 * Xiaomi Dafang Cameras running [custom firmware](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks)
 * Xiaomi MiFlora

--- a/docs/room_intent.yaml
+++ b/docs/room_intent.yaml
@@ -1,0 +1,204 @@
+# Canonical room-purpose and privacy policy for room-sensitive automations.
+# This file is for humans and future Codex runs. Home Assistant does not
+# consume it directly, but automations and docs should stay aligned with it.
+
+version: 1
+last_updated: "2026-03-29"
+owner: rtclauss
+summary: >
+  Treat room purpose as durable context, not chat memory. Guest-capable rooms
+  need privacy-first behavior, even when their default daytime use is
+  something else.
+
+global_policies:
+  - id: guest_privacy_first
+    statement: >
+      Never let automations or managed items intrude into rooms where guests
+      might be sleeping or having private time.
+    automation_implications:
+      - Avoid disruptive automations in guest-capable rooms unless explicitly requested.
+      - Treat audio, bright lighting, vacuuming, announcements, and similar actions as intrusive by default.
+      - Favor privacy over convenience when guest context is ambiguous.
+
+  - id: room_purpose_overrides_default_behavior
+    statement: >
+      A room's default purpose can be temporarily overridden by guest use, and
+      automations should respect that override immediately.
+    automation_implications:
+      - Do not assume the office is safe for normal workday automations when guests may be staying there.
+      - Treat dedicated guest spaces as private at all times, not only overnight.
+
+  - id: broad_guest_mode_controls_intrusive_automation
+    statement: >
+      Keep a broad guest mode. When guest mode is on, intrusive automations
+      should default to off unless explicitly allowed.
+    automation_implications:
+      - Skip automatic vacuuming while guest mode is on.
+      - Suppress convenience automations that assume owner-only use of guest-capable rooms.
+
+rooms:
+  owner_suite_bedroom:
+    primary_purpose: owner sleeping space
+    privacy_policy:
+      baseline: always private
+      priority: high
+    automation_guidance:
+      safe_defaults:
+        - owner-suite bathroom logic should follow bedroom sleep behavior
+
+  owner_suite_bathroom:
+    primary_purpose: owner bathroom
+    privacy_policy:
+      baseline: private bathroom associated with the owner suite
+      follow_sleep_logic_of:
+        - owner_suite_bedroom
+      priority: high
+    automation_guidance:
+      safe_defaults:
+        - humidity-driven exhaust control is acceptable
+        - sleep-related automation should follow owner-suite bedroom state
+
+  office:
+    primary_purpose: daytime workspace
+    secondary_purposes:
+      - overflow guest sleeping space
+    guest_use:
+      guests_may_sleep_here: true
+      guests_may_need_private_time_here: true
+      possible_times:
+        - day
+        - night
+    privacy_policy:
+      baseline: owner workspace during the day
+      override_when_guest_present: treat as guest-private room at any time
+      priority: high
+    automation_guidance:
+      avoid_without_explicit_request:
+        - bright automatic lighting changes
+        - media regrouping, playback, or announcements
+        - vacuum runs or other physical intrusions
+        - actions that assume the room is available for work use
+      safe_defaults:
+        - use normal office behavior only when there is no guest-stay context
+
+  den:
+    primary_purpose: shared room
+    secondary_purposes:
+      - guest sleeping space
+    guest_use:
+      guests_may_sleep_here: true
+      guests_may_need_private_time_here: true
+      possible_times:
+        - day
+        - night
+    privacy_policy:
+      baseline: shared-use room
+      override_when_guest_present: treat as guest-private room at any time
+      priority: high
+    automation_guidance:
+      avoid_without_explicit_request:
+        - vacuum runs or other physical intrusions
+        - bright disruptive lighting changes while guests may be sleeping
+
+  guest_room:
+    primary_purpose: dedicated guest sleeping space
+    guest_use:
+      guests_may_sleep_here: true
+      guests_may_need_private_time_here: true
+      possible_times:
+        - day
+        - night
+    privacy_policy:
+      baseline: always treat as guest-private room
+      priority: high
+    automation_guidance:
+      avoid_without_explicit_request:
+        - bright automatic lighting changes
+        - media playback or announcements
+        - vacuum runs or other physical intrusions
+      safe_defaults:
+        - assume the room may be occupied privately at any time
+
+  guest_bathroom:
+    primary_purpose: guest bathroom
+    guest_use:
+      guests_may_need_private_time_here: true
+      possible_times:
+        - day
+        - night
+    privacy_policy:
+      baseline: always treat as guest-private room
+      priority: high
+    automation_guidance:
+      safe_defaults:
+        - humidity-driven exhaust control is acceptable
+
+  basement_great_room:
+    primary_purpose: shared great room
+    secondary_purposes:
+      - guest sleeping space
+    guest_use:
+      guests_may_sleep_here: true
+      guests_may_need_private_time_here: false
+      possible_times:
+        - day
+        - night
+    privacy_policy:
+      baseline: shared media space
+      override_when_guest_present: treat physical intrusions as guest-sensitive
+      priority: medium
+    automation_guidance:
+      allowed_during_guest_mode:
+        - tv automations
+        - media automations
+      avoid_without_explicit_request:
+        - vacuum runs or other physical intrusions
+
+  kitchen:
+    primary_purpose: shared food-prep space
+    privacy_policy:
+      baseline: shared-use room
+      priority: low
+    automation_guidance:
+      disabled_automations:
+        - kitchen motion lighting
+
+  outside:
+    primary_purpose: exterior circulation and outdoor use
+    privacy_policy:
+      baseline: not privacy-sensitive for guest sleeping rules
+      priority: low
+    automation_guidance:
+      notes:
+        - deck and outside automations do not need extra guest-privacy handling
+
+  dining_room:
+    primary_purpose: dining room
+    privacy_policy:
+      baseline: shared-use room
+      priority: low
+    automation_guidance:
+      notes:
+        - legacy living-room references should be audited and renamed here where appropriate
+
+decision_rules:
+  guest_capable_rooms:
+    - office
+    - den
+    - guest_room
+    - guest_bathroom
+    - basement_great_room
+  treat_as_private_when:
+    - guest mode is on
+    - a guest is known or expected to be staying
+    - the room is marked as a dedicated or overflow guest space
+  broad_guest_mode: true
+  vacuum_policy:
+    when_guest_mode_on: skip_all_automatic_vacuuming
+  legacy_room_mapping:
+    living_room:
+      replacement: dining_room
+      note: Great-room style media behavior now belongs to the basement great room, not the former living room.
+  notes:
+    - This file is the canonical place to add future room-purpose rules.
+    - If runtime helpers or sensors are added later, keep their names and behavior aligned with this policy.

--- a/packages/guest.yaml
+++ b/packages/guest.yaml
@@ -1,5 +1,6 @@
 # Home Assistant package for guest mode.
 # It turns guest Wi-Fi presence into a house-wide guest state and then adjusts climate and UI behavior while visitors are around.
+# Canonical room-purpose and privacy context lives in docs/room_intent.yaml.
 
 ################################################################
 ## Packages / Guest

--- a/packages/house_mode.yaml
+++ b/packages/house_mode.yaml
@@ -1,6 +1,7 @@
 # Home Assistant package for shared house mode transitions.
 # It centralizes arrival, departure, night, guest, and trip side effects so
 # existing automations can delegate to one script entrypoint.
+# Canonical room-purpose and privacy context lives in docs/room_intent.yaml.
 
 ################################################################
 ## Packages / House Mode

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -932,6 +932,8 @@ automation:
 
   - id: kitchen_lights_toggle
     alias: kitchen_lights_toggle
+    description: Disabled pending a new kitchen policy; broad guest mode should not rely on this automation.
+    initial_state: false
     mode: restart
     trigger:
       - trigger: state

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -595,16 +595,6 @@ media_player: []
   # - platform: plex
   #   entity_namespace: 'plex'
 
-  # Configured via the UI
-  # - platform: androidtv
-  #   name: Living Room FireTV
-  #   host: !secret living_room_firetv_ip
-  #   adb_server_ip: !secret adb_server_ip
-  #   adb_server_port: 5037
-  #   #adbkey: "/config/androidtv/adbkey"
-  #   apps:
-  #     com.amazon.tv.launcher: "Fire TV"
-
   # - platform: spotify
   #   client_id: !secret spotify_client_id
   #   client_secret: !secret spotify_client_secret

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -875,6 +875,10 @@ automation:
           condition: state
           entity_id: binary_sensor.bayesian_zeke_home
           state: "off"
+        - alias: "guest mode off"
+          condition: state
+          entity_id: input_boolean.guest_mode
+          state: "off"
     action:
       # Revert back when batteries are all reset/new
       # including main level vacuum
@@ -909,6 +913,9 @@ automation:
           state: "on"
         - condition: state
           entity_id: binary_sensor.bayesian_zeke_home
+          state: "off"
+        - condition: state
+          entity_id: input_boolean.guest_mode
           state: "off"
     action:
       # Revert back when batteries are all reset/new

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -417,7 +417,10 @@ automation:
         event_type: mobile_app_notification_action
         event_data:
           action: VACUUM_HOUSE
-    condition: []
+    condition:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "off"
     action:
       # Revert back when batteries are all reset/new
       # including main level vacuum

--- a/packages/xiaomi_robot_vacuum.yaml
+++ b/packages/xiaomi_robot_vacuum.yaml
@@ -120,6 +120,9 @@ automation:
       - condition: state
         entity_id: binary_sensor.den_doors_contact
         state: "off"
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "off"
     action:
       - delay: "00:00:05"
       - action: vacuum.start

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -608,6 +608,10 @@ automation:
         entity_id: binary_sensor.bayesian_zeke_home
         from: "on"
         to: "off"
+    condition:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "off"
     action:
       - action: vacuum.start
         target:

--- a/travis_secrets.yaml
+++ b/travis_secrets.yaml
@@ -24,7 +24,6 @@ iot_subnet: "10.10.10.0/24"
 ipv6_subnet: "2602:aaaa:bbbb:cccc::/64"
 private_subnet: "192.168.23.0/24"
 lg_tv_ip: 10.0.0.12
-# living_room_firetv_ip: 192.0.2.1
 livingroom_cam_pic_url: http://livingroom/pic
 living_room_cam_ffmpeg_command: -rtsp_transport tcp -i rtsp://10.0.0.4:8554/unicast
 miio_host: 192.0.2.1

--- a/ui-guest.yaml
+++ b/ui-guest.yaml
@@ -224,75 +224,6 @@ views:
               service: media_player.turn_off
               service_data:
                 entity_id: media_player.lg_webos_smart_tv
-      # - id: f077a7073da44af5828c5bfe6a9f0981 # Automatically created id
-      #   type: vertical-stack
-      #   cards:
-      #     - type: horizontal-stack
-      #       cards:
-      #         - type: custom:firetv-card
-      #           entity: media_player.living_room_firetv
-      #           name: TV Remote
-      #           tv: true
-      #           power:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: "input keyevent 26"
-      #               entity_id: media_player.living_room_firetv
-      #           back:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: BACK
-      #               entity_id: media_player.living_room_firetv
-      #           home:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: HOME
-      #               entity_id: media_player.living_room_firetv
-      #           down:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: DOWN
-      #               entity_id: media_player.living_room_firetv
-      #           up:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: UP
-      #               entity_id: media_player.living_room_firetv
-      #           left:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: LEFT
-      #               entity_id: media_player.living_room_firetv
-      #           select:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: "input keyevent 23"
-      #               entity_id: media_player.living_room_firetv
-      #           right:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: RIGHT
-      #               entity_id: media_player.living_room_firetv
-      #           reverse:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: input keyevent 89
-      #               entity_id: media_player.living_room_firetv
-      #           pauseplay:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: input keyevent 85
-      #               entity_id: media_player.living_room_firetv
-      #           forward:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: input keyevent 90
-      #               entity_id: media_player.living_room_firetv
-      #           menu:
-      #             service: androidtv.adb_command
-      #             service_data:
-      #               command: MENU
-      #               entity_id: media_player.living_room_firetv
   ##################################################
 
   - title: Climate
@@ -353,7 +284,7 @@ views:
       - type: markdown
         title: Brewery Help
         content: |
-          Thanks for visiting me. I've tried to make the house smart without being overly complicated for you. 
+          Thanks for visiting me. I've tried to make the house smart without being overly complicated for you.
           This tablet contains the common controls you'll need to do things around the house. A few other things:
           * If you get up in the night the hallway, office, and kitchen light will all turn on and off automatically.
           * Most things in the house can be controlled by Alexa. Just ask her to do your bidding.


### PR DESCRIPTION
## What changed
- added a repo-level room intent policy in `docs/room_intent.yaml` and wired `AGENTS.md` to treat it as the source of truth for room-sensitive work
- updated guest/privacy behavior so broad `guest_mode` suppresses automatic vacuuming and kitchen motion lighting stays disabled
- removed all remaining Fire TV references from the repo and refreshed the living-room cleanup issue

## Why
- room-purpose and privacy rules need to live in durable repo context rather than transient chat memory
- guest-capable rooms now have explicit privacy-first behavior, and guest mode should prevent intrusive automations like vacuuming
- old Fire TV references were stale and no longer reflected the current setup

## User impact
- future Codex and automation work can read a single policy file for room intent
- guests are less likely to be disturbed by automatic lighting/vacuum behavior
- the repo no longer contains Fire TV-specific configuration remnants

## Related issue
- closes #237

## Validation
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" docs/room_intent.yaml packages/guest.yaml packages/house_mode.yaml packages/light.yaml packages/media_player.yaml packages/trips.yaml packages/workday.yaml packages/xiaomi_robot_vacuum.yaml packages/zone.yaml travis_secrets.yaml ui-guest.yaml`
- Ruby YAML parse for the touched YAML files
- `git diff --check`

## Notes
- no Home Assistant container-based `check_config` run was possible because Docker is not available in this environment