### PR TITLE
[codex] Fix garbage pickup runtime template failure

### DIFF
--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -592,39 +592,34 @@ template:
         entity_id: calendar.mn_holidays
     action:
       - variables:
-          garbage_pickup_window_json: >-
-            {% set today = now().date() %}
-            {% set is_wed = today.weekday() == 2 %}
-            {% set after_pickup_time = now().hour >= 12 %}
-            {% set days_until_wed = 2 - today.weekday() %}
-            {% if days_until_wed < 0 %}
-              {% set days_until_wed = days_until_wed + 7 %}
-            {% endif %}
+          today: "{{ now().date() }}"
+          is_wed: "{{ today.weekday() == 2 }}"
+          after_pickup_time: "{{ now().hour >= 12 }}"
+          days_until_wed: >
+            {% set d = 2 - today.weekday() %}
+            {% if d < 0 %}{% set d = d + 7 %}{% endif %}
+            {{ d }}
+          base_wed: >
             {% if is_wed and not after_pickup_time %}
-              {% set base_wed = today %}
+              {{ today }}
             {% else %}
-              {% set base_wed = today + timedelta(days=days_until_wed if not is_wed else 7) %}
+              {{ today + timedelta(days=days_until_wed if (not is_wed) else 7) }}
             {% endif %}
-            {% set week_mon = base_wed - timedelta(days=base_wed.weekday()) %}
-            {{ {
-              'base_wed': base_wed.isoformat(),
-              'week_mon': week_mon.isoformat(),
-              'range_start': week_mon.isoformat() ~ 'T00:00:00',
-              'range_end': (base_wed + timedelta(days=1)).isoformat() ~ 'T23:59:59'
-            } | to_json }}
-          garbage_pickup_window: "{{ garbage_pickup_window_json | from_json }}"
+          week_mon: "{{ base_wed - timedelta(days=base_wed.weekday()) }}"
+          range_start: "{{ week_mon.isoformat() }}T00:00:00"
+          range_end: "{{ (base_wed + timedelta(days=1)).isoformat() }}T23:59:59"
       - action: calendar.get_events
         target:
           entity_id: calendar.mn_holidays
         data:
-          start_date_time: "{{ garbage_pickup_window.range_start }}"
-          end_date_time: "{{ garbage_pickup_window.range_end }}"
+          start_date_time: "{{ range_start }}"
+          end_date_time: "{{ range_end }}"
         response_variable: hols
       - variables:
           holiday_events: "{{ hols.events | default([]) }}"
           holiday_mon_to_wed: >
-            {% set ws = as_datetime(garbage_pickup_window.week_mon).date() %}
-            {% set we = as_datetime(garbage_pickup_window.base_wed).date() %}
+            {% set ws = week_mon %}
+            {% set we = base_wed %}
             {% set ns = namespace(hit=false) %}
             {% for e in holiday_events %}
               {% set d = as_datetime(e.start).date() %}
@@ -634,7 +629,6 @@ template:
             {% endfor %}
             {{ ns.hit }}
           pickup_date: >
-            {% set base_wed = as_datetime(garbage_pickup_window.base_wed).date() %}
             {% if holiday_mon_to_wed in [true, 'true', 'True', 'on'] %}
               {{ (base_wed + timedelta(days=1)).isoformat() }}
             {% else %}
@@ -645,7 +639,7 @@ template:
         unique_id: garbage_pickup_date_apple_valley
         state: "{{ pickup_date }}"
         attributes:
-          base_wednesday: "{{ garbage_pickup_window.base_wed }}"
+          base_wednesday: "{{ base_wed.isoformat() }}"
           holiday_shift_applied: "{{ holiday_mon_to_wed in [true, 'true', 'True', 'on'] }}"
           holiday_events_in_range: "{{ holiday_events | map(attribute='summary') | list }}"
 

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -71,9 +71,11 @@ def test_house_electrical_meter_never_emits_literal_unavailable() -> None:
 def test_garbage_pickup_template_keeps_dates_serializable() -> None:
     text = _read(HOLIDAYS_PATH)
 
-    assert "garbage_pickup_window_json" in text
-    assert "garbage_pickup_window.range_start" in text
-    assert "as_datetime(garbage_pickup_window.week_mon).date()" in text
+    assert "garbage_pickup_window_json" not in text
+    assert "garbage_pickup_window.range_start" not in text
+    assert 'start_date_time: "{{ range_start }}"' in text
+    assert 'end_date_time: "{{ range_end }}"' in text
+    assert 'week_mon: "{{ base_wed - timedelta(days=base_wed.weekday()) }}"' in text
     assert "ns = namespace(hit=false)" in text
     assert "holiday_mon_to_wed in [true, 'true', 'True', 'on']" in text
-    assert 'base_wednesday: "{{ garbage_pickup_window.base_wed }}"' in text
+    assert 'base_wednesday: "{{ base_wed.isoformat() }}"' in text


### PR DESCRIPTION
## Summary
- replace the garbage pickup window JSON round-trip with native template variables so Home Assistant no longer has to `from_json` script-scoped data
- keep the holiday lookup and pickup-date calculation behavior the same while avoiding the live `Template error: from_json got invalid input ...` failure
- update the runtime-log regression test to assert the native-variable form instead of the fragile JSON path

## Live log context
This PR addresses the repo-owned runtime error seen in the live Home Assistant core logs on March 29, 2026:
- `Template error: from_json got invalid input ...` while rendering `{{ garbage_pickup_window_json | from_json }}`

Remaining live log items from this run that still look deployment or environment specific rather than safely fixable in repo YAML:
- `adsb.im` REST timeouts
- `valetudo-yummyhurtfulhornet.local` mDNS resolution failures during startup vacuum reconfiguration
- Alexa cloud `RequireRelink`
- LG webOS notify calls against a powered-off TV

## Validation
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/holidays.yaml`

Refs #182