### PR TITLE
Handle travel detection fallbacks and diagnostics

### DIFF
--- a/docs/travel_detection_regression_matrix.md
+++ b/docs/travel_detection_regression_matrix.md
@@ -1,0 +1,25 @@
+# Travel Detection Regression Matrix
+
+This matrix documents the representative trip-detection cases covered for issues #66 and #67.
+
+## Precedence
+
+1. `flight_return`
+   Use the first qualifying outbound flight from home and the earliest later return-home flight.
+2. `flight_lodging`, `flight_explicit_vacation`, `flight_all_day_trip_block`
+   If an outbound flight exists but no return-home flight is booked yet, use the nearest related fallback window in this order: lodging span, explicit vacation event, all-day trip block.
+3. `calendar_lodging`, `calendar_explicit_vacation`, `calendar_all_day_trip_block`, `calendar_curling_block`
+   If no qualifying outbound flight exists, use the earliest standalone travel block.
+4. `off_outbound_missing_end`, `off_no_candidate`
+   Leave trip mode unscheduled and surface the ignored reason when the data is insufficient or obviously not the user's trip.
+
+## Matrix
+
+| Case | Source | Expected decision | Notes |
+| --- | --- | --- | --- |
+| MSP -> DTW -> AMS -> INV, then AMS -> MSP | multi-leg outbound | `flight_return` | Start at the MSP departure, keep the homebound return, and expose `INV` as the destination instead of the first layover. |
+| Friend flights arriving in MSP | friend homebound | `off_no_candidate` | Ignore friend itineraries so they do not satisfy homebound logic or airport-arrival automations. |
+| Local Rochester appointments | local false positive | `off_no_candidate` | Appointment locations in Rochester/Minneapolis must not be classified as flights. |
+| Hotel/calendar-only trips | lodging fallback | `calendar_lodging` | A lodging span with no flights still produces a durable trip window. |
+| Outbound flight with no return yet, plus lodging | outbound fallback | `flight_lodging` | Use the outbound flight for the trip start and the lodging span for the trip end. |
+| Explicit `#vacation` block without flights | explicit vacation | `calendar_explicit_vacation` | Personal or calendar-tagged vacation blocks should still create a trip window. |

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -48,6 +48,11 @@ homeassistant:
       friendly_name: "Sync Ecobee Calendar Vacation"
       icon: mdi:calendar-sync
 
+    automation.log_calendar_vacation_plan_diagnostics:
+      <<: *customize
+      friendly_name: "Log Calendar Vacation Diagnostics"
+      icon: mdi:clipboard-text-clock
+
     automation.trip_mode_watchdog_home_1h:
       <<: *customize
       friendly_name: "Trip Mode Watchdog"
@@ -604,6 +609,32 @@ automation:
               start_time: "{{ (schedule_start | as_datetime | as_local).strftime('%H:%M:%S') }}"
               end_date: "{{ (schedule_end | as_datetime | as_local).date().isoformat() }}"
               end_time: "{{ (schedule_end | as_datetime | as_local).strftime('%H:%M:%S') }}"
+
+  - id: log_calendar_vacation_plan_diagnostics
+    alias: log_calendar_vacation_plan_diagnostics
+    mode: restart
+    trigger:
+      - trigger: state
+        entity_id: sensor.ecobee_calendar_vacation_schedule
+      - trigger: state
+        entity_id: sensor.ecobee_calendar_vacation_schedule
+        attribute: decision_code
+    variables:
+      decision_summary: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'decision_summary') | default('No travel decision recorded.', true) | string | trim }}"
+      outbound_summary: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'outbound_summary') | default('', true) | string | trim }}"
+      return_summary: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'return_summary') | default('', true) | string | trim }}"
+      fallback_summary: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'fallback_summary') | default('', true) | string | trim }}"
+      fallback_source: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'fallback_source') | default('', true) | string | trim }}"
+      destination_name: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'destination_name') | default('', true) | string | trim }}"
+      ignored_reason: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'ignored_reason') | default('', true) | string | trim }}"
+    action:
+      - action: logbook.log
+        data:
+          entity_id: sensor.ecobee_calendar_vacation_schedule
+          domain: sensor
+          name: Travel detection
+          message: >-
+            {{ decision_summary }}{% if outbound_summary %} Outbound: {{ outbound_summary }}.{% endif %}{% if return_summary %} Return: {{ return_summary }}.{% endif %}{% if fallback_summary %} Fallback{% if fallback_source %} ({{ fallback_source }}){% endif %}: {{ fallback_summary }}.{% endif %}{% if destination_name %} Destination: {{ destination_name }}.{% endif %}{% if ignored_reason and ignored_reason != decision_summary %} Ignored: {{ ignored_reason }}.{% endif %}
 
   - id: trip_mode_watchdog_home_1h
     alias: trip_mode_watchdog_home_1h
@@ -1381,6 +1412,7 @@ template:
               {% set named_flight = summary_lower.startswith('flight to ') or (summary_lower.startswith('flight: ') and ' to ' in summary_lower) %}
               {% set itinerary_marker = 'synced by flighty' in text or 'created from an email you received in gmail' in text or 'booking code:' in text or 'flight time ' in text %}
               {% set looks_like_flight = route_summary or named_flight or itinerary_marker %}
