### PR TITLE
[codex] Use whole-floor vacuum passes in away automations

### DIFF
--- a/packages/curling.yaml
+++ b/packages/curling.yaml
@@ -96,6 +96,7 @@ homeassistant:
 automation:
   - id: leave_home_for_curling
     alias: leave_home_for_curling
+    description: Run one full-floor pass on the main and upstairs levels when leaving for curling.
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -119,18 +120,7 @@ automation:
             - binary_sensor.curling_season
           state: "on"
     action:
-      # Revert back when batteries are all reset/new
-      # including main level vacuum
-      # - alias: Start Vacuums
-      #   action: vacuum.start
-      #   target:
-      #     entity_id: all
-      - action: mqtt.publish
-        data:
-          topic: valetudo/upstairs-vacuum/MapSegmentationCapability/clean/set
-          payload: >-
-            {% set segment_id = now().weekday() + 1 %}
-            {"segment_ids": ["{{segment_id}}"],"iterations": 4,"customOrder": true}
+      - action: script.vacuum_main_and_upstairs_levels
       - action: climate.set_preset_mode
         enabled: false
         target:

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -861,6 +861,7 @@ automation:
 
   - id: vacuum_on_trip
     alias: vacuum_on_trip
+    description: Run one full-floor pass on the main and upstairs levels during trips.
     trigger:
       - trigger: time
         at: "13:00:00"
@@ -880,26 +881,16 @@ automation:
           entity_id: input_boolean.guest_mode
           state: "off"
     action:
-      # Revert back when batteries are all reset/new
-      # including main level vacuum
-      # - alias: Start Vacuums
-      #   action: vacuum.start
-      #   target:
-      #     entity_id: all
-      - action: mqtt.publish
-        data:
-          topic: valetudo/upstairs-vacuum/MapSegmentationCapability/clean/set
-          payload: >-
-            {% set segment_id = now().weekday() + 1 %}
-            {"segment_ids": ["{{segment_id}}"],"iterations": 4,"customOrder": true}
+      - action: script.vacuum_main_and_upstairs_levels
       - action: notify.all
         data:
           data:
             url: "/ryan-new-mushroom/cleaning"
-          message: "Vacuuming part of the house while you're away \U0001F4BA"
+          message: "Vacuuming the main and upstairs levels while you're away \U0001F4BA"
 
   - id: vacuum_flying_home
     alias: vacuum_flying_home
+    description: Run one full-floor pass on the main and upstairs levels before Ryan flies home.
     trigger:
       - entity_id: binary_sensor.flying_home_today
         from: "off"
@@ -918,23 +909,12 @@ automation:
           entity_id: input_boolean.guest_mode
           state: "off"
     action:
-      # Revert back when batteries are all reset/new
-      # including main level vacuum
-      # - alias: Start Vacuums
-      #   action: vacuum.start
-      #   target:
-      #     entity_id: all
-      - action: mqtt.publish
-        data:
-          topic: valetudo/upstairs-vacuum/MapSegmentationCapability/clean/set
-          payload: >-
-            {% set segment_id = now().weekday() + 1 %}
-            {"segment_ids": ["{{segment_id}}"],"iterations": 4,"customOrder": true}
+      - action: script.vacuum_main_and_upstairs_levels
       - action: notify.all
         data:
           data:
             url: "/ryan-new-mushroom/cleaning"
-          message: "Vacuuming the house while you fly home \U0001F4BA"
+          message: "Vacuuming the main and upstairs levels while you fly home \U0001F4BA"
 
   # - id: toggle_vacation_tab
   #   alias: toggle_vacation_tab

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -400,6 +400,7 @@ automation:
 
   - id: vacuum_while_working
     alias: vacuum_while_working
+    description: Run one full-floor pass on the main and upstairs levels while Ryan is away.
     trigger:
       # - platform: state
       #   entity_id: device_tracker.bayesian_zeke_home
@@ -422,18 +423,7 @@ automation:
         entity_id: input_boolean.guest_mode
         state: "off"
     action:
-      # Revert back when batteries are all reset/new
-      # including main level vacuum
-      # - alias: Start Vacuums
-      #   action: vacuum.start
-      #   target:
-      #     entity_id: all
-      - action: mqtt.publish
-        data:
-          topic: valetudo/upstairs-vacuum/MapSegmentationCapability/clean/set
-          payload: >-
-            {% set segment_id = now().weekday() + 1 %}
-            {"segment_ids": ["{{segment_id}}"],"iterations": 4,"customOrder": true}
+      - action: script.vacuum_main_and_upstairs_levels
 
 ########################
 # Scripts

