### PR TITLE
[codex] Fix garbage pickup template serialization and front door helper

### DIFF
--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -588,22 +588,28 @@ template:
         entity_id: calendar.mn_holidays
     action:
       - variables:
-          today: "{{ now().date() }}"
-          is_wed: "{{ today.weekday() == 2 }}"
+          today: "{{ now().date().isoformat() }}"
+          today_weekday: "{{ now().weekday() }}"
+          is_wed: "{{ today_weekday | int == 2 }}"
           after_pickup_time: "{{ now().hour >= 12 }}"
           days_until_wed: >
-            {% set d = 2 - today.weekday() %}
+            {% set d = 2 - (today_weekday | int) %}
             {% if d < 0 %}{% set d = d + 7 %}{% endif %}
             {{ d }}
           base_wed: >
+            {% set today_date = strptime(today, '%Y-%m-%d').date() %}
             {% if is_wed and not after_pickup_time %}
               {{ today }}
             {% else %}
-              {{ today + timedelta(days=days_until_wed if (not is_wed) else 7) }}
+              {{ (today_date + timedelta(days=(days_until_wed | int) if (not is_wed) else 7)).isoformat() }}
             {% endif %}
-          week_mon: "{{ base_wed - timedelta(days=base_wed.weekday()) }}"
-          range_start: "{{ week_mon.isoformat() }}T00:00:00"
-          range_end: "{{ (base_wed + timedelta(days=1)).isoformat() }}T23:59:59"
+          week_mon: >
+            {% set base_wed_date = strptime(base_wed, '%Y-%m-%d').date() %}
+            {{ (base_wed_date - timedelta(days=base_wed_date.weekday())).isoformat() }}
+          range_start: "{{ week_mon }}T00:00:00"
+          range_end: >
+            {% set base_wed_date = strptime(base_wed, '%Y-%m-%d').date() %}
+            {{ (base_wed_date + timedelta(days=1)).isoformat() }}T23:59:59
       - action: calendar.get_events
         target:
           entity_id: calendar.mn_holidays
@@ -614,8 +620,8 @@ template:
       - variables:
           holiday_events: "{{ hols.events | default([]) }}"
           holiday_mon_to_wed: >
-            {% set ws = week_mon %}
-            {% set we = base_wed %}
+            {% set ws = strptime(week_mon, '%Y-%m-%d').date() %}
+            {% set we = strptime(base_wed, '%Y-%m-%d').date() %}
             {% set ns = namespace(hit=false) %}
             {% for e in holiday_events %}
               {% set d = as_datetime(e.start).date() %}
@@ -626,16 +632,16 @@ template:
             {{ ns.hit }}
           pickup_date: >
             {% if holiday_mon_to_wed in [true, 'true', 'True', 'on'] %}
-              {{ (base_wed + timedelta(days=1)).isoformat() }}
+              {{ (strptime(base_wed, '%Y-%m-%d').date() + timedelta(days=1)).isoformat() }}
             {% else %}
-              {{ base_wed.isoformat() }}
+              {{ base_wed }}
             {% endif %}
     sensor:
       - name: Garbage pickup date
         unique_id: garbage_pickup_date_apple_valley
         state: "{{ pickup_date }}"
         attributes:
-          base_wednesday: "{{ base_wed.isoformat() }}"
+          base_wednesday: "{{ base_wed }}"
           holiday_shift_applied: "{{ holiday_mon_to_wed in [true, 'true', 'True', 'on'] }}"
           holiday_events_in_range: "{{ holiday_events | map(attribute='summary') | list }}"
 

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1763,6 +1763,7 @@ device_tracker: []
 input_boolean:
   master_bed_occupancy:
   mail_delivered:
+  front_door_lock:
 
 ########################
 # Input Numbers

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -77,7 +77,24 @@ def test_garbage_pickup_template_keeps_dates_serializable() -> None:
     assert "garbage_pickup_window.range_start" not in text
     assert 'start_date_time: "{{ range_start }}"' in text
     assert 'end_date_time: "{{ range_end }}"' in text
-    assert 'week_mon: "{{ base_wed - timedelta(days=base_wed.weekday()) }}"' in text
+    assert 'today: "{{ now().date().isoformat() }}"' in text
+    assert 'today_weekday: "{{ now().weekday() }}"' in text
+    assert "today.weekday()" not in text
+    assert "week_mon.isoformat()" not in text
+    assert "base_wed.isoformat()" not in text
+    assert "strptime(base_wed, '%Y-%m-%d').date()" in text
     assert "ns = namespace(hit=false)" in text
     assert "holiday_mon_to_wed in [true, 'true', 'True', 'on']" in text
-    assert 'base_wednesday: "{{ base_wed.isoformat() }}"' in text
+    assert 'base_wednesday: "{{ base_wed }}"' in text
+
+
+def test_front_door_lock_template_has_backing_helper() -> None:
+    text = _read(ZIGBEE_ZWAVE_PATH)
+
+    input_boolean_block = text.split("input_boolean:\n", 1)[1].split(
+        "\n########################\n# Input Numbers", 1
+    )[0]
+
+    assert "front_door_lock:" in input_boolean_block
+    assert "unique_id: front_door_lock_template" in text
+    assert "entity_id:\n                - input_boolean.front_door_lock" in text


### PR DESCRIPTION
## Summary
- fix the `packages/holidays.yaml` garbage-pickup date calculation so intermediate values stay serializable strings instead of crashing on `.weekday()` / `.isoformat()` calls against rendered strings
- restore the missing `input_boolean.front_door_lock` helper that backs the `lock.front_door_lock` template lock
- add regression coverage for both log-derived failures in `tests/test_runtime_log_regressions.py`

## Runtime context
From the 2026-03-29/30 Home Assistant core logs:
- `Trigger Update Coordinator: Error rendering template for variables ... 'str object' has no attribute 'weekday'`
- `Referenced entities input_boolean.front_door_lock are missing or not currently available`

## Testing
- `uv run --with pytest pytest tests/test_runtime_log_regressions.py`
- `uv run --with pytest pytest`

## Issue tracking
- No matching existing issue was found for the template crash or missing helper.
- The GitHub connector available in this run can search/fetch issues but cannot create new ones, so this PR is the tracked artifact for these fixes.