### PR TITLE
Fix Tesla calendar preconditioning and destination routing

### DIFF
--- a/docs/tesla_departure_planner.md
+++ b/docs/tesla_departure_planner.md
@@ -125,15 +125,16 @@ Script:
 
 Behavior:
 
-- enables Tesla scheduled departure only for real calendar departures that still have a valid future departure time and need a Home Assistant-managed override
+- enables Tesla scheduled departure only for real calendar departures that still have a valid future departure time
 - does not enable Tesla scheduled departure for alarm-only plans; those only influence charge-limit planning and planner messaging
 - disables Tesla scheduled departure when the planner no longer has a Home Assistant-managed preconditioning plan to keep
 - refuses to schedule preconditioning when the computed departure window is already in the past
+- does not gate real calendar-departure preconditioning on outside temperature; temperature only adjusts the departure buffer and some alarm-only charge-limit planning
 - stores the last Home Assistant-managed Tesla departure as a Unix timestamp in `input_number.tesla_managed_departure_ts` and tracks whether that schedule is active with `input_boolean.tesla_managed_departure_active`
 - clears that Home Assistant-managed Tesla schedule as soon as the stored departure time passes, even if the car is no longer at home
 - skips scheduled departure for all-day calendar events
 - preserves Tesla-app charging schedules at `home` unless the planner needs a non-default home charge target
-- skips Tesla scheduled-departure writes for protected-location default-`80%` plans so preconditioning-only home plans do not create extra Tesla schedule entries
+- at `home`, a default-`80%` calendar departure can still set Tesla scheduled departure for cabin preconditioning without enabling Home Assistant-managed off-peak charging
 - preserves Tesla-app charging schedules at protected locations during cleanup by only clearing Tesla when the live scheduled-departure state still matches the stored HA-managed departure and Tesla is not advertising scheduled charging or off-peak charging
 
 ### Notifications
@@ -192,9 +193,9 @@ Manual regression cases worth checking in Template Developer Tools or against li
 - Tesla `sensor.nigori_charging_rate` `time_left` as `HH:MM:SS` or ISO8601 still produces a valid `charge_complete` timestamp.
 - A just-finished calendar departure disappears from `binary_sensor.upcoming_trip_charging` and clears Tesla scheduled departure on the next planner recompute.
 - A calendar event that is still upcoming but already inside the departure buffer skips scheduled preconditioning instead of creating a stale past-due Tesla schedule.
-- At `home`, default-`80%` alarm or calendar departures do not create extra Tesla schedule entries, while non-default charge targets can still create a temporary Home Assistant-managed override.
+- At `home`, default-`80%` alarm plans do not create Tesla scheduled departure entries, while real calendar departures can still set Tesla scheduled departure for cabin preconditioning without taking over off-peak charging.
 - Alarm-only plans adjust charge limit and planner messaging but do not create Tesla scheduled departure or cabin-preconditioning overrides.
-- At `home`, a real calendar departure can still create or update Tesla scheduled departure/preconditioning when the planner needs a non-default charge target, while default-`80%` home plans leave the Tesla app schedule in place.
+- At `home`, a real calendar departure can still create or update Tesla scheduled departure/preconditioning whether the charge target stays at `80%` or rises above it, while only the non-default charge-target cases enable a temporary Home Assistant-managed off-peak charging override.
 - At `parents`, `OCC`, and `SPCC`, Tesla dashboard text reflects that Home Assistant is preserving Tesla-app defaults and not actively planning departures there.
 - When there is no active stored `input_number.tesla_managed_departure_ts`, the planner does not send a redundant Tesla disable call.
 - At protected locations, cleanup/no-plan disables only call the Tesla API when the live Tesla scheduled-departure state still matches the stored HA-managed departure and Tesla is not advertising scheduled charging or off-peak charging.

