### PR TITLE
[codex] Replace legacy egress group with dynamic sensors

### DIFF
--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -163,16 +163,18 @@ automation:
     mode: restart
     trigger:
       - trigger: state
-        entity_id: group.egress_points
+        entity_id: binary_sensor.any_egress_open
+        from: "off"
+        to: "on"
       - trigger: state
         entity_id: binary_sensor.office_occupancy_2
         from: "off"
         to: "on"
     variables:
       open_egress_points: >-
-        {{ expand('group.egress_points') | selectattr('state', 'eq', 'on') | map(attribute='name') | join(', ') }}
+        {{ state_attr('sensor.open_egress_points', 'friendly_names') | default('', true) }}
       trigger_label: >-
-        {% if trigger.entity_id == 'group.egress_points' %}
+        {% if trigger.entity_id == 'binary_sensor.any_egress_open' %}
           {{ open_egress_points if open_egress_points else 'an egress point' }}
         {% else %}
           {{ trigger.to_state.attributes.friendly_name }}

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -31,6 +31,11 @@ homeassistant:
     ################################################
     ## Binary Sensors
     ################################################
+    binary_sensor.any_egress_open:
+      <<: *customize
+      friendly_name: "Any egress open"
+      device_class: opening
+
     binary_sensor.basement_window_contact:
       <<: *customize
       device_class: window
@@ -233,27 +238,13 @@ homeassistant:
     ################################################
 
     ################################################
-    ## Groups
-    ################################################
-    group.egress_points:
-      <<: *customize
-      friendly_name: Sensors on Doors and Windows
-
-    ################################################
-    ## Input Boolean
-    ################################################
-
-    ################################################
-    ## Input Numbers
-    ################################################
-
-    ################################################
-    ## Scripts
-    ################################################
-
-    ################################################
     ## Sensors
     ################################################
+    sensor.open_egress_points:
+      <<: *customize
+      friendly_name: "Open egress points"
+      icon: mdi:door-open
+
     sensor.arrival_sensor_battery:
       <<: *customize
       friendly_name: "Arrival Sensor Battery"
@@ -1767,47 +1758,6 @@ binary_sensor:
 device_tracker: []
 
 ########################
-# Groups
-########################
-group:
-  egress_points:
-    entities:
-      # Canonical egress inventory for security and leave-home automations.
-      - binary_sensor.basement_window_contact
-      - binary_sensor.unfinished_basement_window_contact
-      - binary_sensor.se_basement_window_contact
-      - binary_sensor.sw_basement_window_contact
-      - binary_sensor.deck_door_contact
-      - binary_sensor.dining_room_north_window_contact
-      - binary_sensor.dining_room_south_window_contact
-      - binary_sensor.ene_window_contact
-      - binary_sensor.ese_window_contact
-      - binary_sensor.guest_bathroom_window_contact
-      - binary_sensor.guest_room_window_contact
-      - binary_sensor.hall_garage_entry_contact
-      - binary_sensor.kitchen_bay_middle_window_contact
-      - binary_sensor.kitchen_bay_north_window_contact
-      - binary_sensor.kitchen_bay_south_window_contact
-      - binary_sensor.kitchen_north_window_contact
-      - binary_sensor.kitchen_south_window_contact
-      - binary_sensor.main_foyer_front_door_contact
-      - binary_sensor.nne_window_contact
-      - binary_sensor.north_kitchen_sink_window_contact
-      - binary_sensor.north_master_bedroom_window_contact
-      - binary_sensor.nw_basement_window_contact
-      - binary_sensor.office_window_contact
-      - binary_sensor.office_north_window_contact
-      - binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
-      - binary_sensor.owner_suite_bathroom_bay_north_window_contact
-      - binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
-      - binary_sensor.owner_suite_bathroom_bay_south_window_contact
-      - binary_sensor.owner_suite_north_window_contact
-      - binary_sensor.owner_suite_south_window_contact
-      - binary_sensor.powder_room_window_contact
-      - binary_sensor.sse_window_contact
-      - binary_sensor.tiki_room_deck_contact
-
-########################
 # Input Booleans
 ########################
 input_boolean:
@@ -2828,6 +2778,12 @@ sensor: []
 ########################
 template:
   - binary_sensor:
+      - name: any_egress_open
+        unique_id: any_egress_open
+        default_entity_id: binary_sensor.any_egress_open
+        device_class: opening
+        state: "{{ states('sensor.open_egress_points') | int(0) > 0 }}"
+
       - name: master_bed_occupancy
         unique_id: master_bed_occupancy
         delay_on: 00:00:30
