### PR TITLE
[codex] Add dynamic outdoor holiday lighting scenes

### DIFF
--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -48,14 +48,6 @@ homeassistant:
       <<: *customize
       friendly_name: "Reset lights after holiday"
 
-    automation.st_andrews_day_light_loop:
-      <<: *customize
-      friendly_name: "St Andrews Day lights"
-
-    automation.halloween_light_loop:
-      <<: *customize
-      friendly_name: "Halloween lights"
-
     automation.outdoor_holiday_light_loop:
       <<: *customize
       friendly_name: "Outdoor holiday lights"
@@ -111,11 +103,6 @@ homeassistant:
     sensor.active_outdoor_holiday:
       <<: *customize
       friendly_name: "Active outdoor holiday"
-      icon: mdi:string-lights
-
-    sensor.active_holiday_lighting:
-      <<: *customize
-      friendly_name: "Active holiday lighting"
       icon: mdi:string-lights
 
     light.outdoor_holiday_facade_rgb_lights:
@@ -180,39 +167,6 @@ automation:
         target:
           entity_id: light.christmas_lights
 
-  - id: christmas_outside_light_loop_1
-    alias: christmas_outside_light_loop_1
-    trigger:
-      - trigger: sun
-        event: sunset
-        offset: -00:45:00
-      - trigger: time_pattern
-        minutes: "/1"
-    condition:
-      - alias: "Christmas-time"
-        condition: state
-        entity_id: binary_sensor.christmas_season
-        state: "on"
-      - alias: "Yield New Year's Eve to Hogmanay scenes"
-        condition: state
-        entity_id: binary_sensor.hogmanay
-        state: "off"
-      - condition: or
-        conditions:
-          - alias: "Sunset"
-            condition: sun
-            after: sunset
-            after_offset: -00:45:00
-          - alias: "Sunrise"
-            condition: sun
-            before: sunrise
-            before_offset: 00:45:00
-    action:
-      - action: scene.turn_on
-        data:
-          transition: 30
-          entity_id: scene.scene_christmas_outdoors_{{ now().minute % 4 + 1 | int }}
-
   - id: toggle_christmas_automations_on_season_change
     alias: toggle_christmas_automations_on_season_change
     trigger:
@@ -235,9 +189,6 @@ automation:
       - action: script.toggle_christmas_automation_during_christmas_season
         data:
           entity_id: automation.christmas_lights_off_bedroom_off
-      - action: script.toggle_christmas_automation_during_christmas_season
-        data:
-          entity_id: automation.christmas_outside_light_loop_1
 
   - id: reset_after_holiday
     alias: reset_after_holiday
@@ -254,64 +205,6 @@ automation:
       - action: light.turn_off
         data:
           entity_id: light.outside_front_hue
