### PR TITLE
Add trace review skill for Home Assistant issue triage

### DIFF
--- a/.codex/skills/trace-review/SKILL.md
+++ b/.codex/skills/trace-review/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: trace-review
+description: Review Home Assistant automation, scene, and script traces; separate benign runs from real faults; and turn confirmed defects into the smallest validated fix or PR-ready issue update.
+---
+
+# Trace Review
+
+Use this skill when a task involves Home Assistant traces, runtime failures, noisy automations, or issue sweeps such as repo issues `#314` and `#316`.
+
+## Modes
+
+Choose one mode before you start:
+
+- `Issue mode`: investigate a specific automation, script, or scene named in an issue or repair.
+- `Sweep mode`: review a bounded set of live automation/script/scene traces, classify the failures, and turn confirmed defects into issue or PR work without rewriting healthy logic.
+
+Read `references/sweep-playbook.md` when you need the full sweep procedure or GitHub triage loop.
+
+## Workflow
+
+1. Orient on the live system first.
+   Use:
+   - `ha_get_overview(detail_level="minimal", include_entity_id=True)`
+   - `ha_search_entities(query="", domain_filter="automation")`
+   - `ha_search_entities(query="", domain_filter="script")`
+   - `ha_search_entities(query="", domain_filter="scene")`
+
+2. Pull the current config before judging a trace.
+   Use:
+   - `ha_config_get_automation`
+   - `ha_config_get_script`
+   - `ha_deep_search` for referenced helpers, scripts, dashboards, and consumers
+
+3. Pull recent traces, then drill into suspicious runs.
+   Use `ha_get_automation_traces(<entity_id>, limit=10)` first.
+   Fetch detailed evidence with `ha_get_automation_traces(..., run_id=<id>, detailed=True)`.
+
+4. Separate noise from defects.
+   Treat these as normally benign unless they violate the intent:
+   - `failed_conditions` where the guard correctly blocked execution
+   - one-off `failed_single` runs caused by overlapping equivalent triggers
+
+   Treat these as real bugs:
+   - stale or unavailable entity references
+   - action/service-call errors
+   - repeated overlap that suppresses materially different runs
+   - logic that contradicts room policy or package intent
+
+5. Preserve room policy before changing room-targeted logic.
+   Read `docs/room_intent.yaml` before changing occupancy, lighting, media, vacuum, climate, dashboards, or guest-sensitive automations.
+
+6. Correlate the finding with GitHub before editing.
+   Prefer updating an existing issue. Search for a linked open PR before starting new implementation work.
+   If the bug is new, open or update the issue with the trace evidence, affected entity, and minimal proposed fix.
+
+7. Make the smallest safe change.
+   Prefer:
+   - fixing stale entity references
+   - tightening triggers or guards
+   - removing noisy duplicate paths
+   - adding explicit protection for unavailable entities
+
+   Avoid:
+   - rewriting the automation because a newer pattern exists
+   - changing the core intent when the trace only shows a benign blocked run
+
+8. Add or update tests for every accepted fix.
+   Cover:
+   - the entity IDs or services involved
+   - the trigger or condition path you changed
+   - the regression exposed by the trace
+
+9. Validate before proposing a PR.
+   Run targeted tests first, then `uv run --with pytest pytest` when the repo change is ready.
+   If you touched Home Assistant YAML, also run the repo's relevant config validation and any touched-file linting.
+
+## Review Output
+
+When you report results, separate them into:
+
+- `Confirmed bug`
+- `Benign trace`
+- `Needs runtime verification`
+
+For each confirmed bug, include:
+
+- affected entity
+- triggering trace pattern
+- live state or device evidence
+- why the current logic is wrong
+- the minimal fix
+- the test that proves it
+- whether there is already an issue or PR for the defect

