### PR TITLE
[codex] Harden morning audio wake-up flow

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -429,6 +429,9 @@ automation:
               - action: script.turn_on
                 target:
                   entity_id: script.spotify_wake_up
+                data:
+                  variables:
+                    playback_entity_id: media_player.bathroom_sonos_2
               - action: media_player.volume_set
                 data:
                   entity_id:
@@ -450,6 +453,9 @@ automation:
           - action: script.turn_on
             target:
               entity_id: script.spotify_wake_up
+            data:
+              variables:
+                playback_entity_id: media_player.bathroom_sonos_2
           - alias: "Set Volume 0.09 in office"
             action: media_player.volume_set
             data:
@@ -472,6 +478,43 @@ automation:
                     # As time passes, the delay gets smaller and smaller. 60, 30s, 20s, 15s, 12s,..., 2s
                     seconds: "{{ (1/(tan(repeat.index/60, 5))) | round(0, 'ceil', 5)}}"
               until: "{{repeat.index == 30}}"
+
+  - id: recover_stuck_morning_audio_scripts
+    alias: recover_stuck_morning_audio_scripts
+    trace:
+      stored_traces: 20
+    mode: single
+    trigger:
+      - trigger: state
+        entity_id: script.music_assistant_prepare_bedroom_group
+        to: "on"
+        for:
+          minutes: 1
+      - trigger: state
+        entity_id:
+          - script.spotify_wake_up
+          - script.music_assistant_radio_wake_up
+        to: "on"
+        for:
+          minutes: 3
+    action:
+      - action: logbook.log
+        data:
+          entity_id: "{{ trigger.entity_id }}"
+          domain: script
+          name: Morning audio recovery
+          message: "Stopped a stalled morning audio script and cleared the wake-up latch."
+      - action: script.turn_off
+        continue_on_error: true
+        target:
+          entity_id:
+            - script.music_assistant_prepare_bedroom_group
+            - script.music_assistant_radio_wake_up
+            - script.spotify_wake_up
+      - action: input_boolean.turn_off
+        continue_on_error: true
+        target:
+          entity_id: input_boolean.morning_routine
 
   - id: restart_sonos_unavailable
     alias: restart_sonos_unavailable
@@ -691,7 +734,9 @@ script:
     sequence:
       - delay:
           seconds: 2
-      - action: script.music_assistant_prepare_bedroom_group
+      - action: script.turn_on
+        target:
+          entity_id: script.music_assistant_prepare_bedroom_group
 
   music_assistant_prepare_arrival_group:
     alias: "Prepare arrival Music Assistant group"
@@ -741,7 +786,9 @@ script:
     sequence:
       - delay:
           seconds: 2
-      - action: script.music_assistant_prepare_arrival_group
+      - action: script.turn_on
+        target:
+          entity_id: script.music_assistant_prepare_arrival_group
 
   music_assistant_prepare_house_party_group:
     alias: "Prepare house party Music Assistant group"
@@ -1037,8 +1084,14 @@ script:
         description: "Music Assistant radio URI"
       initial_delay:
         description: "Optional delay before playback starts"
+      playback_entity_id:
+        description: "Preferred Music Assistant player for wake-up playback"
+    variables:
+      playback_player: "{{ playback_entity_id | default('media_player.bedroom_sonos_2') }}"
     sequence:
-      - action: script.music_assistant_prepare_bedroom_group
+      - action: script.turn_on
+        target:
+          entity_id: script.music_assistant_prepare_bedroom_group
       - action: media_player.volume_set
         continue_on_error: true
         data:
@@ -1055,7 +1108,7 @@ script:
       - action: music_assistant.play_media
         continue_on_error: true
         target:
-          entity_id: media_player.bedroom_sonos_2
+          entity_id: "{{ playback_player }}"
         data:
           media_id: "{{ radio_uri }}"
           media_type: radio
@@ -1699,7 +1752,11 @@ script:
     alias: "Spotify Wake Up"
     icon: mdi:weather-sunset-up
     description: "Play music in the morning when I visit the bathroom."
+    fields:
+      playback_entity_id:
+        description: "Preferred Music Assistant player for wake-up playback"
     variables:
