### PR TITLE
Use state check for Tesla planner home

### DIFF
--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -174,9 +174,9 @@ automation:
       - condition: state
         entity_id: binary_sensor.nigori_parking_brake
         state: "on"
-      - condition: zone
+      - condition: state
         entity_id: device_tracker.nigori_location_tracker
-        zone: zone.home
+        state: "home"
     action:
       - choose:
           - conditions:

--- a/tests/test_issue_tesla_planner_home_condition.py
+++ b/tests/test_issue_tesla_planner_home_condition.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+CAR_PATH = Path(__file__).resolve().parents[1] / "packages" / "car.yaml"
+
+
+def _automation_block(automation_id: str) -> str:
+    text = CAR_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(rf"^  - id: {re.escape(automation_id)}\n(.*?)(?=^  - id: |\Z)", re.MULTILINE | re.DOTALL)
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+    return match.group(0)
+
+
+def test_tesla_departure_planner_uses_state_check_for_home_presence() -> None:
+    block = _automation_block("tesla_departure_planner_apply")
+
+    assert 'entity_id: device_tracker.nigori_location_tracker' in block
+    assert 'condition: zone' not in block
+    assert 'state: "home"' in block
+    assert 'zone: zone.home' not in block


### PR DESCRIPTION
## Summary
- replace the fragile `zone` condition in `tesla_departure_planner_apply`
- use the Tesla location tracker state directly so startup evaluation does not fail on `zone.home`
- add focused regression coverage for the planner home condition

## Testing
- `uv run --with pytest pytest tests/test_issue_tesla_planner_home_condition.py tests/test_repair_followups.py tests/test_runtime_log_regressions.py`
- `uv run --with pytest pytest`

## Issue tracking
- No matching existing issue was found in `rtclauss/hass-config` for this item.
- The GitHub connector available in this run can search/fetch issues but cannot create new ones, so this PR is the only GitHub artifact I could open automatically for now.