### PR TITLE
Fix guest Wi-Fi template warnings

### DIFF
--- a/packages/guest.yaml
+++ b/packages/guest.yaml
@@ -346,17 +346,14 @@ template:
       - default_entity_id: binary_sensor.guest_on_wifi
         unique_id: guest_on_wifi
         state: >-
-          {% set state = states('sensor.barley_guest') %} {% if is_number(state) and state | float >= 1 %}
-            True
-          {% else %}
-            False
-          {% endif %}"
+          {% set state = states('sensor.barley_guest') %}
+          {{ is_number(state) and state | float >= 1 }}
         name: guest_on_wifi
   - sensor:
       - name: guests_on_wifi
         unique_id: guests_on_wifi
         state: >-
-          {{ (states.device_tracker | selectattr('state','eq','home') | selectattr('attributes.is_guest', 'eq', true) | list) }}
+          {{ states.device_tracker | selectattr('state', 'eq', 'home') | selectattr('attributes.is_guest', 'eq', true) | list | count }}
 
 ########################
 # Zone

--- a/tests/test_issue_guest_wifi_state.py
+++ b/tests/test_issue_guest_wifi_state.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+GUEST_PATH = Path(__file__).resolve().parents[1] / "packages" / "guest.yaml"
+
+
+def test_guest_wifi_templates_emit_boolean_and_short_count() -> None:
+    text = GUEST_PATH.read_text(encoding="utf-8")
+
+    assert "unique_id: guest_on_wifi" in text
+    assert "{{ is_number(state) and state | float >= 1 }}" in text
+    assert "unique_id: guests_on_wifi" in text
+    assert (
+        "{{ states.device_tracker | selectattr('state', 'eq', 'home') | "
+        "selectattr('attributes.is_guest', 'eq', true) | list | count }}"
+    ) in text


### PR DESCRIPTION
This fixes the guest Wi-Fi template warnings by:
- rendering `binary_sensor.guest_on_wifi` as a boolean expression
- reducing `sensor.guests_on_wifi` to a short numeric count instead of a list
- adding a regression test for the guest Wi-Fi template block

Validation:
- `uv run --with pytest pytest tests/test_issue_guest_wifi_state.py`
- `uv run --with pytest pytest`

No matching existing issue was found in the repo search.