### PR TITLE
Add den ceiling Bond light reconcile automation

### DIFF
--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -122,6 +122,122 @@ automation:
                 data:
                   entity_id: fan.den_ceiling
 
+
+  - alias: den_ceiling_bond_state_reconcile
+    id: den_ceiling_bond_state_reconcile
+    description: >
+      Keep Bond's tracked state for the Den ceiling light aligned with the
+      room's overnight lighting reality. When the den is occupied at night and
+      illuminance is bright while the nearby spill-light sources stay off, mark
+      the ceiling light as on in Bond. When the room goes dark, mark it off.
+      After midnight, if the room has been vacant for an hour and still reads
+      bright with those spill-light sources off, force the ceiling light off so
+      it cannot stay on all night.
+    trigger:
+      - trigger: state
+        entity_id: binary_sensor.den_motion_occupancy
+        to: "on"
+      - trigger: numeric_state
+        entity_id: sensor.den_motion_illuminance
+        above: 100
+        for:
+          minutes: 1
+      - trigger: numeric_state
+        entity_id: sensor.den_motion_illuminance
+        below: 10
+        for:
+          minutes: 5
+      - trigger: time_pattern
+        minutes: "/30"
+    action:
+      - choose:
+          - conditions:
+              - condition: time
+                after: "00:30:00"
+              - condition: sun
+                before: sunrise
+              - condition: state
+                entity_id: binary_sensor.den_motion_occupancy
+                state: "off"
+                for:
+                  hours: 1
+              - &den_ceiling_spill_lights_off
+                condition: state
+                entity_id: light.den_flood_switch
+                state: "off"
+              - condition: state
+                entity_id: light.den_lamp
+                state: "off"
+              - condition: state
+                entity_id: light.kitchen_all
+                state: "off"
+              - condition: state
+                entity_id: light.tiki_room_lights_tiki_room_strip
+                state: "off"
+              - condition: numeric_state
+                entity_id: sensor.den_motion_illuminance
+                above: 100
+            sequence:
+              - action: bond.set_light_power_tracked_state
+                data:
+                  entity_id: light.den_ceiling
+                  power_state: true
+              - delay:
+                  seconds: 2
+              - action: light.turn_off
+                target:
+                  entity_id: light.den_ceiling
+              - delay:
+                  seconds: 2
+              - action: bond.set_light_power_tracked_state
+                data:
+                  entity_id: light.den_ceiling
+                  power_state: false
+          - conditions:
+              - condition: sun
+                after: sunset
+                before: sunrise
+              - condition: state
+                entity_id: binary_sensor.den_motion_occupancy
+                state: "on"
+              - condition: state
+                entity_id: light.den_ceiling
+                state: "off"
+              - *den_ceiling_spill_lights_off
+              - condition: state
+                entity_id: light.den_lamp
+                state: "off"
+              - condition: state
+                entity_id: light.kitchen_all
+                state: "off"
+              - condition: state
+                entity_id: light.tiki_room_lights_tiki_room_strip
+                state: "off"
+              - condition: numeric_state
+                entity_id: sensor.den_motion_illuminance
+                above: 100
+            sequence:
+              - action: bond.set_light_power_tracked_state
+                data:
+                  entity_id: light.den_ceiling
+                  power_state: true
+          - conditions:
+              - condition: sun
+                after: sunset
+                before: sunrise
+              - condition: state
+                entity_id: light.den_ceiling
+                state: "on"
+              - condition: numeric_state
+                entity_id: sensor.den_motion_illuminance
+                below: 10
+            sequence:
+              - action: bond.set_light_power_tracked_state
+                data:
+                  entity_id: light.den_ceiling
+                  power_state: false
+    mode: restart
+
   # - alias: turn_off_fan_if_den_unoccupied
   #   id: turn_off_fan_if_den_unoccupied
   #   trigger:

--- a/tests/test_den_ceiling_bond_reconcile.py
+++ b/tests/test_den_ceiling_bond_reconcile.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+FANS_PATH = Path(__file__).resolve().parents[1] / "packages" / "fans.yaml"
+
+
+def _automation_block(alias: str) -> str:
+    lines = FANS_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  - alias: {alias}"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation alias {alias!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - alias: "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_den_ceiling_bond_reconcile_uses_expected_sensors_and_bond_service() -> None:
+    block = _automation_block("den_ceiling_bond_state_reconcile")
+
+    assert "binary_sensor.den_motion_occupancy" in block
+    assert "sensor.den_motion_illuminance" in block
+    assert "light.den_ceiling" in block
+    assert "action: bond.set_light_power_tracked_state" in block
+    assert "above: 100" in block
+    assert "below: 10" in block
+
+
+def test_den_ceiling_bond_reconcile_excludes_neighboring_spill_lights() -> None:
+    block = _automation_block("den_ceiling_bond_state_reconcile")
+
+    assert "light.den_flood_switch" in block
+    assert "light.den_lamp" in block
+    assert "light.kitchen_all" in block
+    assert "light.tiki_room_lights_tiki_room_strip" in block
+
+
+def test_den_ceiling_bond_reconcile_has_overnight_force_off_failsafe() -> None:
+    block = _automation_block("den_ceiling_bond_state_reconcile")
+
+    assert 'after: "00:30:00"' in block
+    assert "before: sunrise" in block
+    assert 'state: "off"' in block
+    assert "hours: 1" in block
+    assert "action: light.turn_off" in block
+    assert 'minutes: "/30"' in block


### PR DESCRIPTION
## Summary
- add `den_ceiling_bond_state_reconcile` to `packages/fans.yaml`
- infer Bond tracked on-state only when the Den is occupied, illuminance is high, and nearby spill-light sources stay off
- add an overnight failsafe that forces `light.den_ceiling` off after `00:30` if the room has been vacant for an hour and still reads bright
- add regression tests covering the entities, thresholds, and overnight off sequence

## Test Cases
- `tests/test_den_ceiling_bond_reconcile.py::test_den_ceiling_bond_reconcile_uses_expected_sensors_and_bond_service`
- `tests/test_den_ceiling_bond_reconcile.py::test_den_ceiling_bond_reconcile_excludes_neighboring_spill_lights`
- `tests/test_den_ceiling_bond_reconcile.py::test_den_ceiling_bond_reconcile_has_overnight_force_off_failsafe`
- `tests/test_zigbee_zwave_den_bindings.py`

## Verification
- `uv run --with pytest pytest tests/test_den_ceiling_bond_reconcile.py tests/test_zigbee_zwave_den_bindings.py`
- `uv run --with pytest pytest`

## Coverage
- Repo note: there is no line-coverage reporter configured in this checkout, so no percentage report was generated.
- Change coverage: the new den ceiling Bond reconcile automation is covered by targeted regression tests and also passed the full suite (`161 passed`).
