### PR TITLE
Update laundry Lovelace running sensors

### DIFF
--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -2370,10 +2370,10 @@
                   "type": "entities",
                   "entities": [
                     {
-                      "entity": "sensor.front_load_washer"
+                      "entity": "binary_sensor.washing_machine_running"
                     },
                     {
-                      "entity": "sensor.dryer"
+                      "entity": "binary_sensor.dryer_running"
                     }
                   ]
                 },
@@ -2398,8 +2398,15 @@
                   "chips": [
                     {
                       "type": "entity",
-                      "entity": "binary_sensor.laundry_washer_vibration_vibration",
+                      "entity": "binary_sensor.washing_machine_running",
+                      "name": "Washer",
                       "icon": "mdi:washing-machine"
+                    },
+                    {
+                      "type": "entity",
+                      "entity": "binary_sensor.dryer_running",
+                      "name": "Dryer",
+                      "icon": "mdi:tumble-dryer"
                     }
                   ]
                 }
@@ -3215,11 +3222,11 @@
                 {
                   "type": "custom:mushroom-template-card",
                   "primary": "Washer",
-                  "secondary": "{% if is_state(\"sensor.front_load_washer\", \"on\") %}\nRunning {{ state_attr(\"sensor.front_load_washer\", \"current_course\") }}\nCurrently {{ state_attr(\"sensor.front_load_washer\", \"run_state\") }}\n{{ state_attr(\"sensor.front_load_washer\", \"initial_time\") }} total, {{ state_attr(\"sensor.front_load_washer\", \"remain_time\") }} to go\n{% elif state_attr(\"sensor.front_load_washer\", \"run_completed\") == \"on\" %}\nReady to unload\n{% else %}\nOff\n{% endif %}",
+                  "secondary": "{% set power = states(\"sensor.laundry_room_washing_machine_power\") %}\n{% set current = states(\"sensor.laundry_room_washing_machine_current\") %}\n{% if power in [\"unknown\", \"unavailable\"] or current in [\"unknown\", \"unavailable\"] %}\nTelemetry unavailable\n{% elif is_state(\"binary_sensor.washing_machine_running\", \"on\") %}\nRunning\n{{ power }} W \u00b7 {{ current }} A\n{% else %}\nIdle\n{{ power }} W \u00b7 {{ current }} A\n{% endif %}",
                   "icon": "mdi:washing-machine",
-                  "entity": "sensor.front_load_washer",
+                  "entity": "binary_sensor.washing_machine_running",
                   "multiline_secondary": true,
-                  "icon_color": "{{ \"indigo\" if is_state(\"sensor.front_load_washer\", \"on\") else \"\" }}",
+                  "icon_color": "{{ \"indigo\" if is_state(\"binary_sensor.washing_machine_running\", \"on\") else \"\" }}",
                   "tap_action": {
                     "action": "more-info"
                   }
@@ -3227,11 +3234,11 @@
                 {
                   "type": "custom:mushroom-template-card",
                   "primary": "Dryer",
-                  "secondary": "{% if is_state(\"sensor.dryer\", \"on\") %}\nRunning {{ state_attr(\"sensor.dryer\", \"current_course\") }}\nCurrently {{ state_attr(\"sensor.dryer\", \"run_state\") }}\n{{ state_attr(\"sensor.dryer\", \"initial_time\") }} total, {{ state_attr(\"sensor.dryer\", \"remain_time\") }} to go\n{% elif state_attr(\"sensor.front_load_washer\", \"run_completed\") == \"on\" %}\nReady to unload\n{% else %}\nOff\n{% endif %}",
+                  "secondary": "{% set power = states(\"sensor.laundry_room_dryer_power\") %}\n{% set current = states(\"sensor.laundry_room_dryer_current\") %}\n{% if power in [\"unknown\", \"unavailable\"] or current in [\"unknown\", \"unavailable\"] %}\nTelemetry unavailable\n{% elif is_state(\"binary_sensor.dryer_running\", \"on\") %}\nRunning\n{{ power }} W \u00b7 {{ current }} A\n{% else %}\nIdle\n{{ power }} W \u00b7 {{ current }} A\n{% endif %}",
                   "icon": "mdi:tumble-dryer",
-                  "entity": "sensor.dryer",
+                  "entity": "binary_sensor.dryer_running",
                   "multiline_secondary": true,
-                  "icon_color": "{{ \"indigo\" if is_state(\"sensor.dryer\", \"on\") else \"\" }}",
+                  "icon_color": "{{ \"indigo\" if is_state(\"binary_sensor.dryer_running\", \"on\") else \"\" }}",
                   "tap_action": {
                     "action": "more-info"
                   }

--- a/tests/test_laundry_lovelace_dashboard.py
+++ b/tests/test_laundry_lovelace_dashboard.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD_PATH = ROOT / ".storage" / "lovelace.ryan_new_mushroom"
+
+
+def _dashboard_config() -> dict:
+    dashboard = json.loads(DASHBOARD_PATH.read_text(encoding="utf-8"))
+    return dashboard["data"]["config"]
+
+
+def _find_dashboard_section_cards(config: dict, *, heading: str) -> list[dict]:
+    for view in config["views"]:
+        cards = _find_view_section_cards(view, heading=heading)
+        if cards is not None:
+            return cards
+    raise AssertionError(f"Could not find section with heading {heading!r}")
+
+
+def _find_view_section_cards(view: dict, *, heading: str) -> list[dict] | None:
+    for section in view.get("sections", []):
+        cards = section.get("cards", [])
+        if any(card.get("heading") == heading for card in cards):
+            return cards
+    return None
+
+
+def _find_cleaning_card(config: dict, *, primary: str) -> dict:
+    cleaning_view = next(
+        (view for view in config["views"] if view.get("title") == "Cleaning-v2"),
+        None,
+    )
+    assert cleaning_view is not None, "Cleaning-v2 view should exist"
+
+    clothes_cards = _find_view_section_cards(cleaning_view, heading="Clothes")
+    assert clothes_cards is not None, "Cleaning-v2 should expose a Clothes section"
+    for card in clothes_cards:
+        if card.get("primary") == primary:
+            return card
+    raise AssertionError(f"Could not find {primary!r} card in Cleaning-v2")
+
+
+def test_main_floor_laundry_room_cards_use_running_binary_sensors() -> None:
+    config = _dashboard_config()
+    laundry_cards = _find_dashboard_section_cards(config, heading="Laundry Room")
+
+    entities_card = next(card for card in laundry_cards if card.get("type") == "entities")
+    assert [entry["entity"] for entry in entities_card["entities"]] == [
+        "binary_sensor.washing_machine_running",
+        "binary_sensor.dryer_running",
+    ]
+
+    chips_card = next(
+        card for card in laundry_cards if card.get("type") == "custom:mushroom-chips-card"
+    )
+    assert [(chip["entity"], chip["name"], chip["icon"]) for chip in chips_card["chips"]] == [
+        ("binary_sensor.washing_machine_running", "Washer", "mdi:washing-machine"),
+        ("binary_sensor.dryer_running", "Dryer", "mdi:tumble-dryer"),
+    ]
+
+
+def test_cleaning_view_clothes_cards_use_power_based_binary_sensors() -> None:
+    config = _dashboard_config()
+
+    washer_card = _find_cleaning_card(config, primary="Washer")
+    assert washer_card["entity"] == "binary_sensor.washing_machine_running"
+    assert "sensor.laundry_room_washing_machine_power" in washer_card["secondary"]
+    assert "sensor.laundry_room_washing_machine_current" in washer_card["secondary"]
+    assert "sensor.front_load_washer" not in washer_card["secondary"]
+    assert "binary_sensor.washing_machine_running" in washer_card["icon_color"]
+
+    dryer_card = _find_cleaning_card(config, primary="Dryer")
+    assert dryer_card["entity"] == "binary_sensor.dryer_running"
+    assert "sensor.laundry_room_dryer_power" in dryer_card["secondary"]
+    assert "sensor.laundry_room_dryer_current" in dryer_card["secondary"]
+    assert 'is_state("sensor.dryer"' not in dryer_card["secondary"]
+    assert "binary_sensor.dryer_running" in dryer_card["icon_color"]


### PR DESCRIPTION
## Summary
- replace stale laundry dashboard entities with the new washer and dryer running binary sensors
- update the cleaning view cards to show power/current-backed running state
- add regression coverage for the Lovelace dashboard storage config

## Testing
- uv run --with pytest pytest