### PR TITLE
Standardize room names with registry enforcement

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -24,6 +24,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pytest:
+    name: Pytest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Run pytest
+        run: uv run --with pytest pytest
+
   yaml-lint:
     name: YAML Lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 # Use the pinned interpreter from .python-version (for example via pyenv)
 python -m pip install --upgrade pip yamllint
 python scripts/check_ha_python_support.py --python-version-file .python-version
+uv run --with pytest pytest
 ```
 
 ## Music Assistant Media Flow
@@ -149,6 +150,7 @@ docker run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:stable \
 
 - [House Transition Framework](docs/house_transition_framework.md)
 - [Room Intent Policy](docs/room_intent.yaml)
+- [Room Naming Model](docs/room_names.md)
 - [ESPHome Layout And Bermuda BLE Proxy Notes](docs/esphome.md)
 - [EV Charging Tariff](docs/ev_charging_tariff.md)
 - [Tesla Departure Planner](docs/tesla_departure_planner.md)

--- a/docs/room_names.md
+++ b/docs/room_names.md
@@ -1,0 +1,40 @@
+# Room Naming Model
+
+Issue `#317` uses a single canonical key per room or space and keeps legacy live namespaces explicit instead of allowing ad hoc drift.
+
+Rules:
+
+- `docs/room_intent.yaml` remains the source of truth for behavior, privacy, and room-sensitive automation decisions.
+- `scripts/room_name_registry.py` is the naming source of truth used by tests and automation-safe checks.
+- Use the `Preferred UI Name` for new dashboards, helpers, script aliases, notifications, and friendly names.
+- Do not mass-rename live entity IDs or Zigbee2MQTT `friendly_name` values just to match the preferred UI name. Open a separate safe-refactor issue first.
+- If an existing live namespace is still required, add it to the registry instead of introducing a new alias.
+
+## Canonical Names
+
+| Key | Preferred UI Name | HA Area | Live Namespace / Allowed Legacy Labels |
+| --- | --- | --- | --- |
+| `owner_suite_bedroom` | `Owner Suite Bedroom` | `Bedroom` | `Owner Suite`, `Master Bedroom`, `Bedroom` |
+| `owner_suite_bathroom` | `Owner Suite Bathroom` | `Owner Suite Bathroom` | — |
+| `guest_room` | `Guest Room` | `Guest Room` | `Guest Bedroom` |
+| `guest_bathroom` | `Guest Bathroom` | `Guest Bathroom` | `Guest Bathroom` |
+| `bathroom` | `Bathroom` | `Bathroom` | `Bathroom` |
+| `office` | `Office` | `Office` | `Office` |
+| `den` | `Den` | `Den` | `Den` |
+| `dining_room` | `Dining Room` | `Dining Room` | `Dining Room`, `Living Room` |
+| `laundry_room` | `Laundry Room` | `Laundry Room` | `Laundry`, `Laundry Room` |
+| `kitchen` | `Kitchen` | `Kitchen` | `Kitchen` |
+| `hallway` | `Hallway` | `Hallway` | `Hall` |
+| `main_foyer` | `Main Foyer` | `Main Foyer` | `Main Foyer` |
+| `garage` | `Garage` | `Garage` | `Garage` |
+| `deck` | `Deck` | `Deck` | `Deck` |
+| `outside` | `Outside` | `Outside` | `Outside` |
+| `powder_room` | `Powder Room` | `Powder Room` | `Powder Room` |
+| `basement_great_room` | `Basement Great Room` | `Basement Great Room` | `Basement` |
+| `unfinished_basement` | `Unfinished Basement` | `Unfinished Basement` | `Unfinished Basement` |
+| `tiki_room` | `Tiki Room` | `Tiki Room` | `Tiki Room` |
+
+## Enforcement
+
+- `tests/test_room_name_registry.py` validates that `docs/room_intent.yaml`, Zigbee2MQTT room prefixes, and selected user-facing names stay inside the registry.
+- GitHub Actions now runs `uv run --with pytest pytest`, so unexpected room-name drift fails in CI instead of waiting for a manual review.

--- a/lovelace/tiles/tiles_guest_room.yaml
+++ b/lovelace/tiles/tiles_guest_room.yaml
@@ -1,8 +1,8 @@
 # Guest room tile include for the main Lovelace dashboard.
-# This section keeps the guest bedroom controls isolated so guest-facing updates do not clutter other room tiles.
+# This section keeps the guest room controls isolated so guest-facing updates do not clutter other room tiles.
 
 type: custom:vertical-stack-in-card
-title: Guest Bedroom
+title: Guest Room
 cards:
   - type: horizontal-stack
     cards:

--- a/lovelace/tiles/tiles_master_bedroom.yaml
+++ b/lovelace/tiles/tiles_master_bedroom.yaml
@@ -2,7 +2,7 @@
 # It groups the bedroom lighting, climate, and occupancy-related controls into a dedicated section.
 
 type: custom:vertical-stack-in-card
-title: Master Bedroom
+title: Owner Suite Bedroom
 cards:
   - type: horizontal-stack
     cards:
@@ -76,7 +76,7 @@ cards:
         #   action: more-info
     #   - type: "custom:button-card"
     #     icon: attribute
-    #     name: Master Bedroom
+    #     name: Owner Suite Bedroom
     #     entity: light.master_bedroom
   - type: horizontal-stack
     cards:

--- a/scripts/room_name_registry.py
+++ b/scripts/room_name_registry.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RoomNameSpec:
+    key: str
+    preferred_label: str
+    home_assistant_area: str
+    intent_key: str | None = None
+    zigbee2mqtt_namespaces: tuple[str, ...] = ()
+    legacy_labels: tuple[str, ...] = ()
+    notes: str = ""
+
+    @property
+    def all_labels(self) -> tuple[str, ...]:
+        return (self.preferred_label, *self.legacy_labels)
+
+
+ROOM_NAME_SPECS: tuple[RoomNameSpec, ...] = (
+    RoomNameSpec(
+        key="owner_suite_bedroom",
+        preferred_label="Owner Suite Bedroom",
+        home_assistant_area="Bedroom",
+        intent_key="owner_suite_bedroom",
+        zigbee2mqtt_namespaces=("Owner Suite",),
+        legacy_labels=("Master Bedroom", "Bedroom"),
+        notes="Keep the Owner Suite Zigbee2MQTT namespace stable until a dedicated safe-refactor updates every consumer.",
+    ),
+    RoomNameSpec(
+        key="owner_suite_bathroom",
+        preferred_label="Owner Suite Bathroom",
+        home_assistant_area="Owner Suite Bathroom",
+        intent_key="owner_suite_bathroom",
+    ),
+    RoomNameSpec(
+        key="office",
+        preferred_label="Office",
+        home_assistant_area="Office",
+        intent_key="office",
+        zigbee2mqtt_namespaces=("Office",),
+    ),
+    RoomNameSpec(
+        key="den",
+        preferred_label="Den",
+        home_assistant_area="Den",
+        intent_key="den",
+        zigbee2mqtt_namespaces=("Den",),
+    ),
+    RoomNameSpec(
+        key="guest_room",
+        preferred_label="Guest Room",
+        home_assistant_area="Guest Room",
+        intent_key="guest_room",
+        zigbee2mqtt_namespaces=("Guest Room",),
+        legacy_labels=("Guest Bedroom",),
+    ),
+    RoomNameSpec(
+        key="guest_bathroom",
+        preferred_label="Guest Bathroom",
+        home_assistant_area="Guest Bathroom",
+        intent_key="guest_bathroom",
+        zigbee2mqtt_namespaces=("Guest Bathroom",),
+    ),
+    RoomNameSpec(
+        key="bathroom",
+        preferred_label="Bathroom",
+        home_assistant_area="Bathroom",
+        zigbee2mqtt_namespaces=("Bathroom",),
+    ),
+    RoomNameSpec(
+        key="basement_great_room",
+        preferred_label="Basement Great Room",
+        home_assistant_area="Basement Great Room",
+        intent_key="basement_great_room",
+        zigbee2mqtt_namespaces=("Basement",),
+        legacy_labels=("Basement",),
+        notes="The live Zigbee2MQTT namespace is still the shorter Basement prefix.",
+    ),
+    RoomNameSpec(
+        key="kitchen",
+        preferred_label="Kitchen",
+        home_assistant_area="Kitchen",
+        intent_key="kitchen",
+        zigbee2mqtt_namespaces=("Kitchen",),
+    ),
+    RoomNameSpec(
+        key="outside",
+        preferred_label="Outside",
+        home_assistant_area="Outside",
+        intent_key="outside",
+        zigbee2mqtt_namespaces=("Outside",),
+    ),
+    RoomNameSpec(
+        key="dining_room",
+        preferred_label="Dining Room",
+        home_assistant_area="Dining Room",
+        intent_key="dining_room",
+        zigbee2mqtt_namespaces=("Dining Room", "Living Room"),
+        legacy_labels=("Living Room",),
+        notes="Living Room remains an allowed legacy label until the dining-room migration can safely update all live entity names.",
+    ),
+    RoomNameSpec(
+        key="hallway",
+        preferred_label="Hallway",
+        home_assistant_area="Hallway",
+        zigbee2mqtt_namespaces=("Hall",),
+        legacy_labels=("Hall",),
+    ),
+    RoomNameSpec(
+        key="main_foyer",
+        preferred_label="Main Foyer",
+        home_assistant_area="Main Foyer",
+        zigbee2mqtt_namespaces=("Main Foyer",),
+    ),
+    RoomNameSpec(
+        key="laundry_room",
+        preferred_label="Laundry Room",
+        home_assistant_area="Laundry Room",
+        zigbee2mqtt_namespaces=("Laundry", "Laundry Room"),
+        legacy_labels=("Laundry",),
+        notes="Laundry remains a valid live device namespace, but new UI labels should use Laundry Room.",
+    ),
+    RoomNameSpec(
+        key="garage",
+        preferred_label="Garage",
+        home_assistant_area="Garage",
+        zigbee2mqtt_namespaces=("Garage",),
+    ),
+    RoomNameSpec(
+        key="deck",
+        preferred_label="Deck",
+        home_assistant_area="Deck",
+        zigbee2mqtt_namespaces=("Deck",),
+    ),
+    RoomNameSpec(
+        key="powder_room",
+        preferred_label="Powder Room",
+        home_assistant_area="Powder Room",
+        zigbee2mqtt_namespaces=("Powder Room",),
+    ),
+    RoomNameSpec(
+        key="tiki_room",
+        preferred_label="Tiki Room",
+        home_assistant_area="Tiki Room",
+        zigbee2mqtt_namespaces=("Tiki Room",),
+    ),
+    RoomNameSpec(
+        key="unfinished_basement",
+        preferred_label="Unfinished Basement",
+        home_assistant_area="Unfinished Basement",
+        zigbee2mqtt_namespaces=("Unfinished Basement",),
+    ),
+)
+
+
+ROOM_NAME_SPECS_BY_KEY = {spec.key: spec for spec in ROOM_NAME_SPECS}
+
+
+def specs_with_intent_keys() -> tuple[RoomNameSpec, ...]:
+    return tuple(spec for spec in ROOM_NAME_SPECS if spec.intent_key is not None)
+
+
+def allowed_room_labels() -> set[str]:
+    return {label for spec in ROOM_NAME_SPECS for label in spec.all_labels}
+
+
+def allowed_zigbee2mqtt_namespaces() -> set[str]:
+    return {name for spec in ROOM_NAME_SPECS for name in spec.zigbee2mqtt_namespaces}
+
+
+def resolve_room_key(label: str) -> str:
+    normalized_label = label.replace("_", " ").lower()
+    for spec in ROOM_NAME_SPECS:
+        if normalized_label in {
+            spec.key.replace("_", " ").lower(),
+            (spec.intent_key or "").replace("_", " ").lower(),
+        }:
+            return spec.key
+        if normalized_label in {value.lower() for value in spec.all_labels}:
+            return spec.key
+        if normalized_label in {value.lower() for value in spec.zigbee2mqtt_namespaces}:
+            return spec.key
+    raise KeyError(label)