--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -279,7 +279,7 @@ automation:
             {% endif %}
             {% set manage_tesla_schedule = (not preserve_default_charging_schedule) or charge_limit != 80 %}
             {% set departure_window_open = departure_dt is not none and departure_dt > now() %}
-            {% set precondition = has_calendar_departure and departure_window_open and manage_tesla_schedule %}
+            {% set precondition = has_calendar_departure and departure_window_open %}
             {% if trip_all_day %}
               {% set precondition = false %}
             {% endif %}
@@ -366,7 +366,7 @@ automation:
       - choose:
           - conditions:
               - condition: template
-                value_template: "{{ tesla_plan.precondition and tesla_plan.departure_time != '' and tesla_plan.manage_tesla_schedule }}"
+                value_template: "{{ tesla_plan.precondition and tesla_plan.departure_time != '' }}"
             sequence:
               - action: script.tesla_set_precondition_schedule_time
                 data:
@@ -1110,49 +1110,33 @@ template:
         unique_id: calendar_destination
         name: Next Calendar Destination
         state: >-
-          {% if state_attr("calendar.ryan_claussen", "start_time")  != None %}
-            {% set personal_meeting_time = (state_attr("calendar.ryan_claussen", "start_time") | as_datetime|as_local) %}
-          {% else %}
-            {% set personal_meeting_time = as_datetime(13596565062) %}
-          {% endif %}
-
-          {% if state_attr("binary_sensor.work_trip_today", "start_time") not in [none, ''] %}
-            {% set work_meeting_upcoming = state_attr("binary_sensor.work_trip_today", "start_time")| as_datetime|as_local %}
-          {% else %}
-            {% set work_meeting_upcoming = as_datetime(13596565062) %}
-          {% endif %}
-
-          {% if state_attr("calendar.curling", "start_time")  != None %}
-            {% set curling_upcoming = (state_attr("calendar.curling", "start_time")| as_datetime|as_local) %}
-          {% else %}
-            {% set curling_upcoming = as_datetime(13596565062) %}
-          {% endif %}
-
-          {% if (personal_meeting_time < curling_upcoming) %}
-            {% if (personal_meeting_time < work_meeting_upcoming) %}
-              {% if (personal_meeting_time - now())< timedelta(hours=24) and state_attr('calendar.ryan_claussen', 'location') != "" %}
-                {{ state_attr('calendar.ryan_claussen', 'location') }}
-              {% else %}
-                {{states("input_text.home_address")}}
-              {% endif %}
-            {% else %}
-                {{ state_attr('binary_sensor.work_trip_today', 'location') }}
-            {% endif %}
-          {% else %}
-            {% if (curling_upcoming < work_meeting_upcoming) %}
-              {% if (curling_upcoming - now())< timedelta(hours=24) and state_attr('calendar.curling', 'location') != "" %}
-                {{ state_attr('calendar.curling', 'location') }}
-              {% else %}
-                {{states("input_text.home_address")}}
-              {% endif %}
-            {% else %}
-            {% if (curling_upcoming - now())< timedelta(hours=24) and state_attr('binary_sensor.work_trip_today', 'location') not in [none, ''] %}
-                {{ state_attr('binary_sensor.work_trip_today', 'location') }}
-              {% else %}
-                {{states("input_text.home_address")}}
+          {% set now_local = now() %}
+          {% set horizon = now_local + timedelta(hours=24) %}
+          {% set ns = namespace(start=none, value=states('input_text.home_address')) %}
+          {% set candidates = [
+            {
+              'start_raw': state_attr('calendar.ryan_claussen', 'start_time'),
+              'location': state_attr('calendar.ryan_claussen', 'location') | default('', true) | trim
+            },
+            {
+              'start_raw': state_attr('binary_sensor.work_trip_today', 'start_time'),
+              'location': state_attr('binary_sensor.work_trip_today', 'location') | default('', true) | trim
+            },
+            {
+              'start_raw': state_attr('calendar.curling', 'start_time'),
+              'location': state_attr('calendar.curling', 'location') | default('', true) | trim
+            }
+          ] %}
+          {% for candidate in candidates %}
+            {% if candidate.start_raw not in [none, ''] and candidate.location != '' %}
+              {% set candidate_start = candidate.start_raw | as_datetime | as_local %}
+              {% if candidate_start is not none and candidate_start > now_local and candidate_start < horizon and (ns.start is none or candidate_start < ns.start) %}
+                {% set ns.start = candidate_start %}
+                {% set ns.value = candidate.location %}
               {% endif %}
             {% endif %}
