### PR TITLE
[codex] Disable deck flood smart bulb mode

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2237,7 +2237,6 @@ script:
             - select.hall_transition_switch_smartbulbmode
             - select.hall_foyer_switch_smartbulbmode
             - select.kitchen_sink_overhead_switch_smartbulbmode
-            - select.deck_flood_lights_smartbulbmode
             - select.deck_kitchen_door_smartbulbmode
             - select.dining_room_wall_switch_smartbulbmode
             - select.office_fan_switch_smartbulbmode
@@ -2257,6 +2256,7 @@ script:
             - select.kitchen_bay_switch_smartbulbmode
         - option: "Disabled"
           entities:
+            - select.deck_flood_lights_smartbulbmode
             - select.guest_bathroom_exhaust_smartbulbmode
             - select.owner_suite_bathroom_exhaust_smartbulbmode
             - select.basement_bathroom_exhaust_smartbulbmode

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -132,12 +132,27 @@ def test_reset_script_replays_current_live_switch_modes_readably() -> None:
     block = _script_block("reset_inovelli_switches")
 
     assert 'option: "Disabled"' in block
+    assert "select.deck_flood_lights_smartbulbmode" in block
     assert "select.owner_suite_bathroom_vanity_smartbulbmode" in block
     assert 'option: "On/Off"' in block
     assert "select.garage_overhead_switch_outputmode" in block
     assert 'option: "3-Way Aux Switch"' in block
     assert "select.garage_overhead_switch_switchtype" in block
     assert "select.hall_foyer_switch_switchtype" in block
+
+
+def test_reset_script_does_not_restore_deck_flood_lights_smart_bulb_mode() -> None:
+    block = _script_block("reset_inovelli_switches")
+    smart_bulb_section = _section(
+        block,
+        'inovelli_smart_bulb_mode_replay:',
+        'inovelli_output_mode_replay:',
+    )
+
+    smart_bulb_option, disabled_option = smart_bulb_section.split('        - option: "Disabled"', 1)
+
+    assert "select.deck_flood_lights_smartbulbmode" not in smart_bulb_option
+    assert "select.deck_flood_lights_smartbulbmode" in disabled_option
 
 
 def test_reset_script_replays_current_live_group_memberships_and_bindings() -> None:


### PR DESCRIPTION
## Summary
- move `select.deck_flood_lights_smartbulbmode` out of the smart-bulb replay list and into the disabled replay list
- add regression coverage so `reset_inovelli_switches` does not restore Deck/Flood Lights to smart bulb mode
- align the live Home Assistant switch mode with the repo by setting Deck/Flood Lights smart bulb mode to `Disabled`

## Root cause
The replay snapshot in `packages/zigbee_zwave.yaml` still treated `Deck/Flood Lights` as a smart-bulb circuit. Any reset/replay path would reapply that stale mode even though the switch should behave as a normal on/off load.

## Validation
- `uv run --with pytest pytest tests/test_zigbee_zwave_inovelli_reset_replay.py`
- `uv run --with pytest pytest`