### PR TITLE
Fix tire rotation startup parsing

### DIFF
--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -633,7 +633,11 @@ automation:
       - trigger: numeric_state
         entity_id: sensor.nigori_odometer
         value_template: >-
-          {{ state | int % 6250  }}
+          {% if has_value('sensor.nigori_odometer') %}
+            {{ (states('sensor.nigori_odometer') | float(default=0)) % 6250 }}
+          {% else %}
+            6250
+          {% endif %}
         below: 20
     condition:
     action:

--- a/tests/test_issue_tire_rotation_trigger.py
+++ b/tests/test_issue_tire_rotation_trigger.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+CAR_PATH = Path(__file__).resolve().parents[1] / "packages" / "car.yaml"
+
+
+def test_tire_rotations_trigger_template_handles_missing_odometer_values() -> None:
+    text = CAR_PATH.read_text(encoding="utf-8")
+
+    assert "alias: Tire Rotations" in text
+    assert "id: tire_rotation" in text
+    assert "trigger: numeric_state" in text
+    assert "entity_id: sensor.nigori_odometer" in text
+    assert "state | int" not in text
+    assert "has_value('sensor.nigori_odometer')" in text
+    assert "states('sensor.nigori_odometer') | float(default=0)" in text
+    assert re.search(r"below:\s+20", text)


### PR DESCRIPTION
Fix the `Tire Rotations` `numeric_state` trigger so it does not try to parse the raw `state` object during startup or when the odometer is unavailable.

Changes:
- Replace the brittle `state | int` template with a guarded `has_value()` + `states()` conversion.
- Add a focused regression test for the trigger block.

Validation:
- `uv run --with pytest pytest tests/test_issue_tire_rotation_trigger.py`
- `uv run --with pytest pytest`

No matching open issue was found for this specific warning.