### PR TITLE
[codex] Restart Music Assistant on a recurring cadence

### DIFF
--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -371,6 +371,26 @@ automation:
         data:
           addon: a0d7b954_appdaemon
 
+  - alias: Restart Music Assistant every 12.17 hours
+    description: >
+      Restart the Music Assistant add-on on a self-rescheduling loop to work
+      around Sonos DNS issues.
+    id: restart_music_assistant_every_12_17_hours
+    trigger:
+      - trigger: homeassistant
+        event: start
+    action:
+      - repeat:
+          while:
+            - condition: template
+              value_template: "{{ true }}"
+          sequence:
+            # 12.17 hours interpreted as decimal hours: 12 hours, 10 minutes, 12 seconds.
+            - delay: "12:10:12"
+            - action: hassio.addon_restart
+              data:
+                addon: d5369777_music_assistant
+
   - alias: Turn Sump Back On
     id: turn_sump_back_on
     trigger:

--- a/tests/test_utilities_music_assistant_restart.py
+++ b/tests/test_utilities_music_assistant_restart.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+UTILITIES_PATH = Path(__file__).resolve().parents[1] / "packages" / "utilities.yaml"
+
+
+def _automation_block(automation_id: str) -> str:
+    lines = UTILITIES_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line != f"    id: {automation_id}":
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - alias: "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+
+    end = len(lines)
+    next_automation = re.compile(r"^  - alias: ")
+    for index in range(start + 1, len(lines)):
+        if next_automation.match(lines[index]):
+            end = index
+            break
+
+    block = "\n".join(lines[start:end])
+    assert f"id: {automation_id}" in block
+    return block
+
+
+def test_music_assistant_restart_loop_uses_the_music_assistant_addon() -> None:
+    block = _automation_block("restart_music_assistant_every_12_17_hours")
+
+    for token in (
+        "trigger: homeassistant",
+        "event: start",
+        "repeat:",
+        'delay: "12:10:12"',
+        "addon: d5369777_music_assistant",
+        "self-rescheduling loop",
+    ):
+        assert token in block


### PR DESCRIPTION
## Summary
- add a startup-driven recurring restart loop for the Music Assistant add-on
- restart add-on `d5369777_music_assistant` every `12:10:12`
- add focused regression coverage for the new automation

## Why
Music Assistant needs a periodic restart to work around Sonos DNS issues.

## Validation
- `uv run --with pytest pytest`

Closes #302