### PR TITLE
Bound tiki room lava and thunder decay

### DIFF
--- a/esphome/tikiroom_effects.h
+++ b/esphome/tikiroom_effects.h
@@ -19,6 +19,9 @@ constexpr uint8_t MAX_RIPPLE_STEPS = 16;
 constexpr uint8_t COOLING = 55;
 constexpr uint8_t SPARKING = 120;
 constexpr uint8_t GLITTER_FADE_AMOUNT = 20;
+constexpr uint8_t LAVA_FIELD_BLEND_AMOUNT = 72;
+constexpr uint8_t THUNDERSTORM_BLEND_AMOUNT = 76;
+constexpr uint8_t THUNDERSTORM_FLASH_BLEND_AMOUNT = 255;
 constexpr size_t LAVA_FIELD_CELLS = 48;
 constexpr size_t THUNDERSTORM_CELLS = 40;
 constexpr float PI_F = 3.14159265f;
@@ -466,8 +469,6 @@ inline void apply_lava_field(AddressableLight &it, float speed, bool initial_run
     return;
   }
 
-  fade_to_black(GLITTER_FADE_AMOUNT);
-
   drift_offset += 1 + static_cast<uint16_t>(speed / 92.0f);
   ember_offset += 1 + static_cast<uint16_t>(speed / 124.0f);
   const float elapsed_s = now_ms() / 1000.0f;
@@ -514,7 +515,8 @@ inline void apply_lava_field(AddressableLight &it, float speed, bool initial_run
   }
 
   for (uint16_t i = 0; i < NUM_LEDS; i++) {
-    add_scaled_inplace(rt.leds[i], sample_coarse_cells(lava_cells, i), GLITTER_FADE_AMOUNT);
+    const Color target = sample_coarse_cells(lava_cells, i);
+    rt.leds[i] = blend(rt.leds[i], target, LAVA_FIELD_BLEND_AMOUNT);
   }
 
   copy_to_output(it);
@@ -850,8 +852,6 @@ inline void apply_thunderstorm(AddressableLight &it, float speed, bool initial_r
     return;
   }
 