-          {% endif %}
+          {% endfor %}
+          {{ ns.value }}
 ########################
 # Zone
 ########################

--- a/tests/test_tesla_charging_dashboard.py
+++ b/tests/test_tesla_charging_dashboard.py
@@ -44,19 +44,41 @@ def test_home_default_charge_plan_skips_extra_tesla_schedule_override() -> None:
     package_text = CAR_PACKAGE_PATH.read_text(encoding="utf-8")
 
     assert "{% set manage_tesla_schedule = (not preserve_default_charging_schedule) or charge_limit != 80 %}" in package_text
-    assert "tesla_plan.manage_tesla_schedule" in package_text
     assert "No extra home charging override is needed." in package_text
 
 
 def test_alarm_only_planner_skips_preconditioning_without_real_departure() -> None:
     package_text = CAR_PACKAGE_PATH.read_text(encoding="utf-8")
 
-    assert "{% set precondition = has_calendar_departure and departure_window_open and manage_tesla_schedule %}" in package_text
+    assert "{% set precondition = has_calendar_departure and departure_window_open %}" in package_text
     assert (
         "{% set precondition = (has_calendar_departure or alarm_enabled) and departure_window_open %}"
         not in package_text
     )
     assert "skip cabin preconditioning until a real next-day departure is scheduled" in package_text
+
+
+def test_home_default_charge_plan_still_runs_real_departure_preconditioning() -> None:
+    package_text = CAR_PACKAGE_PATH.read_text(encoding="utf-8")
+
+    assert 'value_template: "{{ tesla_plan.precondition and tesla_plan.departure_time != \'\' }}"' in package_text
+    assert 'value_template: "{{ tesla_plan.precondition and tesla_plan.departure_time != \'\' and tesla_plan.manage_tesla_schedule }}"' not in package_text
+
+
+def test_real_calendar_preconditioning_is_not_gated_by_temperature() -> None:
+    package_text = CAR_PACKAGE_PATH.read_text(encoding="utf-8")
+
+    assert "{% set precondition = has_calendar_departure and departure_window_open %}" in package_text
+    assert "{% set precondition = has_calendar_departure and departure_window_open and cold_weather %}" not in package_text
+    assert "{% set precondition = has_calendar_departure and departure_window_open and outside_temp_f" not in package_text
+
+
+def test_calendar_destination_ignores_blank_location_events_before_falling_back_home() -> None:
+    package_text = CAR_PACKAGE_PATH.read_text(encoding="utf-8")
+
+    assert "{% set ns = namespace(start=none, value=states('input_text.home_address')) %}" in package_text
+    assert "{% if candidate.start_raw not in [none, ''] and candidate.location != '' %}" in package_text
+    assert "{% if (personal_meeting_time < curling_upcoming) %}" not in package_text
 
 
 def test_dashboard_copy_explains_alarm_only_days_and_home_schedule_override_logic() -> None:


### PR DESCRIPTION
## Summary
- allow real calendar departures to set Tesla preconditioning even when the charge target stays at 80%
- keep calendar-departure preconditioning independent of outside temperature gating
- fix `sensor.calendar_destination` so blank-location earlier events do not override a later real destination with the home address
- update Tesla planner docs and regression coverage for the new behavior

## Testing
- `uv run --with pytest pytest`
- `uv run --with pytest pytest tests/test_tesla_charging_dashboard.py`