### PR TITLE
Fix Sonos regrouping for arrival and wake-up playback

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -648,6 +648,15 @@ script:
     alias: "Prepare bedroom Music Assistant group"
     mode: restart
     sequence:
+      - alias: "Split bedroom wake-up players before regrouping"
+        continue_on_error: true
+        action: media_player.unjoin
+        target:
+          entity_id:
+            - media_player.bedroom_sonos_2
+            - media_player.bathroom_sonos_2
+            - media_player.den_sonos_2
+            - media_player.office_sonos_2
       - if:
           - alias: "Check if guests are here."
             condition: state
@@ -666,15 +675,6 @@ script:
                 - media_player.den_sonos_2
                 - media_player.office_sonos_2
         else:
-          - alias: "Split guest-area players before regrouping"
-            continue_on_error: true
-            action: media_player.unjoin
-            target:
-              entity_id:
-                - media_player.bedroom_sonos_2
-                - media_player.bathroom_sonos_2
-                - media_player.den_sonos_2
-                - media_player.office_sonos_2
           - alias: "Limit wake-up audio to bedroom and bathroom"
             continue_on_error: true
             action: media_player.join
@@ -696,6 +696,16 @@ script:
   music_assistant_prepare_arrival_group:
     alias: "Prepare arrival Music Assistant group"
     sequence:
+      - alias: "Split arrival players before regrouping"
+        continue_on_error: true
+        action: media_player.unjoin
+        target:
+          entity_id:
+            - media_player.bedroom_sonos_2
+            - media_player.bathroom_sonos_2
+            - media_player.den_sonos_2
+            - media_player.office_sonos_2
+            - media_player.tiki_room_2
       - if:
           - alias: "Check if guests are here."
             condition: state
@@ -715,16 +725,6 @@ script:
                 - media_player.office_sonos_2
                 - media_player.tiki_room_2
         else:
-          - alias: "Split guest-area players before regrouping"
-            continue_on_error: true
-            action: media_player.unjoin
-            target:
-              entity_id:
-                - media_player.bedroom_sonos_2
-                - media_player.bathroom_sonos_2
-                - media_player.den_sonos_2
-                - media_player.office_sonos_2
-                - media_player.tiki_room_2
           - alias: "Keep arrival audio in bedroom suite only"
             continue_on_error: true
             action: media_player.join
@@ -734,6 +734,14 @@ script:
             data:
               group_members:
                 - media_player.bathroom_sonos_2
+
+  music_assistant_try_join_arrival_group_after_play:
+    alias: "Try joining arrival Music Assistant followers after playback"
+    mode: restart
+    sequence:
+      - delay:
+          seconds: 2
+      - action: script.music_assistant_prepare_arrival_group
 
   music_assistant_prepare_house_party_group:
     alias: "Prepare house party Music Assistant group"
@@ -1052,6 +1060,9 @@ script:
           media_id: "{{ radio_uri }}"
           media_type: radio
           enqueue: replace
+      - action: script.turn_on
+        target:
+          entity_id: script.music_assistant_try_join_bedroom_group_after_play
       - repeat:
           sequence:
             - alias: "Increase Volume by 0.01"
@@ -1447,6 +1458,9 @@ script:
         data:
           entity_id: "{{ playback_entity }}"
           spotify_uri: "{{ playlist }}"
+      - action: script.turn_on
+        target:
+          entity_id: script.music_assistant_try_join_arrival_group_after_play
       - action: logbook.log
         data:
           entity_id: "{{ playback_entity }}"
@@ -1847,6 +1861,9 @@ script:
         data:
           entity_id: media_player.bedroom_sonos_2
           spotify_uri: "{{ playlist }}"
+      - action: script.turn_on
+        target:
+          entity_id: script.music_assistant_try_join_bedroom_group_after_play
 
 ########################
 # Sensor

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -115,6 +115,42 @@ def test_bedroom_group_helper_restarts_instead_of_blocking_new_runs() -> None:
     block = _script_block("music_assistant_prepare_bedroom_group")
 
     assert 'mode: restart' in block
+    assert 'action: media_player.unjoin' in block
+    for media_player in (
+        "media_player.bedroom_sonos_2",
+        "media_player.bathroom_sonos_2",
+        "media_player.den_sonos_2",
+        "media_player.office_sonos_2",
+    ):
+        assert media_player in block
+
+
+def test_arrival_group_helper_resets_players_before_regrouping() -> None:
+    block = _script_block("music_assistant_prepare_arrival_group")
+
+    assert 'action: media_player.unjoin' in block
+    assert '"Join whole-house arrival group"' in block
+    for media_player in (
+        "media_player.bedroom_sonos_2",
+        "media_player.bathroom_sonos_2",
+        "media_player.den_sonos_2",
+        "media_player.office_sonos_2",
+        "media_player.tiki_room_2",
+    ):
+        assert media_player in block
+
+
+def test_arrival_join_retry_runs_after_playback_starts() -> None:
+    helper_block = _script_block("music_assistant_try_join_arrival_group_after_play")
+    arrival_block = _script_block("spotify_arrival")
+
+    assert 'mode: restart' in helper_block
+    assert 'seconds: 2' in helper_block
+    assert 'action: script.music_assistant_prepare_arrival_group' in helper_block
+    assert 'entity_id: script.music_assistant_try_join_arrival_group_after_play' in arrival_block
+    assert arrival_block.index('action: script.music_assistant_play_spotify_uri') < arrival_block.index(
+        'entity_id: script.music_assistant_try_join_arrival_group_after_play'
+    )
 
 
 def test_bedtime_join_retry_runs_after_playback_starts() -> None:
@@ -126,6 +162,24 @@ def test_bedtime_join_retry_runs_after_playback_starts() -> None:
     assert 'action: script.music_assistant_prepare_bedroom_group' in helper_block
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in bedtime_block
     assert bedtime_block.index('action: script.music_assistant_play_item') < bedtime_block.index(
+        'entity_id: script.music_assistant_try_join_bedroom_group_after_play'
+    )
+
+
+def test_radio_wakeup_join_retry_runs_after_playback_starts() -> None:
+    block = _script_block("music_assistant_radio_wake_up")
+
+    assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in block
+    assert block.index('action: music_assistant.play_media') < block.index(
+        'entity_id: script.music_assistant_try_join_bedroom_group_after_play'
+    )
+
+
+def test_spotify_wakeup_join_retry_runs_after_playback_starts() -> None:
+    block = _script_block("spotify_wake_up")
+
+    assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in block
+    assert block.index('action: script.music_assistant_play_spotify_uri') < block.index(
         'entity_id: script.music_assistant_try_join_bedroom_group_after_play'
     )
 


### PR DESCRIPTION
## Summary
- make arrival regrouping deterministic by unjoining target speakers before rebuilding the Sonos/Music Assistant group
- do the same for the bedroom wake-up regroup helper so wake-up playback does not leave one room on an old queue
- retry regrouping shortly after playback starts for arrival, radio wake-up, and Spotify wake-up flows

## Testing
- uv run --with pytest pytest tests/test_media_player_music_assistant.py
- uv run --with pytest pytest