### PR TITLE
Fix house electrical meter state class

### DIFF
--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -772,7 +772,7 @@ template:
       - name: house_electrical_meter
         unique_id: house_electrical_meter
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         unit_of_measurement: kWh
         availability: >
           {{ states('sensor.filtered_raw_electrical_sensor') not in ['unknown', 'unavailable', 'none', 'None', ''] }}

--- a/tests/test_ev_cost_comparison.py
+++ b/tests/test_ev_cost_comparison.py
@@ -62,7 +62,7 @@ def test_utilities_package_keeps_the_raw_meter_as_measurement_only() -> None:
     text = UTILITIES_PATH.read_text(encoding="utf-8")
 
     assert "name: house_electrical_meter" in text
-    assert "state_class: measurement" in text
+    assert "state_class: total_increasing" in text
     assert "name: house_electrical_meter_non_ev" in text
     assert "state_class: total_increasing" in text
     assert "states('device_tracker.nigori_location_tracker') | default('', true) | lower != 'home'" in text

--- a/tests/test_issue_house_electrical_meter_state_class.py
+++ b/tests/test_issue_house_electrical_meter_state_class.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+UTILITIES_PATH = Path(__file__).resolve().parents[1] / "packages" / "utilities.yaml"
+
+
+def test_house_electrical_meter_uses_energy_compatible_state_class() -> None:
+    text = UTILITIES_PATH.read_text(encoding="utf-8")
+
+    block = text.split("name: house_electrical_meter", 1)[1].split(
+        "name: house_electrical_meter_non_ev", 1
+    )[0]
+    assert "device_class: energy" in block
+    assert "state_class: total_increasing" in block
+    assert "state_class: measurement" not in block


### PR DESCRIPTION
## Summary
- change `sensor.house_electrical_meter` to an energy-compatible `total_increasing` state class
- keep the existing non-EV meter semantics intact
- add focused regression coverage for the template sensor metadata

## Testing
- `uv run --with pytest pytest tests/test_issue_house_electrical_meter_state_class.py tests/test_ev_cost_comparison.py`
- `uv run --with pytest pytest`

## Issue tracking
- No matching existing issue was found in `rtclauss/hass-config` for this item.
- The GitHub connector available in this run can search/fetch issues but cannot create new ones, so this PR is the only GitHub artifact I could open automatically for now.