### PR TITLE
[codex] Fix weatheralerts custom component constants

### DIFF
--- a/custom_components/weatheralerts/__init__.py
+++ b/custom_components/weatheralerts/__init__.py
@@ -110,9 +110,9 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
         name = entry.data.get(CONF_NAME, "").strip()
 
     if CONF_ZONE_NAME in entry.options:
-        name = entry.options[CONF_ZONE_NAME].strip()
+        zone_name = entry.options[CONF_ZONE_NAME].strip()
     else:
-        name = entry.data.get(CONF_ZONE_NAME, "").strip()
+        zone_name = entry.data.get(CONF_ZONE_NAME, "").strip()
 
     if CONF_ENTITY_NAME in entry.options:
         entity_name = entry.options[CONF_ENTITY_NAME].strip()
@@ -129,7 +129,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     if marine_zones:
         parts.extend(z.strip() for z in marine_zones.split(",") if z.strip())
     feed_id = ",".join(parts)
-    title = name or f"NWS {feed_id}"
+    title = name or zone_name or f"NWS {feed_id}"
 
     # Build the new static data dict
     new_data: dict[str, str] = {

--- a/custom_components/weatheralerts/const.py
+++ b/custom_components/weatheralerts/const.py
@@ -1,0 +1,45 @@
+"""Constants for the local weatheralerts custom integration copy."""
+
+DOMAIN = "weatheralerts"
+VERSION = "2026.1.0"
+
+CONF_ZONE = "zone"
+CONF_COUNTY = "county"
+CONF_ZONE_NAME = "zone_name"
+CONF_NAME = "name"
+CONF_ENTITY_NAME = "entity_name"
+CONF_MARINE_ZONES = "marine_zones"
+CONF_UPDATE_INTERVAL = "update_interval"
+CONF_API_TIMEOUT = "api_timeout"
+CONF_DEDUPLICATE_ALERTS = "deduplicate_alerts"
+CONF_EVENT_ICONS = "event_icons"
+CONF_DEFAULT_ICON = "default_icon"
+
+ALERTS_API = "https://api.weather.gov/alerts/active?zone={}"
+HEADERS = {
+    "accept": "application/json",
+    "user-agent": f"HomeAssistant_weatheralerts/{VERSION}",
+}
+
+DEFAULT_UPDATE_INTERVAL = 90
+DEFAULT_API_TIMEOUT = 20
+DEFAULT_DEDUPLICATE_ALERTS = False
+
+DEFAULT_EVENT_ICON = "hass:alert-rhombus"
+DEFAULT_EVENT_ICONS = {
+    "Air Quality Alert": "hass:blur",
+    "Blizzard Warning": "hass:snowflake-alert",
+    "Dense Fog Advisory": "hass:weather-fog",
+    "Extreme Fire Danger": "hass:fire-alert",
+    "Flash Flood Warning": "hass:water-alert",
+    "Flood Warning": "hass:water-alert",
+    "Freeze Warning": "hass:thermometer-minus",
+    "Hazardous Weather Outlook": "hass:message-alert",
+    "Heat Advisory": "hass:thermometer-plus",
+    "High Wind Warning": "hass:weather-windy",
+    "Severe Thunderstorm Warning": "hass:weather-lightning",
+    "Special Weather Statement": "hass:message-alert",
+    "Tornado Warning": "hass:weather-tornado",
+    "Winter Storm Warning": "hass:snowflake-alert",
+    "Winter Weather Advisory": "hass:snowflake-alert",
+}

--- a/tests/test_weatheralerts_component.py
+++ b/tests/test_weatheralerts_component.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONST_PATH = ROOT / "custom_components" / "weatheralerts" / "const.py"
+INIT_PATH = ROOT / "custom_components" / "weatheralerts" / "__init__.py"
+
+
+def test_weatheralerts_const_module_exists_with_required_defaults() -> None:
+    text = CONST_PATH.read_text(encoding="utf-8")
+
+    assert 'DOMAIN = "weatheralerts"' in text
+    assert 'ALERTS_API = "https://api.weather.gov/alerts/active?zone={}"' in text
+    assert "DEFAULT_UPDATE_INTERVAL = 90" in text
+    assert "DEFAULT_API_TIMEOUT = 20" in text
+    assert "DEFAULT_EVENT_ICONS" in text
+
+
+def test_weatheralerts_update_listener_tracks_zone_name_explicitly() -> None:
+    text = INIT_PATH.read_text(encoding="utf-8")
+
+    assert "zone_name = entry.options[CONF_ZONE_NAME].strip()" in text
+    assert 'zone_name = entry.data.get(CONF_ZONE_NAME, "").strip()' in text
+    assert "CONF_ZONE_NAME: zone_name" in text
+    assert "title = name or zone_name or f\"NWS {feed_id}\"" in text


### PR DESCRIPTION
## Summary
- restore the missing `custom_components/weatheralerts/const.py` module required by the local custom integration copy
- fix the `zone_name` handling in the integration update listener so config-entry metadata does not reference an undefined name
- add regression coverage for the restored constants module and listener wiring

## Validation
- `uv run --with pytest pytest tests/test_weatheralerts_component.py`
- `python3 -m py_compile custom_components/weatheralerts/__init__.py custom_components/weatheralerts/const.py`
- `uv run --with homeassistant==2026.3.4 python -m homeassistant --config <temp copy> --script check_config` (the earlier weatheralerts platform-import warning no longer reproduced)

## Log context
This addresses the repo-side `weatheralerts` warning seen during Home Assistant config validation while triaging remaining HA log errors.