### PR TITLE
Exclude non-egress contacts from open egress tracking

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2968,7 +2968,11 @@ template:
         default_entity_id: sensor.open_egress_points
         icon: mdi:door-open
         state: >-
-          {% set excluded = ['binary_sensor.mailbox_contact'] %}
+          {% set excluded = [
+            'binary_sensor.mailbox_contact',
+            'binary_sensor.den_doors_contact',
+            'binary_sensor.laundry_room_washing_machine_door_contact'
+          ] %}
           {% set open_entities = namespace(entity_ids=[]) %}
           {% for sensor in states.binary_sensor %}
             {% set entity_id = sensor.entity_id %}
@@ -2984,7 +2988,11 @@ template:
           {{ open_entities.entity_ids | count }}
         attributes:
           entity_ids: >-
-            {% set excluded = ['binary_sensor.mailbox_contact'] %}
+            {% set excluded = [
+              'binary_sensor.mailbox_contact',
+              'binary_sensor.den_doors_contact',
+              'binary_sensor.laundry_room_washing_machine_door_contact'
+            ] %}
             {% set open_entities = namespace(entity_ids=[]) %}
             {% for sensor in states.binary_sensor %}
               {% set entity_id = sensor.entity_id %}
@@ -2999,7 +3007,11 @@ template:
             {% endfor %}
             {{ open_entities.entity_ids | sort | join(', ') }}
           friendly_names: >-
-            {% set excluded = ['binary_sensor.mailbox_contact'] %}
+            {% set excluded = [
+              'binary_sensor.mailbox_contact',
+              'binary_sensor.den_doors_contact',
+              'binary_sensor.laundry_room_washing_machine_door_contact'
+            ] %}
             {% set open_entities = namespace(names=[]) %}
             {% for sensor in states.binary_sensor %}
               {% set entity_id = sensor.entity_id %}

--- a/tests/test_window_egress_automation_coverage.py
+++ b/tests/test_window_egress_automation_coverage.py
@@ -35,6 +35,28 @@ def _automation_block(path: Path, automation_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
+def _template_sensor_block(path: Path, sensor_name: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"      - name: {sensor_name}"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find template sensor block {sensor_name!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("      - name: ") or lines[index].startswith("  - lock:"):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
 def test_motion_detected_on_trip_watches_all_known_window_and_egress_contacts() -> None:
     block = _automation_block(ALERTS_PATH, "motion_detected_on_trip")
 
@@ -61,14 +83,18 @@ def test_doors_open_when_leaving_home_checks_windows_and_doors() -> None:
 
 
 def test_dynamic_egress_sensors_replace_legacy_group() -> None:
-    text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
+    block = _template_sensor_block(ZIGBEE_ZWAVE_PATH, "open_egress_points")
 
-    assert "default_entity_id: sensor.open_egress_points" in text
-    assert "default_entity_id: binary_sensor.any_egress_open" in text
-    assert "entity_id.endswith('_contact')" in text
-    assert "device_class in ['door', 'window', 'opening']" in text
-    assert "binary_sensor.mailbox_contact" in text
-    assert "group.egress_points" not in text
+    assert "default_entity_id: sensor.open_egress_points" in block
+    assert "entity_id.endswith('_contact')" in block
+    assert "device_class in ['door', 'window', 'opening']" in block
+    for entity_id in (
+        "binary_sensor.mailbox_contact",
+        "binary_sensor.den_doors_contact",
+        "binary_sensor.laundry_room_washing_machine_door_contact",
+    ):
+        assert entity_id in block
+    assert "group.egress_points" not in block
 
 
 def test_fresh_air_open_reuses_any_window_open_state() -> None:


### PR DESCRIPTION
## Summary
- exclude the den doors and washing machine door contacts from the dynamic open-egress inventory
- preserve the existing mailbox exclusion
- tighten regression coverage around the generated egress sensor block

## Verification
- `uv run --with pytest pytest`

Closes #318