--- a/.codex/skills/trace-review/agents/openai.yaml
+++ b/.codex/skills/trace-review/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Trace Review"
+  short_description: "Review HA traces and turn defects into validated fixes"
+  default_prompt: "Use $trace-review to inspect Home Assistant traces, classify benign vs real failures, and prepare the smallest tested fix or PR-ready issue update."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/trace-review/references/sweep-playbook.md
+++ b/.codex/skills/trace-review/references/sweep-playbook.md
@@ -1,0 +1,71 @@
+# Trace Sweep Playbook
+
+Use this reference when the task is to review many traces rather than debug a single named automation or script.
+
+## Candidate Selection
+
+Build a bounded candidate set instead of scanning the entire system blindly.
+
+Prefer this order:
+
+1. entities named in the issue or repair
+2. entities mentioned in recent errors, persistent notifications, or open runtime issues
+3. enabled automations/scripts in the affected package or area
+
+Use `ha_search_entities(query="", domain_filter="automation")` and `ha_search_entities(query="", domain_filter="script")` to enumerate candidates when the issue is broad.
+
+## Trace Classification
+
+For each candidate:
+
+1. call `ha_get_automation_traces(..., limit=10)`
+2. group runs into:
+   - completed as expected
+   - benign `failed_conditions`
+   - benign one-off `failed_single`
+   - repeated overlap that changes behavior
+   - runtime faults
+3. fetch detailed traces only for suspicious runs
+
+Do not create work for harmless guard-condition failures.
+
+## GitHub Triage Loop
+
+For each confirmed defect:
+
+1. look for an existing open issue first
+2. check whether an open PR already references it
+3. if no issue exists, open or update one with:
+   - affected entity
+   - short trace summary
+   - minimal fix hypothesis
+   - verification needed
+4. if the defect is implementable now, prepare a branch from `origin/develop`, add tests, and open a PR targeting `develop`
+
+When a defect is blocked by missing credentials, hardware access, or unsafe ambiguity, leave the issue with a concise blocker note rather than guessing.
+
+## Fix Scope Guardrails
+
+Preserve the automation's existing job unless the trace proves the job itself is wrong.
+
+Prefer:
+
+- stale entity fixes
+- explicit availability guards
+- narrower triggers
+- shorter waits or corrected mode only when traces show missed behavior
+
+Avoid:
+
+- policy changes without room-intent review
+- broad refactors unrelated to the failing path
+- opening one giant PR for unrelated trace bugs
+
+## Verification Checklist
+
+Before you call the work done:
+
+- touched tests pass
+- `uv run --with pytest pytest` passes
+- touched Home Assistant YAML, if any, passes the repo validation path
+- the issue or PR summary distinguishes confirmed bugs from benign traces

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@
 !inventory.md
 !docs/
 !docs/*.md
+!.codex/
+!.codex/skills/
+!.codex/skills/trace-review/
+!.codex/skills/trace-review/**
 !scripts/
 !scripts/*.py
 !scripts/*.sh

--- a/tests/test_trace_review_skill.py
+++ b/tests/test_trace_review_skill.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GITIGNORE_PATH = ROOT / ".gitignore"
+SKILL_PATH = ROOT / ".codex" / "skills" / "trace-review" / "SKILL.md"
+REFERENCE_PATH = ROOT / ".codex" / "skills" / "trace-review" / "references" / "sweep-playbook.md"
+AGENT_PATH = ROOT / ".codex" / "skills" / "trace-review" / "agents" / "openai.yaml"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_gitignore_tracks_trace_review_skill_files() -> None:
+    text = _read(GITIGNORE_PATH)
+
+    assert "!.codex/" in text
+    assert "!.codex/skills/" in text
+    assert "!.codex/skills/trace-review/" in text
+    assert "!.codex/skills/trace-review/**" in text
+
+
+def test_trace_review_skill_defines_issue_and_sweep_modes() -> None:
+    text = _read(SKILL_PATH)
+
+    assert "## Modes" in text
+    assert "`Issue mode`" in text
+    assert "`Sweep mode`" in text
+    assert "references/sweep-playbook.md" in text
+
+
+def test_trace_review_skill_anchors_live_trace_tools_and_repo_guardrails() -> None:
+    text = _read(SKILL_PATH)
+
+    assert "ha_get_overview(detail_level=\"minimal\", include_entity_id=True)" in text
+    assert "ha_search_entities(query=\"\", domain_filter=\"automation\")" in text
+    assert "ha_get_automation_traces(<entity_id>, limit=10)" in text
+    assert "docs/room_intent.yaml" in text
+    assert "uv run --with pytest pytest" in text
+
+
+def test_trace_review_reference_covers_issue_and_pr_triage() -> None:
+    text = _read(REFERENCE_PATH)
+
+    assert "## GitHub Triage Loop" in text
+    assert "look for an existing open issue first" in text
+    assert "check whether an open PR already references it" in text
+    assert "branch from `origin/develop`" in text
+
+
+def test_trace_review_agent_prompt_mentions_skill_and_pr_ready_updates() -> None:
+    text = _read(AGENT_PATH)
+
+    assert 'display_name: "Trace Review"' in text
+    assert 'default_prompt: "Use $trace-review' in text
+    assert "PR-ready issue update" in text
+    assert "allow_implicit_invocation: true" in text


### PR DESCRIPTION
## Summary
- add a repo-local `trace-review` skill with issue-mode and sweep-mode workflows for Home Assistant traces
- add a reference playbook for turning confirmed trace defects into issue and PR work while preserving existing automation intent
- track the new skill bundle in git and add pytest coverage for the skill contract

## Verification
- `pytest tests/test_trace_review_skill.py`
- `uv run --with pyyaml python /Users/rtclauss/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/trace-review`
- `uv run --with pytest pytest`

Closes #316