### PR TITLE
[codex] Guard root automations placeholder drift

### DIFF
--- a/tests/test_root_automations_placeholder.py
+++ b/tests/test_root_automations_placeholder.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+AUTOMATIONS_PATH = Path(__file__).resolve().parents[1] / "automations.yaml"
+
+
+def test_root_automations_yaml_stays_as_empty_placeholder() -> None:
+    lines = [line.rstrip() for line in AUTOMATIONS_PATH.read_text(encoding="utf-8").splitlines()]
+
+    assert lines[0] == "# Intentionally kept empty."
+    assert lines[1] == (
+        "# This repo stores automations inside domain packages so behavior stays grouped "
+        "with the entities and helpers it depends on."
+    )
+    assert lines[-1] == "[]"
+    assert not any(line.lstrip().startswith("- id:") for line in lines)

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -44,8 +44,10 @@ def test_bedroom_hour_of_day_remains_numeric() -> None:
 def test_bird_templates_guard_missing_json_fields() -> None:
     text = _read(BIRDS_PATH)
 
-    assert "value_json is defined and value_json is mapping and value_json.common_name is defined" in text
-    assert "{{ value }}" in text
+    assert "{% set raw_value = value | default('', true) | trim %}" in text
+    assert "{% set raw_json = raw_value | replace('&#34;', '\"') | replace('&quot;', '\"') %}" in text
+    assert "{% set payload = raw_json | from_json(default={}) %}" in text
+    assert "payload is mapping and payload.common_name is defined" in text
     assert "value_json is defined and value_json is mapping and value_json.species is defined and value_json.species | count > 0" in text
     assert "value_json is defined and value_json is mapping and value_json.detections is defined and value_json.detections | length > 0" in text
 


### PR DESCRIPTION
## Summary
- add a regression test that keeps root `automations.yaml` as the intentional empty placeholder
- refresh the bird runtime-log regression assertion so it matches the current guarded JSON parsing in `packages/birds.yaml`
- close #276 with a repo-side guard after confirming the live HAOS `automations.yaml` entries were drift, not source-of-truth config

## Why
- the live HAOS box had uncommitted content in `/config/automations.yaml` even though active window-climate automations already live in `packages/climate.yaml`
- the Tiki Room ESPHome trace automation was already introduced for issue-205 debugging and intentionally removed in PR #231
- keeping root `automations.yaml` empty by test helps catch future live-only drift before it lands in git

## Validation
- `uv run --with pytest pytest`

Closes #276.