### PR TITLE
Guard house temp change rate templates

### DIFF
--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -1076,17 +1076,19 @@ template:
         default_entity_id: sensor.rate_of_house_temp_change_1h
         unique_id: rate_of_house_temp_change_1h
         availability: >-
-          {{ states("sensor.house_temperature_stats_1h", "change_rate") != None }}
+          {{ state_attr('sensor.house_temperature_stats_1h', 'change_rate') is not none }}
         state: >-
-          {{ state_attr('sensor.house_temperature_stats_1h', 'change_rate') * 60.0 * 5.0 |float(default=0)}}
+          {% set change_rate = state_attr('sensor.house_temperature_stats_1h', 'change_rate') %}
+          {{ (change_rate | float(default=0)) * 60.0 * 5.0 }}
         name: rate_of_house_temp_change_1h
       - unit_of_measurement: °F/5 minute
         default_entity_id: sensor.rate_of_house_temp_change_30m
         unique_id: rate_of_house_temp_change_30m
         availability: >-
-          {{ states("sensor.house_temperature_stats_30m", "change_rate") != None }}
+          {{ state_attr('sensor.house_temperature_stats_30m', 'change_rate') is not none }}
         state: >-
-          {{ state_attr('sensor.house_temperature_stats_30m', 'change_rate') * 60.0 * 5.0 |float(default=0)}}
+          {% set change_rate = state_attr('sensor.house_temperature_stats_30m', 'change_rate') %}
+          {{ (change_rate | float(default=0)) * 60.0 * 5.0 }}
         name: rate_of_house_temp_change_30m
       - device_class: temperature
         unit_of_measurement: °F

--- a/tests/test_issue_climate_temp_rate.py
+++ b/tests/test_issue_climate_temp_rate.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+CLIMATE_PATH = Path(__file__).resolve().parents[1] / "packages" / "climate.yaml"
+
+
+def test_house_temp_rate_templates_guard_missing_change_rate_attributes() -> None:
+    text = CLIMATE_PATH.read_text(encoding="utf-8")
+
+    assert "state_attr('sensor.house_temperature_stats_1h', 'change_rate') is not none" in text
+    assert "state_attr('sensor.house_temperature_stats_30m', 'change_rate') is not none" in text
+    assert "{% set change_rate = state_attr('sensor.house_temperature_stats_1h', 'change_rate') %}" in text
+    assert "{% set change_rate = state_attr('sensor.house_temperature_stats_30m', 'change_rate') %}" in text
+    assert "{{ (change_rate | float(default=0)) * 60.0 * 5.0 }}" in text


### PR DESCRIPTION
## Summary
- guard the 1h and 30m house temperature change-rate templates against missing `change_rate` attributes
- avoid `NoneType * float` template errors during startup
- add focused regression coverage for the 1h and 30m template blocks

## Testing
- `uv run --with pytest pytest tests/test_issue_climate_temp_rate.py`
- `uv run --with pytest pytest`

## Issue tracking
- No matching existing issue was found in `rtclauss/hass-config` for this item.
- The GitHub connector available in this run can search/fetch issues but cannot create new ones, so this PR is the only GitHub artifact I could open automatically for now.