### PR TITLE
Fix wake-up script light payloads

### DIFF
--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -598,21 +598,24 @@ script:
           - switch.adaptive_lighting_adapt_brightness_owner_suite
           - switch.adaptive_lighting_adapt_color_owner_suite
       - alias: "Turn on light at dimmest setting. Adaptive Lighting will apply"
+        continue_on_error: true
         action: light.turn_on
         data:
           entity_id:
             - light.owner_suite_lamps
             - light.bed_lightstrip
-          kelvin: 370
+          color_temp_kelvin: 2700
           brightness_pct: 1
       - delay:
           seconds: 5
-      - action: light.turn_on
+      - alias: "Ramp bedroom lights up to full wake-up brightness"
+        continue_on_error: true
+        action: light.turn_on
         data:
           entity_id:
             - light.owner_suite_lamps
             - light.bed_lightstrip
-          kelvin: 153
+          color_temp_kelvin: 6500
           brightness_pct: 100
           transition: 300
       - delay:

--- a/tests/test_owner_suite_blinds_automation.py
+++ b/tests/test_owner_suite_blinds_automation.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKDAY_PATH = ROOT / "packages" / "workday.yaml"
+
+
+def _script_block(path: Path, script_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  ") and lines[index].endswith(":") and not lines[index].startswith("    "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_wake_up_script_uses_supported_color_temperature_fields_and_keeps_running() -> None:
+    block = _script_block(WORKDAY_PATH, "wake_up_script")
+
+    assert "cover.owner_suite_blinds_ha" in block
+    assert "color_temp_kelvin: 2700" in block
+    assert "color_temp_kelvin: 6500" in block
+    assert "\n          kelvin:" not in block
+    assert block.count("continue_on_error: true") >= 3


### PR DESCRIPTION
## Summary
- replace invalid wake-up light kelvin payloads with supported color_temp_kelvin values
- allow the bedroom light steps to continue on error so the blind-opening sequence still runs
- add regression coverage for the wake-up script payloads and error-handling guard

## Testing
- uv run --with pytest pytest tests/test_owner_suite_blinds_automation.py
- uv run --with pytest pytest