### PR TITLE
[codex] Fix holiday scene rotation

### DIFF
--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -252,7 +252,7 @@ automation:
       - action: scene.turn_on
         data:
           transition: 30
-          entity_id: scene.scene_st_andrews_day_outdoors_{{ now().minute % 4 + 1 | int }}
+          entity_id: scene.scene_st_andrews_day_outdoors_{{ (now().minute // 2) % 4 + 1 | int }}
 
   - id: halloween_light_loop
     alias: halloween_light_loop
@@ -281,7 +281,7 @@ automation:
       - action: scene.turn_on
         data:
           transition: 30
-          entity_id: scene.scene_halloween_outdoors_{{ now().minute % 4 + 1 | int }}
+          entity_id: scene.scene_halloween_outdoors_{{ (now().minute // 2) % 4 + 1 | int }}
 
   - alias: Garbage Holiday Update
     id: garbage_holiday_update

--- a/tests/test_holidays_scene_rotation.py
+++ b/tests/test_holidays_scene_rotation.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+HOLIDAYS_PATH = Path(__file__).resolve().parents[1] / "packages" / "holidays.yaml"
+
+
+def _automation_block(automation_id: str) -> str:
+    lines = HOLIDAYS_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_two_minute_holiday_loops_use_half_minute_indexing() -> None:
+    st_andrews = _automation_block("st_andrews_day_light_loop")
+    halloween = _automation_block("halloween_light_loop")
+
+    assert 'minutes: "/2"' in st_andrews
+    assert 'minutes: "/2"' in halloween
+
+    assert (
+        "scene.scene_st_andrews_day_outdoors_{{ (now().minute // 2) % 4 + 1 | int }}"
+        in st_andrews
+    )
+    assert "scene.scene_st_andrews_day_outdoors_{{ now().minute % 4 + 1 | int }}" not in st_andrews
+
+    assert (
+        "scene.scene_halloween_outdoors_{{ (now().minute // 2) % 4 + 1 | int }}" in halloween
+    )
+    assert "scene.scene_halloween_outdoors_{{ now().minute % 4 + 1 | int }}" not in halloween
+
+
+def test_two_minute_holiday_loops_can_reach_all_four_scenes() -> None:
+    scene_indexes = {(minute // 2) % 4 + 1 for minute in range(0, 60, 2)}
+
+    assert scene_indexes == {1, 2, 3, 4}
+
+
+def test_christmas_loop_keeps_per_minute_rotation() -> None:
+    christmas = _automation_block("christmas_outside_light_loop_1")
+
+    assert 'minutes: "/1"' in christmas
+    assert "scene.scene_christmas_outdoors_{{ now().minute % 4 + 1 | int }}" in christmas
+
+    scene_indexes = {minute % 4 + 1 for minute in range(60)}
+    assert scene_indexes == {1, 2, 3, 4}


### PR DESCRIPTION
## Summary
- fix the St Andrew's Day and Halloween scene rotation math so 2-minute loops can reach all four scene variants
- keep the Christmas loop unchanged because its 1-minute cadence already exercised all scene indices
- add regression tests covering both 2-minute loops and the Christmas control case

## Root cause
The St Andrew's Day and Halloween automations triggered every two minutes but selected scenes with `now().minute % 4 + 1`. On a steady 2-minute cadence that only produced scene indices `1` and `3`, leaving `2` and `4` effectively unreachable except for the sunset edge trigger.

## Validation
- `pytest tests/test_holidays_scene_rotation.py`
- `pytest`
