### PR TITLE
Add research plans for pending Home Assistant follow-ups

### DIFF
--- a/docs/issue_research_310_312_319_321_322.md
+++ b/docs/issue_research_310_312_319_321_322.md
@@ -1,0 +1,179 @@
+# Issue Research Notes
+
+Reviewed on 2026-04-01 for issues `#310`, `#312`, `#319`, `#321`, and `#322`.
+
+This note separates verified findings from proposed follow-up work so the repo
+captures the research without forcing speculative YAML changes before runtime
+validation exists.
+
+## Issue 310: Refine the Person Identification
+
+### Findings
+
+- The repo already contains camera- and snapshot-oriented building blocks in
+  [`packages/camera.yaml`](../packages/camera.yaml),
+  commented historical face-processing config in
+  [`configuration.yaml`](../configuration.yaml), room/privacy context in
+  [`docs/room_intent.yaml`](./room_intent.yaml), and an `llmvision` service
+  surface in
+  [`custom_components/llmvision/services.yaml`](../custom_components/llmvision/services.yaml).
+- The live Home Assistant instance does not currently expose a loaded
+  `llmvision` integration or an OpenAI integration, so a repo-only automation
+  change would be untestable today.
+- The live Home Assistant instance does expose front-door entities such as
+  `lock.front_door_lock`, so high-trust known-visitor actions are conceptually
+  possible once the image-analysis layer exists.
+
+### Plan
+
+1. Keep Scrypted or the camera pipeline as the motion/person trigger source.
+2. Add a second-stage image-analysis integration only after the live HA system
+   actually exposes it.
+3. Return structured detection output such as `person_name`, `confidence`,
+   `logo_or_uniform`, `delivery_hint`, and `ignored`.
+4. Start with simple HA-native controls for notification suppression, such as
+   per-person helpers, instead of a free-form ignore list.
+5. Gate high-trust actions such as an unlock prompt behind a stricter confidence
+   threshold and keep those actions confined to the front-door flow.
+6. Re-check [`docs/room_intent.yaml`](./room_intent.yaml) before adding any
+   indoor-camera identity behavior.
+
+### Sources
+
+- [Home Assistant room intent file](./room_intent.yaml)
+- [`packages/camera.yaml`](../packages/camera.yaml)
+- [`configuration.yaml`](../configuration.yaml)
+- [`custom_components/llmvision/services.yaml`](../custom_components/llmvision/services.yaml)
+
+## Issue 312: UniFi DNS Logging and Outbound DNS Enforcement
+
+### Findings
+
+- UniFi officially documents Traffic Flows / Traffic Logging, DHCP DNS
+  assignment, content or domain filtering behavior, and DNAT/SNAT building
+  blocks.
+- Those docs are enough to support evidence capture and policy design, but I
+  did not have live controller access to validate the exact UDM Pro UI flow on
+  this system.
+- Blocking or redirecting port `53` alone does not fully contain DoH, DoT, or
+  other encrypted DNS paths, so the final policy needs to decide whether the
+  goal is classic-DNS enforcement only or broader resolver control.
+
+### Plan
+
+1. Use UniFi Traffic Flows first to capture current outbound DNS behavior.
+2. Set Pi-hole as the DHCP-provided resolver if the intended steady state is
+   "clients naturally use Pi-hole first."
+3. Add explicit allow rules for Pi-hole and Unbound before broader DNS
+   restrictions go in.
+4. Add a redirect path for residual client TCP/UDP `53` traffic if the live UDM
+   Pro UI supports that cleanly on this installation.
+5. Add an explicit deny for remaining LAN-to-Internet `53` traffic after the
+   allow and redirect rules are in place.
+6. Re-run flow logging and preserve before/after evidence from UniFi plus
+   query-side evidence from Pi-hole and Unbound.
+
+### Sources
+
+- [Traffic Flows and Traffic Logging in UniFi Network](https://help.ui.com/hc/en-us/articles/32201256219799-Traffic-Flows-and-Traffic-Logging-in-UniFi-Network)
+- [UniFi DNS Records and Local Hostnames](https://help.ui.com/hc/en-us/articles/15179064940439-UniFi-DNS-Records-and-Local-Hostnames)
+- [Content and Domain Filtering in UniFi](https://help.ui.com/hc/en-us/articles/12568927589143-Content-and-Domain-Filtering-in-UniFi)
+- [DNAT, SNAT, and Masquerading in UniFi](https://help.ui.com/hc/en-us/articles/16437942532759-DNAT-SNAT-and-Masquerading-in-UniFi)
+- [Zone-Based Firewalls in UniFi](https://help.ui.com/hc/en-us/articles/115003173168-Zone-Based-Firewalls-in-UniFi)
+
+## Issue 319: Should I Add TruffleHog?
+
+### Findings
+
+- This repo already has CI validation in
+  [`.github/workflows/validate-config.yml`](../.github/workflows/validate-config.yml),
+  and it does not currently have a `.pre-commit-config.yaml`.
+- TruffleHog officially supports both CI scanning and local pre-commit hooks.
+- TruffleHog also documents comparatively heavier scanner runtime expectations,
+  which makes CI-first adoption a better fit here than mandatory local hooks on
+  every commit.
+
+### Plan
+
+1. Add TruffleHog as a dedicated PR/push workflow that scans the diff against
+   the base branch and fails on verified findings.
+2. Optionally add a scheduled full-history scan on `develop` after the PR-path
+   behavior is stable.
+3. Keep any local hook opt-in until false-positive handling and developer
+   friction are better understood.
+4. Only add a required `pre-commit` hook after CI has proven useful and quiet
+   enough for this repo.
+
+### Sources
+
+- [Scanning in CI](https://docs.trufflesecurity.com/scanning-in-ci)
+- [Pre-commit Hooks](https://docs.trufflesecurity.com/pre-commit-hooks)
+- [Running the Scanner](https://docs.trufflesecurity.com/running-the-scanner)
+- [`.github/workflows/validate-config.yml`](../.github/workflows/validate-config.yml)
+
+## Issue 321: Identify Improvements Based on the 2026.4 Changelog
+
+### Findings
+
+- The 2026.4 release most directly maps to this repo through domain-specific
+  action and automation improvements for battery sensors, windows and doors,
+  media, remotes, labels, and floors.
+- Those areas line up with current custom logic in
+  [`packages/batteries.yaml`](../packages/batteries.yaml),
+  [`packages/zigbee_zwave.yaml`](../packages/zigbee_zwave.yaml),
+  [`packages/tv.yaml`](../packages/tv.yaml), and
+  [`packages/light.yaml`](../packages/light.yaml).
+- The dashboard-side 2026.4 improvements look lower priority here because the
+  repo is still largely using classic include-based views such as
+  [`lovelace/views/view_home.yaml`](../lovelace/views/view_home.yaml), not a
+  sections-first dashboard architecture.
+
+### Plan
+
+1. Prioritize native-HA simplifications where battery, egress, or media logic
+   is still carrying extra template glue.
+2. Treat dashboard improvements as optional follow-up work rather than required
+   repairs.
+3. Revisit label and floor support only where those features clearly simplify an
+   existing manual convention.
+4. Prefer incremental refactors in touched packages rather than a repo-wide
+   template migration campaign.
+
+### Sources
+
+- [Home Assistant 2026.4 release notes](https://www.home-assistant.io/blog/2026/04/01/release-20264/)
+- [`packages/batteries.yaml`](../packages/batteries.yaml)
+- [`packages/zigbee_zwave.yaml`](../packages/zigbee_zwave.yaml)
+- [`packages/tv.yaml`](../packages/tv.yaml)
+- [`packages/light.yaml`](../packages/light.yaml)
+- [`lovelace/views/view_home.yaml`](../lovelace/views/view_home.yaml)
+
+## Issue 322: Identify Improvements Based on the 2026.3 Changelog
+
+### Findings
+
+- The most relevant 2026.3 improvement for this repo is native area-based
+  vacuum cleaning.
+- This repo still uses manual segment and zoned cleaning logic in
+  [`packages/xiaomi_robot_vacuum.yaml`](../packages/xiaomi_robot_vacuum.yaml)
+  and related UI references in
+  [`lovelace/views/views_template.yaml`](../lovelace/views/views_template.yaml).
+- The same release also exposed `continue_on_error`, but the repo is already
+  aligned with that pattern in its vacuum package.
+
+### Plan
+
+1. Verify on the live HA system whether the current Valetudo-backed vacuum path
+   exposes area cleaning in a way Home Assistant can use directly.
+2. If native area cleaning is exposed cleanly, prototype a thin HA-native path
+   for one or two rooms before replacing the existing segment-based flow.
+3. If the live runtime does not expose the needed area-cleaning capability, keep
+   the current segment and zone implementation and document that constraint.
+4. Treat `continue_on_error` as already satisfied unless a specific action path
+   shows a runtime problem.
+
+### Sources
+
+- [Home Assistant 2026.3 release notes](https://www.home-assistant.io/blog/2026/03/04/release-20263/)
+- [`packages/xiaomi_robot_vacuum.yaml`](../packages/xiaomi_robot_vacuum.yaml)
+- [`lovelace/views/views_template.yaml`](../lovelace/views/views_template.yaml)


### PR DESCRIPTION
## Summary
- add a research note covering issues #310, #312, #319, #321, and #322
- separate verified findings from recommended next steps for each issue
- include direct links to the repo files and external sources that informed each plan

## Verification
- `uv run --with pytest pytest`

Refs #310
Refs #312
Refs #319
Refs #321
Refs #322