### PR TITLE
Add laundry smart-plug monitoring

### DIFF
--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -156,25 +156,37 @@ alarm_control_panel: []
 automation:
   - id: wash_finished
     alias: wash_finished
+    description: Notify when washer power drops back to standby long enough to count as a completed cycle.
     trigger:
       - trigger: state
-        # entity_id: binary_sensor.washer_door
-        # to: "off"
-        entity_id: binary_sensor.front_load_washer_wash_completed
-        to: "on"
+        entity_id: binary_sensor.washing_machine_running
+        from: "on"
+        to: "off"
     action:
       - action: notify.all
         data:
           message: "Washing machine finished! \U0001F9FA"
 
-  - id: washer_reminder
-    alias: washer_reminder
+  - id: dryer_finished
+    alias: dryer_finished
+    description: Notify when dryer power drops back to standby long enough to count as a completed cycle.
     trigger:
       - trigger: state
-        # entity_id: binary_sensor.washer_door
-        # to: "off"
-        entity_id: binary_sensor.front_load_washer_wash_completed
-        to: "on"
+        entity_id: binary_sensor.dryer_running
+        from: "on"
+        to: "off"
+    action:
+      - action: notify.all
+        data:
+          message: "Dryer finished! \U0001F9FA"
+
+  - id: washer_reminder
+    alias: washer_reminder
+    description: Remind after a completed wash cycle if wet clothes have likely been sitting too long.
+    trigger:
+      - trigger: state
+        entity_id: binary_sensor.washing_machine_running
+        to: "off"
         for:
           hours: 18
     action:
@@ -280,17 +292,24 @@ template:
         unique_id: dishwasher_running
         state: "{{ is_state('binary_sensor.dishwasher', 'on') }}"
         name: dishwasher_running
-      - delay_off: 0:10:00
-        delay_on: 0:05:00
+      # Dryers bounce around their heater cycles, so only stop after a short
+      # sustained return to standby.
+      - delay_off: 0:03:00
+        delay_on: 0:02:00
         default_entity_id: binary_sensor.dryer_running
         unique_id: dryer_running
-        state: "{{ is_state('binary_sensor.dryer', 'on') }}"
+        availability: "{{ has_value('sensor.laundry_room_dryer_power') }}"
+        state: "{{ states('sensor.laundry_room_dryer_power') | float(0) > 75 }}"
         name: dryer_running
-      - delay_off: 0:10:00
-        delay_on: 0:05:00
+      # Washers often have multi-minute pauses between phases, so keep the
+      # cycle marked active until power stays near standby for a while.
+      - delay_off: 0:08:00
+        delay_on: 0:01:00
         default_entity_id: binary_sensor.washing_machine_running
         unique_id: washing_machine_running
-        state: "{{ is_state('binary_sensor.washer', 'on') }}"
+        availability: "{{ has_value('sensor.laundry_room_washing_machine_power') }}"
+        state: >-
+          {{ states('sensor.laundry_room_washing_machine_power') | float(0) > 8 }}
         name: washing_machine_running
   - trigger:
       - trigger: state

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -390,6 +390,28 @@ automation:
           entity_id:
             - switch.basement_sump_pump
 
+  - alias: Turn Laundry Plugs Back On
+    id: turn_laundry_plugs_back_on
+    trigger:
+      - trigger: state
+        entity_id:
+          - switch.laundry_room_washing_machine
+          - switch.laundry_room_dryer
+        to: "off"
+      - trigger: state
+        entity_id:
+          - switch.laundry_room_washing_machine
+          - switch.laundry_room_dryer
+        not_to: "on"
+      - trigger: homeassistant
+        event: start
+    action:
+      - action: switch.turn_on
+        target:
+          entity_id:
+            - switch.laundry_room_washing_machine
+            - switch.laundry_room_dryer
+
   - alias: Notify Sump Pit Getting Full
     id: notify_sump_pit_getting_full
     trigger:

--- a/tests/test_laundry_plug_monitoring.py
+++ b/tests/test_laundry_plug_monitoring.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLEANING_PATH = ROOT / "packages" / "cleaning.yaml"
+UTILITIES_PATH = ROOT / "packages" / "utilities.yaml"
+
+
+def _automation_block(path: Path, automation_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _template_binary_sensor_block(unique_id: str) -> str:
+    lines = CLEANING_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line != f"        unique_id: {unique_id}":
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("      - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find template binary sensor {unique_id!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("      - ") or lines[index].startswith("  - trigger:"):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_cleaning_package_uses_smart_plug_power_for_laundry_running_detection() -> None:
+    washer_block = _template_binary_sensor_block("washing_machine_running")
+    dryer_block = _template_binary_sensor_block("dryer_running")
+
+    assert "delay_on: 0:01:00" in washer_block
+    assert "delay_off: 0:08:00" in washer_block
+    assert "sensor.laundry_room_washing_machine_power" in washer_block
+    assert "| float(0) > 8" in washer_block
+    assert "is_state('binary_sensor.washer'" not in washer_block
+
+    assert "delay_on: 0:02:00" in dryer_block
+    assert "delay_off: 0:03:00" in dryer_block
+    assert "sensor.laundry_room_dryer_power" in dryer_block
+    assert "| float(0) > 75" in dryer_block
+    assert "is_state('binary_sensor.dryer'" not in dryer_block
+
+
+def test_cleaning_package_notifies_from_power_based_running_sensors() -> None:
+    wash_finished = _automation_block(CLEANING_PATH, "wash_finished")
+    dryer_finished = _automation_block(CLEANING_PATH, "dryer_finished")
+    washer_reminder = _automation_block(CLEANING_PATH, "washer_reminder")
+
+    assert "entity_id: binary_sensor.washing_machine_running" in wash_finished
+    assert 'from: "on"' in wash_finished
+    assert 'to: "off"' in wash_finished
+    assert "binary_sensor.front_load_washer_wash_completed" not in wash_finished
+
+    assert "entity_id: binary_sensor.dryer_running" in dryer_finished
+    assert 'from: "on"' in dryer_finished
+    assert 'to: "off"' in dryer_finished
+    assert 'message: "Dryer finished!' in dryer_finished
+
+    assert "entity_id: binary_sensor.washing_machine_running" in washer_reminder
+    assert "hours: 18" in washer_reminder
+    assert "binary_sensor.front_load_washer_wash_completed" not in washer_reminder
+
+
+def test_utilities_package_keeps_laundry_plugs_powered() -> None:
+    block = _automation_block(UTILITIES_PATH, "turn_laundry_plugs_back_on")
+
+    assert "switch.laundry_room_washing_machine" in block
+    assert "switch.laundry_room_dryer" in block
+    assert 'to: "off"' in block
+    assert 'event: start' in block
+    assert "- action: switch.turn_on" in block


### PR DESCRIPTION
## Summary
- keep the new laundry smart plugs powered on like the sump pump and CPAP plugs
- drive washer and dryer completion notifications from the new power-monitoring plugs
- add regression coverage for the new laundry automations

## Testing
- uv run --with pytest pytest