-
-  - id: st_andrews_day_light_loop
-    alias: st_andrews_day_light_loop
-    trigger:
-      - trigger: sun
-        event: sunset
-        offset: -00:45:00
-      - trigger: time_pattern
-        minutes: "/2"
-    condition:
-      - alias: "St Andrews Day"
-        condition: state
-        entity_id: binary_sensor.st_andrews_day
-        state: "on"
-      - condition: or
-        conditions:
-          - alias: "Sunset"
-            condition: sun
-            after: sunset
-            after_offset: -00:45:00
-          - alias: "Sunrise"
-            condition: sun
-            before: sunrise
-            before_offset: 00:45:00
-    action:
-      - action: scene.turn_on
-        data:
-          transition: 30
-          entity_id: scene.scene_st_andrews_day_outdoors_{{ (now().minute // 2) % 4 + 1 | int }}
-
-  - id: halloween_light_loop
-    alias: halloween_light_loop
-    trigger:
-      - trigger: sun
-        event: sunset
-        offset: -00:45:00
-      - trigger: time_pattern
-        minutes: "/2"
-    condition:
-      - alias: "Halloween"
-        condition: state
-        entity_id: binary_sensor.halloween
-        state: "on"
-      - condition: or
-        conditions:
-          - alias: "Sunset"
-            condition: sun
-            after: sunset
-            after_offset: -00:45:00
-          - alias: "Sunrise"
-            condition: sun
-            before: sunrise
-            before_offset: 00:45:00
-    action:
-      - action: scene.turn_on
-        data:
-          transition: 30
-          entity_id: scene.scene_halloween_outdoors_{{ (now().minute // 2) % 4 + 1 | int }}
 
   - id: outdoor_holiday_light_loop
     alias: outdoor_holiday_light_loop
@@ -351,16 +244,16 @@ automation:
       - alias: "Holiday lighting active today"
         condition: template
         value_template: >-
-          {{ states('sensor.active_holiday_lighting') | trim not in ['none', 'unknown', 'unavailable', ''] }}
+          {{ states('sensor.active_outdoor_holiday') | trim not in ['none', 'unknown', 'unavailable', ''] }}
       - alias: "Notification message available"
         condition: template
         value_template: >-
-          {{ state_attr('sensor.active_holiday_lighting', 'notification_message') | default('', true) | trim != '' }}
+          {{ state_attr('sensor.active_outdoor_holiday', 'notification_message') | default('', true) | trim != '' }}
     action:
       - action: notify.all
         data:
           title: Holiday lighting
-          message: "{{ state_attr('sensor.active_holiday_lighting', 'notification_message') }}"
+          message: "{{ state_attr('sensor.active_outdoor_holiday', 'notification_message') }}"
 
   - alias: Garbage Holiday Update
     id: garbage_holiday_update
@@ -685,6 +578,93 @@ script:
             }
           holiday_definitions_json: >-
             {
+              "christmas_season": {
+                "label": "Christmas Season",
+                "cadence_minutes": 1,
+                "transition_seconds": 30,
+                "scene_count": 4,
+                "target_behaviors": {
+                  "facade_rgb_lights": "Classic red and green Christmas facade loop.",
+                  "front_ambient_light": "Warm white porch glow with subtle holiday red and green accents.",
+                  "accent_path_lights": "Warm white base with alternating red and green accents when path lights exist."
+                },
+                "facade_palette": [
+                  {"rgb_color": [0, 255, 0], "brightness": 255},
+                  {"rgb_color": [255, 0, 0], "brightness": 255},
+                  {"rgb_color": [0, 255, 0], "brightness": 255},
+                  {"rgb_color": [255, 0, 0], "brightness": 255}
+                ],
+                "ambient_palette": [
+                  {"color_temp_kelvin": 2500, "brightness": 155},
+                  {"rgb_color": [255, 90, 90], "brightness": 135},
+                  {"rgb_color": [90, 220, 120], "brightness": 135},
+                  {"color_temp_kelvin": 2400, "brightness": 160}
+                ],
+                "path_palette": [
+                  {"color_temp_kelvin": 2600, "brightness": 112},
+                  {"rgb_color": [255, 0, 0], "brightness": 108},
+                  {"rgb_color": [0, 255, 0], "brightness": 108},
+                  {"color_temp_kelvin": 2600, "brightness": 112}
+                ]
+              },
+              "st_andrews_day": {
+                "label": "St Andrew's Day",
+                "cadence_minutes": 2,
+                "transition_seconds": 30,
+                "scene_count": 4,
+                "target_behaviors": {
+                  "facade_rgb_lights": "Saltire-inspired blue and white with warm amber accents.",
+                  "front_ambient_light": "Cool white and blue porch wash with a restrained amber variant.",
+                  "accent_path_lights": "Blue and white stepping pattern with amber accents when path lights exist."
+                },
+                "facade_palette": [
+                  {"rgb_color": [0, 0, 255], "brightness": 255},
+                  {"rgb_color": [255, 255, 255], "brightness": 255},
+                  {"rgb_color": [255, 69, 0], "brightness": 255},
+                  {"rgb_color": [30, 144, 255], "brightness": 255}
+                ],
+                "ambient_palette": [
+                  {"rgb_color": [0, 0, 255], "brightness": 145},
+                  {"rgb_color": [255, 255, 255], "brightness": 150},
+                  {"color_temp_kelvin": 2600, "brightness": 135},
+                  {"rgb_color": [30, 144, 255], "brightness": 145}
+                ],
+                "path_palette": [
+                  {"rgb_color": [0, 0, 255], "brightness": 112},
+                  {"rgb_color": [255, 255, 255], "brightness": 112},
+                  {"color_temp_kelvin": 2600, "brightness": 108},
+                  {"rgb_color": [30, 144, 255], "brightness": 110}
+                ]
+              },
+              "halloween": {
+                "label": "Halloween",
+                "cadence_minutes": 2,
+                "transition_seconds": 30,
+                "scene_count": 4,
+                "target_behaviors": {
+                  "facade_rgb_lights": "Spooky Halloween facade loop with red, orange, purple, and eerie green.",
+                  "front_ambient_light": "Porch glow shifts between jack-o-lantern orange, ghostly purple, and toxic green.",
+                  "accent_path_lights": "Warm orange base with purple and green accents when path lights exist."
+                },
+                "facade_palette": [
+                  {"rgb_color": [255, 0, 0], "brightness": 255},
+                  {"rgb_color": [255, 120, 0], "brightness": 255},
+                  {"rgb_color": [60, 0, 120], "brightness": 255},
+                  {"rgb_color": [0, 255, 100], "brightness": 255}
+                ],
+                "ambient_palette": [
+                  {"rgb_color": [255, 64, 0], "brightness": 145},
+                  {"rgb_color": [255, 150, 0], "brightness": 150},
+                  {"rgb_color": [120, 0, 220], "brightness": 140},
+                  {"rgb_color": [0, 180, 70], "brightness": 140}
+                ],
+                "path_palette": [
+                  {"rgb_color": [255, 120, 0], "brightness": 112},
+                  {"rgb_color": [120, 0, 220], "brightness": 108},
+                  {"rgb_color": [0, 180, 70], "brightness": 108},
+                  {"rgb_color": [255, 64, 0], "brightness": 110}
+                ]
+              },
               "burns_night": {
                 "label": "Burns Night",
                 "cadence_minutes": 2,
@@ -1383,6 +1363,10 @@ template:
         state: >-
           {%- if is_state('binary_sensor.hogmanay', 'on') -%}
             hogmanay
+          {%- elif is_state('binary_sensor.halloween', 'on') -%}
+            halloween
+          {%- elif is_state('binary_sensor.st_andrews_day', 'on') -%}
+            st_andrews_day
           {%- elif is_state('binary_sensor.burns_night', 'on') -%}
             burns_night
           {%- elif is_state('binary_sensor.national_curling_month', 'on') -%}
@@ -1419,13 +1403,18 @@ template:
             veterans_day
           {%- elif is_state('binary_sensor.thanksgiving', 'on') -%}
             thanksgiving
+          {%- elif is_state('binary_sensor.christmas_season', 'on') -%}
+            christmas_season
           {%- else -%}
             none
           {%- endif -%}
         attributes:
           friendly_label: >-
             {% set labels = {
-              'none': 'No dynamic holiday',
+              'none': 'No holiday lighting',
+              'christmas_season': 'Christmas Season',
+              'st_andrews_day': "St Andrew's Day",
+              'halloween': 'Halloween',
               'hogmanay': "Hogmanay",
               'burns_night': "Burns Night",
               'national_curling_month': "National Curling Month",
@@ -1448,46 +1437,16 @@ template:
             } %}
             {% set active = states('sensor.active_outdoor_holiday') | trim %}
             {{ labels.get(active, active | replace('_', ' ') | title) }}
-
-      - name: active_holiday_lighting
-        unique_id: active_holiday_lighting
-        state: >-
-          {%- set dynamic = states('sensor.active_outdoor_holiday') | trim -%}
-          {%- if dynamic not in ['none', 'unknown', 'unavailable', ''] -%}
-            {{ dynamic }}
-          {%- elif is_state('binary_sensor.halloween', 'on') -%}
-            halloween
-          {%- elif is_state('binary_sensor.st_andrews_day', 'on') -%}
-            st_andrews_day
-          {%- elif is_state('binary_sensor.christmas_season', 'on') -%}
-            christmas_season
-          {%- else -%}
-            none
-          {%- endif -%}
-        attributes:
-          friendly_label: >-
-            {% set active = states('sensor.active_holiday_lighting') | trim %}
-            {% set labels = {
-              'none': 'No holiday lighting',
-              'christmas_season': 'Christmas Season',
-              'halloween': 'Halloween',
-              'st_andrews_day': "St Andrew's Day"
-            } %}
-            {% if active in labels %}
-              {{ labels[active] }}
-            {% else %}
-              {{ state_attr('sensor.active_outdoor_holiday', 'friendly_label') | default(active | replace('_', ' ') | title, true) }}
-            {% endif %}
           notification_message: >-
-            {% set active = states('sensor.active_holiday_lighting') | trim %}
+            {% set active = states('sensor.active_outdoor_holiday') | trim %}
             {% if active in ['none', 'unknown', 'unavailable', ''] %}
               {{ '' }}
             {% elif active == 'christmas_season' %}
-              Today's special lighting is Christmas Season. The tree and outdoor Christmas scenes will start before sunset.
+              Today's special lighting is Christmas Season. The tree and palette-driven outdoor Christmas scenes will start before sunset.
             {% elif active == 'halloween' %}
-              Today's special lighting is Halloween. The existing spooky outdoor loop will start before sunset.
+              Today's special lighting is Halloween. The palette-driven outdoor holiday scenes will start before sunset.
             {% elif active == 'st_andrews_day' %}
-              Today's special lighting is St Andrew's Day. The Saltire-inspired outdoor loop will start before sunset.
+              Today's special lighting is St Andrew's Day. The palette-driven outdoor holiday scenes will start before sunset.
             {% else %}
               Today's special lighting is {{ state_attr('sensor.active_outdoor_holiday', 'friendly_label') | default(active | replace('_', ' ') | title, true) }}. The palette-driven outdoor holiday scenes will start before sunset.
             {% endif %}

--- a/tests/test_holiday_calendar_logic.py
+++ b/tests/test_holiday_calendar_logic.py
@@ -108,14 +108,16 @@ def test_active_outdoor_holiday_prioritizes_specific_days_over_broader_seasons()
     assert block.index("binary_sensor.burns_night") < block.index(
         "binary_sensor.national_curling_month"
     )
+    assert block.index("binary_sensor.thanksgiving") < block.index(
+        "binary_sensor.christmas_season"
+    )
 
 
-def test_active_holiday_lighting_includes_existing_holidays_after_dynamic_selector() -> None:
-    block = _template_sensor_block("active_holiday_lighting")
+def test_active_outdoor_holiday_now_includes_existing_holidays() -> None:
+    block = _template_sensor_block("active_outdoor_holiday")
 
-    assert "states('sensor.active_outdoor_holiday') | trim" in block
     assert block.index("binary_sensor.halloween") < block.index("binary_sensor.st_andrews_day")
-    assert block.index("binary_sensor.st_andrews_day") < block.index(
+    assert block.index("binary_sensor.thanksgiving") < block.index(
         "binary_sensor.christmas_season"
     )
     assert "Today's special lighting is Christmas Season." in block
@@ -123,11 +125,21 @@ def test_active_holiday_lighting_includes_existing_holidays_after_dynamic_select
     assert "Today's special lighting is St Andrew's Day." in block
 
 
+def test_unified_holiday_registry_includes_legacy_holidays() -> None:
+    text = _text()
+
+    assert '"christmas_season": {' in text
+    assert '"st_andrews_day": {' in text
+    assert '"halloween": {' in text
+    assert '"lighting_engine": "legacy_scene_loop"' not in text
+    assert '"legacy_scene_prefix":' not in text
+
+
 def test_holiday_lighting_notification_only_sends_on_holiday_days() -> None:
     text = _text()
 
     assert "- id: notify_holiday_lighting_day" in text
     assert "entity_id: sensor.active_holiday_lighting" not in text
-    assert "states('sensor.active_holiday_lighting') | trim not in ['none', 'unknown', 'unavailable', '']" in text
-    assert "state_attr('sensor.active_holiday_lighting', 'notification_message')" in text
+    assert "states('sensor.active_outdoor_holiday') | trim not in ['none', 'unknown', 'unavailable', '']" in text
+    assert "state_attr('sensor.active_outdoor_holiday', 'notification_message')" in text
     assert "action: notify.all" in text

--- a/tests/test_holiday_palette_engine.py
+++ b/tests/test_holiday_palette_engine.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 HOLIDAYS_PATH = Path(__file__).resolve().parents[1] / "packages" / "holidays.yaml"
 
-EXPECTED_DYNAMIC_HOLIDAYS = {
+EXPECTED_HOLIDAYS = {
+    "christmas_season",
+    "st_andrews_day",
+    "halloween",
     "burns_night",
     "national_curling_month",
     "groundhog_day",
@@ -86,13 +89,13 @@ def _expand_scene(
     return entities
 
 
-def test_dynamic_holiday_definitions_cover_issue_244_observances() -> None:
+def test_holiday_definitions_cover_existing_and_issue_244_observances() -> None:
     definitions = _holiday_definitions()
 
-    assert set(definitions) == EXPECTED_DYNAMIC_HOLIDAYS
+    assert set(definitions) == EXPECTED_HOLIDAYS
 
 
-def test_dynamic_holiday_definitions_include_target_behaviors_and_palette_counts() -> None:
+def test_holiday_definitions_include_target_behaviors_and_palette_counts() -> None:
     definitions = _holiday_definitions()
 
     for holiday_key, definition in definitions.items():
@@ -107,7 +110,14 @@ def test_dynamic_holiday_definitions_include_target_behaviors_and_palette_counts
         assert len(definition["path_palette"]) >= definition["scene_count"], holiday_key
 
 
-def test_dynamic_holiday_rotation_reaches_every_declared_scene_index() -> None:
+def test_unified_registry_no_longer_uses_legacy_engine_markers() -> None:
+    text = HOLIDAYS_PATH.read_text(encoding="utf-8")
+
+    assert '"lighting_engine": "legacy_scene_loop"' not in text
+    assert '"legacy_scene_prefix":' not in text
+
+
+def test_holiday_rotation_reaches_every_declared_scene_index() -> None:
     definitions = _holiday_definitions()
 
     for holiday_key, definition in definitions.items():

--- a/tests/test_holidays_scene_rotation.py
+++ b/tests/test_holidays_scene_rotation.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 
@@ -34,43 +33,28 @@ def _automation_block(automation_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
-def test_two_minute_holiday_loops_use_half_minute_indexing() -> None:
-    st_andrews = _automation_block("st_andrews_day_light_loop")
-    halloween = _automation_block("halloween_light_loop")
+def test_single_outdoor_holiday_loop_replaces_legacy_holiday_loop_automations() -> None:
+    text = HOLIDAYS_PATH.read_text(encoding="utf-8")
 
-    assert 'minutes: "/2"' in st_andrews
-    assert 'minutes: "/2"' in halloween
-
-    assert (
-        "scene.scene_st_andrews_day_outdoors_{{ (now().minute // 2) % 4 + 1 | int }}"
-        in st_andrews
-    )
-    assert "scene.scene_st_andrews_day_outdoors_{{ now().minute % 4 + 1 | int }}" not in st_andrews
-
-    assert (
-        "scene.scene_halloween_outdoors_{{ (now().minute // 2) % 4 + 1 | int }}" in halloween
-    )
-    assert "scene.scene_halloween_outdoors_{{ now().minute % 4 + 1 | int }}" not in halloween
+    assert "- id: outdoor_holiday_light_loop" in text
+    assert "- id: christmas_outside_light_loop_1" not in text
+    assert "- id: st_andrews_day_light_loop" not in text
+    assert "- id: halloween_light_loop" not in text
 
 
-def test_two_minute_holiday_loops_can_reach_all_four_scenes() -> None:
-    scene_indexes = {(minute // 2) % 4 + 1 for minute in range(0, 60, 2)}
+def test_outdoor_holiday_loop_uses_active_outdoor_holiday_selector_and_script() -> None:
+    block = _automation_block("outdoor_holiday_light_loop")
 
-    assert scene_indexes == {1, 2, 3, 4}
-
-
-def test_christmas_loop_keeps_per_minute_rotation() -> None:
-    christmas = _automation_block("christmas_outside_light_loop_1")
-
-    assert 'minutes: "/1"' in christmas
-    assert "scene.scene_christmas_outdoors_{{ now().minute % 4 + 1 | int }}" in christmas
-
-    scene_indexes = {minute % 4 + 1 for minute in range(60)}
-    assert scene_indexes == {1, 2, 3, 4}
+    assert 'minutes: "/1"' in block
+    assert "states('sensor.active_outdoor_holiday') | trim" in block
+    assert "action: script.apply_outdoor_holiday_scene" in block
+    assert 'holiday_key: "{{ states(\'sensor.active_outdoor_holiday\') | trim }}"' in block
 
 
-def test_christmas_loop_yields_new_years_eve_to_hogmanay() -> None:
-    christmas = _automation_block("christmas_outside_light_loop_1")
+def test_christmas_toggle_only_manages_tree_automations() -> None:
+    block = _automation_block("toggle_christmas_automations_on_season_change")
 
-    assert 'entity_id: binary_sensor.hogmanay' in christmas
-    assert 'state: "off"' in christmas
+    assert "automation.christmas_tree_on" in block
+    assert "automation.christmas_tree_off_midnight" in block
+    assert "automation.christmas_lights_off_bedroom_off" in block
+    assert "automation.christmas_outside_light_loop_1" not in block


### PR DESCRIPTION
## Summary
- unify all outdoor holiday lighting under one palette-driven engine in `packages/holidays.yaml`
- include the legacy holidays (`christmas_season`, `halloween`, and `st_andrews_day`) in the same holiday definition registry as the newer observances
- add a one-shot holiday-lighting reminder that only sends on days with active holiday lighting

## Validation
- `uv run --with pytest pytest`

Closes #244
