### PR TITLE
[codex] Fix bird sensor state parsing warnings

### DIFF
--- a/packages/birds.yaml
+++ b/packages/birds.yaml
@@ -223,12 +223,26 @@ mqtt:
         state_topic: "birdpi/apprise"
         json_attributes_topic: "birdpi/apprise"
         value_template: >-
-          {% if value_json is defined and value_json is mapping and value_json.common_name is defined %}
-            {{ value_json.common_name }}
-          {% elif value | default('', true) | trim != '' %}
-            {{ value }}
+          {% set raw_value = value | default('', true) | trim %}
+          {% set raw_json = raw_value | replace('&#34;', '"') | replace('&quot;', '"') %}
+          {% set payload = raw_json | from_json(default={}) %}
+          {% if payload is mapping and payload.common_name is defined and payload.common_name | string | trim != '' %}
+            {{ payload.common_name }}
+          {% elif raw_value in ['unknown', 'unavailable'] %}
+            {{ raw_value }}
+          {% elif raw_value != '' and raw_value[:1] not in ['{', '['] %}
+            {{ raw_value }}
           {% else %}
             {{ states('sensor.garden_birds') | default('unknown', true) }}
+          {% endif %}
+        json_attributes_template: >-
+          {% set raw_value = value | default('', true) | trim %}
+          {% set raw_json = raw_value | replace('&#34;', '"') | replace('&quot;', '"') %}
+          {% set payload = raw_json | from_json(default={}) %}
+          {% if payload is mapping %}
+            {{ payload | tojson }}
+          {% else %}
+            {}
           {% endif %}
 
 ########################

--- a/tests/test_aircraft_and_birds_packages.py
+++ b/tests/test_aircraft_and_birds_packages.py
@@ -12,8 +12,10 @@ def test_garden_birds_sensor_handles_missing_common_name_without_template_errors
     text = BIRDS_PATH.read_text(encoding="utf-8")
 
     assert 'name: "Garden Birds"' in text
-    assert "value_json is mapping" in text
-    assert "value_json.common_name is defined" in text
+    sensor_block = text.split('name: "Garden Birds"', 1)[1].split("########################", 1)[0]
+    assert "from_json(default={})" in sensor_block
+    assert "payload.common_name is defined" in sensor_block
+    assert "states('sensor.garden_birds')" in sensor_block
     assert "unknown" in text
 
 

--- a/tests/test_birds_package.py
+++ b/tests/test_birds_package.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BIRDS_PATH = ROOT / "packages" / "birds.yaml"
+
+
+def test_garden_birds_sensor_decodes_html_escaped_json_without_using_raw_payload_as_state() -> None:
+    text = BIRDS_PATH.read_text(encoding="utf-8")
+    sensor_block = text.split('name: "Garden Birds"', 1)[1].split("########################", 1)[0]
+
+    assert "raw_json = raw_value | replace('&#34;', '\"') | replace('&quot;', '\"')" in sensor_block
+    assert "payload = raw_json | from_json(default={})" in sensor_block
+    assert "payload.common_name is defined" in sensor_block
+    assert "raw_value[:1] not in ['{', '[']" in sensor_block
+    assert "states('sensor.garden_birds') | default('unknown', true)" in sensor_block
+
+
+def test_garden_birds_sensor_normalizes_json_attributes_before_parsing() -> None:
+    text = BIRDS_PATH.read_text(encoding="utf-8")
+    sensor_block = text.split('name: "Garden Birds"', 1)[1].split("########################", 1)[0]
+
+    assert "json_attributes_template" in sensor_block
+    assert "{{ payload | tojson }}" in sensor_block
+    assert "{}" in sensor_block


### PR DESCRIPTION
## Summary
- normalize HTML-escaped BirdNet MQTT payloads before parsing them so the garden bird sensor can still extract `common_name`
- stop falling back to the full raw payload as the sensor state, which was exceeding Home Assistant's 255-character state limit
- add focused regression coverage for the sanitized state and attribute parsing paths

## Log context
This addresses the active Home Assistant core log warnings on March 29, 2026 for `sensor.garden_birds` on topic `birdpi/apprise`:
- `Erroneous JSON`
- `Cannot update state ... exceeds the maximum allowed length (255)`
- `Invalid state message ... from 'birdpi/apprise'`

## Validation
- `uv run --with pytest pytest tests/test_birds_package.py tests/test_aircraft_and_birds_packages.py`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/birds.yaml`