@@ -2856,6 +2812,60 @@ template:
           {% set offline_pct = states('sensor.z2m_router_offline_pct') | float(0) %}
           {% set threshold_pct = states('input_number.z2m_router_offline_threshold_pct') | float(15) %}
           {{ total > 0 and offline_pct >= threshold_pct }}
+
+  - sensor:
+      # Build the egress inventory from live contact entities so stale IDs do
+      # not accumulate in a manually maintained group.
+      - name: open_egress_points
+        unique_id: open_egress_points
+        default_entity_id: sensor.open_egress_points
+        icon: mdi:door-open
+        state: >-
+          {% set excluded = ['binary_sensor.mailbox_contact'] %}
+          {% set open_entities = namespace(entity_ids=[]) %}
+          {% for sensor in states.binary_sensor %}
+            {% set entity_id = sensor.entity_id %}
+            {% set device_class = sensor.attributes.device_class | default('', true) | lower %}
+            {% if sensor.state == 'on'
+                  and entity_id.endswith('_contact')
+                  and entity_id not in excluded
+                  and not entity_id.startswith('binary_sensor.0x')
+                  and device_class in ['door', 'window', 'opening'] %}
+              {% set open_entities.entity_ids = open_entities.entity_ids + [entity_id] %}
+            {% endif %}
+          {% endfor %}
+          {{ open_entities.entity_ids | count }}
+        attributes:
+          entity_ids: >-
+            {% set excluded = ['binary_sensor.mailbox_contact'] %}
+            {% set open_entities = namespace(entity_ids=[]) %}
+            {% for sensor in states.binary_sensor %}
+              {% set entity_id = sensor.entity_id %}
+              {% set device_class = sensor.attributes.device_class | default('', true) | lower %}
+              {% if sensor.state == 'on'
+                    and entity_id.endswith('_contact')
+                    and entity_id not in excluded
+                    and not entity_id.startswith('binary_sensor.0x')
+                    and device_class in ['door', 'window', 'opening'] %}
+                {% set open_entities.entity_ids = open_entities.entity_ids + [entity_id] %}
+              {% endif %}
+            {% endfor %}
+            {{ open_entities.entity_ids | sort | join(', ') }}
+          friendly_names: >-
+            {% set excluded = ['binary_sensor.mailbox_contact'] %}
+            {% set open_entities = namespace(names=[]) %}
+            {% for sensor in states.binary_sensor %}
+              {% set entity_id = sensor.entity_id %}
+              {% set device_class = sensor.attributes.device_class | default('', true) | lower %}
+              {% if sensor.state == 'on'
+                    and entity_id.endswith('_contact')
+                    and entity_id not in excluded
+                    and not entity_id.startswith('binary_sensor.0x')
+                    and device_class in ['door', 'window', 'opening'] %}
+                {% set open_entities.names = open_entities.names + [sensor.name] %}
+              {% endif %}
+            {% endfor %}
+            {{ open_entities.names | sort | join(', ') }}
 
   - lock:
       - name: Front door lock

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -236,10 +236,10 @@ automation:
         to: "off"
     variables:
       open_egress_points: >-
-        {{ expand('group.egress_points') | selectattr('state', 'eq', 'on') | map(attribute='name') | join(', ') }}
+        {{ state_attr('sensor.open_egress_points', 'friendly_names') | default('', true) }}
     condition:
       - condition: state
-        entity_id: group.egress_points
+        entity_id: binary_sensor.any_egress_open
         state: "on"
     action:
       - action: notify.all

--- a/tests/test_window_egress_automation_coverage.py
+++ b/tests/test_window_egress_automation_coverage.py
@@ -6,42 +6,6 @@ CLIMATE_PATH = Path(__file__).resolve().parents[1] / "packages" / "climate.yaml"
 ZONE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zone.yaml"
 ZIGBEE_ZWAVE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zigbee_zwave.yaml"
 
