### PR TITLE
Remove deprecated weatheralerts YAML config

### DIFF
--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -698,11 +698,6 @@ sensor:
   #  - visibility
   #  - ozone
 
-  - platform: weatheralerts
-    state: !secret home_state
-    zone: !secret nws_zone
-    county: !secret nws_county
-
   # Follow the Tesla's coordinates so rain detection works away from home.
   - platform: rest
     name: nigori_precip_next_2hr

--- a/tests/test_issue_weatheralerts_yaml_deprecation.py
+++ b/tests/test_issue_weatheralerts_yaml_deprecation.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WEATHER_PATH = Path(__file__).resolve().parents[1] / "packages" / "weather.yaml"
+
+
+def test_weather_package_uses_ui_managed_nws_alerts_instead_of_weatheralerts_yaml() -> None:
+    text = WEATHER_PATH.read_text(encoding="utf-8")
+
+    assert "sensor.nws_alerts" in text
+    assert "sensor.nws_dakota_county_alerts_active_alerts" in text
+    assert "sensor.nws_dakota_county_alerts_alerts_are_active" in text
+    assert "- platform: weatheralerts" not in text
+    assert "state: !secret home_state" not in text
+    assert "zone: !secret nws_zone" not in text
+    assert "county: !secret nws_county" not in text


### PR DESCRIPTION
Remove the deprecated `weatheralerts` YAML sensor block from `packages/weather.yaml` so the package relies on the UI-managed NWS alerts path only.

Tests:
- `uv run --with pytest pytest tests/test_issue_weatheralerts_yaml_deprecation.py tests/test_weather_package.py`
- `uv run --with pytest pytest`

No matching existing issue was found in the repo issue search.