### PR TITLE
[codex] Fix bedtime playback before Sonos regroup

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -646,6 +646,7 @@ script:
 
   music_assistant_prepare_bedroom_group:
     alias: "Prepare bedroom Music Assistant group"
+    mode: restart
     sequence:
       - if:
           - alias: "Check if guests are here."
@@ -683,6 +684,14 @@ script:
             data:
               group_members:
                 - media_player.bathroom_sonos_2
+
+  music_assistant_try_join_bedroom_group_after_play:
+    alias: "Try joining bedroom Music Assistant followers after playback"
+    mode: restart
+    sequence:
+      - delay:
+          seconds: 2
+      - action: script.music_assistant_prepare_bedroom_group
 
   music_assistant_prepare_arrival_group:
     alias: "Prepare arrival Music Assistant group"
@@ -1576,16 +1585,6 @@ script:
           {% set pindex =  (range(0, (plists | length))|random) -%}
           {{ plists[pindex] }}
     sequence:
-      # - action: media_player.join
-      #   target:
-      #     entity_id:
-      #       - media_player.bedroom
-      #   data:
-      #     group_members:
-      #       - media_player.bathroom
-      #       - media_player.office
-      #       - media_player.den
-      - action: script.music_assistant_prepare_bedroom_group
       - action: media_player.shuffle_set
         continue_on_error: true
         target:
@@ -1625,6 +1624,9 @@ script:
         data:
           entity_id: media_player.bedroom_sonos_2
           media_item: "{{ playlist }}"
+      - action: script.turn_on
+        target:
+          entity_id: script.music_assistant_try_join_bedroom_group_after_play
       - wait_for_trigger:
           - trigger: state
             entity_id: binary_sensor.owner_suite_bathroom_room_occupancy

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -111,6 +111,25 @@ def test_house_party_helper_joins_every_sonos_zone() -> None:
         assert media_player in block
 
 
+def test_bedroom_group_helper_restarts_instead_of_blocking_new_runs() -> None:
+    block = _script_block("music_assistant_prepare_bedroom_group")
+
+    assert 'mode: restart' in block
+
+
+def test_bedtime_join_retry_runs_after_playback_starts() -> None:
+    helper_block = _script_block("music_assistant_try_join_bedroom_group_after_play")
+    bedtime_block = _script_block("spotify_bedtime")
+
+    assert 'mode: restart' in helper_block
+    assert 'seconds: 2' in helper_block
+    assert 'action: script.music_assistant_prepare_bedroom_group' in helper_block
+    assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in bedtime_block
+    assert bedtime_block.index('action: script.music_assistant_play_item') < bedtime_block.index(
+        'entity_id: script.music_assistant_try_join_bedroom_group_after_play'
+    )
+
+
 def test_bedtime_playlist_includes_somafm_station_names() -> None:
     block = _script_block("spotify_bedtime")
 


### PR DESCRIPTION
## Summary
- start bedtime playback on the bedroom group leader before attempting to regroup the other Sonos players
- add an asynchronous post-play regroup helper so a stuck join cannot block the bedtime play step
- add regression coverage for the restart-safe helper and the play-before-join ordering

## Testing
- uv run --with pytest pytest
