### PR TITLE
Stage basement light auto-on from landing to TV

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -400,23 +400,7 @@ automation:
           - input_boolean.bayesian_zeke_home
         state: "on"
     action:
-      - action: adaptive_lighting.apply
-        data:
-          lights:
-            - light.basement_great_room
-          entity_id: switch.adaptive_lighting_basement
-          adapt_brightness: true
-          adapt_color: true
-          turn_on_lights: true
-      # - action: light.turn_on
-      #   data:
-      #     entity_id:
-      #       - light.basement_great_room_east_and_middle_switch
-      #       - light.basement_north_hallway_switch
-      #       - light.basement_landing_switch
-      #       - light.basement_great_room_west_switch
-      #       - light.basement_great_room_landing_switch_2
-      #       - light.basement_great_room
+      - action: script.turn_on_basement_lights_sequentially
 
   - id: cpap_on_lights_off
     alias: cpap_on_lights_off
@@ -2199,6 +2183,35 @@ script:
           entity_id: scene.scene_reset_basement
         data:
           transition: 15
+
+  turn_on_basement_lights_sequentially:
+    alias: "Turn On Basement Lights Sequentially"
+    description: >-
+      Turn on the basement path in stages from the landing toward the TV, then
+      bring up the TV bias light last.
+    mode: restart
+    sequence:
+      - repeat:
+          for_each:
+            - light.basement_landing_switch
+            - light.basement_great_room_landing_switch_2
+            - light.basement_north_hallway_switch
+            - light.basement_great_room_east_and_middle_switch
+            - light.basement_great_room_west_switch
+          sequence:
+            - action: adaptive_lighting.apply
+              data:
+                entity_id: switch.adaptive_lighting_basement
+                lights:
+                  - "{{ repeat.item }}"
+                adapt_brightness: true
+                adapt_color: true
+                turn_on_lights: true
+            - delay:
+                seconds: 1
+      - action: light.turn_on
+        target:
+          entity_id: light.basement_tv_bias
 
   tiki_room_solid:
     alias: "Tiki Room Solid"

--- a/tests/test_goodnight_integrity.py
+++ b/tests/test_goodnight_integrity.py
@@ -147,7 +147,29 @@ def test_basement_lights_auto_on_respects_plex_basement_playback() -> None:
     assert "media_player.plex_basement_apple_tv" in block
     assert "condition: not" in block
     assert "condition: or" in block
-    assert "light.basement_great_room" in block
+    assert "script.turn_on_basement_lights_sequentially" in block
+
+
+def test_turn_on_basement_lights_sequentially_stages_path_lights_before_tv_bias() -> None:
+    block = _script_block(LIGHT_PATH, "turn_on_basement_lights_sequentially")
+
+    assert "Turn on the basement path in stages" in block
+    assert "switch.adaptive_lighting_basement" in block
+    assert "for_each:" in block
+    assert "{{ repeat.item }}" in block
+
+    ordered_entities = (
+        "light.basement_landing_switch",
+        "light.basement_great_room_landing_switch_2",
+        "light.basement_north_hallway_switch",
+        "light.basement_great_room_east_and_middle_switch",
+        "light.basement_great_room_west_switch",
+        "light.basement_tv_bias",
+    )
+
+    positions = [block.index(entity_id) for entity_id in ordered_entities]
+    assert positions == sorted(positions)
+    assert block.count("seconds: 1") == 1
 
 
 def test_tv_bed_prep_stops_short_of_full_goodnight_shutdown() -> None:


### PR DESCRIPTION
## Summary
- replace the one-shot basement auto-on with a shared staged helper script
- turn on the basement path lights in order from the landing toward the TV
- add regression coverage for the automation handoff and the staged light order

## Testing
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/light.yaml`

## Notes
- The Home Assistant YAML DRY verifier still reports pre-existing duplicate trigger/condition/action patterns elsewhere in `packages/light.yaml`; this change does not add new duplication.
- Full Home Assistant `check_config` was not run because Docker is not installed in this environment.

Fixes #12