--- a/packages/xiaomi_robot_vacuum.yaml
+++ b/packages/xiaomi_robot_vacuum.yaml
@@ -1,5 +1,7 @@
 # Home Assistant package for the Xiaomi/Valetudo vacuum.
-# It wraps room-cleaning scripts, schedule helpers, and error recovery so the vacuum can be controlled by name instead of raw segment commands.
+# It wraps whole-floor and room-cleaning scripts, schedule helpers, and error
+# recovery so the vacuum can be controlled by name instead of raw segment
+# commands.
 
 ################################################################
 ## Packages / Xiaomi Vacuum
@@ -210,6 +212,30 @@ scene: []
 # Scripts
 ########################
 script:
+  vacuum_main_level_full_floor:
+    alias: "Vacuum Main Level Full Floor"
+    sequence:
+      - action: vacuum.start
+        target:
+          entity_id: vacuum.valetudo_mainlevel
+
+  vacuum_upstairs_full_floor:
+    alias: "Vacuum Upstairs Full Floor"
+    sequence:
+      - action: vacuum.start
+        target:
+          entity_id: vacuum.valetudo_upstairs_vacuum
+
+  vacuum_main_and_upstairs_levels:
+    alias: "Vacuum Main And Upstairs Levels"
+    description: Run one full-floor cleaning pass on both resident levels.
+    mode: queued
+    sequence:
+      - action: script.vacuum_main_level_full_floor
+        continue_on_error: true
+      - action: script.vacuum_upstairs_full_floor
+        continue_on_error: true
+
   vacuum_master_bedroom:
     alias: "Vacuum Master Bedroom"
     sequence:

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -490,13 +490,6 @@ automation:
             data:
               mode: away
               reason: leave_home
-          # Vacuum request payload is identical for both paths, so keep one action.
-          - action: mqtt.publish
-            data:
-              topic: valetudo/upstairs-vacuum/MapSegmentationCapability/clean/set
-              payload: >-
-                {% set segment_id = now().weekday() + 1 %}
-                {"segment_ids": ["{{segment_id}}"],"iterations": 4,"customOrder": true}
           # - action: notify.all
           #   data:
           #     title: "Auf wiedersehen"
@@ -602,7 +595,7 @@ automation:
 
   - id: vacuum_leave_home
     alias: vacuum_leave_home
-    description: Start the den, main level, and upstairs vacuums when Ryan leaves home.
+    description: Run the main and upstairs levels on departure, plus the den when its door is closed.
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
@@ -613,9 +606,7 @@ automation:
         entity_id: input_boolean.guest_mode
         state: "off"
     action:
-      - action: vacuum.start
-        target:
-          entity_id: vacuum.valetudo_mainlevel
+      - action: script.vacuum_main_and_upstairs_levels
         continue_on_error: true
       - if:
           - condition: state
@@ -626,10 +617,6 @@ automation:
             target:
               entity_id: vacuum.valetudo_den
             continue_on_error: true
-      - action: vacuum.start
-        target:
-          entity_id: vacuum.valetudo_upstairs_vacuum
-        continue_on_error: true
 
 ########################
 # Binary Sensors

--- a/tests/test_den_vacuum_door_guard.py
+++ b/tests/test_den_vacuum_door_guard.py
@@ -48,8 +48,7 @@ def test_den_vacuum_error_retry_requires_the_den_door_to_be_closed() -> None:
 def test_leave_home_only_starts_the_den_vacuum_when_the_den_door_is_closed() -> None:
     block = _automation_block(ZONE_PATH, "vacuum_leave_home")
 
-    assert "entity_id: vacuum.valetudo_mainlevel" in block
-    assert "entity_id: vacuum.valetudo_upstairs_vacuum" in block
+    assert "action: script.vacuum_main_and_upstairs_levels" in block
     assert "- if:" in block
     assert "entity_id: binary_sensor.den_doors_contact" in block
     assert 'state: "off"' in block

