### PR TITLE
[codex] Refine trip-mode Inovelli LED handling

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1391,6 +1391,43 @@ automation:
     action:
       - action: script.reset_inovelli_switches
 
+  - id: sync_trip_mode_inovelli_leds
+    alias: sync_trip_mode_inovelli_leds
+    description: Keep all Inovelli LED bars dark during trips and restore the normal LED profile when trip mode clears.
+    trigger:
+      - trigger: homeassistant
+        event: start
+        id: startup
+      - trigger: state
+        entity_id: input_boolean.trip
+        to: "on"
+        id: trip_on
+      - trigger: state
+        entity_id: input_boolean.trip
+        to: "off"
+        id: trip_off
+    action:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id:
+                  - startup
+                  - trip_on
+              - condition: state
+                entity_id: input_boolean.trip
+                state: "on"
+            sequence:
+              - action: script.turn_on
+                target:
+                  entity_id: script.turn_off_all_inovelli_switch_leds
+          - conditions:
+              - condition: trigger
+                id: trip_off
+            sequence:
+              - action: script.turn_on
+                target:
+                  entity_id: script.restore_inovelli_switch_leds_from_trip
+
   - id: reset_z2m_reboot_counter
     alias: reset_z2m_reboot_counter
     trigger:
@@ -1915,6 +1952,10 @@ script:
       all_switches_led_intensity_off: >
         {%- for device in states.number | select('match', '.*ledintensitywhenoff.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
     sequence:
+      - &trip_led_updates_allowed
+        condition: state
+        entity_id: input_boolean.trip
+        state: "off"
       - action: logbook.log
         data:
           entity_id: script.night_tv_mode_switches
@@ -1945,6 +1986,7 @@ script:
   day_mode_switches:
     icon: mdi:light-switch
     sequence:
+      - *trip_led_updates_allowed
       - action: script.turn_on
         target:
           entity_id:
@@ -2012,6 +2054,7 @@ script:
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
     sequence:
+      - *trip_led_updates_allowed
       - action: logbook.log
         data:
           entity_id: script.day_mode_switches_general
@@ -2082,6 +2125,7 @@ script:
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
     sequence:
+      - *trip_led_updates_allowed
       - action: logbook.log
         data:
           entity_id: script.day_mode_switches_owner_suite_bedroom
@@ -2137,6 +2181,7 @@ script:
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
     sequence:
+      - *trip_led_updates_allowed
       - action: logbook.log
         data:
           entity_id: script.day_mode_switches_office_guest_room
@@ -2197,7 +2242,7 @@ script:
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       # Snapshot captured from the live Zigbee2MQTT MQTT bridge on 2026-03-28.
-      inovelli_led_notification_targets:
+      inovelli_led_notification_targets: &inovelli_led_notification_targets
         - Basement/Bathroom/Exhaust
         - Basement/Bathroom/Shower Switch
         - Basement/Great Room East and Middle Switch
@@ -2704,6 +2749,99 @@ script:
           message: >
             Replayed the saved Inovelli smart bulb modes, output modes, switch types,
             group memberships, and bindings for switches and bulbs/groups.
+
+  turn_off_all_inovelli_switch_leds:
+    icon: mdi:light-switch-off
+    variables:
+      all_switches_led_intensity_on: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenon') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      all_switches_led_intensity_off: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenoff') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      inovelli_led_notification_targets: *inovelli_led_notification_targets
+    sequence:
+      - action: logbook.log
+        data:
+          entity_id: script.turn_off_all_inovelli_switch_leds
+          name: Exclude log
+          message: "Turning off all Inovelli LED bars while trip mode is active"
+          domain: script
+      - action: number.set_value
+        data:
+          entity_id: >
+            {{ all_switches_led_intensity_off }}
+          value: 0
+      - action: number.set_value
+        data:
+          entity_id: >
+            {{ all_switches_led_intensity_on }}
+          value: 0
+      - repeat:
+          for_each: "{{ inovelli_led_notification_targets }}"
+          sequence:
+            - action: mqtt.publish
+              data:
+                topic: "zigbee2mqtt/{{ repeat.item }}/set"
+                payload: >
+                  {{ {'led_effect': {'effect': 'clear_effect'}} | tojson }}
+
+  restore_inovelli_switch_leds_from_trip:
+    icon: mdi:light-switch
+    variables:
+      office_guest_room_day_mode_ready: >-
+        {{ is_state('input_boolean.guest_mode', 'off') or now() >= today_at('12:00') }}
+      owner_suite_bedroom_day_mode_ready: >-
+        {{
+          now() >= today_at('08:00')
+          and is_state('binary_sensor.bayesian_bed_occupancy', 'off')
+          and (
+            is_state('binary_sensor.owner_suite_bathroom_room_occupancy', 'on')
+            or states.binary_sensor.owner_suite_bathroom_room_occupancy.last_changed >= today_at('08:00')
+          )
+          and (
+            is_state('binary_sensor.hall_upstairs_motion_occupancy', 'on')
+            or states.binary_sensor.hall_upstairs_motion_occupancy.last_changed >= today_at('08:00')
+          )
+        }}
+    sequence:
+      - *trip_led_updates_allowed
+      - choose:
+          - conditions:
+              - condition: or
+                conditions:
+                  - condition: state
+                    entity_id: switch.sleep_mode
+                    state: "on"
+                  - condition: state
+                    entity_id: sun.sun
+                    state: "below_horizon"
+            sequence:
+              - action: script.turn_on
+                target:
+                  entity_id: script.night_tv_mode_switches
+        default:
+          - action: script.turn_on
+            target:
+              entity_id: script.day_mode_switches_general
+          - if:
+              - condition: template
+                value_template: "{{ office_guest_room_day_mode_ready }}"
+            then:
+              - action: script.turn_on
+                target:
+                  entity_id: script.day_mode_switches_office_guest_room
+          - if:
+              - condition: template
+                value_template: "{{ owner_suite_bedroom_day_mode_ready }}"
+            then:
+              - action: script.turn_on
+                target:
+                  entity_id: script.day_mode_switches_owner_suite_bedroom
 
   turn_off_owner_suite_inovelli_switch_leds:
     icon: mdi:light-switch

--- a/tests/test_issue_trip_led_suspend.py
+++ b/tests/test_issue_trip_led_suspend.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ZIGBEE_ZWAVE_PATH = ROOT / "packages" / "zigbee_zwave.yaml"
+
+
+def _script_block(script_id: str) -> str:
+    lines = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line == f"  {script_id}:":
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script {script_id!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  ") and not lines[index].startswith("    "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _automation_block(automation_id: str) -> str:
+    lines = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line == f"  - id: {automation_id}":
+            start = index
+            break
+
+        if line != f"    id: {automation_id}":
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_trip_mode_sync_automation_suspends_and_restores_inovelli_leds() -> None:
+    block = _automation_block("sync_trip_mode_inovelli_leds")
+
+    assert "event: start" in block
+    assert "entity_id: input_boolean.trip" in block
+    assert 'to: "on"' in block
+    assert 'to: "off"' in block
+    assert "script.turn_off_all_inovelli_switch_leds" in block
+    assert "script.restore_inovelli_switch_leds_from_trip" in block
+
+
+def test_trip_suspend_script_zeros_led_intensities_and_clears_active_effects() -> None:
+    block = _script_block("turn_off_all_inovelli_switch_leds")
+
+    assert "all_switches_led_intensity_on" in block
+    assert "all_switches_led_intensity_off" in block
+    assert "value: 0" in block
+    assert "'clear_effect'" in block
+    assert "zigbee2mqtt/{{ repeat.item }}/set" in block
+
+
+def test_trip_restore_script_reuses_existing_day_and_night_profiles() -> None:
+    block = _script_block("restore_inovelli_switch_leds_from_trip")
+
+    for token in (
+        "entity_id: switch.sleep_mode",
+        "entity_id: sun.sun",
+        "state: \"below_horizon\"",
+        "script.night_tv_mode_switches",
+        "script.day_mode_switches_general",
+        "script.day_mode_switches_office_guest_room",
+        "script.day_mode_switches_owner_suite_bedroom",
+        "is_state('input_boolean.guest_mode', 'off')",
+        "today_at('12:00')",
+        "binary_sensor.bayesian_bed_occupancy",
+        "binary_sensor.owner_suite_bathroom_room_occupancy",
+        "binary_sensor.hall_upstairs_motion_occupancy",
+        "today_at('08:00')",
+    ):
+        assert token in block
+
+
+def test_trip_mode_blocks_day_and_night_led_scripts_from_relighting_switches() -> None:
+    for script_id in (
+        "night_tv_mode_switches",
+        "day_mode_switches",
+        "day_mode_switches_general",
+        "day_mode_switches_owner_suite_bedroom",
+        "day_mode_switches_office_guest_room",
+    ):
+        block = _script_block(script_id)
+
+        assert (
+            re.search(
+                r"entity_id: input_boolean\.trip\n\s+state: \"off\"",
+                block,
+            )
+            or "*trip_led_updates_allowed" in block
+        ), f"{script_id} should stop when trip mode is active"


### PR DESCRIPTION
## Summary
- add a dedicated trip-mode automation that turns off all Inovelli LED bar updates while `input_boolean.trip` is active
- add centralized suspend/restore scripts so trip mode clears active Zigbee2MQTT LED effects and restores the normal day/night LED profile on return
- gate the existing day/night Inovelli LED scripts behind the shared trip policy so other automations cannot relight switches during a trip
- add regression coverage for the new trip automation and suspend/restore scripts

## Why
Issue #297 requested that trip mode suppress all Inovelli LED updates and LED bar activity while away, then resume the normal behavior when returning home. Previously, existing day/night scripts and active LED effects could still relight the bars during trip mode.

## Impact
Trip mode now has a single source of truth for Inovelli LED suppression. Entering trip mode shuts down the LED bars and clears active notification effects; leaving trip mode restores the appropriate profile based on current sleep/day conditions.

## Root Cause
The Inovelli LED behavior was controlled by several reusable scripts, but none of them were centrally suspended by trip mode and active Zigbee2MQTT LED effects were not explicitly cleared.

## Validation
- added regression tests in `tests/test_issue_trip_led_suspend.py`
- `uv run --with pytest pytest`