### PR TITLE
[codex] Fix battery iOS notification refresh

### DIFF
--- a/packages/batteries.yaml
+++ b/packages/batteries.yaml
@@ -245,19 +245,13 @@ automation:
         {{ states('sensor.battery_low_20') | int(0) }}
       battery_summary: >-
         {{ state_attr('sensor.battery_low_20', 'summary') | default('', true) }}
+      notification_tag: low-battery-20
       battery_label: >-
         {{ 'battery sensor' if battery_count == 1 else 'battery sensors' }}
       battery_title: >-
         {{ battery_count }} {{ battery_label }} below 20%
       battery_message: >-
         {{ ('Affected sensor' if battery_count == 1 else 'Affected sensors') ~ ':\n' ~ battery_summary }}
-      count_increased: >-
-        {{ trigger.id == 'summary_change'
-           and trigger.from_state is not none
-           and trigger.to_state is not none
-           and trigger.from_state.state not in ['unknown', 'unavailable']
-           and trigger.to_state.state not in ['unknown', 'unavailable']
-           and trigger.to_state.state | int(0) > trigger.from_state.state | int(0) }}
     action:
       - choose:
           - conditions:
@@ -268,6 +262,12 @@ automation:
               - action: persistent_notification.dismiss
                 data:
                   notification_id: low-battery-20
+              - continue_on_error: true
+                action: notify.all
+                data:
+                  message: clear_notification
+                  data:
+                    tag: "{{ notification_tag }}"
         default:
           - action: persistent_notification.dismiss
             data:
@@ -279,14 +279,20 @@ automation:
               notification_id: low-battery-20
           - choose:
               - conditions:
+                  - condition: trigger
+                    id: summary_change
                   - condition: template
                     value_template: >-
-                      {{ count_increased }}
+                      {{ battery_summary | trim != '' }}
                 sequence:
-                  - action: notify.all
+                  - continue_on_error: true
+                    action: notify.all
                     data:
                       title: "{{ battery_title }}"
                       message: "{{ battery_message }}"
+                      data:
+                        tag: "{{ notification_tag }}"
+                        persistent: true
 
   - id: notify_battery_dying_10
     alias: notify_battery_dying_10
@@ -306,19 +312,13 @@ automation:
         {{ states('sensor.battery_low_10') | int(0) }}
       battery_summary: >-
         {{ state_attr('sensor.battery_low_10', 'summary') | default('', true) }}
+      notification_tag: low-battery-10
       battery_label: >-
         {{ 'battery sensor' if battery_count == 1 else 'battery sensors' }}
       battery_title: >-
         {{ battery_count }} {{ battery_label }} below 10%
       battery_message: >-
         {{ ('Affected sensor' if battery_count == 1 else 'Affected sensors') ~ ':\n' ~ battery_summary }}
-      count_increased: >-
-        {{ trigger.id == 'summary_change'
-           and trigger.from_state is not none
-           and trigger.to_state is not none
-           and trigger.from_state.state not in ['unknown', 'unavailable']
-           and trigger.to_state.state not in ['unknown', 'unavailable']
-           and trigger.to_state.state | int(0) > trigger.from_state.state | int(0) }}
     action:
       - choose:
           - conditions:
@@ -329,6 +329,12 @@ automation:
               - action: persistent_notification.dismiss
                 data:
                   notification_id: low-battery-10
+              - continue_on_error: true
+                action: notify.all
+                data:
+                  message: clear_notification
+                  data:
+                    tag: "{{ notification_tag }}"
         default:
           - action: persistent_notification.dismiss
             data:
@@ -340,14 +346,20 @@ automation:
               notification_id: low-battery-10
           - choose:
               - conditions:
+                  - condition: trigger
+                    id: summary_change
                   - condition: template
                     value_template: >-
-                      {{ count_increased }}
+                      {{ battery_summary | trim != '' }}
                 sequence:
-                  - action: notify.all
+                  - continue_on_error: true
+                    action: notify.all
                     data:
                       title: "{{ battery_title }}"
                       message: "{{ battery_message }}"
+                      data:
+                        tag: "{{ notification_tag }}"
+                        persistent: true
 
   - id: notify_battery_dead
     alias: notify_battery_dead
@@ -367,19 +379,13 @@ automation:
         {{ states('sensor.battery_dead') | int(0) }}
       battery_summary: >-
         {{ state_attr('sensor.battery_dead', 'summary') | default('', true) }}
+      notification_tag: battery-dead
       battery_label: >-
         {{ 'battery sensor' if battery_count == 1 else 'battery sensors' }}
       battery_title: >-
         {{ battery_count }} {{ battery_label }} offline
       battery_message: >-
         {{ ('Affected sensor' if battery_count == 1 else 'Affected sensors') ~ ':\n' ~ battery_summary }}
