### PR TITLE
[codex] Fix bedtime goodnight timing

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -437,6 +437,9 @@ automation:
           entity_id:
             - light.owner_suite_lamps
             - light.bed_lightstrip
+      - action: script.goodnight_integrity
+        data:
+          reason: cpap_sleep
 
   # - id: deck_light_auto_off
   #   alias: deck_light_auto_off
@@ -1683,14 +1686,23 @@ automation:
           entity_id:
             - input_boolean.guest_mode
           state: "off"
+        - alias: "CPAP not already driving full sleep shutdown"
+          condition: numeric_state
+          entity_id: sensor.owner_suite_cpap_plug_power
+          below: 1.3
     action:
       - action: switch.turn_on
         data:
           entity_id:
             - switch.sleep_mode
-      - action: script.goodnight_integrity
+      - action: script.lights_off_except
         data:
-          reason: bed_lamps_off
+          exclude_lights:
+            - light.outside_front_hue
+            - light.outside_north_west_garage
+            - light.outside_south_west_garage
+            - light.outside_front_door
+          transition: 30
         # Only turn on the humidifier when it's winter
         # Not used with whole-home humidifier
         # - condition: and

--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -205,9 +205,6 @@ automation:
       - action: script.turn_on
         target:
           entity_id: script.spotify_bedtime
-      - action: script.goodnight_integrity
-        data:
-          reason: tv_bed_prep
       - delay: "00:20:00"
       - action: switch.turn_off
         target:

--- a/tests/test_goodnight_integrity.py
+++ b/tests/test_goodnight_integrity.py
@@ -111,29 +111,43 @@ def test_goodnight_integrity_only_notifies_on_verification_exceptions() -> None:
         assert token in block
 
 
-def test_bed_lamps_off_delegates_to_goodnight_integrity() -> None:
+def test_cpap_bedtime_lights_off_still_treats_cpap_as_full_sleep() -> None:
+    block = _automation_block(LIGHT_PATH, "cpap_on_lights_off")
+    action_block = block.split("    action:", 1)[1]
+
+    assert "sensor.owner_suite_cpap_plug_power" in block
+    assert "input_boolean.wakeup_alarm_firing" in block
+    assert "light.owner_suite_lamps" in action_block
+    assert "light.bed_lightstrip" in action_block
+    assert "script.goodnight_integrity" in action_block
+    assert "reason: cpap_sleep" in action_block
+
+
+def test_bed_lamps_off_only_finishes_turning_off_lights() -> None:
     block = _automation_block(LIGHT_PATH, "turn_off_all_lights_when_bed_off")
 
-    assert "script.goodnight_integrity" in block
-    assert "reason: bed_lamps_off" in block
+    assert "sensor.owner_suite_cpap_plug_power" in block
+    assert "script.lights_off_except" in block
+    assert "light.outside_front_hue" in block
+    assert "light.outside_front_door" in block
 
     for token in (
-        "script.lights_off_except",
         "switch.office_red_lava_lamp",
         "media_player.lg_webos_smart_tv",
         "media_player.basement",
+        "script.goodnight_integrity",
     ):
         assert token not in block
 
 
-def test_tv_bed_prep_delegates_to_goodnight_integrity() -> None:
+def test_tv_bed_prep_stops_short_of_full_goodnight_shutdown() -> None:
     block = _automation_block(TV_PATH, "tv_off_at_night_bed_prep")
 
-    assert "script.goodnight_integrity" in block
-    assert "reason: tv_bed_prep" in block
+    assert "scene.bedroom_prep" in block
     assert "script.spotify_bedtime" in block
 
     for token in (
+        "script.goodnight_integrity",
         "cover.garage_door",
         "action: media_player.turn_off",
     ):


### PR DESCRIPTION
## Summary
- reserve the full `goodnight_integrity` shutdown for the CPAP sleep path
- stop the TV bedroom prep flow from running the aggressive house-wide shutdown too early
- keep the lamp-off automation as a lighter `lights_off_except` cleanup path

## Why
`goodnight_integrity` was being invoked before actual sleep, which shut down the house too early when bedroom prep started or when the owner-suite lamps first went off.

## Validation
- `uv run --with pytest pytest`

Closes #300
