### PR TITLE
[codex] Fix battery notification self-inclusion

### DIFF
--- a/packages/batteries.yaml
+++ b/packages/batteries.yaml
@@ -92,8 +92,12 @@ template:
         icon: mdi:battery-20
         variables: &battery_monitor_exclusions
           # Exact entity_ids that should never appear in the low-battery monitor.
-          # Keep this empty unless a specific sensor should be suppressed.
-          battery_exclude_entities: []
+          # Exclude the monitor sensors themselves so they never recurse into
+          # their own summaries if Home Assistant marks them as battery class.
+          battery_exclude_entities:
+            - sensor.battery_low_20
+            - sensor.battery_low_10
+            - sensor.battery_dead
         state: >-
           {% set monitored_batteries = states.sensor
             | selectattr('attributes.device_class', 'eq', 'battery')

--- a/tests/test_batteries_package.py
+++ b/tests/test_batteries_package.py
@@ -38,7 +38,13 @@ def test_battery_template_sensors_scan_all_battery_device_class_entities() -> No
     block_10 = _sensor_block("battery_low_10")
     block_dead = _sensor_block("battery_dead")
 
-    assert "battery_exclude_entities: []" in block_20
+    assert "battery_exclude_entities:" in block_20
+    for excluded_sensor in (
+        "sensor.battery_low_20",
+        "sensor.battery_low_10",
+        "sensor.battery_dead",
+    ):
+        assert excluded_sensor in block_20
     assert "variables: *battery_monitor_exclusions" in block_10
     assert "variables: *battery_monitor_exclusions" in block_dead
 


### PR DESCRIPTION
## Summary
- exclude the battery monitor sensors from the battery monitor scan
- keep the regression test aligned with the exclusion list

## Why
Issue #338 showed the notification was counting `sensor.battery_dead`, `sensor.battery_low_10`, and `sensor.battery_low_20` instead of real battery-powered devices.

## Impact
Battery notifications now report actual low or offline devices instead of the helper sensors that summarize the alert state.

## Root Cause
The dynamic battery scan selected every sensor with `device_class: battery`, which let the monitor sensors include themselves when Home Assistant surfaced them as battery-class entities.

## Validation
- `uv run --with pytest pytest tests/test_batteries_package.py`
- `uv run --with pytest pytest`