-EGRESS_ENTITY_IDS = (
-    "binary_sensor.basement_window_contact",
-    "binary_sensor.unfinished_basement_window_contact",
-    "binary_sensor.se_basement_window_contact",
-    "binary_sensor.sw_basement_window_contact",
-    "binary_sensor.deck_door_contact",
-    "binary_sensor.dining_room_north_window_contact",
-    "binary_sensor.dining_room_south_window_contact",
-    "binary_sensor.ene_window_contact",
-    "binary_sensor.ese_window_contact",
-    "binary_sensor.guest_bathroom_window_contact",
-    "binary_sensor.guest_room_window_contact",
-    "binary_sensor.hall_garage_entry_contact",
-    "binary_sensor.kitchen_bay_middle_window_contact",
-    "binary_sensor.kitchen_bay_north_window_contact",
-    "binary_sensor.kitchen_bay_south_window_contact",
-    "binary_sensor.kitchen_north_window_contact",
-    "binary_sensor.kitchen_south_window_contact",
-    "binary_sensor.main_foyer_front_door_contact",
-    "binary_sensor.nne_window_contact",
-    "binary_sensor.north_kitchen_sink_window_contact",
-    "binary_sensor.north_master_bedroom_window_contact",
-    "binary_sensor.nw_basement_window_contact",
-    "binary_sensor.office_window_contact",
-    "binary_sensor.office_north_window_contact",
-    "binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact",
-    "binary_sensor.owner_suite_bathroom_bay_north_window_contact",
-    "binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact",
-    "binary_sensor.owner_suite_bathroom_bay_south_window_contact",
-    "binary_sensor.owner_suite_north_window_contact",
-    "binary_sensor.owner_suite_south_window_contact",
-    "binary_sensor.powder_room_window_contact",
-    "binary_sensor.sse_window_contact",
-    "binary_sensor.tiki_room_deck_contact",
-)
-
 
 def _automation_block(path: Path, automation_id: str) -> str:
     lines = path.read_text(encoding="utf-8").splitlines()
@@ -74,27 +38,37 @@ def _automation_block(path: Path, automation_id: str) -> str:
 def test_motion_detected_on_trip_watches_all_known_window_and_egress_contacts() -> None:
     block = _automation_block(ALERTS_PATH, "motion_detected_on_trip")
 
-    assert "entity_id: group.egress_points" in block
+    assert "entity_id: binary_sensor.any_egress_open" in block
+    assert 'from: "off"' in block
+    assert 'to: "on"' in block
     assert "entity_id: binary_sensor.office_occupancy_2" in block
-    assert "expand('group.egress_points')" in block
+    assert "state_attr('sensor.open_egress_points', 'friendly_names')" in block
+    assert "| default('', true)" in block
     assert "trigger_label" in block
     assert "Activity detected at {{ trigger_label }} while you're away!" in block
+    assert "group.egress_points" not in block
 
 
 def test_doors_open_when_leaving_home_checks_windows_and_doors() -> None:
     block = _automation_block(ZONE_PATH, "doors_open_when_leaving_home")
 
-    assert "entity_id: group.egress_points" in block
+    assert "entity_id: binary_sensor.any_egress_open" in block
     assert 'state: "on"' in block
-    assert "expand('group.egress_points')" in block
+    assert "state_attr('sensor.open_egress_points', 'friendly_names')" in block
+    assert "| default('', true)" in block
     assert "Door or window left open: {{ open_egress_points }}." in block
+    assert "group.egress_points" not in block
 
 
-def test_egress_group_centralizes_all_window_and_door_contacts() -> None:
+def test_dynamic_egress_sensors_replace_legacy_group() -> None:
     text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
 
-    for entity_id in EGRESS_ENTITY_IDS:
-        assert entity_id in text
+    assert "default_entity_id: sensor.open_egress_points" in text
+    assert "default_entity_id: binary_sensor.any_egress_open" in text
+    assert "entity_id.endswith('_contact')" in text
+    assert "device_class in ['door', 'window', 'opening']" in text
+    assert "binary_sensor.mailbox_contact" in text
+    assert "group.egress_points" not in text
 
 
 def test_fresh_air_open_reuses_any_window_open_state() -> None:


### PR DESCRIPTION
## Summary
- replace the hard-coded `group.egress_points` helper with dynamic `sensor.open_egress_points` and `binary_sensor.any_egress_open` templates
- repoint the away-alert and leave-home automations to the new dynamic sensors
- update regression coverage so the legacy group cannot quietly return

## Why
Spook flagged `group.egress_points` because it was still carrying stale contact entity IDs that no longer exist at runtime. The group was still in use, so removing it outright would have broken alerts. Replacing it with dynamic sensors keeps the behavior while eliminating the manual member list that drifted.

## Impact
- away-mode intrusion alerts now trigger from `binary_sensor.any_egress_open`
- leave-home notifications pull open-point names from `sensor.open_egress_points`
- future contact renames/removals no longer require hand-editing a static egress group

## Validation
- `uv run --with pytest pytest`
- Home Assistant `ha_check_config` returned `valid`

Closes #265