### PR TITLE
[codex] Clean HA lint and stale customize drift

### DIFF
--- a/esphome/bedloadcell1.yaml
+++ b/esphome/bedloadcell1.yaml
@@ -5,7 +5,7 @@
 #  and the western most western half of the bed
 esphome:
   name: bedloadcell1
-  
+
 esp8266:
   board: esp01_1m
 
@@ -65,10 +65,10 @@ time:
 #     device_class: weight
 #     state_class: measurement
 #     unit_of_measurement: kg
-#     dout_pin: 
+#     dout_pin:
 #       number: GPIO0
 #       allow_other_uses: True
-#     clk_pin: 
+#     clk_pin:
 #       number: GPIO14
 #       allow_other_uses: True
 #     gain: 128
@@ -137,10 +137,10 @@ time:
 #   #   name: "Raw Bed Load Cell 1"
 #   #   state_class: measurement
 #   #   unit_of_measurement: value
-#   #   dout_pin: 
+#   #   dout_pin:
 #   #     number: GPIO0
 #   #     allow_other_uses: True
-#   #   clk_pin: 
+#   #   clk_pin:
 #   #     number: GPIO14
 #   #     allow_other_uses: True
 #   #   gain: 128
@@ -157,10 +157,10 @@ time:
 #   #   name: "Raw Bed Load Cell 1"
 #   #   state_class: measurement
 #   #   unit_of_measurement: raw
-#   #   dout_pin: 
+#   #   dout_pin:
 #   #     number: GPIO0
 #   #     allow_other_uses: True
-#   #   clk_pin: 
+#   #   clk_pin:
 #   #     number: GPIO14
 #   #     allow_other_uses: True
 #   #   gain: 128
@@ -221,10 +221,10 @@ time:
 #   #   id: raw_bed_load_cell
 #   #   state_class: measurement
 #   #   unit_of_measurement: raw
-#   #   dout_pin: 
+#   #   dout_pin:
 #   #     number: GPIO0
 #   #     allow_other_uses: True
-#   #   clk_pin: 
+#   #   clk_pin:
 #   #     number: GPIO14
 #   #     allow_other_uses: True
 #   #   gain: 128
@@ -299,10 +299,10 @@ time:
 #     id: raw_bed_load_cell
 #     state_class: measurement
 #     unit_of_measurement: raw
-#     dout_pin: 
+#     dout_pin:
 #       number: GPIO0
 #       allow_other_uses: True
-#     clk_pin: 
+#     clk_pin:
 #       number: GPIO14
 #       allow_other_uses: True
 #     gain: 128

--- a/esphome/bluetoothproxy1.yaml
+++ b/esphome/bluetoothproxy1.yaml
@@ -1,6 +1,6 @@
 esphome:
   name: denbluetoothproxy
-  project: 
+  project:
     name: rtclauss.bluetooth
     version: 1.0.0
 
@@ -32,7 +32,6 @@ wifi:
   password: !secret wifi_password
   min_auth_mode: WPA2
   power_save_mode: NONE
-  
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "Bluetoothproxy1 Fallback Hotspot"

--- a/esphome/livingroombtproxy.yaml
+++ b/esphome/livingroombtproxy.yaml
@@ -1,6 +1,6 @@
 esphome:
   name: diningroom-bt-proxy
-  project: 
+  project:
     name: rtclauss.bluetoothproxy
     version: 1.0.0
 
@@ -40,7 +40,6 @@ wifi:
   #   gateway: 192.168.1.1
   #   # The subnet of the network. 255.255.255.0 works for most home networks.
   #   subnet: 255.255.255.0
-  
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "LivingRoomBt Fallback Hotspot"

--- a/esphome/office-bt-proxy.yaml
+++ b/esphome/office-bt-proxy.yaml
@@ -1,10 +1,10 @@
 esphome:
   name: office-bt-proxy
-  project: 
+  project:
     name: rtclauss.bluetoothproxy
     version: 1.0.0
   platformio_options:
-    build_flags: 
+    build_flags:
       - -Wno-maybe-uninitialized
 
 substitutions:
@@ -36,7 +36,6 @@ wifi:
   password: !secret wifi_password
   min_auth_mode: WPA2
   power_save_mode: NONE
-  
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "OfficeBt Fallback Hotspot"
@@ -58,33 +57,33 @@ esp32_ble_tracker:
     active: true
     interval: 320ms
     window: 320ms
