### PR TITLE
Persist owner suite adaptive lighting baseline

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -1,0 +1,23 @@
+automation:
+  - id: reconcile_owner_suite_adaptive_lighting
+    alias: reconcile_owner_suite_adaptive_lighting
+    description: >
+      Reapply the owner suite Adaptive Lighting baseline after Home Assistant
+      starts so scene-friendly bedroom tuning survives restarts.
+    mode: single
+    trigger:
+      - trigger: homeassistant
+        event: start
+    action:
+      - delay: "00:00:30"
+      - action: adaptive_lighting.change_switch_settings
+        data:
+          entity_id: switch.adaptive_lighting_owner_suite
+          use_defaults: current
+          include_config_in_attributes: true
+          take_over_control: true
+          adapt_only_on_bare_turn_on: true
+          only_once: true
+          initial_transition: 2
+          transition: 5
+          detect_non_ha_changes: false

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ADAPTIVE_LIGHTING_PATH = (
+    Path(__file__).resolve().parents[1] / "packages" / "adaptive_lighting.yaml"
+)
+
+
+def _automation_block(automation_id: str) -> str:
+    lines = ADAPTIVE_LIGHTING_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_owner_suite_adaptive_lighting_reconciles_supported_scene_safe_settings() -> None:
+    block = _automation_block("reconcile_owner_suite_adaptive_lighting")
+
+    assert "trigger: homeassistant" in block
+    assert "event: start" in block
+    assert 'delay: "00:00:30"' in block
+    assert "action: adaptive_lighting.change_switch_settings" in block
+    assert "entity_id: switch.adaptive_lighting_owner_suite" in block
+    assert "use_defaults: current" in block
+    assert "include_config_in_attributes: true" in block
+    assert "take_over_control: true" in block
+    assert "adapt_only_on_bare_turn_on: true" in block
+    assert "only_once: true" in block
+    assert "initial_transition: 2" in block
+    assert "transition: 5" in block
+    assert "detect_non_ha_changes: false" in block


### PR DESCRIPTION
## Summary
- add a repo-managed startup reconciliation automation for `switch.adaptive_lighting_owner_suite`
- persist the owner-suite scene-safe Adaptive Lighting options (`take_over_control`, `adapt_only_on_bare_turn_on`, `only_once`) plus shorter transitions
- add regression coverage for the reconciliation automation contract

## Testing
- `uv run --with pytest pytest`
- `uv run --with pytest pytest tests/test_adaptive_lighting_reconcile.py`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/adaptive_lighting.yaml`
- `uv run --with pyyaml python /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/adaptive_lighting.yaml --strict`

## Notes
- Home Assistant `check_config` could not complete in this environment because the shared HA virtualenv tries to install `colorlog==6.10.1` through a path that breaks on the spaced repo path (`/Users/rtclauss/Documents/New project`).

Fixes #103