### PR TITLE
Add percent unit to outside humidity

### DIFF
--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -3392,6 +3392,7 @@ template:
     - name: outside_humidity
       unique_id: outside_humidity
       device_class: humidity
+      unit_of_measurement: "%"
       state: "{{ state_attr('sensor.active_weather_entity_id', 'humidity') | int(default=0) }}"
 
     - name: outside_temperature

--- a/tests/test_issue_outside_humidity_unit.py
+++ b/tests/test_issue_outside_humidity_unit.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WEATHER_PATH = Path(__file__).resolve().parents[1] / "packages" / "weather.yaml"
+
+
+def test_outside_humidity_sensor_uses_percent_unit() -> None:
+    text = WEATHER_PATH.read_text(encoding="utf-8")
+
+    block = text.split("- name: outside_humidity", 1)[1].split("- name: outside_temperature", 1)[0]
+    assert 'device_class: humidity' in block
+    assert 'unit_of_measurement: "%"' in block


### PR DESCRIPTION
## Summary
- add the missing `%` native unit to `sensor.outside_humidity`
- align the template sensor metadata with the Home Assistant humidity device class
- add focused regression coverage for the outside humidity block

## Testing
- `uv run --with pytest pytest tests/test_issue_outside_humidity_unit.py tests/test_weather_package.py`
- `uv run --with pytest pytest`

## Issue tracking
- No matching existing issue was found in `rtclauss/hass-config` for this item.
- The GitHub connector available in this run can search/fetch issues but cannot create new ones, so this PR is the only GitHub artifact I could open automatically for now.