### PR TITLE
Fix runtime HA notification and sensor warnings

### DIFF
--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -407,7 +407,8 @@ automation:
                   - condition: template
                     value_template: "{{ trigger.id == 'early_morning' and tesla_plan.precondition and tesla_plan.low_tpms }}"
             sequence:
-              - action: notify.all
+              - continue_on_error: true
+                action: notify.notify_all
                 data:
                   data:
                     url: "/ryan-new-mushroom/tesla-v2"

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -291,17 +291,28 @@ automation:
       - trigger: numeric_state
         entity_id: sensor.nws_alerts
         above: 0
-    condition:
-      - condition: template
-        value_template: >-
-          {% set alert_type = state_attr('sensor.nws_alerts', 'TYPE') | default('', true) %}
-          {% set description = state_attr('sensor.nws_alerts', 'Description') | default('', true) %}
-          {{ not (alert_type == "TOR" or description == "Tornado Warning") }}
     action:
-      - action: notify.all
-        data:
-          message: >-
-            {{ state_attr('sensor.nws_alerts', 'Description') }}
+      - variables:
+          nws_alerts: "{{ state_attr('sensor.nws_alerts', 'Alerts') | default([], true) }}"
+          primary_alert: "{{ nws_alerts[0] if nws_alerts is sequence and nws_alerts | count > 0 else dict() }}"
+          alert_type: >-
+            {{ primary_alert.Event | default(state_attr('sensor.nws_alerts', 'TYPE') | default('', true), true) }}
+          alert_message: >-
+            {% set description = primary_alert.Description | default(state_attr('sensor.nws_alerts', 'Description') | default('', true), true) %}
+            {% if description | trim != '' %}
+              {{ description }}
+            {% else %}
+              {{ primary_alert.Headline | default('', true) }}
+            {% endif %}
+      - if:
+          - condition: template
+            value_template: >-
+              {{ alert_type not in ['TOR', 'Tornado Warning'] and alert_message | trim != '' }}
+        then:
+          - action: notify.notify_all
+            data:
+              title: "{{ alert_type if alert_type | trim != '' else 'Weather alert' }}"
+              message: "{{ alert_message }}"
 
   - id: window_open_departure_rain_warning
     alias: window_open_departure_rain_warning

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -3195,8 +3195,6 @@ template:
       - name: "east_bed_occupied_num"
         unique_id: east_bed_occupied_num
         state_class: measurement
-        unit_of_measurement: "1"
-        device_class: power_factor
         availability: "{{ states('input_boolean.east_bed_occupied') in ['on','off'] }}"
         state: >-
           {% set s = states('input_boolean.east_bed_occupied') %}
@@ -3205,8 +3203,6 @@ template:
       - name: "west_bed_occupied_num"
         unique_id: west_bed_occupied_num
         state_class: measurement
-        unit_of_measurement: "1"
-        device_class: power_factor
         availability: "{{ states('input_boolean.west_bed_occupied') in ['on','off'] }}"
         state: >-
           {% set s = states('input_boolean.west_bed_occupied') %}

--- a/tests/test_issue_bed_occupied_sensor_units.py
+++ b/tests/test_issue_bed_occupied_sensor_units.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ZIGBEE_ZWAVE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zigbee_zwave.yaml"
+
+
+def test_bed_occupied_numeric_sensors_do_not_use_invalid_power_factor_metadata() -> None:
+    text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
+
+    east_block = text.split('name: "east_bed_occupied_num"', maxsplit=1)[1].split(
+        'name: "west_bed_occupied_num"',
+        maxsplit=1,
+    )[0]
+    west_block = text.split('name: "west_bed_occupied_num"', maxsplit=1)[1].split(
+        "\n\n",
+        maxsplit=1,
+    )[0]
+
+    for block in (east_block, west_block):
+        assert 'state_class: measurement' in block
+        assert 'device_class: power_factor' not in block
+        assert 'unit_of_measurement: "1"' not in block

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -24,6 +24,14 @@ def test_tesla_departure_planner_waits_for_helpers_on_startup() -> None:
     assert 'delay: "00:00:30"' in text
 
 
+def test_tesla_departure_planner_notification_uses_notify_all_with_error_tolerance() -> None:
+    text = _read(CAR_PATH)
+
+    assert "id: tesla_departure_planner_apply" in text
+    assert "continue_on_error: true" in text
+    assert "action: notify.notify_all" in text
+
+
 def test_time_to_home_template_handles_unavailable_source_state() -> None:
     text = _read(TRIPS_PATH)
 

--- a/tests/test_weather_package.py
+++ b/tests/test_weather_package.py
@@ -19,3 +19,15 @@ def test_car_window_alert_closes_windows_even_when_notification_is_throttled() -
     assert "latitude=0&longitude=0" not in text
     assert "Check if we already notified within the last hour" in text
     assert "action: notify.mobile_app_wethop" in text
+
+
+def test_notify_weather_alert_uses_current_nws_alert_payload_shape() -> None:
+    text = WEATHER_PATH.read_text(encoding="utf-8")
+
+    assert "id: notify_weather_alert" in text
+    assert "state_attr('sensor.nws_alerts', 'Alerts')" in text
+    assert "primary_alert.Event" in text
+    assert "primary_alert.Description" in text
+    assert "primary_alert.Headline" in text
+    assert "action: notify.notify_all" in text
+    assert "message: >-\n            {{ state_attr('sensor.nws_alerts', 'Description') }}" not in text


### PR DESCRIPTION
## Summary
- adapt `notify_weather_alert` to the live `sensor.nws_alerts` payload shape and skip empty alert bodies
- route the Tesla planner notification through `notify.notify_all` with `continue_on_error` so startup races do not fail the automation
- remove invalid `power_factor` metadata from the bed occupancy numeric template sensors
- add regression tests for the weather alert payload, Tesla notification path, and bed occupancy metadata

## Validation
- `uv run --with pytest pytest`

## Runtime context
- Retrieved Home Assistant Core logs over SSH from the HA SSH add-on container before making changes
- Observed repo-owned runtime errors around `notify_weather_alert`, `tesla_departure_planner_apply`, and invalid bed occupancy sensor metadata
- Additional runtime issues remain that appear external or upstream-managed (for example Bermuda metadevice errors, LocalTuya connectivity/subscription failures, and intermittent upstream API/network errors)