### PR TITLE
Add Tesla TPMS air reminder to preconditioning planner

### DIFF
--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -229,7 +229,7 @@ automation:
             {% set tariff_name = tariff | lower %}
             {% set tariff_display = tariff | replace('_', '-') | title %}
             {% set high_tariff = tariff_name in ['on_peak', 'on-peak', 'onpeak'] or electrical_rate >= 0.13 %}
-            {% set tpms_reminder_threshold_psi = 41 %}
+            {% set tpms_reminder_threshold_psi = states('input_number.tesla_tpms_air_threshold_psi') | float(default=38) %}
             {% set tpms_readings = [
               {'label': 'front left', 'psi': states('sensor.nigori_tpms_front_left') | float(default=999)},
               {'label': 'front right', 'psi': states('sensor.nigori_tpms_front_right') | float(default=999)},
@@ -724,6 +724,15 @@ input_number:
     mode: box
     unit_of_measurement: s
     icon: mdi:calendar-clock
+  tesla_tpms_air_threshold_psi:
+    name: Tesla TPMS Air Threshold
+    initial: 38
+    min: 30
+    max: 50
+    step: 1
+    mode: slider
+    unit_of_measurement: psi
+    icon: mdi:gauge-low
   # nigori_charge_limit:
   #   name: Nigori Charge Limit
   #   min: 0

--- a/tests/test_tesla_charging_dashboard.py
+++ b/tests/test_tesla_charging_dashboard.py
@@ -78,7 +78,11 @@ def test_dashboard_copy_explains_alarm_only_days_and_home_schedule_override_logi
 def test_preconditioning_plan_includes_low_tpms_air_reminder() -> None:
     package_text = CAR_PACKAGE_PATH.read_text(encoding="utf-8")
 
-    assert "{% set tpms_reminder_threshold_psi = 41 %}" in package_text
+    assert "tesla_tpms_air_threshold_psi:" in package_text
+    assert "name: Tesla TPMS Air Threshold" in package_text
+    assert "initial: 38" in package_text
+    assert "unit_of_measurement: psi" in package_text
+    assert "states('input_number.tesla_tpms_air_threshold_psi') | float(default=38)" in package_text
     assert "sensor.nigori_tpms_front_left" in package_text
     assert "sensor.nigori_tpms_front_right" in package_text
     assert "sensor.nigori_tpms_rear_left" in package_text


### PR DESCRIPTION
## Summary
- add a TPMS-based air reminder to the Tesla departure planner when preconditioning is active
- repeat the reminder on the early-morning planner run if tire pressure is still low
- make the TPMS air threshold configurable with an input number defaulting to 38 psi

## Testing
- uv run --with pytest pytest