### PR TITLE
Fix gas price live sensor parsing

### DIFF
--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -712,11 +712,11 @@ rest:
         icon: mdi:gas-station
         unit_of_measurement: USD/gal
         value_template: >-
-          {% set match = value | regex_findall_index('Week Ago Avg\\.\\s*\\$([0-9]+\\.[0-9]+)', 0) %}
-          {% if match not in [none, ''] %}
-            {{ match | float(default=0) | round(2) }}
+          {% set matches = value | regex_findall('Week Ago Avg\\.\\s*\\$([0-9]+\\.[0-9]+)') %}
+          {% if matches | count > 0 %}
+            {{ matches[0] | float(default=0) | round(2) }}
           {% else %}
-            {{ 'unknown' }}
+            {{ none }}
           {% endif %}
 
 ########################

--- a/tests/test_ev_cost_comparison.py
+++ b/tests/test_ev_cost_comparison.py
@@ -18,6 +18,7 @@ def test_utilities_package_defines_weekly_gas_price_and_ev_comparison_sensors() 
         "resource: https://www.way.com/gas/prices/minnesota/woodbury",
         "woodbury_weekly_regular_gas_price_live",
         "Week Ago Avg.",
+        "regex_findall(",
         "weekly_regular_gas_price_55125",
         "average_daily_ev_charging_cost",
         "average_daily_vehicle_miles",

--- a/tests/test_issue_gas_price_live_sensor.py
+++ b/tests/test_issue_gas_price_live_sensor.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+UTILITIES_PATH = Path(__file__).resolve().parents[1] / "packages" / "utilities.yaml"
+
+
+def test_gas_price_live_sensor_guards_missing_scraped_matches() -> None:
+    text = UTILITIES_PATH.read_text(encoding="utf-8")
+
+    assert "name: Woodbury Weekly Regular Gas Price Live" in text
+    assert "regex_findall_index(" not in text
+    assert "regex_findall('Week Ago Avg\\\\.\\\\s*\\\\$([0-9]+\\\\.[0-9]+)')" in text
+    assert "{{ matches[0] | float(default=0) | round(2) }}" in text
+    assert "{{ none }}" in text


### PR DESCRIPTION
## Summary
- guard the Way.com gas-price scrape against missing regex matches
- return `none` instead of throwing a template parsing error during startup
- add focused regression coverage for the live gas-price sensor

## Testing
- `uv run --with pytest pytest tests/test_issue_gas_price_live_sensor.py tests/test_ev_cost_comparison.py`
- `uv run --with pytest pytest`

## Issue tracking
- No matching existing issue was found in `rtclauss/hass-config` for this item.
- The GitHub connector available in this run can search/fetch issues but cannot create new ones, so this PR is the only GitHub artifact I could open automatically for now.