### PR TITLE
Expose TV watch scripts to Siri

### DIFF
--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -35,6 +35,70 @@ homeassistant:
     ################################################
     ## Scripts
     ################################################
+    script.watch_tv:
+      <<: *expose
+      friendly_name: "Watch TV"
+      icon: mdi:television
+
+    script.watch_youtube:
+      <<: *expose
+      friendly_name: "Watch YouTube"
+      icon: mdi:youtube-tv
+
+    script.watch_netflix:
+      <<: *expose
+      friendly_name: "Watch Netflix"
+      icon: mdi:netflix
+
+    script.watch_plex:
+      <<: *expose
+      friendly_name: "Watch Plex"
+      icon: mdi:plex
+
+    script.watch_f1:
+      <<: *expose
+      friendly_name: "Watch F1"
+      icon: mdi:flag-checkered
+
+    script.watch_letterkenny:
+      <<: *expose
+      friendly_name: "Watch Letterkenny"
+      icon: mdi:television-play
+
+    script.watch_the_simpsons:
+      <<: *expose
+      friendly_name: "Watch The Simpsons"
+      icon: mdi:television-play
+
+    script.watch_american_dad:
+      <<: *expose
+      friendly_name: "Watch American Dad"
+      icon: mdi:television-play
+
+    script.watch_aqua_teen:
+      <<: *expose
+      friendly_name: "Watch Aqua Teen"
+      icon: mdi:television-play
+
+    script.watch_bobs_burgers:
+      <<: *expose
+      friendly_name: "Watch Bob's Burgers"
+      icon: mdi:television-play
+
+    script.watch_ds9:
+      <<: *expose
+      friendly_name: "Watch DS9"
+      icon: mdi:television-play
+
+    script.watch_rick_and_morty:
+      <<: *expose
+      friendly_name: "Watch Rick and Morty"
+      icon: mdi:television-play
+
+    script.watch_tng:
+      <<: *expose
+      friendly_name: "Watch TNG"
+      icon: mdi:television-play
 
 ################################################
 ## Automation

--- a/tests/test_tv_package.py
+++ b/tests/test_tv_package.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+TV_PATH = Path(__file__).resolve().parents[1] / "packages" / "tv.yaml"
+
+
+def _customize_block(entity_id: str) -> str:
+    lines = TV_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"    {entity_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find customize block {entity_id!r} in {TV_PATH.name}")
+
+    end = len(lines)
+    next_entry = re.compile(r"^    [A-Za-z0-9_.]+:$")
+    for index in range(start + 1, len(lines)):
+        if next_entry.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _script_block(script_id: str) -> str:
+    lines = TV_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r} in {TV_PATH.name}")
+
+    end = len(lines)
+    next_script = re.compile(r"^  [A-Za-z0-9_]+:$")
+    for index in range(start + 1, len(lines)):
+        if next_script.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_all_watch_scripts_are_exposed_to_siri_and_voice_integrations() -> None:
+    package = TV_PATH.read_text(encoding="utf-8")
+    watch_scripts = set(re.findall(r"^  (watch_[a-z0-9_]+):$", package, flags=re.MULTILINE))
+    exposed_scripts = {
+        line.removeprefix("    script.").removesuffix(":")
+        for line in package.splitlines()
+        if line.startswith("    script.watch_")
+    }
+
+    assert exposed_scripts == watch_scripts
+
+    for script_id in sorted(watch_scripts):
+        block = _customize_block(f"script.{script_id}")
+
+        assert "<<: *expose" in block
+        assert 'friendly_name: "' in block
+
+
+def test_watch_f1_script_uses_basement_apple_tv_path() -> None:
+    block = _script_block("watch_f1")
+
+    for token in (
+        "entity_id: media_player.basement",
+        'source: "HDMI 3"',
+        'source: "F1 TV"',
+        "action: script.wait_for_basement_media_player_ready",
+        "action: script.music_assistant_pause_house_audio",
+    ):
+        assert token in block


### PR DESCRIPTION
## Summary
- expose every `watch_*` TV script through the existing Homebridge/Siri customize path
- keep `watch_f1` on the existing Apple TV `F1 TV` source flow
- add regression coverage for Siri exposure and the F1 launch path

## Testing
- `uv run --with pytest pytest`
- `uv run --with homeassistant python -m homeassistant --config . --script check_config` with temporary placeholder secrets; no TV-package errors, existing warning remains for `weatheralerts` custom component loading