-  fade_to_black(GLITTER_FADE_AMOUNT);
-
   if (!burst_active && now >= next_event_ms) {
     burst_active = true;
     flash_on = true;
@@ -941,7 +941,7 @@ inline void apply_thunderstorm(AddressableLight &it, float speed, bool initial_r
   }
 
   for (uint16_t i = 0; i < NUM_LEDS; i++) {
-    add_scaled_inplace(rt.leds[i], sample_coarse_cells(ambient_cells, i), GLITTER_FADE_AMOUNT);
+    Color pixel = sample_coarse_cells(ambient_cells, i);
 
     if (flash_on) {
       const uint8_t texture = static_cast<uint8_t>(176 + ((i * 19 + (now >> 3)) % 64));
@@ -949,8 +949,11 @@ inline void apply_thunderstorm(AddressableLight &it, float speed, bool initial_r
           clamp_u8(static_cast<int>((flash_level * texture) / 255)),
           clamp_u8(static_cast<int>((flash_level * texture) / 255)),
           clamp_u8(static_cast<int>((flash_level * (texture - 18)) / 255)));
-      add_scaled_inplace(rt.leds[i], flash_overlay, 88);
+      add_inplace(pixel, scale_color(flash_overlay, 88));
     }
+
+    const uint8_t blend_amount = flash_on ? THUNDERSTORM_FLASH_BLEND_AMOUNT : THUNDERSTORM_BLEND_AMOUNT;
+    rt.leds[i] = blend(rt.leds[i], pixel, blend_amount);
   }
 
   copy_to_output(it);

--- a/tests/test_tikiroom_effects_header.py
+++ b/tests/test_tikiroom_effects_header.py
@@ -18,13 +18,16 @@ def test_tikiroom_effects_header_exposes_smoothing_helper() -> None:
 
     assert "inline float smoothstep(float edge0, float edge1, float value)" in text
     assert "constexpr uint8_t GLITTER_FADE_AMOUNT = 20;" in text
+    assert "constexpr uint8_t LAVA_FIELD_BLEND_AMOUNT = 72;" in text
+    assert "constexpr uint8_t THUNDERSTORM_BLEND_AMOUNT = 76;" in text
+    assert "constexpr uint8_t THUNDERSTORM_FLASH_BLEND_AMOUNT = 255;" in text
     assert "constexpr size_t LAVA_FIELD_CELLS = 48;" in text
     assert "constexpr size_t THUNDERSTORM_CELLS = 40;" in text
     assert "inline void add_scaled_inplace(Color &base, const Color &added, uint8_t scale)" in text
     assert "inline Color sample_coarse_cells(const std::array<Color, CELL_COUNT> &cells, uint16_t led_index)" in text
 
 
-def test_lava_field_layers_heat_and_uses_fade_carryover() -> None:
+def test_lava_field_layers_heat_and_blends_toward_a_bounded_target() -> None:
     block = _function_block("apply_lava_field")
 
     assert "std::array<Color, LAVA_FIELD_CELLS> lava_cells{};" in block
@@ -32,23 +35,26 @@ def test_lava_field_layers_heat_and_uses_fade_carryover() -> None:
     assert "cluster_radii" in block
     assert "clump_heat" in block
     assert "ember_wave" in block
-    assert "fade_to_black(GLITTER_FADE_AMOUNT);" in block
     assert "smoothstep(0.18f, 0.96f, molten_mix)" in block
     assert "lava_cells[cell] = pixel;" in block
-    assert "add_scaled_inplace(rt.leds[i], sample_coarse_cells(lava_cells, i), GLITTER_FADE_AMOUNT);" in block
+    assert "const Color target = sample_coarse_cells(lava_cells, i);" in block
+    assert "rt.leds[i] = blend(rt.leds[i], target, LAVA_FIELD_BLEND_AMOUNT);" in block
+    assert "fade_to_black(GLITTER_FADE_AMOUNT);" not in block
 
 
-def test_thunderstorm_uses_jungle_canopy_palette_and_fade_carryover() -> None:
+def test_thunderstorm_uses_jungle_canopy_palette_and_bounded_flash_blending() -> None:
     block = _function_block("apply_thunderstorm")
 
     assert "foliage_phases" in block
     assert "rain_phases" in block
     assert "std::array<Color, THUNDERSTORM_CELLS> ambient_cells{};" in block
-    assert "fade_to_black(GLITTER_FADE_AMOUNT);" in block
     assert "ambient_cells[cell] = pixel;" in block
     assert "rain_group" in block
-    assert "add_scaled_inplace(rt.leds[i], sample_coarse_cells(ambient_cells, i), GLITTER_FADE_AMOUNT);" in block
-    assert "add_scaled_inplace(rt.leds[i], flash_overlay, 88);" in block
+    assert "Color pixel = sample_coarse_cells(ambient_cells, i);" in block
+    assert "add_inplace(pixel, scale_color(flash_overlay, 88));" in block
+    assert "const uint8_t blend_amount = flash_on ? THUNDERSTORM_FLASH_BLEND_AMOUNT : THUNDERSTORM_BLEND_AMOUNT;" in block
+    assert "rt.leds[i] = blend(rt.leds[i], pixel, blend_amount);" in block
+    assert "fade_to_black(GLITTER_FADE_AMOUNT);" not in block
 
 
 def test_f1_race_can_trigger_random_overtakes() -> None:


### PR DESCRIPTION
## Summary
- replace additive lava-field carryover with bounded target blending
- replace thunderstorm fade-plus-add buildup with bounded target blending while keeping flash overlays strong
- update tiki room effect header tests to lock in the non-accumulating render path

## Why
The slowdown and persistent brightness on the strip looked like frame accumulation rather than a heap leak. Both effects were fading the previous frame and then adding new color into it every tick, which can ratchet brightness upward over time and keep the strip from decaying back to black cleanly.

## Validation
- `uv run --with pytest pytest`
- `.venv/bin/esphome config esphome/tikiroom.yaml`
- `.venv/bin/esphome compile esphome/tikiroom.yaml`