### PR TITLE
Fix tan() template error killing volume ramp in wake-up scripts

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -470,7 +470,7 @@ automation:
                       - media_player.bathroom_sonos_2
                 - delay:
                     # As time passes, the delay gets smaller and smaller. 60, 30s, 20s, 15s, 12s,..., 2s
-                    seconds: "{{ (1/(tan(repeat.index/60, 5))) | round(0, 'ceil', 5)}}"
+                    seconds: "{{ (1/(tan(repeat.index/60))) | round(0, 'ceil', 5)}}"
               until: "{{repeat.index == 30}}"
 
   - id: restart_sonos_unavailable
@@ -1064,7 +1064,7 @@ script:
                   - media_player.bedroom_sonos_2
                   - media_player.bathroom_sonos_2
             - delay:
-                seconds: "{{ (1/(tan(repeat.index/120, 5))) | round(0, 'ceil', 5)}}"
+                seconds: "{{ (1/(tan(repeat.index/120))) | round(0, 'ceil', 5)}}"
           until: "{{ repeat.index == 30 }}"
 
   bedroom_playlist_0:


### PR DESCRIPTION
## Summary

- `tan()` in Jinja2 takes only one argument; both volume ramp loops were calling `tan(repeat.index/N, 5)` — the `, 5` is a leftover that belongs as the `round()` default, not a second arg to `tan()`
- This caused a template error on the very first `delay` step of each repeat iteration, aborting the loop immediately
- Result: alarm played at 0.01 volume forever with no ramp-up

## Affected scripts

| Script/Automation | Location |
|---|---|
| `script.music_assistant_radio_wake_up` | `packages/media_player.yaml` ~line 1067 |
| `automation.play_music_in_bathroom_when_up` | `packages/media_player.yaml` ~line 473 |

## Trace evidence (2026-04-03 8:25am)

- `script.music_assistant_radio_wake_up` ran for exactly ~60s (one loop pass) instead of several minutes
- MPR played but never got louder
- Blinds opened correctly (unrelated script, unaffected)

## Test plan

- [ ] Trigger weekday alarm and confirm volume ramps from 0.01 to 0.30 over ~5 minutes
- [ ] Confirm `tan()` template evals correctly in Developer Tools > Template with `{{ (1/(tan(1/120))) | round(0, 'ceil', 5) }}`

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)