--- a/tests/test_house_mode_zone.py
+++ b/tests/test_house_mode_zone.py
@@ -31,6 +31,33 @@ def _script_block(script_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
+def _automation_block(path: Path, automation_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
 def test_house_transition_no_longer_queues_later_mode_changes() -> None:
     text = _script_block("house_transition")
 
@@ -39,9 +66,12 @@ def test_house_transition_no_longer_queues_later_mode_changes() -> None:
     assert "script.lights_off_except" in text
 
 
-def test_departure_vacuum_publish_runs_in_parallel_with_house_transition() -> None:
-    text = ZONE_PATH.read_text(encoding="utf-8")
+def test_departure_house_transition_runs_in_parallel_without_embedding_vacuum_logic() -> None:
+    transition_block = _automation_block(ZONE_PATH, "turn_off_lights_when_i_leave")
+    vacuum_block = _automation_block(ZONE_PATH, "vacuum_leave_home")
 
-    assert "parallel:" in text
-    assert "action: script.house_transition" in text
-    assert "action: mqtt.publish" in text
+    assert "parallel:" in transition_block
+    assert "action: script.house_transition" in transition_block
+    assert "action: mqtt.publish" not in transition_block
+    assert "action: script.vacuum_main_and_upstairs_levels" not in transition_block
+    assert "action: script.vacuum_main_and_upstairs_levels" in vacuum_block

--- a/tests/test_vacuum_whole_floor_policy.py
+++ b/tests/test_vacuum_whole_floor_policy.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VACUUM_PATH = ROOT / "packages" / "xiaomi_robot_vacuum.yaml"
+ZONE_PATH = ROOT / "packages" / "zone.yaml"
+WORKDAY_PATH = ROOT / "packages" / "workday.yaml"
+TRIPS_PATH = ROOT / "packages" / "trips.yaml"
+CURLING_PATH = ROOT / "packages" / "curling.yaml"
+
+
+def _automation_block(path: Path, automation_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _script_block(path: Path, script_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+    target = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == target:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script block {script_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line.startswith("  ") and not line.startswith("    ") and line.endswith(":"):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_whole_floor_helper_starts_both_levels() -> None:
+    helper_block = _script_block(VACUUM_PATH, "vacuum_main_and_upstairs_levels")
+    main_level_block = _script_block(VACUUM_PATH, "vacuum_main_level_full_floor")
+    upstairs_block = _script_block(VACUUM_PATH, "vacuum_upstairs_full_floor")
+
+    assert "action: script.vacuum_main_level_full_floor" in helper_block
+    assert "action: script.vacuum_upstairs_full_floor" in helper_block
+    assert "MapSegmentationCapability/clean/set" not in helper_block
+    assert '"iterations": 4' not in helper_block
+
+    assert "entity_id: vacuum.valetudo_mainlevel" in main_level_block
+    assert "action: vacuum.start" in main_level_block
+    assert "entity_id: vacuum.valetudo_upstairs_vacuum" in upstairs_block
+    assert "action: vacuum.start" in upstairs_block
+
+
+def test_departure_transition_no_longer_embeds_weekday_room_rotation() -> None:
+    block = _automation_block(ZONE_PATH, "turn_off_lights_when_i_leave")
+
+    assert "script.house_transition" in block
+    assert "MapSegmentationCapability/clean/set" not in block
+    assert '"iterations": 4' not in block
+    assert "script.vacuum_main_and_upstairs_levels" not in block
+
+
+def test_away_automations_use_shared_whole_floor_helper() -> None:
+    automation_locations = [
+        (ZONE_PATH, "vacuum_leave_home"),
+        (WORKDAY_PATH, "vacuum_while_working"),
+        (TRIPS_PATH, "vacuum_on_trip"),
+        (TRIPS_PATH, "vacuum_flying_home"),
+        (CURLING_PATH, "leave_home_for_curling"),
+    ]
+
+    for path, automation_id in automation_locations:
+        block = _automation_block(path, automation_id)
+        assert "action: script.vacuum_main_and_upstairs_levels" in block
+        assert "MapSegmentationCapability/clean/set" not in block
+        assert '"iterations": 4' not in block


### PR DESCRIPTION
## Summary
- switch away/departure vacuum automations from weekday room rotation to one whole-floor pass on the main and upstairs levels
- centralize the shared whole-floor behavior in reusable vacuum scripts and keep the den door guard on departure
- add regression tests covering the shared helper, the departure split, and the updated away automations

## Why
The previous weekday segment rotation only cleaned one upstairs room at four iterations per run and left the rest of the main/upstairs floors untouched. This change normalizes the policy to a single whole-floor pass when away-home automations decide it is safe to vacuum.

## Validation
- `uv run --with pytest pytest`
