### PR TITLE
Notify when den ceiling Bond failsafe fires

### DIFF
--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -193,6 +193,12 @@ automation:
                 data:
                   entity_id: light.den_ceiling
                   power_state: false
+              - action: notify.all
+                data:
+                  title: Den ceiling light failsafe
+                  message: >-
+                    Den ceiling Bond failsafe turned the ceiling light off
+                    after the den stayed vacant overnight.
           - conditions:
               - condition: sun
                 after: sunset

--- a/tests/test_den_ceiling_bond_reconcile.py
+++ b/tests/test_den_ceiling_bond_reconcile.py
@@ -56,4 +56,6 @@ def test_den_ceiling_bond_reconcile_has_overnight_force_off_failsafe() -> None:
     assert 'state: "off"' in block
     assert "hours: 1" in block
     assert "action: light.turn_off" in block
+    assert "action: notify.all" in block
+    assert "Den ceiling light failsafe" in block
     assert 'minutes: "/30"' in block


### PR DESCRIPTION
## Summary
- add a `notify.all` alert to the overnight Den ceiling Bond failsafe after it forces the light off
- keep regular Bond tracked-state reconciliation silent so only the overnight corrective path notifies
- extend the Den ceiling reconcile regression test to require the failsafe notification

## Test Cases
- `uv run --with pytest pytest tests/test_den_ceiling_bond_reconcile.py tests/test_zigbee_zwave_den_bindings.py`
- `uv run --with pytest pytest`

## Coverage
- Added regression coverage in `tests/test_den_ceiling_bond_reconcile.py`
- Full suite passed locally (`169 passed`)
