### PR TITLE
[codex] Limit Inovelli reset aurora indicator window

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2172,7 +2172,9 @@ script:
       aurora_effect: aurora
       aurora_color: 187
       aurora_level: 51
-      aurora_duration: 255
+      # Keep the aurora notification visible for 10 minutes, then let the
+      # devices fall back to whichever LED defaults are already active.
+      aurora_duration: 600
       all_inovelli_switches_energy_report_rate: >
         {%- for device in states.number | select('match', '.*periodicpowerandenergyreports.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
       all_inovelli_switches_active_energy_report_rate: >
@@ -2673,29 +2675,34 @@ script:
                   {% endif %}
                   {{ payload | tojson }}
             - delay: "{{ mqtt_bind_delay }}"
-      - repeat:
-          for_each: "{{ inovelli_led_notification_targets }}"
-          sequence:
-            - action: mqtt.publish
-              data:
-                topic: "zigbee2mqtt/{{ repeat.item }}/set"
-                payload: >
-                  {{ {
-                    'led_effect': {
-                      'effect': aurora_effect,
-                      'color': aurora_color,
-                      'level': aurora_level,
-                      'duration': aurora_duration
-                    }
-                  } | tojson }}
-            - delay: "{{ mqtt_bind_delay }}"
+      - choose:
+          - conditions:
+              - condition: state
+                entity_id: binary_sensor.bayesian_bed_occupancy
+                state: "off"
+            sequence:
+              - repeat:
+                  for_each: "{{ inovelli_led_notification_targets }}"
+                  sequence:
+                    - action: mqtt.publish
+                      data:
+                        topic: "zigbee2mqtt/{{ repeat.item }}/set"
+                        payload: >
+                          {{ {
+                            'led_effect': {
+                              'effect': aurora_effect,
+                              'color': aurora_color,
+                              'level': aurora_level,
+                              'duration': aurora_duration
+                            }
+                          } | tojson }}
+                    - delay: "{{ mqtt_bind_delay }}"
       - action: logbook.log
         data:
           name: Zigbee2MQTT Reset
           message: >
             Replayed the saved Inovelli smart bulb modes, output modes, switch types,
-            group memberships, and bindings for switches and bulbs/groups,
-            and set the Inovelli LED bar to aurora so the completed reset is easy to verify.
+            group memberships, and bindings for switches and bulbs/groups.
 
   turn_off_owner_suite_inovelli_switch_leds:
     icon: mdi:light-switch

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -315,6 +315,16 @@ def test_reset_script_finishes_with_the_issue_aurora_led_effect() -> None:
     assert "aurora_effect: aurora" in block
     assert "aurora_color: 187" in block
     assert "aurora_level: 51" in block
-    assert "aurora_duration: 255" in block
+    assert "aurora_duration: 600" in block
     assert 'topic: "zigbee2mqtt/{{ repeat.item }}/set"' in block
     assert "'led_effect': {" in block
+
+
+def test_reset_script_skips_aurora_notification_while_bed_is_occupied() -> None:
+    block = _script_block("reset_inovelli_switches")
+
+    assert "binary_sensor.bayesian_bed_occupancy" in block
+    assert 'state: "off"' in block
+    assert block.index("binary_sensor.bayesian_bed_occupancy") < block.index(
+        'topic: "zigbee2mqtt/{{ repeat.item }}/set"'
+    )


### PR DESCRIPTION
## Summary
- extend the reset aurora LED effect to a 10-minute verification window
- skip the aurora notification while bed occupancy is active
- keep the existing switch LED defaults to resume after the effect expires

## Why
The reset indicator needed to stay visible long enough to verify the reset without disturbing bedtime behavior.

## Validation
- `uv run --with pytest pytest`

Closes #301