### PR TITLE
Gate ESPHome CI builds on changed configs

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -45,10 +45,78 @@ jobs:
             packages \
             zigbee2mqtt
 
+  detect-esphome-changes:
+    name: Detect ESPHome Config Changes
+    runs-on: ubuntu-latest
+    outputs:
+      esphome_changed: ${{ steps.detect.outputs.esphome_changed }}
+      esphome_configs: ${{ steps.detect.outputs.esphome_configs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed ESPHome configs
+        id: detect
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git fetch --no-tags origin "$BASE_REF"
+            diff_output=$(git diff --name-only "origin/$BASE_REF...HEAD")
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            if [[ -n "$BEFORE_SHA" && "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]]; then
+              diff_output=$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA")
+            else
+              diff_output=$(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA")
+            fi
+          else
+            echo "esphome_changed=false" >> "$GITHUB_OUTPUT"
+            echo "esphome_configs=" >> "$GITHUB_OUTPUT"
+            echo "ESPHome build skipped for $EVENT_NAME events."
+            exit 0
+          fi
+
+          config_files=()
+          while IFS= read -r config; do
+            [[ -z "$config" ]] && continue
+            if [[ -f "$config" ]]; then
+              config_files+=("$config")
+            else
+              echo "Skipping removed ESPHome config: $config"
+            fi
+          done < <(printf '%s\n' "$diff_output" | grep -E '^esphome/.*\.ya?ml$' | sort -u || true)
+
+          if [[ ${#config_files[@]} -eq 0 ]]; then
+            echo "esphome_changed=false" >> "$GITHUB_OUTPUT"
+            echo "esphome_configs=" >> "$GITHUB_OUTPUT"
+            echo "No ESPHome config changes detected."
+            exit 0
+          fi
+
+          echo "esphome_changed=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "esphome_configs<<EOF"
+            printf '%s\n' "${config_files[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Changed ESPHome configs:"
+          printf '  - %s\n' "${config_files[@]}"
+
   esphome-build:
     name: ESPHome Build
     runs-on: ubuntu-latest
-    needs: yaml-lint
+    if: ${{ needs.detect-esphome-changes.outputs.esphome_changed == 'true' }}
+    needs:
+      - yaml-lint
+      - detect-esphome-changes
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -99,23 +167,19 @@ jobs:
                 file.write(f"{key}: ci_placeholder\n")
           PY
 
-      - name: Validate and compile ESPHome configs
+      - name: Validate and compile changed ESPHome configs
+        env:
+          ESPHOME_CONFIGS: ${{ needs.detect-esphome-changes.outputs.esphome_configs }}
         run: |
           set -euo pipefail
 
-          shopt -s nullglob
-          config_files=(esphome/*.yaml)
-
-          if [[ ${#config_files[@]} -eq 0 ]]; then
-            echo "No ESPHome configs found."
+          if [[ -z "$ESPHOME_CONFIGS" ]]; then
+            echo "No changed ESPHome configs were provided."
             exit 1
           fi
 
-          for config in "${config_files[@]}"; do
-            if [[ "$(basename "$config")" == "secrets.yaml" ]]; then
-              continue
-            fi
-
+          while IFS= read -r config; do
+            [[ -z "$config" ]] && continue
             echo "::group::ESPHome config check: $config"
             esphome config "$config"
             echo "::endgroup::"
@@ -123,14 +187,12 @@ jobs:
             echo "::group::ESPHome compile: $config"
             esphome compile "$config"
             echo "::endgroup::"
-          done
+          done <<< "$ESPHOME_CONFIGS"
 
   home-assistant-check-config:
     name: Home Assistant Check Config
     runs-on: ubuntu-latest
-    needs:
-      - yaml-lint
-      - esphome-build
+    needs: yaml-lint
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/tests/test_validate_config_workflow.py
+++ b/tests/test_validate_config_workflow.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "validate-config.yml"
+
+
+def test_esphome_build_only_runs_for_changed_esphome_yaml() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "detect-esphome-changes:" in workflow_text
+    assert "grep -E '^esphome/.*\\.ya?ml$'" in workflow_text
+    assert "esphome_changed: ${{ steps.detect.outputs.esphome_changed }}" in workflow_text
+    assert "esphome_configs: ${{ steps.detect.outputs.esphome_configs }}" in workflow_text
+    assert "if: ${{ needs.detect-esphome-changes.outputs.esphome_changed == 'true' }}" in workflow_text
+    assert "ESPHOME_CONFIGS: ${{ needs.detect-esphome-changes.outputs.esphome_configs }}" in workflow_text
+    assert "while IFS= read -r config; do" in workflow_text
+
+
+def test_home_assistant_config_check_does_not_depend_on_esphome_build() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    ha_section = workflow_text.split("home-assistant-check-config:", maxsplit=1)[1]
+    ha_needs_section = ha_section.split("    steps:", maxsplit=1)[0]
+
+    assert "    needs: yaml-lint" in ha_needs_section
+    assert "esphome-build" not in ha_needs_section


### PR DESCRIPTION
## Summary
- detect changed ESPHome YAML files for pull requests and pushes
- only run the ESPHome build job when one or more tracked configs changed
- compile only the changed ESPHome configs and keep Home Assistant config validation independent
- add a pytest regression test that locks the workflow behavior

## Testing
- `uv run --with pytest pytest`