### PR TITLE
[codex] Fix Inovelli reset group sync

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2347,6 +2347,8 @@ script:
             - select.hall_upstairs_switch_switchtype
             - select.hall_stairway_switchtype
       # Recreate switch endpoint memberships in Zigbee groups after a reset.
+      # For smart-bulb groups, endpoint 1 receives group state so the switch
+      # load/LED stays in sync while endpoint 2 remains the bound controller.
       inovelli_group_membership_replay:
         - group: "Basement/Great Room"
           members:
@@ -2371,21 +2373,19 @@ script:
         - group: "Den/Floods"
           members:
             - device: "Den/Flood Switch"
-              endpoint: 2
+              endpoint: 1
         - group: "Dining Room/Over Table"
           members:
             - device: "Dining Room/Table Switch"
               endpoint: 1
-            - device: "Dining Room/Table Switch"
-              endpoint: 2
             - device: "Dining Room/Wall Switch"
               endpoint: 1
         - group: "Hall/All"
           members:
             - device: "Hall/Foyer Switch"
-              endpoint: 2
+              endpoint: 1
             - device: "Hall/Garage Laundry Switch"
-              endpoint: 2
+              endpoint: 1
             - device: "Hall/Transition Switch"
               endpoint: 1
             - device: "Hall/Upstairs/Switch"
@@ -2399,13 +2399,13 @@ script:
         - group: "Outside/Front Hue"
           members:
             - device: "Outside/Front Lights"
-              endpoint: 2
+              endpoint: 1
         - group: "Owner Suite/Bathroom/Lights"
           members:
             - device: "Owner Suite/Bathroom/Shower Switch"
-              endpoint: 2
+              endpoint: 1
             - device: "Owner Suite/Bathroom/Tub Switch"
-              endpoint: 2
+              endpoint: 1
       # Recreate custom switch bindings to bulbs or Zigbee groups after a reset.
       inovelli_binding_replay:
         - from: "Basement/Bathroom/Shower Switch"

--- a/tests/test_zigbee_zwave_den_bindings.py
+++ b/tests/test_zigbee_zwave_den_bindings.py
@@ -34,9 +34,13 @@ def _script_block(script_id: str) -> str:
 def test_reset_script_keeps_den_flood_switch_group_membership() -> None:
     block = _script_block("reset_inovelli_switches")
 
-    assert 'group: "Den/Floods"' in block
-    assert 'device: "Den/Flood Switch"' in block
-    assert "endpoint: 2" in block
+    assert re.search(
+        r'- group: "Den/Floods"\n'
+        r'\s+members:\n'
+        r'\s+- device: "Den/Flood Switch"\n'
+        r'\s+endpoint: 1',
+        block,
+    )
 
 
 def test_reset_script_keeps_den_flood_switch_bindings_to_group_and_lamp() -> None:

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -151,19 +151,18 @@ def test_reset_script_replays_current_live_group_memberships_and_bindings() -> N
         ("Basement/Great Room", "Basement/North Hallway Switch", 1),
         ("Deck/All", "Deck/Kitchen Door", 2),
         ("Deck/Hue", "Deck/Kitchen Door", 1),
-        ("Den/Floods", "Den/Flood Switch", 2),
+        ("Den/Floods", "Den/Flood Switch", 1),
         ("Dining Room/Over Table", "Dining Room/Table Switch", 1),
-        ("Dining Room/Over Table", "Dining Room/Table Switch", 2),
         ("Dining Room/Over Table", "Dining Room/Wall Switch", 1),
-        ("Hall/All", "Hall/Foyer Switch", 2),
-        ("Hall/All", "Hall/Garage Laundry Switch", 2),
+        ("Hall/All", "Hall/Foyer Switch", 1),
+        ("Hall/All", "Hall/Garage Laundry Switch", 1),
         ("Hall/All", "Hall/Transition Switch", 1),
         ("Hall/All", "Hall/Upstairs/Switch", 1),
         ("Kitchen/All", "Kitchen/Bay Switch", 1),
         ("Kitchen/All", "Kitchen/Switch", 1),
-        ("Outside/Front Hue", "Outside/Front Lights", 2),
-        ("Owner Suite/Bathroom/Lights", "Owner Suite/Bathroom/Shower Switch", 2),
-        ("Owner Suite/Bathroom/Lights", "Owner Suite/Bathroom/Tub Switch", 2),
+        ("Outside/Front Hue", "Outside/Front Lights", 1),
+        ("Owner Suite/Bathroom/Lights", "Owner Suite/Bathroom/Shower Switch", 1),
+        ("Owner Suite/Bathroom/Lights", "Owner Suite/Bathroom/Tub Switch", 1),
     }
     expected_bindings = {
         (
@@ -281,6 +280,18 @@ def test_reset_script_replays_current_live_group_memberships_and_bindings() -> N
 
     assert _parse_group_memberships(block) == expected_memberships
     assert _parse_bindings(block) == expected_bindings
+
+
+def test_reset_script_replays_endpoint_1_membership_for_group_bound_switch_sync() -> None:
+    block = _script_block("reset_inovelli_switches")
+
+    memberships = _parse_group_memberships(block)
+    for device, from_endpoint, group, to_endpoint, _clusters in _parse_bindings(block):
+        if from_endpoint != 2 or to_endpoint is not None:
+            continue
+
+        assert (group, device, 1) in memberships
+        assert (group, device, 2) not in memberships
 
 
 def test_reset_script_finishes_with_the_issue_aurora_led_effect() -> None:


### PR DESCRIPTION
## Summary
- update `script.reset_inovelli_switches` to replay endpoint 1 group memberships for smart-bulb Inovelli groups while keeping endpoint 2 bindings as the control path
- remove stale endpoint 2 memberships that left switch LED/load state out of sync after a reset
- add regression coverage for the new membership pattern in the Inovelli reset tests

## Why
The reset snapshot still restored several group-bound Inovelli switches as endpoint 2 group members. That allowed the bulbs to respond but left the switch LED/load state behind after resets. Replaying endpoint 1 membership for those smart-bulb groups keeps the switch state synchronized with the Zigbee2MQTT group while endpoint 2 remains bound for control.

## Validation
- `uv run --with pytest pytest tests/test_zigbee_zwave_inovelli_reset_replay.py tests/test_zigbee_zwave_den_bindings.py tests/test_zigbee_zwave_inovelli_day_mode.py`
- `uv run --with pytest pytest`