### PR TITLE
Guard closest aircraft template attributes

### DIFF
--- a/packages/airplanes.yaml
+++ b/packages/airplanes.yaml
@@ -330,6 +330,7 @@ template:
           {% set max_km = 5 * 1.609344 %}
 
           {% set ns = namespace(best=None, best_d=999999) %}
+          {% if home_lat is not none and home_lon is not none %}
           {% for p in planes %}
             {% set lat = p.lat | default(none) %}
             {% set lon = p.lon | default(none) %}
@@ -345,6 +346,7 @@ template:
               {% endif %}
             {% endif %}
           {% endfor %}
+          {% endif %}
 
           {% if ns.best %}
             {% set cs = (ns.best.flight | default('')) | trim %}
@@ -366,6 +368,7 @@ template:
             {% set max_km = 5 * 1.609344 %}
 
             {% set ns = namespace(best=None, best_d=999999) %}
+            {% if home_lat is not none and home_lon is not none %}
             {% for p in planes %}
               {% set lat = p.lat | default(none) %}
               {% set lon = p.lon | default(none) %}
@@ -381,19 +384,20 @@ template:
                 {% endif %}
               {% endif %}
             {% endfor %}
+            {% endif %}
             {{ ns.best if ns.best else dict() }}
 
           hex: >-
-            {% set p = this.attributes.raw %}
+            {% set p = this.attributes.get('raw') %}
             {{ p.hex if p and p.hex is defined else none }}
 
           callsign: >-
-            {% set p = this.attributes.raw %}
+            {% set p = this.attributes.get('raw') %}
             {% set cs = (p.flight | default('')) | trim if p else '' %}
             {{ cs if cs != '' else none }}
 
           altitude_ft: >-
-            {% set p = this.attributes.raw %}
+            {% set p = this.attributes.get('raw') %}
             {% if p %}
               {{ p.alt_baro if p.alt_baro is defined else (p.alt_geom if p.alt_geom is defined else none) }}
             {% else %}
@@ -402,39 +406,41 @@ template:
 
           distance_km: >-
             {# Use computed distance from selection pass, if present in feed; else recompute #}
-            {% set p = this.attributes.raw %}
-            {% if p and p.lat is defined and p.lon is defined %}
-              {% set home_lat = state_attr('zone.home', 'latitude') %}
-              {% set home_lon = state_attr('zone.home', 'longitude') %}
-              {{ distance(home_lat, home_lon, p.lat, p.lon) | round(3) }}
+            {% set p = this.attributes.get('raw') %}
+            {% set home_lat = state_attr('zone.home', 'latitude') %}
+            {% set home_lon = state_attr('zone.home', 'longitude') %}
+            {% if p and p.lat is defined and p.lon is defined and home_lat is not none and home_lon is not none %}
+              {% set d_km = distance(home_lat, home_lon, p.lat, p.lon) %}
+              {{ d_km | round(3) if d_km is not none else none }}
             {% else %}
               {{ none }}
             {% endif %}
 
           distance_mi: >-
-            {% if this.attributes.distance_km is not none %}
-              {{ (this.attributes.distance_km | float * 0.621371) | round(2) }}
+            {% set distance_km = this.attributes.get('distance_km') %}
+            {% if distance_km is not none %}
+              {{ (distance_km | float(default=0)) * 0.621371 | round(2) }}
             {% else %}
               {{ none }}
             {% endif %}
 
           # Plane description + ICAO type code
           desc: >-
-            {% set p = this.attributes.raw %}
+            {% set p = this.attributes.get('raw') %}
             {{ p.desc if p and p.desc is defined else none }}
 
           type_code: >-
-            {% set p = this.attributes.raw %}
+            {% set p = this.attributes.get('raw') %}
             {{ p.t if p and p.t is defined else none }}
 
           # Military flag comes directly from your feed (best)
           is_military: >-
-            {% set p = this.attributes.raw %}
+            {% set p = this.attributes.get('raw') %}
             {{ p.is_military | default(false) if p else false }}
 
           # Route: best-effort from whatever your feed has
           route: >-
-            {% set p = this.attributes.raw %}
+            {% set p = this.attributes.get('raw') %}
             {% if not p %}
               {{ none }}
             {% elif p.route is defined and (p.route | string | trim) != '' %}

--- a/tests/test_issue_aircraft_template_guards.py
+++ b/tests/test_issue_aircraft_template_guards.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AIRPLANES_PATH = Path(__file__).resolve().parents[1] / "packages" / "airplanes.yaml"
+
+
+def test_closest_aircraft_templates_guard_missing_attributes_and_home_zone() -> None:
+    text = AIRPLANES_PATH.read_text(encoding="utf-8")
+
+    assert "this.attributes.get('raw')" in text
+    assert "this.attributes.get('distance_km')" in text
+    assert "home_lat is not none and home_lon is not none" in text
+    assert "{{ d_km | round(3) if d_km is not none else none }}" in text
+    assert "{{ (distance_km | float(default=0)) * 0.621371 | round(2) }}" in text


### PR DESCRIPTION
## Summary
- guard the `closest_aircraft_overhead` template sensor against missing `raw` and `distance_km` attributes
- avoid startup warnings when `zone.home` coordinates or aircraft payload fields are unavailable
- add focused regression coverage for the attribute templates

## Testing
- `uv run --with pytest pytest tests/test_issue_aircraft_template_guards.py tests/test_aircraft_and_birds_packages.py`
- `uv run --with pytest pytest`

## Issue tracking
- No matching existing issue was found in `rtclauss/hass-config` for this item.
- The GitHub connector available in this run can search/fetch issues but cannot create new ones, so this PR is the only GitHub artifact I could open automatically for now.