-  on_ble_advertise:
-    - then:
-      # Look for manufacturer data of form: 4c00 10 05 YY 98 XXXXXX
-      # Where YY can be 01..0F or 20..2F; and XXXXXX is ignored
-      - lambda: |-
-          optional<int16_t> best_rssi = nullopt;
-          for (auto data : x.get_manufacturer_datas()) {
-            // Guard against non-Apple datagrams, or those that are too small.
-            if (data.data.size() < 4 || data.uuid.to_string() != "0x004C" || data.data[0] != 0x10 || data.data[1] < 5) {
-              continue;
-            }
-            const int16_t rssi = x.get_rssi();
-            const uint8_t status_flags = data.data[2] >> 4;  // High nibble
-            const uint8_t data_flags = data.data[3];
-            
-            if (data_flags == 0x98) {  // Match unlocked Apple Watch. To also match locked watch use: if (data_flags == 0x98 || data_flags == 0x18) {
-              if (status_flags == 0 || status_flags == 2) {
-                best_rssi = max(rssi, best_rssi.value_or(rssi));
-                ESP_LOGD("ble_adv", "Found Apple Watch (mac %s) rssi %i", x.address_str().c_str(), rssi);
-              } else {
-                ESP_LOGD("ble_adv", "Possible Apple Watch? (mac %s) rssi %i, unrecognised status/action flags %#04x", x.address_str().c_str(), rssi, data.data[2]);
+    on_ble_advertise:
+      - then:
+          # Look for manufacturer data of form: 4c00 10 05 YY 98 XXXXXX
+          # Where YY can be 01..0F or 20..2F; and XXXXXX is ignored
+          - lambda: |-
+              optional<int16_t> best_rssi = nullopt;
+              for (auto data : x.get_manufacturer_datas()) {
+                // Guard against non-Apple datagrams, or those that are too small.
+                if (data.data.size() < 4 || data.uuid.to_string() != "0x004C" || data.data[0] != 0x10 || data.data[1] < 5) {
+                  continue;
+                }
+                const int16_t rssi = x.get_rssi();
+                const uint8_t status_flags = data.data[2] >> 4;  // High nibble
+                const uint8_t data_flags = data.data[3];
+
+                if (data_flags == 0x98) {  // Match unlocked Apple Watch. To also match locked watch use: if (data_flags == 0x98 || data_flags == 0x18) {
+                  if (status_flags == 0 || status_flags == 2) {
+                    best_rssi = max(rssi, best_rssi.value_or(rssi));
+                    ESP_LOGD("ble_adv", "Found Apple Watch (mac %s) rssi %i", x.address_str().c_str(), rssi);
+                  } else {
+                    ESP_LOGD("ble_adv", "Possible Apple Watch? (mac %s) rssi %i, unrecognised status/action flags %#04x", x.address_str().c_str(), rssi, data.data[2]);
+                  }
+                }
               }
-            }
-          }
-          if (best_rssi) {
-            id(apple_watch_rssi).publish_state(*best_rssi);
-          }
+              if (best_rssi) {
+                id(apple_watch_rssi).publish_state(*best_rssi);
+              }
 
 xiaomi_ble:
 
@@ -116,14 +115,14 @@ sensor:
               id(room_presence_debounce).publish_state(0);
             }
         - script.execute: presence_timeout # Publish 0 if no rssi received
-  
+
   - platform: template
     id: room_presence_debounce
     filters:
       - sliding_window_moving_average:
           window_size: 3
           send_every: 1
-          
+
   - platform: homeassistant
     name: HA RSSI Present Value
     entity_id: input_number.rssi_present

--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -27,16 +27,6 @@ homeassistant:
     ################################################
     ## Automations
     ################################################
-    automation.turn_off_nest_when_windows_open:
-      <<: *customize
-      friendly_name: "Turn Off Nest When Egress Open"
-      icon: mdi:window-open
-
-    automation.turn_on_nest_when_windows_closed:
-      <<: *customize
-      friendly_name: "Turn On Nest When All Egresses Close"
-      icon: mdi:window-closed
-
     automation.window_climate_action_handler:
       <<: *customize
       friendly_name: "Window Climate Action Handler"

--- a/packages/curling.yaml
+++ b/packages/curling.yaml
@@ -33,29 +33,14 @@ homeassistant:
     #   friendly_name: "Leave home for curling"
     #   icon: mdi:curling
 
-    automation.return_home_from_OCC:
-      <<: *customize
-      friendly_name: "Return home from OCC"
-      icon: mdi:curling
-
     automation.return_home_from_spcc:
       <<: *customize
       friendly_name: "Return home from SPCC"
       icon: mdi:curling
 
-    automation.display_curling_tab:
-      <<: *customize
-      friendly_name: "Display Curling tab"
-      icon: mdi:curling
-
     automation.toggle_curling_automations_on_season_change:
       <<: *customize
       friendly_name: "Toggle Curling season automations"
-      icon: mdi:curling
-
-    automation.toggle_curling_tab:
-      <<: *customize
-      friendly_name: "Toggle Curling tab"
       icon: mdi:curling
 
     ################################################

--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -44,10 +44,6 @@ homeassistant:
       <<: *customize
       friendly_name: "Display Christmas tab"
 