+              {% set is_friend_itinerary = 'friend' in text %}
               {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
               {% set end_raw = event.end.dateTime | default(event.end.date, true) | default(event.end, true) %}
               {% set start_dt = as_datetime(start_raw) %}
@@ -1402,7 +1434,7 @@ template:
               {% if named_destination != '' %}
                 {% set destination_code = named_destination.split(' (', 1)[0].split(' •', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
               {% endif %}
-              {% if looks_like_flight and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL'] and start_dt is not none and end_dt is not none %}
+              {% if looks_like_flight and not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL'] and start_dt is not none and end_dt is not none %}
                 {% set start_ts = as_timestamp(start_dt) %}
                 {% set end_ts = as_timestamp(end_dt) %}
                 {% if end_ts > now_ts %}
@@ -1449,6 +1481,7 @@ template:
               {% set named_flight = summary_lower.startswith('flight to ') or (summary_lower.startswith('flight: ') and ' to ' in summary_lower) %}
               {% set itinerary_marker = 'synced by flighty' in text or 'created from an email you received in gmail' in text or 'booking code:' in text or 'flight time ' in text %}
               {% set looks_like_flight = route_summary or named_flight or itinerary_marker %}
+              {% set is_friend_itinerary = 'friend' in text %}
               {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
               {% set end_raw = event.end.dateTime | default(event.end.date, true) | default(event.end, true) %}
               {% set start_dt = as_datetime(start_raw) %}
@@ -1470,7 +1503,7 @@ template:
               {% if named_destination != '' %}
                 {% set destination_code = named_destination.split(' (', 1)[0].split(' •', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
               {% endif %}
-              {% if looks_like_flight and destination_code in ['RST', 'ROCHESTER'] and start_dt is not none and end_dt is not none %}
+              {% if looks_like_flight and not is_friend_itinerary and destination_code in ['RST', 'ROCHESTER'] and start_dt is not none and end_dt is not none %}
                 {% set start_ts = as_timestamp(start_dt) %}
                 {% set end_ts = as_timestamp(end_dt) %}
                 {% if end_ts > now_ts %}
@@ -1551,58 +1584,147 @@ template:
               }}
             {% endif %}
           vacation_plan_json: >-
+            {% set now_ts = as_timestamp(now()) %}
+            {% set future_cutoff_ts = now_ts + (180 * 86400) %}
+            {% set home_codes = ['MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER'] %}
             {% set curling_events_list = (curling_events | default('[]', true) | string | trim | from_json) %}
             {% set personal_events_list = (personal_events | default('[]', true) | string | trim | from_json) %}
             {% set work_trip_events_list = (work_trip_events | default('[]', true) | string | trim | from_json) %}
-            {% set ns = namespace(curling_event=None, outbound=None, return_home=None) %}
+            {% set travel_events = personal_events_list + work_trip_events_list %}
+            {% set ns = namespace(
+              outbound=None,
+              final_destination=None,
+              return_home=None,
+              standalone_fallback=None,
+              paired_fallback=None,
+              ignored_reason='No qualifying travel itinerary or calendar trip block was found.'
+            ) %}
             {% for event in curling_events_list %}
+              {% set summary = event.summary | default('Curling', true) | string %}
+              {% set description = event.description | default('', true) | string %}
+              {% set location = event.location | default('', true) | string %}
+              {% set text = [summary, description, location] | join(' ') | lower %}
               {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
               {% set end_raw = event.end.dateTime | default(event.end.date, true) | default(event.end, true) %}
               {% set start_dt = as_datetime(start_raw) %}
               {% set end_dt = as_datetime(end_raw) %}
-              {% set is_all_day = 'T' not in (start_raw | string) %}
-              {% set duration_days = 0 %}
               {% if start_dt is not none and end_dt is not none %}
-                {% set duration_days = ((as_timestamp(end_dt) - as_timestamp(start_dt)) / 86400) | int(0) %}
-              {% endif %}
-              {% if ns.curling_event is none and start_dt is not none and end_dt is not none and is_all_day and duration_days > 2 %}
-                {% set ns.curling_event = {
-                  'reason': 'calendar',
-                  'summary': event.summary | default('Curling', true),
-                  'start': (start_dt | as_local).isoformat(),
-                  'end': (end_dt | as_local).isoformat(),
-                  'return_summary': '',
-                  'vacation_name': event.summary | default('Curling', true)
-                } %}
+                {% set start_ts = as_timestamp(start_dt) %}
+                {% set end_ts = as_timestamp(end_dt) %}
+                {% set is_all_day = 'T' not in (start_raw | string) %}
+                {% set duration_days = ((end_ts - start_ts) / 86400) | int(0) %}
+                {% if end_ts > now_ts and end_ts <= future_cutoff_ts and is_all_day and duration_days > 2 %}
+                  {% set candidate = {
+                    'summary': summary,
+                    'start': (start_dt | as_local).isoformat(),
+                    'end': (end_dt | as_local).isoformat(),
+                    'start_ts': start_ts,
+                    'end_ts': end_ts,
+                    'vacation_name': summary | default('Curling', true),
+                    'source_code': 'curling_block',
+                    'source_label': 'curling block',
+                    'priority': 4
+                  } %}
+                  {% if ns.standalone_fallback is none or candidate.priority < ns.standalone_fallback.priority or (candidate.priority == ns.standalone_fallback.priority and candidate.start_ts < ns.standalone_fallback.start_ts) %}
+                    {% set ns.standalone_fallback = candidate %}
+                  {% endif %}
+                {% endif %}
               {% endif %}
             {% endfor %}
-            {% set travel_events = personal_events_list + work_trip_events_list %}
+            {% for event in personal_events_list %}
+              {% set summary = event.summary | default('Vacation', true) | string %}
+              {% set description = event.description | default('', true) | string %}
+              {% set location = event.location | default('', true) | string %}
+              {% set text = [summary, description, location] | join(' ') | lower %}
+              {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
+              {% set end_raw = event.end.dateTime | default(event.end.date, true) | default(event.end, true) %}
+              {% set start_dt = as_datetime(start_raw) %}
+              {% set end_dt = as_datetime(end_raw) %}
+              {% if start_dt is not none and end_dt is not none %}
+                {% set start_ts = as_timestamp(start_dt) %}
+                {% set end_ts = as_timestamp(end_dt) %}
+                {% set is_all_day = 'T' not in (start_raw | string) %}
+                {% set duration_days = ((end_ts - start_ts) / 86400) | int(0) %}
+                {% set is_explicit_vacation = '#vacation' in text %}
+                {% set is_trip_block = is_all_day and duration_days > 1 and ('vacation' in text or ' trip' in text or text.startswith('trip ') or 'travel' in text or 'out of town' in text or 'pto' in text or 'ooo' in text) %}
+                {% if end_ts > now_ts and end_ts <= future_cutoff_ts and (is_explicit_vacation or is_trip_block) %}
+                  {% set candidate = {
+                    'summary': summary,
+                    'start': (start_dt | as_local).isoformat(),
+                    'end': (end_dt | as_local).isoformat(),
+                    'start_ts': start_ts,
+                    'end_ts': end_ts,
+                    'vacation_name': summary,
+                    'source_code': 'explicit_vacation' if is_explicit_vacation else 'all_day_trip_block',
+                    'source_label': 'explicit vacation event' if is_explicit_vacation else 'all-day trip block',
+                    'priority': 1 if is_explicit_vacation else 3
+                  } %}
+                  {% if ns.standalone_fallback is none or candidate.priority < ns.standalone_fallback.priority or (candidate.priority == ns.standalone_fallback.priority and candidate.start_ts < ns.standalone_fallback.start_ts) %}
+                    {% set ns.standalone_fallback = candidate %}
+                  {% endif %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+            {% for event in work_trip_events_list %}
+              {% set summary = event.summary | default('Work Trip', true) | string %}
+              {% set description = event.description | default('', true) | string %}
+              {% set location = event.location | default('', true) | string %}
+              {% set text = [summary, description, location] | join(' ') | lower %}
+              {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
+              {% set end_raw = event.end.dateTime | default(event.end.date, true) | default(event.end, true) %}
+              {% set start_dt = as_datetime(start_raw) %}
+              {% set end_dt = as_datetime(end_raw) %}
+              {% if start_dt is not none and end_dt is not none %}
+                {% set start_ts = as_timestamp(start_dt) %}
+                {% set end_ts = as_timestamp(end_dt) %}
+                {% set is_all_day = 'T' not in (start_raw | string) %}
+                {% set duration_days = ((end_ts - start_ts) / 86400) | int(0) %}
+                {% set is_lodging = 'stay at' in text or 'hotel' in text or 'airbnb' in text or 'lodging' in text or 'resort' in text or ' inn' in text or text.startswith('inn ') or 'check-in' in text or 'check out' in text %}
+                {% set is_trip_block = is_all_day and duration_days > 1 %}
+                {% if end_ts > now_ts and end_ts <= future_cutoff_ts and (is_lodging or is_trip_block) %}
+                  {% set candidate = {
+                    'summary': summary,
+                    'start': (start_dt | as_local).isoformat(),
+                    'end': (end_dt | as_local).isoformat(),
+                    'start_ts': start_ts,
+                    'end_ts': end_ts,
+                    'vacation_name': summary,
+                    'source_code': 'lodging' if is_lodging else 'all_day_trip_block',
+                    'source_label': 'lodging span' if is_lodging else 'all-day trip block',
+                    'priority': 0 if is_lodging else 3
+                  } %}
+                  {% if ns.standalone_fallback is none or candidate.priority < ns.standalone_fallback.priority or (candidate.priority == ns.standalone_fallback.priority and candidate.start_ts < ns.standalone_fallback.start_ts) %}
+                    {% set ns.standalone_fallback = candidate %}
+                  {% endif %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
             {% for event in travel_events %}
               {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
               {% set start_dt = as_datetime(start_raw) %}
               {% if start_dt is not none %}
-                {% set summary = event.summary | default('Flight', true) %}
-                {% set description = event.description | default('', true) %}
-                {% set location = event.location | default('', true) %}
+                {% set summary = event.summary | default('Flight', true) | string %}
+                {% set description = event.description | default('', true) | string %}
+                {% set location = event.location | default('', true) | string %}
                 {% set summary_lower = summary | lower %}
-                {% set summary_text = summary | string %}
-                {% set flight_text = ([summary, description, location] | join(' ') | lower) %}
-                {% set route_summary = '→' in summary_text %}
+                {% set flight_text = [summary, description, location] | join(' ') | lower %}
+                {% set route_summary = '→' in summary %}
                 {% set named_flight = summary_lower.startswith('flight to ') or (summary_lower.startswith('flight: ') and ' to ' in summary_lower) %}
                 {% set itinerary_marker = 'synced by flighty' in flight_text or 'created from an email you received in gmail' in flight_text or 'booking code:' in flight_text or 'flight time ' in flight_text %}
                 {% set looks_like_flight = route_summary or named_flight or itinerary_marker %}
+                {% set is_friend_itinerary = 'friend' in flight_text %}
                 {% set start_ts = as_timestamp(start_dt) %}
                 {% set origin_code = '' %}
                 {% set destination_name = '' %}
                 {% set destination_code = '' %}
                 {% set named_destination = '' %}
                 {% if route_summary %}
-                  {% set origin_code = summary_text.split('→', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
-                  {% set destination_code = summary_text.split('→', 1)[1].split('•', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
+                  {% set origin_code = summary.split('→', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
+                  {% set destination_code = summary.split('→', 1)[1].split('•', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
                 {% elif summary_lower.startswith('flight to ') %}
-                  {% set named_destination = summary_text[10:] %}
+                  {% set named_destination = summary[10:] %}
                 {% elif summary_lower.startswith('flight: ') and ' to ' in summary_lower %}
-                  {% set flight_tail = summary_text[8:] %}
+                  {% set flight_tail = summary[8:] %}
                   {% set flight_tail_lower = summary_lower[8:] %}
                   {% set to_index = flight_tail_lower.find(' to ') %}
                   {% if to_index != -1 %}
@@ -1617,9 +1739,12 @@ template:
                   {% set destination_name = destination_code %}
                 {% endif %}
                 {% set is_home_origin = origin_code in ['MSP', 'RST'] %}
-                {% set is_home_destination = destination_code in ['MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER'] %}
+                {% set is_home_destination = destination_code in home_codes %}
                 {% set outbound_priority = 0 if is_home_origin else 1 if named_flight else 9 %}
-                {% if looks_like_flight and start_ts >= (as_timestamp(now()) - 3600) and destination_name != '' and not is_home_destination and outbound_priority < 9 %}
+                {% if looks_like_flight and is_friend_itinerary and is_home_destination and ns.ignored_reason == 'No qualifying travel itinerary or calendar trip block was found.' %}
+                  {% set ns.ignored_reason = 'Ignored a friend itinerary arriving home.' %}
+                {% endif %}
+                {% if looks_like_flight and not is_friend_itinerary and start_ts >= (now_ts - 3600) and destination_name != '' and not is_home_destination and outbound_priority < 9 %}
                   {% if ns.outbound is none or outbound_priority < ns.outbound.priority or (outbound_priority == ns.outbound.priority and start_ts < ns.outbound.start_ts) %}
                     {% set ns.outbound = {
                       'summary': summary,
@@ -1633,28 +1758,35 @@ template:
               {% endif %}
             {% endfor %}
             {% if ns.outbound is not none %}
+              {% set ns.final_destination = {
+                'destination_name': ns.outbound.destination_name,
+                'summary': ns.outbound.summary,
+                'start_ts': ns.outbound.start_ts
+              } %}
               {% for event in travel_events %}
                 {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
                 {% set start_dt = as_datetime(start_raw) %}
                 {% if start_dt is not none %}
-                  {% set summary = event.summary | default('Flight', true) %}
-                  {% set description = event.description | default('', true) %}
-                  {% set location = event.location | default('', true) %}
+                  {% set summary = event.summary | default('Flight', true) | string %}
+                  {% set description = event.description | default('', true) | string %}
+                  {% set location = event.location | default('', true) | string %}
                   {% set summary_lower = summary | lower %}
-                  {% set summary_text = summary | string %}
-                  {% set flight_text = ([summary, description, location] | join(' ') | lower) %}
-                  {% set route_summary = '→' in summary_text %}
+                  {% set flight_text = [summary, description, location] | join(' ') | lower %}
+                  {% set route_summary = '→' in summary %}
                   {% set named_flight = summary_lower.startswith('flight to ') or (summary_lower.startswith('flight: ') and ' to ' in summary_lower) %}
                   {% set itinerary_marker = 'synced by flighty' in flight_text or 'created from an email you received in gmail' in flight_text or 'booking code:' in flight_text or 'flight time ' in flight_text %}
                   {% set looks_like_flight = route_summary or named_flight or itinerary_marker %}
+                  {% set is_friend_itinerary = 'friend' in flight_text %}
+                  {% set start_ts = as_timestamp(start_dt) %}
+                  {% set destination_name = '' %}
                   {% set destination_code = '' %}
                   {% set named_destination = '' %}
                   {% if route_summary %}
-                    {% set destination_code = summary_text.split('→', 1)[1].split('•', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
+                    {% set destination_code = summary.split('→', 1)[1].split('•', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
                   {% elif summary_lower.startswith('flight to ') %}
-                    {% set named_destination = summary_text[10:] %}
+                    {% set named_destination = summary[10:] %}
                   {% elif summary_lower.startswith('flight: ') and ' to ' in summary_lower %}
-                    {% set flight_tail = summary_text[8:] %}
+                    {% set flight_tail = summary[8:] %}
                     {% set flight_tail_lower = summary_lower[8:] %}
                     {% set to_index = flight_tail_lower.find(' to ') %}
                     {% if to_index != -1 %}
@@ -1662,10 +1794,23 @@ template:
                     {% endif %}
                   {% endif %}
                   {% if named_destination != '' %}
-                    {% set destination_code = named_destination.split(' (', 1)[0].split(' •', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
+                    {% set destination_name = named_destination.split(' (', 1)[0].split(' •', 1)[0].strip() %}
+                    {% set destination_code = destination_name | regex_replace('[^A-Za-z]', '') | upper %}
                   {% endif %}
-                  {% set start_ts = as_timestamp(start_dt) %}
-                  {% if looks_like_flight and destination_code in ['MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER'] and start_ts > ns.outbound.start_ts %}
+                  {% if destination_name == '' and destination_code not in home_codes %}
+                    {% set destination_name = destination_code %}
+                  {% endif %}
+                  {% set is_home_destination = destination_code in home_codes %}
+                  {% if looks_like_flight and not is_friend_itinerary and destination_name != '' and not is_home_destination and start_ts >= ns.outbound.start_ts and start_ts <= (ns.outbound.start_ts + 172800) %}
+                    {% if ns.final_destination is none or start_ts >= ns.final_destination.start_ts %}
+                      {% set ns.final_destination = {
+                        'destination_name': destination_name,
+                        'summary': summary,
+                        'start_ts': start_ts
+                      } %}
+                    {% endif %}
+                  {% endif %}
+                  {% if looks_like_flight and not is_friend_itinerary and is_home_destination and start_ts > ns.outbound.start_ts %}
                     {% if ns.return_home is none or start_ts < ns.return_home.start_ts %}
                       {% set ns.return_home = {
                         'summary': summary,
@@ -1676,22 +1821,208 @@ template:
                   {% endif %}
                 {% endif %}
               {% endfor %}
+              {% for event in curling_events_list %}
+                {% set summary = event.summary | default('Curling', true) | string %}
+                {% set description = event.description | default('', true) | string %}
+                {% set location = event.location | default('', true) | string %}
+                {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
+                {% set end_raw = event.end.dateTime | default(event.end.date, true) | default(event.end, true) %}
+                {% set start_dt = as_datetime(start_raw) %}
+                {% set end_dt = as_datetime(end_raw) %}
+                {% if start_dt is not none and end_dt is not none %}
+                  {% set start_ts = as_timestamp(start_dt) %}
+                  {% set end_ts = as_timestamp(end_dt) %}
+                  {% set is_all_day = 'T' not in (start_raw | string) %}
+                  {% set duration_days = ((end_ts - start_ts) / 86400) | int(0) %}
+                  {% if end_ts > ns.outbound.start_ts and start_ts <= (ns.outbound.start_ts + 259200) and is_all_day and duration_days > 2 %}
+                    {% set contains_outbound = start_ts <= ns.outbound.start_ts and end_ts >= ns.outbound.start_ts %}
+                    {% set proximity = ((start_ts - ns.outbound.start_ts) | abs) %}
+                    {% set candidate = {
+                      'summary': summary,
+                      'start': (start_dt | as_local).isoformat(),
+                      'end': (end_dt | as_local).isoformat(),
+                      'start_ts': start_ts,
+                      'end_ts': end_ts,
+                      'vacation_name': summary | default('Curling', true),
+                      'source_code': 'curling_block',
+                      'source_label': 'curling block',
+                      'priority': 4,
+                      'contains_outbound': contains_outbound,
+                      'proximity': proximity
+                    } %}
+                    {% if ns.paired_fallback is none or candidate.priority < ns.paired_fallback.priority or (candidate.priority == ns.paired_fallback.priority and candidate.contains_outbound and not ns.paired_fallback.contains_outbound) or (candidate.priority == ns.paired_fallback.priority and candidate.contains_outbound == ns.paired_fallback.contains_outbound and candidate.proximity < ns.paired_fallback.proximity) or (candidate.priority == ns.paired_fallback.priority and candidate.contains_outbound == ns.paired_fallback.contains_outbound and candidate.proximity == ns.paired_fallback.proximity and candidate.start_ts < ns.paired_fallback.start_ts) %}
+                      {% set ns.paired_fallback = candidate %}
+                    {% endif %}
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+              {% for event in personal_events_list %}
+                {% set summary = event.summary | default('Vacation', true) | string %}
+                {% set description = event.description | default('', true) | string %}
+                {% set location = event.location | default('', true) | string %}
+                {% set text = [summary, description, location] | join(' ') | lower %}
+                {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
+                {% set end_raw = event.end.dateTime | default(event.end.date, true) | default(event.end, true) %}
+                {% set start_dt = as_datetime(start_raw) %}
+                {% set end_dt = as_datetime(end_raw) %}
+                {% if start_dt is not none and end_dt is not none %}
+                  {% set start_ts = as_timestamp(start_dt) %}
+                  {% set end_ts = as_timestamp(end_dt) %}
+                  {% set is_all_day = 'T' not in (start_raw | string) %}
+                  {% set duration_days = ((end_ts - start_ts) / 86400) | int(0) %}
+                  {% set is_explicit_vacation = '#vacation' in text %}
+                  {% set is_trip_block = is_all_day and duration_days > 1 and ('vacation' in text or ' trip' in text or text.startswith('trip ') or 'travel' in text or 'out of town' in text or 'pto' in text or 'ooo' in text) %}
+                  {% if end_ts > ns.outbound.start_ts and start_ts <= (ns.outbound.start_ts + 259200) and (is_explicit_vacation or is_trip_block) %}
+                    {% set contains_outbound = start_ts <= ns.outbound.start_ts and end_ts >= ns.outbound.start_ts %}
+                    {% set proximity = ((start_ts - ns.outbound.start_ts) | abs) %}
+                    {% set candidate = {
+                      'summary': summary,
+                      'start': (start_dt | as_local).isoformat(),
+                      'end': (end_dt | as_local).isoformat(),
+                      'start_ts': start_ts,
+                      'end_ts': end_ts,
+                      'vacation_name': summary,
+                      'source_code': 'explicit_vacation' if is_explicit_vacation else 'all_day_trip_block',
+                      'source_label': 'explicit vacation event' if is_explicit_vacation else 'all-day trip block',
+                      'priority': 1 if is_explicit_vacation else 3,
+                      'contains_outbound': contains_outbound,
+                      'proximity': proximity
+                    } %}
+                    {% if ns.paired_fallback is none or candidate.priority < ns.paired_fallback.priority or (candidate.priority == ns.paired_fallback.priority and candidate.contains_outbound and not ns.paired_fallback.contains_outbound) or (candidate.priority == ns.paired_fallback.priority and candidate.contains_outbound == ns.paired_fallback.contains_outbound and candidate.proximity < ns.paired_fallback.proximity) or (candidate.priority == ns.paired_fallback.priority and candidate.contains_outbound == ns.paired_fallback.contains_outbound and candidate.proximity == ns.paired_fallback.proximity and candidate.start_ts < ns.paired_fallback.start_ts) %}
+                      {% set ns.paired_fallback = candidate %}
+                    {% endif %}
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+              {% for event in work_trip_events_list %}
+                {% set summary = event.summary | default('Work Trip', true) | string %}
+                {% set description = event.description | default('', true) | string %}
+                {% set location = event.location | default('', true) | string %}
+                {% set text = [summary, description, location] | join(' ') | lower %}
+                {% set start_raw = event.start.dateTime | default(event.start.date, true) | default(event.start, true) %}
+                {% set end_raw = event.end.dateTime | default(event.end.date, true) | default(event.end, true) %}
+                {% set start_dt = as_datetime(start_raw) %}
+                {% set end_dt = as_datetime(end_raw) %}
+                {% if start_dt is not none and end_dt is not none %}
+                  {% set start_ts = as_timestamp(start_dt) %}
+                  {% set end_ts = as_timestamp(end_dt) %}
+                  {% set is_all_day = 'T' not in (start_raw | string) %}
+                  {% set duration_days = ((end_ts - start_ts) / 86400) | int(0) %}
+                  {% set is_lodging = 'stay at' in text or 'hotel' in text or 'airbnb' in text or 'lodging' in text or 'resort' in text or ' inn' in text or text.startswith('inn ') or 'check-in' in text or 'check out' in text %}
+                  {% set is_trip_block = is_all_day and duration_days > 1 %}
+                  {% if end_ts > ns.outbound.start_ts and start_ts <= (ns.outbound.start_ts + 259200) and (is_lodging or is_trip_block) %}
+                    {% set contains_outbound = start_ts <= ns.outbound.start_ts and end_ts >= ns.outbound.start_ts %}
+                    {% set proximity = ((start_ts - ns.outbound.start_ts) | abs) %}
+                    {% set candidate = {
+                      'summary': summary,
+                      'start': (start_dt | as_local).isoformat(),
+                      'end': (end_dt | as_local).isoformat(),
+                      'start_ts': start_ts,
+                      'end_ts': end_ts,
+                      'vacation_name': summary,
+                      'source_code': 'lodging' if is_lodging else 'all_day_trip_block',
+                      'source_label': 'lodging span' if is_lodging else 'all-day trip block',
+                      'priority': 0 if is_lodging else 3,
+                      'contains_outbound': contains_outbound,
+                      'proximity': proximity
+                    } %}
+                    {% if ns.paired_fallback is none or candidate.priority < ns.paired_fallback.priority or (candidate.priority == ns.paired_fallback.priority and candidate.contains_outbound and not ns.paired_fallback.contains_outbound) or (candidate.priority == ns.paired_fallback.priority and candidate.contains_outbound == ns.paired_fallback.contains_outbound and candidate.proximity < ns.paired_fallback.proximity) or (candidate.priority == ns.paired_fallback.priority and candidate.contains_outbound == ns.paired_fallback.contains_outbound and candidate.proximity == ns.paired_fallback.proximity and candidate.start_ts < ns.paired_fallback.start_ts) %}
+                      {% set ns.paired_fallback = candidate %}
+                    {% endif %}
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
             {% endif %}
             {% if ns.outbound is not none and ns.return_home is not none and (ns.return_home.start_ts - 7200) > ns.outbound.start_ts %}
               {{
                 {
                   'reason': 'flight',
+                  'decision_code': 'flight_return',
+                  'decision_summary': 'Using outbound flight and booked return flight.',
                   'summary': ns.outbound.summary,
                   'start': ns.outbound.start,
                   'end': ((ns.return_home.start | as_datetime | as_local) - timedelta(hours=2)).isoformat(),
                   'return_summary': ns.return_home.summary,
-                  'vacation_name': ns.outbound.destination_name | default(ns.outbound.summary, true)
+                  'vacation_name': ns.final_destination.destination_name | default(ns.outbound.destination_name, true),
+                  'outbound_summary': ns.outbound.summary,
+                  'destination_name': ns.final_destination.destination_name | default(ns.outbound.destination_name, true),
+                  'fallback_summary': '',
+                  'fallback_source': '',
+                  'ignored_reason': ''
                 } | to_json
               }}
-            {% elif ns.curling_event is not none %}
-              {{ ns.curling_event | to_json }}
+            {% elif ns.outbound is not none and ns.paired_fallback is not none and ns.paired_fallback.end_ts > ns.outbound.start_ts %}
+              {{
+                {
+                  'reason': 'flight',
+                  'decision_code': 'flight_' ~ ns.paired_fallback.source_code,
+                  'decision_summary': 'Using outbound flight and ' ~ ns.paired_fallback.source_label ~ ' because no return flight is booked.',
+                  'summary': ns.outbound.summary,
+                  'start': ns.outbound.start,
+                  'end': ns.paired_fallback.end,
+                  'return_summary': '',
+                  'vacation_name': ns.final_destination.destination_name | default(ns.paired_fallback.vacation_name, true),
+                  'outbound_summary': ns.outbound.summary,
+                  'destination_name': ns.final_destination.destination_name | default(ns.paired_fallback.vacation_name, true),
+                  'fallback_summary': ns.paired_fallback.summary,
+                  'fallback_source': ns.paired_fallback.source_label,
+                  'ignored_reason': ''
+                } | to_json
+              }}
+            {% elif ns.outbound is not none %}
+              {{
+                {
+                  'reason': 'off',
+                  'decision_code': 'off_outbound_missing_end',
+                  'decision_summary': 'Found an outbound flight, but no booked return or related fallback trip window.',
+                  'summary': '',
+                  'start': '',
+                  'end': '',
+                  'return_summary': '',
+                  'vacation_name': '',
+                  'outbound_summary': ns.outbound.summary,
+                  'destination_name': ns.final_destination.destination_name | default(ns.outbound.destination_name, true),
+                  'fallback_summary': '',
+                  'fallback_source': '',
+                  'ignored_reason': 'No return flight or linked lodging, vacation event, or all-day trip block was found.'
+                } | to_json
+              }}
+            {% elif ns.standalone_fallback is not none %}
+              {{
+                {
+                  'reason': 'calendar',
+                  'decision_code': 'calendar_' ~ ns.standalone_fallback.source_code,
+                  'decision_summary': 'Using standalone ' ~ ns.standalone_fallback.source_label ~ '.',
+                  'summary': ns.standalone_fallback.summary,
+                  'start': ns.standalone_fallback.start,
+                  'end': ns.standalone_fallback.end,
+                  'return_summary': '',
+                  'vacation_name': ns.standalone_fallback.vacation_name,
+                  'outbound_summary': '',
+                  'destination_name': ns.standalone_fallback.vacation_name,
+                  'fallback_summary': ns.standalone_fallback.summary,
+                  'fallback_source': ns.standalone_fallback.source_label,
+                  'ignored_reason': ''
+                } | to_json
+              }}
             {% else %}
-              {{ {'reason': 'off', 'summary': '', 'start': '', 'end': '', 'return_summary': '', 'vacation_name': ''} | to_json }}
+              {{
+                {
+                  'reason': 'off',
+                  'decision_code': 'off_no_candidate',
+                  'decision_summary': ns.ignored_reason,
+                  'summary': '',
+                  'start': '',
+                  'end': '',
+                  'return_summary': '',
+                  'vacation_name': '',
+                  'outbound_summary': '',
+                  'destination_name': '',
+                  'fallback_summary': '',
+                  'fallback_source': '',
+                  'ignored_reason': ns.ignored_reason
+                } | to_json
+              }}
             {% endif %}
     binary_sensor:
       - name: Curling Vacation Today
@@ -1813,6 +2144,62 @@ template:
               {{ '' }}
             {% else %}
               {{ (raw_plan | from_json).vacation_name | default('') }}
+            {% endif %}
+          decision_code: >-
+            {% set raw_plan = (vacation_plan_json | default('', true) | string | trim) %}
+            {% set raw_plan_state = raw_plan | lower %}
+            {% if raw_plan == '' or raw_plan_state in ['unknown', 'unavailable', 'none', 'null'] %}
+              off_no_candidate
+            {% else %}
+              {{ (raw_plan | from_json).decision_code | default('off_no_candidate') }}
+            {% endif %}
+          decision_summary: >-
+            {% set raw_plan = (vacation_plan_json | default('', true) | string | trim) %}
+            {% set raw_plan_state = raw_plan | lower %}
+            {% if raw_plan == '' or raw_plan_state in ['unknown', 'unavailable', 'none', 'null'] %}
+              {{ 'No qualifying travel itinerary or calendar trip block was found.' }}
+            {% else %}
+              {{ (raw_plan | from_json).decision_summary | default('No qualifying travel itinerary or calendar trip block was found.') }}
+            {% endif %}
+          outbound_summary: >-
+            {% set raw_plan = (vacation_plan_json | default('', true) | string | trim) %}
+            {% set raw_plan_state = raw_plan | lower %}
+            {% if raw_plan == '' or raw_plan_state in ['unknown', 'unavailable', 'none', 'null'] %}
+              {{ '' }}
+            {% else %}
+              {{ (raw_plan | from_json).outbound_summary | default('') }}
+            {% endif %}
+          destination_name: >-
+            {% set raw_plan = (vacation_plan_json | default('', true) | string | trim) %}
+            {% set raw_plan_state = raw_plan | lower %}
+            {% if raw_plan == '' or raw_plan_state in ['unknown', 'unavailable', 'none', 'null'] %}
+              {{ '' }}
+            {% else %}
+              {{ (raw_plan | from_json).destination_name | default('') }}
+            {% endif %}
+          fallback_summary: >-
+            {% set raw_plan = (vacation_plan_json | default('', true) | string | trim) %}
+            {% set raw_plan_state = raw_plan | lower %}
+            {% if raw_plan == '' or raw_plan_state in ['unknown', 'unavailable', 'none', 'null'] %}
+              {{ '' }}
+            {% else %}
+              {{ (raw_plan | from_json).fallback_summary | default('') }}
+            {% endif %}
+          fallback_source: >-
+            {% set raw_plan = (vacation_plan_json | default('', true) | string | trim) %}
+            {% set raw_plan_state = raw_plan | lower %}
+            {% if raw_plan == '' or raw_plan_state in ['unknown', 'unavailable', 'none', 'null'] %}
+              {{ '' }}
+            {% else %}
+              {{ (raw_plan | from_json).fallback_source | default('') }}
+            {% endif %}
+          ignored_reason: >-
+            {% set raw_plan = (vacation_plan_json | default('', true) | string | trim) %}
+            {% set raw_plan_state = raw_plan | lower %}
+            {% if raw_plan == '' or raw_plan_state in ['unknown', 'unavailable', 'none', 'null'] %}
+              {{ 'No qualifying travel itinerary or calendar trip block was found.' }}
+            {% else %}
+              {{ (raw_plan | from_json).ignored_reason | default('') }}
             {% endif %}
   - sensor:
       - name: time_to_home

--- a/tests/test_trips_flight_classification.py
+++ b/tests/test_trips_flight_classification.py
@@ -6,10 +6,13 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
+import pytest
+
 
 CENTRAL = ZoneInfo("America/Chicago")
 HOME_CODES = {"MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "ROCHESTER"}
 TRIPS_PATH = Path(__file__).resolve().parents[1] / "packages" / "trips.yaml"
+MATRIX_PATH = Path(__file__).resolve().parents[1] / "docs" / "travel_detection_regression_matrix.md"
 
 
 @dataclass(frozen=True)
@@ -19,6 +22,18 @@ class FlightSignals:
     origin_code: str
     destination_code: str
     destination_name: str
+    is_friend: bool
+
+
+@dataclass(frozen=True)
+class FallbackCandidate:
+    summary: str
+    start: datetime
+    end: datetime
+    vacation_name: str
+    source_code: str
+    source_label: str
+    priority: int
 
 
 def normalize_code(value: str) -> str:
@@ -74,6 +89,7 @@ def parse_flight_signals(summary: str, description: str = "", location: str = ""
         origin_code=origin_code,
         destination_code=destination_code,
         destination_name=destination_name,
+        is_friend="friend" in flight_text,
     )
 
 
@@ -81,10 +97,140 @@ def iso(value: str) -> datetime:
     return datetime.fromisoformat(value).astimezone(CENTRAL)
 
 
-def build_vacation_plan(events: list[dict], now: datetime) -> dict:
+def event_window(event: dict) -> tuple[datetime, datetime, bool, int]:
+    start = iso(event["start"])
+    end = iso(event["end"])
+    is_all_day = "T" not in str(event["start"])
+    duration_days = int((end - start).total_seconds() / 86400)
+    return start, end, is_all_day, duration_days
+
+
+def standalone_fallback_candidates(
+    curling_events: list[dict],
+    personal_events: list[dict],
+    work_trip_events: list[dict],
+    now: datetime,
+) -> list[FallbackCandidate]:
+    candidates: list[FallbackCandidate] = []
+
+    for event in curling_events:
+        start, end, is_all_day, duration_days = event_window(event)
+        if end > now and is_all_day and duration_days > 2:
+            summary = event.get("summary", "Curling")
+            candidates.append(
+                FallbackCandidate(summary, start, end, summary, "curling_block", "curling block", 4)
+            )
+
+    for event in personal_events:
+        start, end, is_all_day, duration_days = event_window(event)
+        text = " ".join(
+            [
+                event.get("summary", ""),
+                event.get("description", ""),
+                event.get("location", ""),
+            ]
+        ).lower()
+        is_explicit_vacation = "#vacation" in text
+        is_trip_block = is_all_day and duration_days > 1 and any(
+            keyword in text for keyword in ("vacation", " trip", "travel", "out of town", "pto", "ooo")
+        )
+        if end > now and (is_explicit_vacation or is_trip_block):
+            summary = event.get("summary", "Vacation")
+            candidates.append(
+                FallbackCandidate(
+                    summary,
+                    start,
+                    end,
+                    summary,
+                    "explicit_vacation" if is_explicit_vacation else "all_day_trip_block",
+                    "explicit vacation event" if is_explicit_vacation else "all-day trip block",
+                    1 if is_explicit_vacation else 3,
+                )
+            )
+
+    for event in work_trip_events:
+        start, end, is_all_day, duration_days = event_window(event)
+        text = " ".join(
+            [
+                event.get("summary", ""),
+                event.get("description", ""),
+                event.get("location", ""),
+            ]
+        ).lower()
+        is_lodging = any(
+            keyword in text
+            for keyword in ("stay at", "hotel", "airbnb", "lodging", "resort", " inn", "check-in", "check out")
+        )
+        is_trip_block = is_all_day and duration_days > 1
+        if end > now and (is_lodging or is_trip_block):
+            summary = event.get("summary", "Work Trip")
+            candidates.append(
+                FallbackCandidate(
+                    summary,
+                    start,
+                    end,
+                    summary,
+                    "lodging" if is_lodging else "all_day_trip_block",
+                    "lodging span" if is_lodging else "all-day trip block",
+                    0 if is_lodging else 3,
+                )
+            )
+
+    return candidates
+
+
+def best_standalone_fallback(
+    curling_events: list[dict],
+    personal_events: list[dict],
+    work_trip_events: list[dict],
+    now: datetime,
+) -> FallbackCandidate | None:
+    candidates = standalone_fallback_candidates(curling_events, personal_events, work_trip_events, now)
+    if not candidates:
+        return None
+    return min(candidates, key=lambda candidate: (candidate.priority, candidate.start))
+
+
+def best_paired_fallback(
+    outbound_start: datetime,
+    curling_events: list[dict],
+    personal_events: list[dict],
+    work_trip_events: list[dict],
+    now: datetime,
+) -> FallbackCandidate | None:
+    candidates = standalone_fallback_candidates(curling_events, personal_events, work_trip_events, now)
+    eligible = [
+        candidate
+        for candidate in candidates
+        if candidate.end > outbound_start and candidate.start <= outbound_start + timedelta(days=3)
+    ]
+    if not eligible:
+        return None
+
+    def key(candidate: FallbackCandidate) -> tuple[int, int, float, datetime]:
+        contains_outbound = candidate.start <= outbound_start <= candidate.end
+        proximity = abs((candidate.start - outbound_start).total_seconds())
+        return (candidate.priority, 0 if contains_outbound else 1, proximity, candidate.start)
+
+    return min(eligible, key=key)
+
+
+def build_vacation_plan(
+    personal_events: list[dict],
+    now: datetime,
+    *,
+    curling_events: list[dict] | None = None,
+    work_trip_events: list[dict] | None = None,
+) -> dict:
+    curling_events = curling_events or []
+    work_trip_events = work_trip_events or []
+    travel_events = personal_events + work_trip_events
+    standalone_fallback = best_standalone_fallback(curling_events, personal_events, work_trip_events, now)
+
+    ignored_reason = "No qualifying travel itinerary or calendar trip block was found."
     outbound = None
-    for event in events:
-        start_dt = iso(event["start"])
+    for event in travel_events:
+        start_dt, _, _, _ = event_window(event)
         signals = parse_flight_signals(
             event.get("summary", ""),
             event.get("description", ""),
@@ -94,8 +240,12 @@ def build_vacation_plan(events: list[dict], now: datetime) -> dict:
         is_home_destination = signals.destination_code in HOME_CODES
         outbound_priority = 0 if is_home_origin else 1 if signals.named_flight else 9
 
+        if signals.looks_like_flight and signals.is_friend and is_home_destination:
+            ignored_reason = "Ignored a friend itinerary arriving home."
+
         if (
             signals.looks_like_flight
+            and not signals.is_friend
             and start_dt >= now - timedelta(hours=1)
             and signals.destination_name
             and not is_home_destination
@@ -113,35 +263,110 @@ def build_vacation_plan(events: list[dict], now: datetime) -> dict:
                 outbound = candidate
 
     if outbound is None:
-        return {"reason": "off"}
+        if standalone_fallback is None:
+            return {
+                "reason": "off",
+                "decision_code": "off_no_candidate",
+                "decision_summary": ignored_reason,
+                "ignored_reason": ignored_reason,
+            }
+        return {
+            "reason": "calendar",
+            "decision_code": f"calendar_{standalone_fallback.source_code}",
+            "decision_summary": f"Using standalone {standalone_fallback.source_label}.",
+            "summary": standalone_fallback.summary,
+            "start": standalone_fallback.start,
+            "end": standalone_fallback.end,
+            "return_summary": "",
+            "vacation_name": standalone_fallback.vacation_name,
+            "outbound_summary": "",
+            "destination_name": standalone_fallback.vacation_name,
+            "fallback_summary": standalone_fallback.summary,
+            "fallback_source": standalone_fallback.source_label,
+            "ignored_reason": "",
+        }
 
+    final_destination = outbound["destination_name"]
     return_home = None
-    for event in events:
-        start_dt = iso(event["start"])
+    for event in travel_events:
+        start_dt, _, _, _ = event_window(event)
         signals = parse_flight_signals(
             event.get("summary", ""),
             event.get("description", ""),
             event.get("location", ""),
         )
+        is_home_destination = signals.destination_code in HOME_CODES
         if (
             signals.looks_like_flight
-            and signals.destination_code in HOME_CODES
+            and not signals.is_friend
+            and signals.destination_name
+            and not is_home_destination
+            and outbound["start"] <= start_dt <= outbound["start"] + timedelta(days=2)
+        ):
+            final_destination = signals.destination_name
+        if (
+            signals.looks_like_flight
+            and not signals.is_friend
+            and is_home_destination
             and start_dt > outbound["start"]
         ):
             candidate = {"summary": event["summary"], "start": start_dt}
             if return_home is None or candidate["start"] < return_home["start"]:
                 return_home = candidate
 
-    if return_home is None:
-        return {"reason": "off"}
+    if return_home is not None:
+        return {
+            "reason": "flight",
+            "decision_code": "flight_return",
+            "decision_summary": "Using outbound flight and booked return flight.",
+            "summary": outbound["summary"],
+            "start": outbound["start"],
+            "end": return_home["start"] - timedelta(hours=2),
+            "return_summary": return_home["summary"],
+            "vacation_name": final_destination,
+            "outbound_summary": outbound["summary"],
+            "destination_name": final_destination,
+            "fallback_summary": "",
+            "fallback_source": "",
+            "ignored_reason": "",
+        }
+
+    paired_fallback = best_paired_fallback(
+        outbound["start"], curling_events, personal_events, work_trip_events, now
+    )
+    if paired_fallback is not None:
+        return {
+            "reason": "flight",
+            "decision_code": f"flight_{paired_fallback.source_code}",
+            "decision_summary": (
+                f"Using outbound flight and {paired_fallback.source_label} because no return flight is booked."
+            ),
+            "summary": outbound["summary"],
+            "start": outbound["start"],
+            "end": paired_fallback.end,
+            "return_summary": "",
+            "vacation_name": final_destination or paired_fallback.vacation_name,
+            "outbound_summary": outbound["summary"],
+            "destination_name": final_destination or paired_fallback.vacation_name,
+            "fallback_summary": paired_fallback.summary,
+            "fallback_source": paired_fallback.source_label,
+            "ignored_reason": "",
+        }
 
     return {
-        "reason": "flight",
-        "summary": outbound["summary"],
-        "start": outbound["start"],
-        "end": return_home["start"] - timedelta(hours=2),
-        "return_summary": return_home["summary"],
-        "vacation_name": outbound["destination_name"],
+        "reason": "off",
+        "decision_code": "off_outbound_missing_end",
+        "decision_summary": "Found an outbound flight, but no booked return or related fallback trip window.",
+        "summary": "",
+        "start": "",
+        "end": "",
+        "return_summary": "",
+        "vacation_name": "",
+        "outbound_summary": outbound["summary"],
+        "destination_name": final_destination,
+        "fallback_summary": "",
+        "fallback_source": "",
+        "ignored_reason": "No return flight or linked lodging, vacation event, or all-day trip block was found.",
     }
 
 
@@ -192,6 +417,20 @@ def test_trips_package_avoids_case_sensitive_named_flight_splits() -> None:
     assert "flight_tail_lower = summary_lower[8:]" in text
 
 
+def test_trips_package_exposes_vacation_plan_diagnostics_and_logging() -> None:
+    text = TRIPS_PATH.read_text(encoding="utf-8")
+
+    assert "decision_code:" in text
+    assert "decision_summary:" in text
+    assert "fallback_summary:" in text
+    assert "ignored_reason:" in text
+    assert "alias: log_calendar_vacation_plan_diagnostics" in text
+    assert "name: Travel detection" in text
+    assert "attribute: decision_code" in text
+    assert "not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL']" in text
+    assert "not is_friend_itinerary and destination_code in ['RST', 'ROCHESTER']" in text
+
+
 def test_vacation_plan_ignores_barber_and_pairs_real_outbound_with_return() -> None:
     now = iso("2026-03-24T10:30:00-05:00")
     events = [
@@ -200,11 +439,6 @@ def test_vacation_plan_ignores_barber_and_pairs_real_outbound_with_return() -> N
             "location": "3001 Hennepin Ave S, Minneapolis, MN 55408, United States",
             "start": "2026-03-24T11:40:00-05:00",
             "end": "2026-03-24T12:40:00-05:00",
-        },
-        {
-            "summary": "Tartan Day",
-            "start": "2026-04-06T00:00:00-05:00",
-            "end": "2026-04-07T00:00:00-05:00",
         },
         {
             "summary": "✈ MSP→CLT • DL 2819",
@@ -223,8 +457,157 @@ def test_vacation_plan_ignores_barber_and_pairs_real_outbound_with_return() -> N
     plan = build_vacation_plan(events, now)
 
     assert plan["reason"] == "flight"
+    assert plan["decision_code"] == "flight_return"
     assert plan["summary"] == "✈ MSP→CLT • DL 2819"
     assert plan["start"] == iso("2026-04-09T14:20:00-05:00")
     assert plan["end"] == iso("2026-04-13T13:35:00-05:00")
     assert plan["return_summary"] == "✈ CLT→MSP • DL 2820"
     assert plan["vacation_name"] == "CLT"
+
+
+def test_multi_leg_outbound_uses_final_destination_before_homebound_return() -> None:
+    now = iso("2026-03-01T08:00:00-06:00")
+    events = [
+        {
+            "summary": "✈ MSP→DTW • DL 2101",
+            "description": "Synced by Flighty",
+            "start": "2026-03-05T09:10:00-06:00",
+            "end": "2026-03-05T11:30:00-05:00",
+        },
+        {
+            "summary": "✈ DTW→AMS • KL 606",
+            "description": "Synced by Flighty",
+            "start": "2026-03-05T15:45:00-05:00",
+            "end": "2026-03-06T06:10:00+01:00",
+        },
+        {
+            "summary": "✈ AMS→INV • KL 921",
+            "description": "Synced by Flighty",
+            "start": "2026-03-06T09:20:00+01:00",
+            "end": "2026-03-06T10:55:00Z",
+        },
+        {
+            "summary": "✈ AMS→MSP • KL 605",
+            "description": "Synced by Flighty",
+            "start": "2026-03-16T14:15:00+01:00",
+            "end": "2026-03-16T17:20:00-05:00",
+        },
+    ]
+
+    plan = build_vacation_plan(events, now)
+
+    assert plan["decision_code"] == "flight_return"
+    assert plan["summary"] == "✈ MSP→DTW • DL 2101"
+    assert plan["return_summary"] == "✈ AMS→MSP • KL 605"
+    assert plan["vacation_name"] == "INV"
+    assert plan["destination_name"] == "INV"
+
+
+def test_outbound_flight_without_return_uses_lodging_fallback() -> None:
+    now = iso("2026-04-01T08:00:00-05:00")
+    personal_events = [
+        {
+            "summary": "✈ MSP→CLT • DL 2819",
+            "description": "Synced by Flighty",
+            "start": "2026-04-09T14:20:00-05:00",
+            "end": "2026-04-09T17:00:00-04:00",
+        }
+    ]
+    work_trip_events = [
+        {
+            "summary": "Stay at Westin Charlotte",
+            "start": "2026-04-09T18:30:00-04:00",
+            "end": "2026-04-13T10:00:00-04:00",
+            "location": "Charlotte, NC",
+        }
+    ]
+
+    plan = build_vacation_plan(personal_events, now, work_trip_events=work_trip_events)
+
+    assert plan["reason"] == "flight"
+    assert plan["decision_code"] == "flight_lodging"
+    assert plan["return_summary"] == ""
+    assert plan["fallback_summary"] == "Stay at Westin Charlotte"
+    assert plan["fallback_source"] == "lodging span"
+    assert plan["end"] == iso("2026-04-13T10:00:00-04:00")
+
+
+def test_standalone_lodging_trip_without_flights_uses_calendar_window() -> None:
+    now = iso("2026-04-01T08:00:00-05:00")
+    work_trip_events = [
+        {
+            "summary": "Stay at AC Hotel Inverness",
+            "start": "2026-04-09T18:30:00+01:00",
+            "end": "2026-04-13T09:00:00+01:00",
+            "location": "Inverness, Scotland",
+        }
+    ]
+
+    plan = build_vacation_plan([], now, work_trip_events=work_trip_events)
+
+    assert plan["reason"] == "calendar"
+    assert plan["decision_code"] == "calendar_lodging"
+    assert plan["summary"] == "Stay at AC Hotel Inverness"
+    assert plan["fallback_source"] == "lodging span"
+    assert plan["vacation_name"] == "Stay at AC Hotel Inverness"
+
+
+def test_friend_itineraries_to_home_are_ignored() -> None:
+    now = iso("2026-03-01T08:00:00-06:00")
+    events = [
+        {
+            "summary": "✈ AMS→MSP • KL 605",
+            "description": "Synced by Flighty for Friend arrival",
+            "start": "2026-03-16T14:15:00+01:00",
+            "end": "2026-03-16T17:20:00-05:00",
+        }
+    ]
+
+    plan = build_vacation_plan(events, now)
+
+    assert plan["reason"] == "off"
+    assert plan["decision_code"] == "off_no_candidate"
+    assert "friend itinerary" in plan["ignored_reason"].lower()
+
+
+def test_local_rochester_appointments_do_not_create_trip_window() -> None:
+    now = iso("2026-03-01T08:00:00-06:00")
+    events = [
+        {
+            "summary": "Dentist Appointment",
+            "location": "Mayo Clinic, Rochester, MN 55905, United States",
+            "start": "2026-03-02T10:00:00-06:00",
+            "end": "2026-03-02T11:00:00-06:00",
+        },
+        {
+            "summary": "Barber",
+            "location": "3001 Hennepin Ave S, Minneapolis, MN 55408, United States",
+            "start": "2026-03-03T09:00:00-06:00",
+            "end": "2026-03-03T10:00:00-06:00",
+        },
+    ]
+
+    plan = build_vacation_plan(events, now)
+
+    assert plan["reason"] == "off"
+    assert plan["decision_code"] == "off_no_candidate"
+
+
+@pytest.mark.parametrize(
+    ("phrase", "expected_source"),
+    [
+        ("MSP -> DTW -> AMS -> INV", "multi-leg outbound"),
+        ("Friend flights arriving in MSP", "friend homebound"),
+        ("Local Rochester appointments", "local false positive"),
+        ("Hotel/calendar-only trips", "lodging fallback"),
+    ],
+)
+def test_travel_detection_regression_matrix_documents_priority_cases(
+    phrase: str, expected_source: str
+) -> None:
+    text = MATRIX_PATH.read_text(encoding="utf-8")
+
+    assert "Travel Detection Regression Matrix" in text
+    assert "Precedence" in text
+    assert phrase in text
+    assert expected_source in text


### PR DESCRIPTION
## Summary
- extend trip-window synthesis to support outbound flights without booked returns by using lodging spans, explicit vacation events, and all-day trip blocks as fallback end windows
- add travel-detection diagnostics on `sensor.ecobee_calendar_vacation_schedule` plus logbook entries when the decision changes
- expand the regression suite and document the representative travel-detection matrix for future reviews

## Testing
- `uv run --with pytest pytest`

Closes #66
Closes #67