--- a/tests/test_room_name_registry.py
+++ b/tests/test_room_name_registry.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.room_name_registry import (  # noqa: E402
+    ROOM_NAME_SPECS,
+    allowed_zigbee2mqtt_namespaces,
+    resolve_room_key,
+    specs_with_intent_keys,
+)
+
+ROOM_INTENT_PATH = ROOT / "docs" / "room_intent.yaml"
+README_PATH = ROOT / "README.md"
+VACUUM_PATH = ROOT / "packages" / "xiaomi_robot_vacuum.yaml"
+VALIDATE_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "validate-config.yml"
+Z2M_PATH = ROOT / "zigbee2mqtt" / "configuration.yaml"
+OWNER_SUITE_TILE_PATH = ROOT / "lovelace" / "tiles" / "tiles_master_bedroom.yaml"
+GUEST_ROOM_TILE_PATH = ROOT / "lovelace" / "tiles" / "tiles_guest_room.yaml"
+
+
+def _room_intent_keys() -> set[str]:
+    text = ROOM_INTENT_PATH.read_text(encoding="utf-8")
+    match = re.search(r"^rooms:\n(?P<body>.*?)^decision_rules:\n", text, re.MULTILINE | re.DOTALL)
+    if match is None:
+        raise AssertionError("Could not parse rooms block from docs/room_intent.yaml")
+    return set(re.findall(r"^  ([a-z_]+):\n", match.group("body"), re.MULTILINE))
+
+
+def _legacy_room_mapping() -> dict[str, str]:
+    text = ROOM_INTENT_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"^  legacy_room_mapping:\n(?P<body>.*?)(?=^  notes:\n)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError("Could not parse legacy_room_mapping block from docs/room_intent.yaml")
+    return {
+        source: replacement
+        for source, replacement in re.findall(
+            r"^    ([a-z_]+):\n      replacement: ([a-z_]+)\n",
+            match.group("body"),
+            re.MULTILINE,
+        )
+    }
+
+
+def _zigbee2mqtt_prefixes() -> set[str]:
+    text = Z2M_PATH.read_text(encoding="utf-8")
+    prefixes: set[str] = set()
+    for raw_value in re.findall(r"friendly_name:\s*([^\n]+)", text):
+        value = raw_value.strip().strip('"')
+        if "/" not in value:
+            continue
+        prefixes.add(value.split("/", 1)[0])
+    return prefixes
+
+
+def _vacuum_room_options() -> list[str]:
+    text = VACUUM_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"^  vacuum_room:\n    name: .*\n    options:\n(?P<body>(?:      - .*\n)+)",
+        text,
+        re.MULTILINE,
+    )
+    if match is None:
+        raise AssertionError("Could not parse input_select.vacuum_room options")
+    return [line.removeprefix("      - ").strip() for line in match.group("body").splitlines()]
+
+
+def test_room_name_registry_covers_room_intent_rooms() -> None:
+    registered_intent_keys = {spec.intent_key for spec in specs_with_intent_keys()}
+    assert _room_intent_keys() <= registered_intent_keys
+
+
+def test_room_name_registry_covers_legacy_room_mapping() -> None:
+    mapping = _legacy_room_mapping()
+    assert mapping == {"living_room": "dining_room"}
+    assert resolve_room_key("living_room") == "dining_room"
+    assert resolve_room_key("Living Room") == "dining_room"
+    assert resolve_room_key("Dining Room") == "dining_room"
+
+
+def test_room_name_registry_covers_current_zigbee2mqtt_room_prefixes() -> None:
+    assert _zigbee2mqtt_prefixes() <= allowed_zigbee2mqtt_namespaces()
+
+
+def test_owner_suite_and_guest_room_tiles_use_preferred_names() -> None:
+    owner_suite_text = OWNER_SUITE_TILE_PATH.read_text(encoding="utf-8")
+    guest_room_text = GUEST_ROOM_TILE_PATH.read_text(encoding="utf-8")
+    assert "Master Bedroom" not in owner_suite_text
+    assert "Guest Bedroom" not in guest_room_text
+    assert "Owner Suite Bedroom" in owner_suite_text
+    assert "Guest Room" in guest_room_text
+
+
+def test_vacuum_room_picker_uses_registered_room_names() -> None:
+    options = _vacuum_room_options()
+    assert options == [
+        "Select Input",
+        "Master Bedroom",
+        "Guest Room",
+        "Living Room",
+        "Bathroom",
+        "Hallway",
+        "Kitchen",
+        "Office",
+    ]
+    assert [resolve_room_key(option) for option in options[1:]] == [
+        "owner_suite_bedroom",
+        "guest_room",
+        "dining_room",
+        "bathroom",
+        "hallway",
+        "kitchen",
+        "office",
+    ]
+
+
+def test_room_name_registry_is_documented_in_readme() -> None:
+    text = README_PATH.read_text(encoding="utf-8")
+    assert "- [Room Naming Model](docs/room_names.md)" in text
+
+
+def test_validate_config_workflow_runs_pytest_for_room_name_enforcement() -> None:
+    text = VALIDATE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "name: Pytest" in text
+    assert "uv run --with pytest pytest" in text
+
+
+def test_room_name_registry_keys_are_unique() -> None:
+    keys = [spec.key for spec in ROOM_NAME_SPECS]
+    assert len(keys) == len(set(keys))


### PR DESCRIPTION
Closes #317.

## Summary
- add a checked-in room naming registry and documentation for canonical room/space labels
- add pytest coverage for room intent mappings, Zigbee2MQTT namespaces, dashboard titles, and CI enforcement
- run pytest automatically in the validation workflow so room-name drift is caught in CI
- align the owner suite and guest dashboard tile titles with the preferred room names

## Validation
- `uv run --with pytest pytest`
- `uv run --with pyyaml python /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py lovelace/tiles/tiles_master_bedroom.yaml lovelace/tiles/tiles_guest_room.yaml --strict`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" lovelace/tiles/tiles_master_bedroom.yaml lovelace/tiles/tiles_guest_room.yaml .github/workflows/validate-config.yml`

## Notes
- the registry intentionally records legacy live namespaces such as `Living Room`, `Laundry`, and `Master Bedroom` instead of renaming entity IDs or Zigbee2MQTT device names in place
- future renames can move those legacy aliases over one surface at a time under the safe-refactor workflow