-    automation.toggle_christmas_tab:
-      <<: *customize
-      friendly_name: "Display Christmas tab"
-
     automation.reset_after_holiday:
       <<: *customize
       friendly_name: "Reset lights after holiday"

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -32,16 +32,6 @@ homeassistant:
       friendly_name: "Turn on deck lights automatically"
       icon: mdi:nature-people
 
-    automation.front_door_light_auto_off:
-      <<: *customize
-      friendly_name: "Turn off front door light automatically"
-      icon: mdi:home
-
-    automation.front_door_light_auto_on:
-      <<: *customize
-      friendly_name: "Turn on front door light automatically"
-      icon: mdi:home
-
     automation.hallway_light_toggle_at_night:
       <<: *customize
       friendly_name: "Toggle hallway light automatically at night"
@@ -56,20 +46,6 @@ homeassistant:
       <<: *customize
       friendly_name: "Turn off master bedroom lights automatically"
       icon: mdi:ceiling-light
-
-    automation.office_light_on_at_night:
-      <<: *customize
-      friendly_name: "Turn on office light automatically at night"
-      icon: mdi:ceiling-light
-
-    automation.office_light_off_at_night:
-      <<: *customize
-      friendly_name: "Turn off office light automatically"
-      icon: mdi:ceiling-light
-
-    automation.toggle_living_room:
-      <<: *customize
-      friendly_name: "Toggle Living Room"
 
     automation.button_reset_basement:
       <<: *customize

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -28,11 +28,6 @@ homeassistant:
     ## Automations
     ################################################
 
-    automation.initialize_vacation_items:
-      <<: *customize
-      friendly_name: "Initialize Vacation Items"
-      icon: mdi:beach
-
     automation.trip_mode_manager:
       <<: *customize
       friendly_name: "Trip Mode Manager"
@@ -78,10 +73,6 @@ homeassistant:
     automation.vacuum_flying_home:
       <<: *customize
       friendly_name: "Vacuum house when flying home"
-
-    automation.toggle_vacation_tab:
-      <<: *customize
-      friendly_name: "Show/Hide Vacation tab"
 
     ################################################
     ## Binary Sensors

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -57,9 +57,6 @@ homeassistant:
     automation.turn_off_lights_when_i_leave:
       <<: *customize
       friendly_name: Lights Off on Departure
-    automation.update_nest_eta:
-      <<: *customize
-      friendly_name: Update Nest ETA as Approach Home
     automation.vacuum_return_home:
       <<: *customize
       friendly_name: Stop Vacuuming on Arrival

--- a/tests/test_customize_targets_exist.py
+++ b/tests/test_customize_targets_exist.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATHS = [
+    ROOT / "configuration.yaml",
+    ROOT / "automations.yaml",
+    ROOT / "scripts.yaml",
+    *sorted((ROOT / "packages").glob("*.yaml")),
+    *sorted((ROOT / "blueprints").rglob("*.yaml")),
+]
+
+CUSTOMIZE_AUTOMATION_RE = re.compile(r"^\s{4}automation\.([A-Za-z0-9_]+):\s*$")
+AUTOMATION_ID_RE = re.compile(
+    r"^(?:\s{2}-\s+id:\s+|\s{4}id:\s+)([A-Za-z0-9_]+)\s*$"
+)
+
+
+def test_customized_automations_have_matching_definitions() -> None:
+    customized_automations: dict[str, list[str]] = {}
+    defined_automations: set[str] = set()
+
+    for path in CONFIG_PATHS:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            customize_match = CUSTOMIZE_AUTOMATION_RE.match(line)
+            if customize_match:
+                automation_id = customize_match.group(1)
+                customized_automations.setdefault(automation_id, []).append(path.name)
+                continue
+
+            id_match = AUTOMATION_ID_RE.match(line)
+            if id_match:
+                defined_automations.add(id_match.group(1))
+
+    missing = {
+        automation_id: sorted(paths)
+        for automation_id, paths in customized_automations.items()
+        if automation_id not in defined_automations
+    }
+
+    assert not missing, (
+        "Customize entries reference automations with no matching definition: "
+        f"{missing}"
+    )


### PR DESCRIPTION
## What changed
- cleaned up the ESPHome YAML files touched in this audit pass
- removed stale customize-only automation entries that no longer have matching automation definitions
- added a regression test to catch future customize targets that drift away from real automation IDs

## Why
- live Home Assistant had stale customize drift, including `automation.toggle_living_room` showing up as unavailable
- the repo needed a guardrail so missing customize targets stop being reintroduced
- the ESPHome files had formatting issues identified during the audit pass

## Impact
- fewer ghost automation entities from customize drift
- better regression coverage around package customize targets
- no functional changes to the unrelated local AppDaemon edit, which was intentionally excluded

## Validation
- `uv run --with pytest pytest` -> `163 passed`
- live Home Assistant `check_config` -> valid
- live Home Assistant best-practice audit completed against the current server state