### PR TITLE
[codex] Fix hallway motion quiet-window reset

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -804,8 +804,15 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                state: "off"
+                for:
+                  minutes: 3
+              - condition: state
+                entity_id:
                   - binary_sensor.hall_upstairs_motion_occupancy
                 state: "off"
+                for:
+                  minutes: 3
               - action: light.turn_off
                 data:
                   entity_id:
@@ -826,8 +833,15 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                state: "off"
+                for:
+                  minutes: 15
+              - condition: state
+                entity_id:
                   - binary_sensor.hall_upstairs_motion_occupancy
                 state: "off"
+                for:
+                  minutes: 15
               - action: light.turn_off
                 data:
                   entity_id:
@@ -880,8 +894,15 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                state: "off"
+                for:
+                  minutes: 15
+              - condition: state
+                entity_id:
                   - binary_sensor.hall_upstairs_motion_occupancy
                 state: "off"
+                for:
+                  minutes: 15
               - action: light.turn_off
                 data:
                   entity_id:
@@ -901,8 +922,15 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                state: "off"
+                for:
+                  minutes: 3
+              - condition: state
+                entity_id:
                   - binary_sensor.hall_upstairs_motion_occupancy
                 state: "off"
+                for:
+                  minutes: 3
               - action: light.turn_off
                 data:
                   entity_id:
@@ -1521,8 +1549,15 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                state: "off"
+                for:
+                  minutes: 15
+              - condition: state
+                entity_id:
                   - binary_sensor.hall_upstairs_motion_occupancy
                 state: "off"
+                for:
+                  minutes: 15
               - action: light.turn_off
                 data:
                   entity_id:
@@ -1559,8 +1594,15 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                state: "off"
+                for:
+                  minutes: 15
+              - condition: state
+                entity_id:
                   - binary_sensor.hall_upstairs_motion_occupancy
                 state: "off"
+                for:
+                  minutes: 15
               - action: light.turn_off
                 data:
                   entity_id:

--- a/tests/test_issue_333_hallway_motion_restart.py
+++ b/tests/test_issue_333_hallway_motion_restart.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIGHT_PATH = ROOT / "packages" / "light.yaml"
+
+
+def _automation_block(path: Path, automation_name: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^  - (?:id|alias): {re.escape(automation_name)}\n(.*?)(?=^  - (?:id|alias): |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find automation block {automation_name!r} in {path.name}")
+    return match.group(0)
+
+
+def _off_condition_durations(block: str) -> Counter[tuple[str, str]]:
+    pattern = re.compile(
+        r"entity_id:\n\s+- (binary_sensor\.hall_(?:main_foyer|upstairs)_motion_occupancy)\n"
+        r"\s+state: \"off\"\n\s+for:\n\s+minutes: (\d+)"
+    )
+    return Counter(pattern.findall(block))
+
+
+def test_toggle_hallway_day_requires_both_sensors_to_stay_clear_for_15_minutes() -> None:
+    block = _automation_block(LIGHT_PATH, "toggle_hallway_day")
+    durations = _off_condition_durations(block)
+
+    assert durations[("binary_sensor.hall_main_foyer_motion_occupancy", "15")] == 2
+    assert durations[("binary_sensor.hall_upstairs_motion_occupancy", "15")] == 2
+
+
+def test_hallway_night_turn_off_requires_full_quiet_window_from_both_sensors() -> None:
+    block = _automation_block(LIGHT_PATH, "hallway_light_toggle_at_night")
+    durations = _off_condition_durations(block)
+
+    assert durations[("binary_sensor.hall_main_foyer_motion_occupancy", "3")] == 2
+    assert durations[("binary_sensor.hall_main_foyer_motion_occupancy", "15")] == 2
+    assert durations[("binary_sensor.hall_upstairs_motion_occupancy", "3")] == 2
+    assert durations[("binary_sensor.hall_upstairs_motion_occupancy", "15")] == 2


### PR DESCRIPTION
## Summary
- require both hallway motion sensors to remain clear for the full quiet window before hallway lights can turn off
- apply the same protection to both the daytime and nighttime hallway automations so an older countdown cannot beat newer motion on the other sensor
- add a regression test covering the hallway automation quiet-window conditions

## Root Cause
The hallway automations could still shut lights off based on an older per-sensor countdown even after a fresh walk-by on the other hallway motion sensor.

## Validation
- `uv run --with pytest pytest`