-      count_increased: >-
-        {{ trigger.id == 'summary_change'
-           and trigger.from_state is not none
-           and trigger.to_state is not none
-           and trigger.from_state.state not in ['unknown', 'unavailable']
-           and trigger.to_state.state not in ['unknown', 'unavailable']
-           and trigger.to_state.state | int(0) > trigger.from_state.state | int(0) }}
     action:
       - choose:
           - conditions:
@@ -390,6 +396,12 @@ automation:
               - action: persistent_notification.dismiss
                 data:
                   notification_id: battery-dead
+              - continue_on_error: true
+                action: notify.all
+                data:
+                  message: clear_notification
+                  data:
+                    tag: "{{ notification_tag }}"
         default:
           - action: persistent_notification.dismiss
             data:
@@ -401,14 +413,20 @@ automation:
               notification_id: battery-dead
           - choose:
               - conditions:
+                  - condition: trigger
+                    id: summary_change
                   - condition: template
                     value_template: >-
-                      {{ count_increased }}
+                      {{ battery_summary | trim != '' }}
                 sequence:
-                  - action: notify.all
+                  - continue_on_error: true
+                    action: notify.all
                     data:
                       title: "{{ battery_title }}"
                       message: "{{ battery_message }}"
+                      data:
+                        tag: "{{ notification_tag }}"
+                        persistent: true
 
 ########################
 # Binary Sensors

--- a/tests/test_batteries_package.py
+++ b/tests/test_batteries_package.py
@@ -86,16 +86,21 @@ def test_battery_automations_update_notifications_from_dynamic_sensor_summaries(
         assert "notify.all" in block
         assert f"states('sensor.battery_low_{threshold}')" in block
         assert f"state_attr('sensor.battery_low_{threshold}', 'summary')" in block
+        assert f"notification_tag: low-battery-{threshold}" in block
         assert "battery_label" in block
         assert "battery_title" in block
         assert "battery_message" in block
         assert "battery sensor' if battery_count == 1 else 'battery sensors" in block
         assert "Affected sensor' if battery_count == 1 else 'Affected sensors" in block
-        assert "trigger.id == 'summary_change'" in block
-        assert "count_increased" in block
+        assert "condition: trigger" in block
+        assert "id: summary_change" in block
+        assert "battery_summary | trim != ''" in block
+        assert "message: clear_notification" in block
+        assert 'tag: "{{ notification_tag }}"' in block
+        assert "persistent: true" in block
+        assert "continue_on_error: true" in block
         assert f"notification_id: low-battery-{threshold}" in block
         assert f"below {threshold}%" in block
-        assert "trigger.from_state is not none" in block
         assert f"Battery Sensors Below {threshold}% (" not in block
 
 
@@ -112,13 +117,19 @@ def test_battery_dead_automation_updates_notifications_for_unavailable_battery_s
     assert "notify.all" in block
     assert "states('sensor.battery_dead')" in block
     assert "state_attr('sensor.battery_dead', 'summary')" in block
+    assert "notification_tag: battery-dead" in block
     assert "battery_label" in block
     assert "battery_title" in block
     assert "battery_message" in block
     assert "battery sensor' if battery_count == 1 else 'battery sensors" in block
     assert "Affected sensor' if battery_count == 1 else 'Affected sensors" in block
-    assert "trigger.id == 'summary_change'" in block
-    assert "count_increased" in block
+    assert "condition: trigger" in block
+    assert "id: summary_change" in block
+    assert "battery_summary | trim != ''" in block
+    assert "message: clear_notification" in block
+    assert 'tag: "{{ notification_tag }}"' in block
+    assert "persistent: true" in block
+    assert "continue_on_error: true" in block
     assert "notification_id: battery-dead" in block
     assert "offline" in block
     assert "Do not infer dead batteries from last_seen here" not in block


### PR DESCRIPTION
## Summary
- add stable notification tags for battery mobile alerts
- refresh iOS battery pushes whenever the battery summary changes
- clear tagged mobile notifications when a battery alert resolves
- cover the tagged refresh and clear behavior with regression tests

## Why
Issue #338 is still reproducible on iOS after the helper-sensor exclusion fix. The battery helper summaries are correct, but the mobile notification path was not replacing or clearing existing iOS notifications reliably.

## Impact
Battery alerts on iOS should now update in place with the current affected device names instead of leaving an older banner that only shows stale percentages.

## Root Cause
The automation only sent mobile pushes under the old count-increase condition and did not use stable per-alert tags for replace/clear behavior.

## Validation
- `uv run --with pytest pytest`

Closes #338