### PR TITLE
Refactor Tesla trip classification

### DIFF
--- a/docs/tesla_departure_planner.md
+++ b/docs/tesla_departure_planner.md
@@ -146,6 +146,22 @@ Behavior:
 - at `home`, a default-`80%` calendar departure can still set Tesla scheduled departure for cabin preconditioning without enabling Home Assistant-managed off-peak charging
 - preserves Tesla-app charging schedules at protected locations during cleanup by only clearing Tesla when the live scheduled-departure state still matches the stored HA-managed departure and Tesla is not advertising scheduled charging or off-peak charging
 
+### Calendar trip classification
+
+The planner now centralizes calendar filtering in:
+
+- `sensor.tesla_next_drive_departure`
+
+Behavior:
+
+- scans personal, work, and curling sources for the next timed routable drive departure inside the next 24 hours
+- treats `binary_sensor.upcoming_trip_charging` as a derived "this drive is long enough to justify extra charging" signal rather than as the source of truth for trip selection
+- ignores all-day events, blank locations, home-address events, URL/virtual events, and flight-style itineraries by default
+- supports explicit description overrides:
+  - `tesla:drive` forces a timed event with a real location to count as a drive departure
+  - `tesla:home`, `tesla:virtual`, `tesla:flight`, `tesla:ride`, and `tesla:ignore` force the planner to skip that event
+- uses `sensor.calendar_destination` as a simple projection of the canonical drive-departure sensor so routing and trip selection stay in sync
+
 ### Notifications
 
 The planner sends Tesla status notifications with a deep link to the storage dashboard Tesla view:

--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -950,294 +950,101 @@ sensor: []
 # Template
 ########################
 template:
-  - binary_sensor:
-      - name: upcoming_trip_charging
-        unique_id: upcoming_trip_charging
-        availability: >-
-          {{ state_attr("sensor.waze_next_trip_distance", "distance") != None }}
-        attributes:
-          entry: >-
-            {% set now_local = now() %}
-            {% set horizon = now_local + timedelta(hours=24) %}
-            {% set ns = namespace(start=none, entry='None') %}
-            {% set home_street = states('input_text.home_address') | default('', true) | lower | trim | regex_replace(',.*$', '') %}
-            {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-            {% set personal_summary = state_attr('calendar.ryan_claussen', 'message') | default('', true) | string %}
-            {% set personal_description = state_attr('calendar.ryan_claussen', 'description') | default('', true) | string %}
-            {% set personal_location = state_attr('calendar.ryan_claussen', 'location') | default('', true) | string %}
-            {% set personal_text = [personal_summary, personal_description, personal_location] | join(' ') | lower %}
-            {% set personal_summary_lower = personal_summary | lower %}
-            {% set personal_location_lower = personal_location | lower | trim %}
-            {% set personal_all_day = state_attr('calendar.ryan_claussen', 'all_day') in [true, 'true', 'True', 'on'] %}
-            {% set personal_route_summary = '→' in personal_summary %}
-            {% set personal_named_flight = personal_summary_lower.startswith('flight to ') or (personal_summary_lower.startswith('flight: ') and ' to ' in personal_summary_lower) %}
-            {% set personal_itinerary_marker = 'synced by flighty' in personal_text or 'created from an email you received in gmail' in personal_text or 'booking code:' in personal_text or 'flight time ' in personal_text %}
-            {% set personal_looks_like_flight = personal_route_summary or personal_named_flight or personal_itinerary_marker or ' airport' in personal_text or personal_location_lower.endswith(' intl.') or personal_location_lower.endswith(' international airport') %}
-            {% set personal_virtual = personal_location_lower.startswith('http://') or personal_location_lower.startswith('https://') %}
-            {% set personal_home_like = home_street != '' and home_street in personal_location_lower %}
-            {% if personal_start_raw not in [none, ''] %}
-              {% set personal_start = personal_start_raw | as_datetime | as_local %}
-              {% if personal_start is not none and personal_start > now_local and personal_start < horizon and personal_location_lower != '' and not personal_all_day and not personal_virtual and not personal_home_like and not personal_looks_like_flight and 'nocharge' not in personal_text %}
-                {% set ns.start = personal_start %}
-                {% set ns.entry = 'Personal: ' ~ personal_summary %}
-              {% endif %}
-            {% endif %}
-            {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-            {% set work_summary = state_attr('binary_sensor.work_trip_today', 'message') | default('', true) | string %}
-            {% set work_description = state_attr('binary_sensor.work_trip_today', 'description') | default('', true) | string %}
-            {% set work_location = state_attr('binary_sensor.work_trip_today', 'location') | default('', true) | string %}
-            {% set work_text = [work_summary, work_description, work_location] | join(' ') | lower %}
-            {% set work_summary_lower = work_summary | lower %}
-            {% set work_location_lower = work_location | lower | trim %}
-            {% set work_all_day = state_attr('binary_sensor.work_trip_today', 'all_day') in [true, 'true', 'True', 'on'] %}
-            {% set work_route_summary = '→' in work_summary %}
-            {% set work_named_flight = work_summary_lower.startswith('flight to ') or (work_summary_lower.startswith('flight: ') and ' to ' in work_summary_lower) %}
-            {% set work_itinerary_marker = 'synced by flighty' in work_text or 'created from an email you received in gmail' in work_text or 'booking code:' in work_text or 'flight time ' in work_text %}
-            {% set work_looks_like_flight = work_route_summary or work_named_flight or work_itinerary_marker or ' airport' in work_text or work_location_lower.endswith(' intl.') or work_location_lower.endswith(' international airport') %}
-            {% set work_virtual = work_location_lower.startswith('http://') or work_location_lower.startswith('https://') %}
-            {% set work_home_like = home_street != '' and home_street in work_location_lower %}
-            {% if work_start_raw not in [none, ''] %}
-              {% set work_start = work_start_raw | as_datetime | as_local %}
-              {% if work_start is not none and work_start > now_local and work_start < horizon and work_location_lower != '' and not work_all_day and not work_virtual and not work_home_like and not work_looks_like_flight and 'nocharge' not in work_text and (ns.start is none or work_start < ns.start) %}
-                {% set ns.start = work_start %}
-                {% set ns.entry = 'Work: ' ~ work_summary %}
-              {% endif %}
-            {% endif %}
-            {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-            {% set curling_summary = state_attr('calendar.curling', 'message') | default('', true) | string %}
-            {% set curling_description = state_attr('calendar.curling', 'description') | default('', true) | string %}
-            {% set curling_location = state_attr('calendar.curling', 'location') | default('', true) | string %}
-            {% set curling_text = [curling_summary, curling_description, curling_location] | join(' ') | lower %}
-            {% set curling_summary_lower = curling_summary | lower %}
-            {% set curling_location_lower = curling_location | lower | trim %}
-            {% set curling_all_day = state_attr('calendar.curling', 'all_day') in [true, 'true', 'True', 'on'] %}
-            {% set curling_route_summary = '→' in curling_summary %}
-            {% set curling_named_flight = curling_summary_lower.startswith('flight to ') or (curling_summary_lower.startswith('flight: ') and ' to ' in curling_summary_lower) %}
-            {% set curling_itinerary_marker = 'synced by flighty' in curling_text or 'created from an email you received in gmail' in curling_text or 'booking code:' in curling_text or 'flight time ' in curling_text %}
-            {% set curling_looks_like_flight = curling_route_summary or curling_named_flight or curling_itinerary_marker or ' airport' in curling_text or curling_location_lower.endswith(' intl.') or curling_location_lower.endswith(' international airport') %}
-            {% set curling_virtual = curling_location_lower.startswith('http://') or curling_location_lower.startswith('https://') %}
-            {% set curling_home_like = home_street != '' and home_street in curling_location_lower %}
-            {% if curling_start_raw not in [none, ''] %}
-              {% set curling_start = curling_start_raw | as_datetime | as_local %}
-              {% if curling_start is not none and curling_start > now_local and curling_start < horizon and curling_location_lower != '' and not curling_all_day and not curling_virtual and not curling_home_like and not curling_looks_like_flight and 'nocharge' not in curling_text and (ns.start is none or curling_start < ns.start) %}
-                {% set ns.start = curling_start %}
-                {% set ns.entry = 'Curling: ' ~ curling_summary %}
-              {% endif %}
-            {% endif %}
-            {{ ns.entry }}
-          start_time: >-
-            {% set now_local = now() %}
-            {% set horizon = now_local + timedelta(hours=24) %}
-            {% set ns = namespace(start=none, value='None') %}
-            {% set home_street = states('input_text.home_address') | default('', true) | lower | trim | regex_replace(',.*$', '') %}
-            {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-            {% set personal_summary = state_attr('calendar.ryan_claussen', 'message') | default('', true) | string %}
-            {% set personal_description = state_attr('calendar.ryan_claussen', 'description') | default('', true) | string %}
-            {% set personal_location = state_attr('calendar.ryan_claussen', 'location') | default('', true) | string %}
-            {% set personal_text = [personal_summary, personal_description, personal_location] | join(' ') | lower %}
-            {% set personal_summary_lower = personal_summary | lower %}
-            {% set personal_location_lower = personal_location | lower | trim %}
-            {% set personal_all_day = state_attr('calendar.ryan_claussen', 'all_day') in [true, 'true', 'True', 'on'] %}
-            {% set personal_route_summary = '→' in personal_summary %}
-            {% set personal_named_flight = personal_summary_lower.startswith('flight to ') or (personal_summary_lower.startswith('flight: ') and ' to ' in personal_summary_lower) %}
-            {% set personal_itinerary_marker = 'synced by flighty' in personal_text or 'created from an email you received in gmail' in personal_text or 'booking code:' in personal_text or 'flight time ' in personal_text %}
-            {% set personal_looks_like_flight = personal_route_summary or personal_named_flight or personal_itinerary_marker or ' airport' in personal_text or personal_location_lower.endswith(' intl.') or personal_location_lower.endswith(' international airport') %}
-            {% set personal_virtual = personal_location_lower.startswith('http://') or personal_location_lower.startswith('https://') %}
-            {% set personal_home_like = home_street != '' and home_street in personal_location_lower %}
-            {% if personal_start_raw not in [none, ''] %}
-              {% set personal_start = personal_start_raw | as_datetime | as_local %}
-              {% if personal_start is not none and personal_start > now_local and personal_start < horizon and personal_location_lower != '' and not personal_all_day and not personal_virtual and not personal_home_like and not personal_looks_like_flight and 'nocharge' not in personal_text %}
-                {% set ns.start = personal_start %}
-                {% set ns.value = personal_start_raw %}
-              {% endif %}
-            {% endif %}
-            {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-            {% set work_summary = state_attr('binary_sensor.work_trip_today', 'message') | default('', true) | string %}
-            {% set work_description = state_attr('binary_sensor.work_trip_today', 'description') | default('', true) | string %}
-            {% set work_location = state_attr('binary_sensor.work_trip_today', 'location') | default('', true) | string %}
-            {% set work_text = [work_summary, work_description, work_location] | join(' ') | lower %}
-            {% set work_summary_lower = work_summary | lower %}
-            {% set work_location_lower = work_location | lower | trim %}
-            {% set work_all_day = state_attr('binary_sensor.work_trip_today', 'all_day') in [true, 'true', 'True', 'on'] %}
-            {% set work_route_summary = '→' in work_summary %}
-            {% set work_named_flight = work_summary_lower.startswith('flight to ') or (work_summary_lower.startswith('flight: ') and ' to ' in work_summary_lower) %}
-            {% set work_itinerary_marker = 'synced by flighty' in work_text or 'created from an email you received in gmail' in work_text or 'booking code:' in work_text or 'flight time ' in work_text %}
-            {% set work_looks_like_flight = work_route_summary or work_named_flight or work_itinerary_marker or ' airport' in work_text or work_location_lower.endswith(' intl.') or work_location_lower.endswith(' international airport') %}
-            {% set work_virtual = work_location_lower.startswith('http://') or work_location_lower.startswith('https://') %}
-            {% set work_home_like = home_street != '' and home_street in work_location_lower %}
-            {% if work_start_raw not in [none, ''] %}
-              {% set work_start = work_start_raw | as_datetime | as_local %}
-              {% if work_start is not none and work_start > now_local and work_start < horizon and work_location_lower != '' and not work_all_day and not work_virtual and not work_home_like and not work_looks_like_flight and 'nocharge' not in work_text and (ns.start is none or work_start < ns.start) %}
-                {% set ns.start = work_start %}
-                {% set ns.value = work_start_raw %}
-              {% endif %}
-            {% endif %}
-            {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-            {% set curling_summary = state_attr('calendar.curling', 'message') | default('', true) | string %}
-            {% set curling_description = state_attr('calendar.curling', 'description') | default('', true) | string %}
-            {% set curling_location = state_attr('calendar.curling', 'location') | default('', true) | string %}
-            {% set curling_text = [curling_summary, curling_description, curling_location] | join(' ') | lower %}
-            {% set curling_summary_lower = curling_summary | lower %}
-            {% set curling_location_lower = curling_location | lower | trim %}
-            {% set curling_all_day = state_attr('calendar.curling', 'all_day') in [true, 'true', 'True', 'on'] %}
-            {% set curling_route_summary = '→' in curling_summary %}
-            {% set curling_named_flight = curling_summary_lower.startswith('flight to ') or (curling_summary_lower.startswith('flight: ') and ' to ' in curling_summary_lower) %}
-            {% set curling_itinerary_marker = 'synced by flighty' in curling_text or 'created from an email you received in gmail' in curling_text or 'booking code:' in curling_text or 'flight time ' in curling_text %}
-            {% set curling_looks_like_flight = curling_route_summary or curling_named_flight or curling_itinerary_marker or ' airport' in curling_text or curling_location_lower.endswith(' intl.') or curling_location_lower.endswith(' international airport') %}
-            {% set curling_virtual = curling_location_lower.startswith('http://') or curling_location_lower.startswith('https://') %}
-            {% set curling_home_like = home_street != '' and home_street in curling_location_lower %}
-            {% if curling_start_raw not in [none, ''] %}
-              {% set curling_start = curling_start_raw | as_datetime | as_local %}
-              {% if curling_start is not none and curling_start > now_local and curling_start < horizon and curling_location_lower != '' and not curling_all_day and not curling_virtual and not curling_home_like and not curling_looks_like_flight and 'nocharge' not in curling_text and (ns.start is none or curling_start < ns.start) %}
-                {% set ns.start = curling_start %}
-                {% set ns.value = curling_start_raw %}
-              {% endif %}
-            {% endif %}
-            {{ ns.value }}
-          all_day: >-
-            {% set now_local = now() %}
-            {% set horizon = now_local + timedelta(hours=24) %}
-            {% set ns = namespace(start=none, value='None') %}
-            {% set home_street = states('input_text.home_address') | default('', true) | lower | trim | regex_replace(',.*$', '') %}
-            {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-            {% set personal_summary = state_attr('calendar.ryan_claussen', 'message') | default('', true) | string %}
-            {% set personal_description = state_attr('calendar.ryan_claussen', 'description') | default('', true) | string %}
-            {% set personal_location = state_attr('calendar.ryan_claussen', 'location') | default('', true) | string %}
-            {% set personal_text = [personal_summary, personal_description, personal_location] | join(' ') | lower %}
-            {% set personal_summary_lower = personal_summary | lower %}
-            {% set personal_location_lower = personal_location | lower | trim %}
-            {% set personal_all_day = state_attr('calendar.ryan_claussen', 'all_day') in [true, 'true', 'True', 'on'] %}
-            {% set personal_route_summary = '→' in personal_summary %}
-            {% set personal_named_flight = personal_summary_lower.startswith('flight to ') or (personal_summary_lower.startswith('flight: ') and ' to ' in personal_summary_lower) %}
-            {% set personal_itinerary_marker = 'synced by flighty' in personal_text or 'created from an email you received in gmail' in personal_text or 'booking code:' in personal_text or 'flight time ' in personal_text %}
-            {% set personal_looks_like_flight = personal_route_summary or personal_named_flight or personal_itinerary_marker or ' airport' in personal_text or personal_location_lower.endswith(' intl.') or personal_location_lower.endswith(' international airport') %}
-            {% set personal_virtual = personal_location_lower.startswith('http://') or personal_location_lower.startswith('https://') %}
-            {% set personal_home_like = home_street != '' and home_street in personal_location_lower %}
-            {% if personal_start_raw not in [none, ''] %}
-              {% set personal_start = personal_start_raw | as_datetime | as_local %}
-              {% if personal_start is not none and personal_start > now_local and personal_start < horizon and personal_location_lower != '' and not personal_all_day and not personal_virtual and not personal_home_like and not personal_looks_like_flight and 'nocharge' not in personal_text %}
-                {% set ns.start = personal_start %}
-                {% set ns.value = state_attr('calendar.ryan_claussen', 'all_day') %}
-              {% endif %}
-            {% endif %}
-            {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-            {% set work_summary = state_attr('binary_sensor.work_trip_today', 'message') | default('', true) | string %}
-            {% set work_description = state_attr('binary_sensor.work_trip_today', 'description') | default('', true) | string %}
-            {% set work_location = state_attr('binary_sensor.work_trip_today', 'location') | default('', true) | string %}
-            {% set work_text = [work_summary, work_description, work_location] | join(' ') | lower %}
-            {% set work_summary_lower = work_summary | lower %}
-            {% set work_location_lower = work_location | lower | trim %}
-            {% set work_all_day = state_attr('binary_sensor.work_trip_today', 'all_day') in [true, 'true', 'True', 'on'] %}
-            {% set work_route_summary = '→' in work_summary %}
-            {% set work_named_flight = work_summary_lower.startswith('flight to ') or (work_summary_lower.startswith('flight: ') and ' to ' in work_summary_lower) %}
-            {% set work_itinerary_marker = 'synced by flighty' in work_text or 'created from an email you received in gmail' in work_text or 'booking code:' in work_text or 'flight time ' in work_text %}
-            {% set work_looks_like_flight = work_route_summary or work_named_flight or work_itinerary_marker or ' airport' in work_text or work_location_lower.endswith(' intl.') or work_location_lower.endswith(' international airport') %}
-            {% set work_virtual = work_location_lower.startswith('http://') or work_location_lower.startswith('https://') %}
-            {% set work_home_like = home_street != '' and home_street in work_location_lower %}
-            {% if work_start_raw not in [none, ''] %}
-              {% set work_start = work_start_raw | as_datetime | as_local %}
-              {% if work_start is not none and work_start > now_local and work_start < horizon and work_location_lower != '' and not work_all_day and not work_virtual and not work_home_like and not work_looks_like_flight and 'nocharge' not in work_text and (ns.start is none or work_start < ns.start) %}
-                {% set ns.start = work_start %}
-                {% set ns.value = state_attr('binary_sensor.work_trip_today', 'all_day') %}
-              {% endif %}
-            {% endif %}
-            {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-            {% set curling_summary = state_attr('calendar.curling', 'message') | default('', true) | string %}
-            {% set curling_description = state_attr('calendar.curling', 'description') | default('', true) | string %}
-            {% set curling_location = state_attr('calendar.curling', 'location') | default('', true) | string %}
-            {% set curling_text = [curling_summary, curling_description, curling_location] | join(' ') | lower %}
-            {% set curling_summary_lower = curling_summary | lower %}
-            {% set curling_location_lower = curling_location | lower | trim %}
-            {% set curling_all_day = state_attr('calendar.curling', 'all_day') in [true, 'true', 'True', 'on'] %}
-            {% set curling_route_summary = '→' in curling_summary %}
-            {% set curling_named_flight = curling_summary_lower.startswith('flight to ') or (curling_summary_lower.startswith('flight: ') and ' to ' in curling_summary_lower) %}
-            {% set curling_itinerary_marker = 'synced by flighty' in curling_text or 'created from an email you received in gmail' in curling_text or 'booking code:' in curling_text or 'flight time ' in curling_text %}
-            {% set curling_looks_like_flight = curling_route_summary or curling_named_flight or curling_itinerary_marker or ' airport' in curling_text or curling_location_lower.endswith(' intl.') or curling_location_lower.endswith(' international airport') %}
-            {% set curling_virtual = curling_location_lower.startswith('http://') or curling_location_lower.startswith('https://') %}
-            {% set curling_home_like = home_street != '' and home_street in curling_location_lower %}
-            {% if curling_start_raw not in [none, ''] %}
-              {% set curling_start = curling_start_raw | as_datetime | as_local %}
-              {% if curling_start is not none and curling_start > now_local and curling_start < horizon and curling_location_lower != '' and not curling_all_day and not curling_virtual and not curling_home_like and not curling_looks_like_flight and 'nocharge' not in curling_text and (ns.start is none or curling_start < ns.start) %}
-                {% set ns.start = curling_start %}
-                {% set ns.value = state_attr('calendar.curling', 'all_day') %}
-              {% endif %}
-            {% endif %}
-            {{ ns.value }}
+  - sensor:
+      - default_entity_id: sensor.tesla_next_drive_departure
+        unique_id: tesla_next_drive_departure
+        name: Tesla Next Drive Departure
+        icon: mdi:car-clock
         state: >-
           {% set now_local = now() %}
           {% set horizon = now_local + timedelta(hours=24) %}
-          {% set home_street = states('input_text.home_address') | default('', true) | lower | trim | regex_replace(',.*$', '') %}
-          {% set ns = namespace(start=none, eligible=false) %}
-          {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-          {% set personal_summary = state_attr('calendar.ryan_claussen', 'message') | default('', true) | string %}
-          {% set personal_description = state_attr('calendar.ryan_claussen', 'description') | default('', true) | string %}
-          {% set personal_location = state_attr('calendar.ryan_claussen', 'location') | default('', true) | string %}
-          {% set personal_text = [personal_summary, personal_description, personal_location] | join(' ') | lower %}
-          {% set personal_summary_lower = personal_summary | lower %}
-          {% set personal_location_lower = personal_location | lower | trim %}
-          {% set personal_all_day = state_attr('calendar.ryan_claussen', 'all_day') in [true, 'true', 'True', 'on'] %}
-          {% set personal_route_summary = '→' in personal_summary %}
-          {% set personal_named_flight = personal_summary_lower.startswith('flight to ') or (personal_summary_lower.startswith('flight: ') and ' to ' in personal_summary_lower) %}
-          {% set personal_itinerary_marker = 'synced by flighty' in personal_text or 'created from an email you received in gmail' in personal_text or 'booking code:' in personal_text or 'flight time ' in personal_text %}
-          {% set personal_looks_like_flight = personal_route_summary or personal_named_flight or personal_itinerary_marker or ' airport' in personal_text or personal_location_lower.endswith(' intl.') or personal_location_lower.endswith(' international airport') %}
-          {% set personal_virtual = personal_location_lower.startswith('http://') or personal_location_lower.startswith('https://') %}
-          {% set personal_home_like = home_street != '' and home_street in personal_location_lower %}
-          {% if personal_start_raw not in [none, ''] and personal_location_lower != '' and not personal_all_day and not personal_virtual and not personal_home_like and not personal_looks_like_flight and 'nocharge' not in personal_text %}
-            {% set personal_start = personal_start_raw | as_datetime | as_local %}
-            {% if personal_start is not none and personal_start > now_local and personal_start < horizon %}
-              {% set ns.start = personal_start %}
-              {% set ns.eligible = true %}
+          {% set home_address = states('input_text.home_address') | default('', true) | trim %}
+          {% set home_street = home_address | lower | trim | regex_replace(',.*$', '') %}
+          {% set ns = namespace(best=none) %}
+          {% set candidates = [
+            {
+              'source': 'Personal',
+              'summary': state_attr('calendar.ryan_claussen', 'message') | default('', true) | string,
+              'description': state_attr('calendar.ryan_claussen', 'description') | default('', true) | string,
+              'location': state_attr('calendar.ryan_claussen', 'location') | default('', true) | string,
+              'start_raw': state_attr('calendar.ryan_claussen', 'start_time'),
+              'all_day': state_attr('calendar.ryan_claussen', 'all_day') in [true, 'true', 'True', 'on']
+            },
+            {
+              'source': 'Work',
+              'summary': state_attr('binary_sensor.work_trip_today', 'message') | default('', true) | string,
+              'description': state_attr('binary_sensor.work_trip_today', 'description') | default('', true) | string,
+              'location': state_attr('binary_sensor.work_trip_today', 'location') | default('', true) | string,
+              'start_raw': state_attr('binary_sensor.work_trip_today', 'start_time'),
+              'all_day': state_attr('binary_sensor.work_trip_today', 'all_day') in [true, 'true', 'True', 'on']
+            },
+            {
+              'source': 'Curling',
+              'summary': state_attr('calendar.curling', 'message') | default('', true) | string,
+              'description': state_attr('calendar.curling', 'description') | default('', true) | string,
+              'location': state_attr('calendar.curling', 'location') | default('', true) | string,
+              'start_raw': state_attr('calendar.curling', 'start_time'),
+              'all_day': state_attr('calendar.curling', 'all_day') in [true, 'true', 'True', 'on']
+            }
+          ] %}
+          {% for candidate in candidates %}
+            {% if candidate.start_raw not in [none, '', 'None'] %}
+              {% set start_dt = candidate.start_raw | as_datetime | as_local %}
+              {% set location = candidate.location | trim %}
+              {% set location_lower = location | lower %}
+              {% set summary_lower = candidate.summary | lower %}
+              {% set description_lower = candidate.description | lower %}
+              {% set text = [candidate.summary, candidate.description, location] | join(' ') | lower %}
+              {% set route_summary = '→' in candidate.summary %}
+              {% set named_flight = summary_lower.startswith('flight to ') or (summary_lower.startswith('flight: ') and ' to ' in summary_lower) %}
+              {% set itinerary_marker = 'synced by flighty' in text or 'created from an email you received in gmail' in text or 'booking code:' in text or 'flight time ' in text %}
+              {% set looks_like_flight = route_summary or named_flight or itinerary_marker or ' airport' in text or location_lower.endswith(' intl.') or location_lower.endswith(' international airport') %}
+              {% set virtual = location_lower.startswith('http://') or location_lower.startswith('https://') %}
+              {% set home_like = home_street != '' and home_street in location_lower %}
+              {% set explicit_ignore = 'tesla:ignore' in description_lower %}
+              {% set explicit_drive = 'tesla:drive' in description_lower %}
+              {% set explicit_home = 'tesla:home' in description_lower %}
+              {% set explicit_virtual = 'tesla:virtual' in description_lower %}
+              {% set explicit_flight = 'tesla:flight' in description_lower %}
+              {% set explicit_ride = 'tesla:ride' in description_lower %}
+              {% set eligible = false %}
+              {% if start_dt is not none and start_dt > now_local and start_dt < horizon %}
+                {% if explicit_ignore %}
+                  {% set eligible = false %}
+                {% elif candidate.all_day %}
+                  {% set eligible = false %}
+                {% elif explicit_home %}
+                  {% set eligible = false %}
+                {% elif explicit_virtual %}
+                  {% set eligible = false %}
+                {% elif explicit_flight %}
+                  {% set eligible = false %}
+                {% elif explicit_ride %}
+                  {% set eligible = false %}
+                {% elif explicit_drive %}
+                  {% set eligible = location_lower != '' and not virtual %}
+                {% elif 'nocharge' in text %}
+                  {% set eligible = false %}
+                {% else %}
+                  {% set eligible = location_lower != '' and not virtual and not home_like and not looks_like_flight %}
+                {% endif %}
+              {% endif %}
+              {% if eligible and (ns.best is none or start_dt < ns.best.start_dt) %}
+                {% set ns.best = {
+                  'entry': candidate.source ~ ': ' ~ candidate.summary,
+                  'start_time': candidate.start_raw | string,
+                  'all_day': candidate.all_day,
+                  'location': location,
+                  'start_dt': start_dt
+                } %}
+              {% endif %}
             {% endif %}
+          {% endfor %}
+          {% if ns.best is not none %}
+            {{ {'e': ns.best.entry, 's': ns.best.start_time, 'a': ns.best.all_day, 'l': ns.best.location} | to_json }}
+          {% else %}
+            {{ {'e': 'None', 's': 'None', 'a': false, 'l': home_address} | to_json }}
           {% endif %}
-          {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-          {% set work_summary = state_attr('binary_sensor.work_trip_today', 'message') | default('', true) | string %}
-          {% set work_description = state_attr('binary_sensor.work_trip_today', 'description') | default('', true) | string %}
-          {% set work_location = state_attr('binary_sensor.work_trip_today', 'location') | default('', true) | string %}
-          {% set work_text = [work_summary, work_description, work_location] | join(' ') | lower %}
-          {% set work_summary_lower = work_summary | lower %}
-          {% set work_location_lower = work_location | lower | trim %}
-          {% set work_all_day = state_attr('binary_sensor.work_trip_today', 'all_day') in [true, 'true', 'True', 'on'] %}
-          {% set work_route_summary = '→' in work_summary %}
-          {% set work_named_flight = work_summary_lower.startswith('flight to ') or (work_summary_lower.startswith('flight: ') and ' to ' in work_summary_lower) %}
-          {% set work_itinerary_marker = 'synced by flighty' in work_text or 'created from an email you received in gmail' in work_text or 'booking code:' in work_text or 'flight time ' in work_text %}
-          {% set work_looks_like_flight = work_route_summary or work_named_flight or work_itinerary_marker or ' airport' in work_text or work_location_lower.endswith(' intl.') or work_location_lower.endswith(' international airport') %}
-          {% set work_virtual = work_location_lower.startswith('http://') or work_location_lower.startswith('https://') %}
-          {% set work_home_like = home_street != '' and home_street in work_location_lower %}
-          {% if work_start_raw not in [none, ''] and work_location_lower != '' and not work_all_day and not work_virtual and not work_home_like and not work_looks_like_flight and 'nocharge' not in work_text %}
-            {% set work_start = work_start_raw | as_datetime | as_local %}
-            {% if work_start is not none and work_start > now_local and work_start < horizon and (ns.start is none or work_start < ns.start) %}
-              {% set ns.start = work_start %}
-              {% set ns.eligible = true %}
-            {% endif %}
-          {% endif %}
-          {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-          {% set curling_summary = state_attr('calendar.curling', 'message') | default('', true) | string %}
-          {% set curling_description = state_attr('calendar.curling', 'description') | default('', true) | string %}
-          {% set curling_location = state_attr('calendar.curling', 'location') | default('', true) | string %}
-          {% set curling_text = [curling_summary, curling_description, curling_location] | join(' ') | lower %}
-          {% set curling_summary_lower = curling_summary | lower %}
-          {% set curling_location_lower = curling_location | lower | trim %}
-          {% set curling_all_day = state_attr('calendar.curling', 'all_day') in [true, 'true', 'True', 'on'] %}
-          {% set curling_route_summary = '→' in curling_summary %}
-          {% set curling_named_flight = curling_summary_lower.startswith('flight to ') or (curling_summary_lower.startswith('flight: ') and ' to ' in curling_summary_lower) %}
-          {% set curling_itinerary_marker = 'synced by flighty' in curling_text or 'created from an email you received in gmail' in curling_text or 'booking code:' in curling_text or 'flight time ' in curling_text %}
-          {% set curling_looks_like_flight = curling_route_summary or curling_named_flight or curling_itinerary_marker or ' airport' in curling_text or curling_location_lower.endswith(' intl.') or curling_location_lower.endswith(' international airport') %}
-          {% set curling_virtual = curling_location_lower.startswith('http://') or curling_location_lower.startswith('https://') %}
-          {% set curling_home_like = home_street != '' and home_street in curling_location_lower %}
-          {% if curling_start_raw not in [none, ''] and curling_location_lower != '' and not curling_all_day and not curling_virtual and not curling_home_like and not curling_looks_like_flight and 'nocharge' not in curling_text %}
-            {% set curling_start = curling_start_raw | as_datetime | as_local %}
-            {% if curling_start is not none and curling_start > now_local and curling_start < horizon and (ns.start is none or curling_start < ns.start) %}
-              {% set ns.start = curling_start %}
-              {% set ns.eligible = true %}
-            {% endif %}
-          {% endif %}
-          {{ ns.eligible and (state_attr("sensor.waze_next_trip_distance", "distance") | int(0) > 45) }}
-      - default_entity_id: binary_sensor.tesla_daily_plan_active
-        unique_id: tesla_daily_plan_active
-        name: Tesla Daily Plan Active
-        state: >-
-          {{ is_state('input_boolean.long_range_travel', 'off') }}
-  - sensor:
       - name: charge_complete
         unique_id: charge_complete
         device_class: timestamp
@@ -1267,52 +1074,56 @@ template:
         unique_id: calendar_destination
         name: Next Calendar Destination
         state: >-
-          {% set now_local = now() %}
-          {% set horizon = now_local + timedelta(hours=24) %}
-          {% set ns = namespace(start=none, value=states('input_text.home_address')) %}
-          {% set home_street = states('input_text.home_address') | default('', true) | lower | trim | regex_replace(',.*$', '') %}
-          {% set candidates = [
-            {
-              'start_raw': state_attr('calendar.ryan_claussen', 'start_time'),
-              'location': state_attr('calendar.ryan_claussen', 'location') | default('', true) | string,
-              'summary': state_attr('calendar.ryan_claussen', 'message') | default('', true) | string,
-              'description': state_attr('calendar.ryan_claussen', 'description') | default('', true) | string,
-              'all_day': state_attr('calendar.ryan_claussen', 'all_day') in [true, 'true', 'True', 'on']
-            },
-            {
-              'start_raw': state_attr('binary_sensor.work_trip_today', 'start_time'),
-              'location': state_attr('binary_sensor.work_trip_today', 'location') | default('', true) | string,
-              'summary': state_attr('binary_sensor.work_trip_today', 'message') | default('', true) | string,
-              'description': state_attr('binary_sensor.work_trip_today', 'description') | default('', true) | string,
-              'all_day': state_attr('binary_sensor.work_trip_today', 'all_day') in [true, 'true', 'True', 'on']
-            },
-            {
-              'start_raw': state_attr('calendar.curling', 'start_time'),
-              'location': state_attr('calendar.curling', 'location') | default('', true) | string,
-              'summary': state_attr('calendar.curling', 'message') | default('', true) | string,
-              'description': state_attr('calendar.curling', 'description') | default('', true) | string,
-              'all_day': state_attr('calendar.curling', 'all_day') in [true, 'true', 'True', 'on']
-            }
-          ] %}
-          {% for candidate in candidates %}
-            {% set candidate_location_lower = candidate.location | lower | trim %}
-            {% set candidate_summary_lower = candidate.summary | lower %}
-            {% set candidate_text = [candidate.summary, candidate.description, candidate.location] | join(' ') | lower %}
-            {% set candidate_route_summary = '→' in candidate.summary %}
-            {% set candidate_named_flight = candidate_summary_lower.startswith('flight to ') or (candidate_summary_lower.startswith('flight: ') and ' to ' in candidate_summary_lower) %}
-            {% set candidate_itinerary_marker = 'synced by flighty' in candidate_text or 'created from an email you received in gmail' in candidate_text or 'booking code:' in candidate_text or 'flight time ' in candidate_text %}
-            {% set candidate_looks_like_flight = candidate_route_summary or candidate_named_flight or candidate_itinerary_marker or ' airport' in candidate_text or candidate_location_lower.endswith(' intl.') or candidate_location_lower.endswith(' international airport') %}
-            {% set candidate_virtual = candidate_location_lower.startswith('http://') or candidate_location_lower.startswith('https://') %}
-            {% set candidate_home_like = home_street != '' and home_street in candidate_location_lower %}
-            {% if candidate.start_raw not in [none, ''] and candidate_location_lower != '' and not candidate.all_day and not candidate_virtual and not candidate_home_like and not candidate_looks_like_flight and 'nocharge' not in candidate_text %}
-              {% set candidate_start = candidate.start_raw | as_datetime | as_local %}
-              {% if candidate_start is not none and candidate_start > now_local and candidate_start < horizon and (ns.start is none or candidate_start < ns.start) %}
-                {% set ns.start = candidate_start %}
-                {% set ns.value = candidate.location | trim %}
-              {% endif %}
+          {% set plan_text = states('sensor.tesla_next_drive_departure') %}
+          {% if plan_text not in ['unknown', 'unavailable', '', 'None', 'none'] %}
+            {% set plan = plan_text | from_json %}
+          {% else %}
+            {% set plan = {'l': states('input_text.home_address')} %}
+          {% endif %}
+          {{ plan.l | default(states('input_text.home_address')) }}
+  - binary_sensor:
+      - name: upcoming_trip_charging
+        unique_id: upcoming_trip_charging
+        availability: >-
+          {{ states('sensor.tesla_next_drive_departure') not in ['unknown', 'unavailable', ''] }}
+        attributes:
+          entry: >-
+            {% set plan_text = states('sensor.tesla_next_drive_departure') %}
+            {% if plan_text not in ['unknown', 'unavailable', '', 'None', 'none'] %}
+              {% set plan = plan_text | from_json %}
+            {% else %}
+              {% set plan = {'e': 'None'} %}
             {% endif %}
-          {% endfor %}
-          {{ ns.value }}
+            {{ plan.e | default('None') }}
+          start_time: >-
+            {% set plan_text = states('sensor.tesla_next_drive_departure') %}
+            {% if plan_text not in ['unknown', 'unavailable', '', 'None', 'none'] %}
+              {% set plan = plan_text | from_json %}
+            {% else %}
+              {% set plan = {'s': 'None'} %}
+            {% endif %}
+            {{ plan.s | default('None') }}
+          all_day: >-
+            {% set plan_text = states('sensor.tesla_next_drive_departure') %}
+            {% if plan_text not in ['unknown', 'unavailable', '', 'None', 'none'] %}
+              {% set plan = plan_text | from_json %}
+            {% else %}
+              {% set plan = {'a': false} %}
+            {% endif %}
+            {{ plan.a | default(false) }}
+        state: >-
+          {% set plan_text = states('sensor.tesla_next_drive_departure') %}
+          {% if plan_text not in ['unknown', 'unavailable', '', 'None', 'none'] %}
+            {% set plan = plan_text | from_json %}
+          {% else %}
+            {% set plan = {'s': 'None'} %}
+          {% endif %}
+          {{ plan.s not in [none, '', 'None'] and (state_attr("sensor.waze_next_trip_distance", "distance") | int(0) > 45) }}
+      - default_entity_id: binary_sensor.tesla_daily_plan_active
+        unique_id: tesla_daily_plan_active
+        name: Tesla Daily Plan Active
+        state: >-
+          {{ is_state('input_boolean.long_range_travel', 'off') }}
 ########################
 # Zone
 ########################

--- a/tests/test_tesla_charging_dashboard.py
+++ b/tests/test_tesla_charging_dashboard.py
@@ -76,26 +76,42 @@ def test_real_calendar_preconditioning_is_not_gated_by_temperature() -> None:
 def test_calendar_destination_ignores_blank_location_events_before_falling_back_home() -> None:
     package_text = CAR_PACKAGE_PATH.read_text(encoding="utf-8")
 
-    assert "{% set ns = namespace(start=none, value=states('input_text.home_address')) %}" in package_text
-    assert "candidate_location_lower != ''" in package_text
-    assert "not candidate_virtual" in package_text
-    assert "not candidate_home_like" in package_text
-    assert "not candidate_looks_like_flight" in package_text
+    assert "default_entity_id: sensor.tesla_next_drive_departure" in package_text
+    assert "default_entity_id: sensor.calendar_destination" in package_text
+    assert "{% set plan_text = states('sensor.tesla_next_drive_departure') %}" in package_text
+    assert "{% set plan = {'l': states('input_text.home_address')} %}" in package_text
+    assert "{{ plan.l | default(states('input_text.home_address')) }}" in package_text
     assert "{% if (personal_meeting_time < curling_upcoming) %}" not in package_text
 
 
 def test_upcoming_trip_selector_ignores_home_virtual_blank_and_flight_events() -> None:
     package_text = CAR_PACKAGE_PATH.read_text(encoding="utf-8")
 
-    assert "{% set home_street = states('input_text.home_address') | default('', true) | lower | trim | regex_replace(',.*$', '') %}" in package_text
-    assert "personal_location_lower != ''" in package_text
-    assert "not personal_all_day" in package_text
-    assert "not personal_virtual" in package_text
-    assert "not personal_home_like" in package_text
-    assert "not personal_looks_like_flight" in package_text
-    assert "'booking code:' in personal_text" in package_text
-    assert "'flight time ' in personal_text" in package_text
-    assert "personal_location_lower.startswith('https://')" in package_text
+    assert "{% set home_street = home_address | lower | trim | regex_replace(',.*$', '') %}" in package_text
+    assert "location_lower != '' and not virtual and not home_like and not looks_like_flight" in package_text
+    assert "{% elif candidate.all_day %}" in package_text
+    assert "{% elif explicit_home %}" in package_text
+    assert "{% elif explicit_virtual %}" in package_text
+    assert "{% elif explicit_flight %}" in package_text
+    assert "{% elif explicit_ride %}" in package_text
+    assert "{% elif explicit_drive %}" in package_text
+    assert "'booking code:' in text" in package_text
+    assert "'flight time ' in text" in package_text
+    assert "location_lower.startswith('https://')" in package_text
+
+
+def test_drive_selector_supports_explicit_description_overrides() -> None:
+    package_text = CAR_PACKAGE_PATH.read_text(encoding="utf-8")
+
+    for marker in (
+        "tesla:drive",
+        "tesla:home",
+        "tesla:virtual",
+        "tesla:flight",
+        "tesla:ride",
+        "tesla:ignore",
+    ):
+        assert marker in package_text
 
 
 def test_dashboard_copy_explains_alarm_only_days_and_home_schedule_override_logic() -> None:


### PR DESCRIPTION
## Summary
- ignore home, virtual, ride, all-day, blank-location, and flight calendar items when selecting Tesla drive departures
- centralize trip selection in a new canonical template sensor and derive routing/charge gating from it
- document the explicit tesla:* override markers and add regression coverage

## Testing
- uv run --with pytest pytest tests/test_tesla_charging_dashboard.py
- uv run --with pytest pytest