+      playback_player: "{{ playback_entity_id | default('media_player.bedroom_sonos_2') }}"
       playlist: >-
         {#
         ## Your Top Songs 2017 : spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW
@@ -1811,21 +1868,23 @@ script:
           {% set pindex =  (range(0, (plists | length - 1 ) )|random) -%}
           {{ plists[pindex] }}
     sequence:
-      - action: script.music_assistant_prepare_bedroom_group
+      - action: script.turn_on
+        target:
+          entity_id: script.music_assistant_prepare_bedroom_group
       - delay:
           seconds: 2
       - alias: "Pause currently playing media"
         continue_on_error: true
         action: media_player.media_pause
         data:
-          entity_id: media_player.bedroom_sonos_2
+          entity_id: "{{ playback_player }}"
       - delay:
           seconds: 2
       - alias: "Enable Shuffle"
         continue_on_error: true
         action: media_player.shuffle_set
         target:
-          entity_id: media_player.bedroom_sonos_2
+          entity_id: "{{ playback_player }}"
         data:
           shuffle: >-
             {%- set shuffle = [true, false] -%}
@@ -1836,7 +1895,7 @@ script:
         data:
           repeat: all
         target:
-          entity_id: media_player.bedroom_sonos_2
+          entity_id: "{{ playback_player }}"
       - delay:
           seconds: 2
       - alias: "Set volume low"
@@ -1859,7 +1918,7 @@ script:
       - alias: "Play wake-up music"
         action: script.music_assistant_play_spotify_uri
         data:
-          entity_id: media_player.bedroom_sonos_2
+          entity_id: "{{ playback_player }}"
           spotify_uri: "{{ playlist }}"
       - action: script.turn_on
         target:

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -31,6 +31,29 @@ def _script_block(script_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
+def _automation_block(automation_id: str) -> str:
+    lines = MEDIA_PLAYER_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  - id: {automation_id}"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation id {automation_id!r}")
+
+    end = len(lines)
+    next_automation = re.compile(r"^  - id: ")
+    for index in range(start + 1, len(lines)):
+        if next_automation.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
 def test_music_assistant_item_helper_is_generic_pass_through() -> None:
     block = _script_block("music_assistant_play_item")
 
@@ -146,7 +169,8 @@ def test_arrival_join_retry_runs_after_playback_starts() -> None:
 
     assert 'mode: restart' in helper_block
     assert 'seconds: 2' in helper_block
-    assert 'action: script.music_assistant_prepare_arrival_group' in helper_block
+    assert 'action: script.turn_on' in helper_block
+    assert 'entity_id: script.music_assistant_prepare_arrival_group' in helper_block
     assert 'entity_id: script.music_assistant_try_join_arrival_group_after_play' in arrival_block
     assert arrival_block.index('action: script.music_assistant_play_spotify_uri') < arrival_block.index(
         'entity_id: script.music_assistant_try_join_arrival_group_after_play'
@@ -159,7 +183,8 @@ def test_bedtime_join_retry_runs_after_playback_starts() -> None:
 
     assert 'mode: restart' in helper_block
     assert 'seconds: 2' in helper_block
-    assert 'action: script.music_assistant_prepare_bedroom_group' in helper_block
+    assert 'action: script.turn_on' in helper_block
+    assert 'entity_id: script.music_assistant_prepare_bedroom_group' in helper_block
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in bedtime_block
     assert bedtime_block.index('action: script.music_assistant_play_item') < bedtime_block.index(
         'entity_id: script.music_assistant_try_join_bedroom_group_after_play'
@@ -169,6 +194,12 @@ def test_bedtime_join_retry_runs_after_playback_starts() -> None:
 def test_radio_wakeup_join_retry_runs_after_playback_starts() -> None:
     block = _script_block("music_assistant_radio_wake_up")
 
+    assert 'playback_entity_id:' in block
+    assert 'playback_player' in block
+    assert 'action: script.music_assistant_prepare_bedroom_group' not in block
+    assert 'action: script.turn_on' in block
+    assert 'entity_id: script.music_assistant_prepare_bedroom_group' in block
+    assert 'entity_id: "{{ playback_player }}"' in block
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in block
     assert block.index('action: music_assistant.play_media') < block.index(
         'entity_id: script.music_assistant_try_join_bedroom_group_after_play'
@@ -178,10 +209,37 @@ def test_radio_wakeup_join_retry_runs_after_playback_starts() -> None:
 def test_spotify_wakeup_join_retry_runs_after_playback_starts() -> None:
     block = _script_block("spotify_wake_up")
 
+    assert 'playback_entity_id:' in block
+    assert 'playback_player' in block
+    assert 'action: script.music_assistant_prepare_bedroom_group' not in block
+    assert 'action: script.turn_on' in block
+    assert 'entity_id: script.music_assistant_prepare_bedroom_group' in block
+    assert 'entity_id: "{{ playback_player }}"' in block
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in block
     assert block.index('action: script.music_assistant_play_spotify_uri') < block.index(
         'entity_id: script.music_assistant_try_join_bedroom_group_after_play'
     )
+
+
+def test_bathroom_wakeup_automation_targets_bathroom_player() -> None:
+    block = _automation_block("play_music_in_bathroom_when_up")
+
+    assert 'entity_id: script.spotify_wake_up' in block
+    assert block.count('playback_entity_id: media_player.bathroom_sonos_2') == 2
+
+
+def test_stuck_morning_audio_scripts_are_recovered() -> None:
+    block = _automation_block("recover_stuck_morning_audio_scripts")
+
+    assert 'entity_id: script.music_assistant_prepare_bedroom_group' in block
+    assert 'entity_id:\n          - script.spotify_wake_up\n          - script.music_assistant_radio_wake_up' in block
+    assert 'minutes: 1' in block
+    assert 'minutes: 3' in block
+    assert 'action: script.turn_off' in block
+    assert 'script.music_assistant_prepare_bedroom_group' in block
+    assert 'script.music_assistant_radio_wake_up' in block
+    assert 'script.spotify_wake_up' in block
+    assert 'entity_id: input_boolean.morning_routine' in block
 
 
 def test_bedtime_playlist_includes_somafm_station_names() -> None:


### PR DESCRIPTION
## Summary
- make the bathroom morning routine launch wake-up playback on the bathroom Sonos player
- stop wake-up and regroup retry helpers from blocking on Sonos bedroom-group prep
- add a recovery automation that clears stalled morning audio scripts and resets `input_boolean.morning_routine`
- extend media-player coverage for the non-blocking wake-up path and recovery behavior

## Root Cause
The bathroom morning routine was triggering correctly, but `script.spotify_wake_up` could block on `script.music_assistant_prepare_bedroom_group`. When that regroup helper hung during Sonos `unjoin`/`join`, playback never reached the play step and the morning latch stayed on for the rest of the day.

## Validation
- `uv run --with pytest pytest tests/test_media_player_music_assistant.py`
- `uv run --with pytest pytest`