### PR TITLE
Apply HA 2026.3 improvements: continue_on_error and watch script refactor (#322)

### DIFF
--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -188,26 +188,22 @@ automation:
         target:
           entity_id: alarm_control_panel.home_alarm
       - action: notify.all
+        continue_on_error: true
         data:
           message: >
             Activity detected at {{ trigger_label }} while you're away!
       #    - action: tts.google_say
       #      data:
       #        message: "Intruder Alert! Intruder Alert! You are detected and recorded."
-      - action: light.turn_on
-        data:
-          entity_id: light.dining_room_lamps
-          flash: long
-      - delay: 00:00:02
-      - action: light.turn_on
-        data:
-          entity_id: light.dining_room_lamps
-          flash: long
-      - delay: 00:00:02
-      - action: light.turn_on
-        data:
-          entity_id: light.dining_room_lamps
-          flash: long
+      - repeat:
+          count: 3
+          sequence:
+            - action: light.turn_on
+              continue_on_error: true
+              data:
+                entity_id: light.dining_room_lamps
+                flash: long
+            - delay: 00:00:02
 
   - alias: send_notification_when_alarm_triggered
     id: send_notification_when_alarm_triggered
@@ -217,9 +213,14 @@ automation:
         to: "triggered"
     action:
       - action: notify.all
+        continue_on_error: true
         data:
           message: >
             Alarm triggered while you're away
+      - action: notify.mobile_app_wethop
+        continue_on_error: true
+        data:
+          message: "Something triggered alarm panel at home!"
 
   - alias: mirror_shared_notifications_to_lg_tv_when_on
     id: mirror_shared_notifications_to_lg_tv_when_on
@@ -299,11 +300,13 @@ automation:
         data:
           code: !secret alarm_code
       - action: switch.turn_on
+        continue_on_error: true
         target:
           entity_id:
             - switch.livingroom_motion_detection
             - switch.tikiroomcam_tikiroom_motion_detection
       - action: input_boolean.turn_on
+        continue_on_error: true
         target:
           entity_id:
             - input_boolean.house_unoccupied
@@ -322,6 +325,7 @@ automation:
         data:
           code: !secret alarm_code
       - action: switch.turn_off
+        continue_on_error: true
         target:
           entity_id:
             - switch.livingroom_motion_detection
@@ -331,20 +335,10 @@ automation:
       #        message: >
       #          Disabled alarm and turned off motion detection
       - action: input_boolean.turn_off
+        continue_on_error: true
         target:
           entity_id:
             - input_boolean.house_unoccupied
-
-  - alias: notify_ios_app
-    id: notify_ios_app
-    trigger:
-      - trigger: state
-        entity_id: alarm_control_panel.home_alarm
-        to: "triggered"
-    action:
-      - action: notify.mobile_app_wethop
-        data:
-          message: "Something triggered alarm panel at home!"
 
 ########################
 # Binary Sensors

--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -378,23 +378,28 @@ automation:
                 state: "on"
             sequence:
               - action: ecobee.resume_program
+                continue_on_error: true
                 data:
                   entity_id: climate.my_ecobee
                   resume_all: true
               - action: climate.turn_on
+                continue_on_error: true
                 data:
                   entity_id:
                     - climate.my_ecobee
                     - climate.my_ecobee_2
               - action: input_boolean.turn_off
+                continue_on_error: true
                 data:
                   entity_id: input_boolean.window_climate_paused_by_windows
       - action: notify.mobile_app_wethop
+        continue_on_error: true
         data:
           message: clear_notification
           data:
             tag: window-climate-open
       - action: notify.mobile_app_wethop
+        continue_on_error: true
         data:
           message: clear_notification
           data:

--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -192,17 +192,20 @@ automation:
           state: "off"
     action:
       - action: media_player.volume_set
+        continue_on_error: true
         data:
           entity_id:
             - media_player.bedroom_sonos_2
             - media_player.bathroom_sonos_2
           volume_level: 0.02
       - action: scene.turn_on
+        continue_on_error: true
         target:
           entity_id: scene.bedroom_prep
         data:
           transition: 60
       - action: script.turn_on
+        continue_on_error: true
         target:
           entity_id: script.spotify_bedtime
       - delay: "00:20:00"
@@ -315,11 +318,13 @@ automation:
           state: "off"
     action:
       - action: media_player.media_pause
+        continue_on_error: true
         data:
           entity_id:
             - media_player.office_sonos_2
             - media_player.den_sonos_2
       - action: script.lights_off_except
+        continue_on_error: true
         data:
           exclude_lights:
             - light.outside_front_hue
@@ -329,13 +334,16 @@ automation:
             - light.basement_tv_bias
           transition: 15
       - action: script.turn_on
+        continue_on_error: true
         target:
           entity_id: script.night_tv_mode_switches
       - action: media_player.media_pause
+        continue_on_error: true
         data:
           entity_id:
             - media_player.den_sonos_2
       - action: script.music_assistant_pause_house_audio
+        continue_on_error: true
 
 ################################################
 ## Scenes
@@ -440,8 +448,11 @@ script:
             entity_id: media_player.plex_basement_apple_tv
             state: "unavailable"
 
-  watch_tv:
-    alias: "Watch TV"
+  # Shared preamble: power on basement media player, wait for ready,
+  # then switch the LG TV to HDMI 3. Called by all watch_* scripts.
+  watch_basement_tv_startup:
+    alias: "Basement TV Startup"
+    mode: parallel
     sequence:
       - action: media_player.turn_on
         data:
@@ -453,231 +464,20 @@ script:
         data:
           entity_id: media_player.lg_webos_smart_tv
           source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "YouTube TV"
 
-  watch_youtube:
-    alias: "Watch YouTube"
+  # Shared Plex-show launcher. Runs startup, selects Plex source, scans
+  # for the Apple TV Plex client, then plays the requested show shuffled.
+  watch_plex_show:
+    alias: "Watch Plex Show"
+    mode: parallel
+    fields:
+      show_name:
+        description: "Plex library show name (must match library exactly)"
+        required: true
+        selector:
+          text: {}
     sequence:
-      - action: media_player.turn_on
-        data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "YouTube"
-
-  watch_netflix:
-    alias: "Watch Netflix"
-    sequence:
-      - action: media_player.turn_on
-        data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "Netflix"
-      - delay:
-          seconds: 2
-      - action: script.music_assistant_pause_house_audio
-
-  watch_plex:
-    alias: "Watch Plex"
-    sequence:
-      - action: media_player.turn_on
-        data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "Plex"
-      - delay:
-          seconds: 2
-      - action: script.music_assistant_pause_house_audio
-
-  watch_f1:
-    alias: "Watch F1"
-    sequence:
-      - action: media_player.turn_on
-        data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "F1 TV"
-      - delay:
-          seconds: 2
-      - action: script.music_assistant_pause_house_audio
-
-  watch_letterkenny:
-    alias: "Watch Letterkenny"
-    sequence:
-      - action: media_player.turn_on
-        data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "Plex"
-      - delay:
-          seconds: 2
-      - action: button.press
-        target:
-          entity_id: button.fermentor_scan_clients
-      - action: script.wait_for_basement_plex_client_ready
-      - action: media_player.play_media
-        data:
-          entity_id: media_player.plex_basement_apple_tv
-          media_content_type: EPISODE
-          media_content_id: '{ "library_name": "TV", "show_name": "Letterkenny", "shuffle": "1" }'
-      - delay:
-          seconds: 2
-      - action: script.music_assistant_pause_house_audio
-
-  watch_the_simpsons:
-    alias: "Watch The Simpsons"
-    sequence:
-      - action: media_player.turn_on
-        data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "Plex"
-      - delay:
-          seconds: 2
-      - action: button.press
-        target:
-          entity_id: button.fermentor_scan_clients
-      - action: script.wait_for_basement_plex_client_ready
-      - action: media_player.play_media
-        data:
-          entity_id: media_player.plex_basement_apple_tv
-          media_content_type: EPISODE
-          media_content_id: '{ "library_name": "TV", "show_name": "The Simpsons", "shuffle": "1" }'
-      - action: script.music_assistant_pause_house_audio
-
-  watch_american_dad:
-    alias: "Watch American Dad"
-    sequence:
-      - action: media_player.turn_on
-        data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "Plex"
-      - delay:
-          seconds: 2
-      - action: button.press
-        target:
-          entity_id: button.fermentor_scan_clients
-      - action: script.wait_for_basement_plex_client_ready
-      - action: media_player.play_media
-        data:
-          entity_id: media_player.plex_basement_apple_tv
-          media_content_type: EPISODE
-          media_content_id: '{ "library_name": "TV", "show_name": "American Dad", "shuffle": "1" }'
-      - delay:
-          seconds: 2
-      - action: script.music_assistant_pause_house_audio
-
-  watch_aqua_teen:
-    alias: "Watch Aqua Teen"
-    sequence:
-      - action: media_player.turn_on
-        data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "Plex"
-      - delay:
-          seconds: 2
-      - action: button.press
-        target:
-          entity_id: button.fermentor_scan_clients
-      - action: script.wait_for_basement_plex_client_ready
-      - action: media_player.play_media
-        data:
-          entity_id: media_player.plex_basement_apple_tv
-          media_content_type: EPISODE
-          media_content_id: '{ "library_name": "TV", "show_name": "Aqua Teen Hunger Force", "shuffle": "1" }'
-      - delay:
-          seconds: 2
-      - action: script.music_assistant_pause_house_audio
-
-  watch_bobs_burgers:
-    alias: "Watch Bobs Burgers"
-    sequence:
-      - action: media_player.turn_on
-        data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
+      - action: script.watch_basement_tv_startup
       - action: media_player.select_source
         data:
           entity_id: media_player.basement
@@ -693,103 +493,121 @@ script:
           entity_id: media_player.plex_basement_apple_tv
           media_content_type: EPISODE
           media_content_id: >-
-            { "library_name": "TV", "show_name": "Bob's Burgers", "shuffle": "1" }
+            { "library_name": "TV", "show_name": "{{ show_name }}", "shuffle": "1" }
       - delay:
           seconds: 2
       - action: script.music_assistant_pause_house_audio
+        continue_on_error: true
+
+  watch_tv:
+    alias: "Watch TV"
+    sequence:
+      - action: script.watch_basement_tv_startup
+      - action: media_player.select_source
+        data:
+          entity_id: media_player.basement
+          source: "YouTube TV"
+
+  watch_youtube:
+    alias: "Watch YouTube"
+    sequence:
+      - action: script.watch_basement_tv_startup
+      - action: media_player.select_source
+        data:
+          entity_id: media_player.basement
+          source: "YouTube"
+
+  watch_netflix:
+    alias: "Watch Netflix"
+    sequence:
+      - action: script.watch_basement_tv_startup
+      - action: media_player.select_source
+        data:
+          entity_id: media_player.basement
+          source: "Netflix"
+      - delay:
+          seconds: 2
+      - action: script.music_assistant_pause_house_audio
+        continue_on_error: true
+
+  watch_plex:
+    alias: "Watch Plex"
+    sequence:
+      - action: script.watch_basement_tv_startup
+      - action: media_player.select_source
+        data:
+          entity_id: media_player.basement
+          source: "Plex"
+      - delay:
+          seconds: 2
+      - action: script.music_assistant_pause_house_audio
+        continue_on_error: true
+
+  watch_f1:
+    alias: "Watch F1"
+    sequence:
+      - action: script.watch_basement_tv_startup
+      - action: media_player.select_source
+        data:
+          entity_id: media_player.basement
+          source: "F1 TV"
+      - delay:
+          seconds: 2
+      - action: script.music_assistant_pause_house_audio
+        continue_on_error: true
+
+  watch_letterkenny:
+    alias: "Watch Letterkenny"
+    sequence:
+      - action: script.watch_plex_show
+        data:
+          show_name: "Letterkenny"
+
+  watch_the_simpsons:
+    alias: "Watch The Simpsons"
+    sequence:
+      - action: script.watch_plex_show
+        data:
+          show_name: "The Simpsons"
+
+  watch_american_dad:
+    alias: "Watch American Dad"
+    sequence:
+      - action: script.watch_plex_show
+        data:
+          show_name: "American Dad"
+
+  watch_aqua_teen:
+    alias: "Watch Aqua Teen"
+    sequence:
+      - action: script.watch_plex_show
+        data:
+          show_name: "Aqua Teen Hunger Force"
+
+  watch_bobs_burgers:
+    alias: "Watch Bobs Burgers"
+    sequence:
+      - action: script.watch_plex_show
+        data:
+          show_name: "Bob's Burgers"
 
   watch_ds9:
     alias: "Watch DS9"
     sequence:
-      - action: media_player.turn_on
+      - action: script.watch_plex_show
         data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "Plex"
-      - delay:
-          seconds: 2
-      - action: button.press
-        target:
-          entity_id: button.fermentor_scan_clients
-      - action: script.wait_for_basement_plex_client_ready
-      - action: media_player.play_media
-        data:
-          entity_id: media_player.plex_basement_apple_tv
-          media_content_type: EPISODE
-          media_content_id: '{ "library_name": "TV", "show_name": "Star Trek: Deep Space Nine", "shuffle": "1" }'
-      - delay:
-          seconds: 2
-      - action: script.music_assistant_pause_house_audio
+          show_name: "Star Trek: Deep Space Nine"
 
   watch_rick_and_morty:
     alias: "Watch Rick and Morty"
     sequence:
-      - action: media_player.turn_on
+      - action: script.watch_plex_show
         data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "Plex"
-      - delay:
-          seconds: 2
-      - action: button.press
-        target:
-          entity_id: button.fermentor_scan_clients
-      - action: script.wait_for_basement_plex_client_ready
-      - action: media_player.play_media
-        data:
-          entity_id: media_player.plex_basement_apple_tv
-          media_content_type: EPISODE
-          media_content_id: '{ "library_name": "TV", "show_name": "Rick and Morty", "shuffle": "1" }'
-      - delay:
-          seconds: 2
-      - action: script.music_assistant_pause_house_audio
+          show_name: "Rick and Morty"
 
   watch_tng:
     alias: "Watch TNG"
     sequence:
-      - action: media_player.turn_on
+      - action: script.watch_plex_show
         data:
-          entity_id: media_player.basement
-      - action: script.wait_for_basement_media_player_ready
-      - delay:
-          seconds: 10
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.lg_webos_smart_tv
-          source: "HDMI 3"
-      - action: media_player.select_source
-        data:
-          entity_id: media_player.basement
-          source: "Plex"
-      - delay:
-          seconds: 2
-      - action: button.press
-        target:
-          entity_id: button.fermentor_scan_clients
-      - action: script.wait_for_basement_plex_client_ready
-      - action: media_player.play_media
-        data:
-          entity_id: media_player.plex_basement_apple_tv
-          media_content_type: EPISODE
-          media_content_id: '{ "library_name": "TV", "show_name": "Star Trek: The Next Generation", "shuffle": "1" }'
-      - delay:
-          seconds: 2
-      - action: script.music_assistant_pause_house_audio
+          show_name: "Star Trek: The Next Generation"

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -235,21 +235,25 @@ automation:
       #   id: nonsummer
     action:
       - action: select.select_option
+        continue_on_error: true
         target:
           entity_id: select.hourly_electricity
         data:
           option: "{{ tariff }}"
       - action: select.select_option
+        continue_on_error: true
         target:
           entity_id: select.daily_electricity
         data:
           option: "{{ tariff }}"
       - action: select.select_option
+        continue_on_error: true
         target:
           entity_id: select.monthly_electricity
         data:
           option: "{{ tariff }}"
       - action: input_number.set_value
+        continue_on_error: true
         target:
           entity_id: input_number.electrical_rate
         data:
@@ -310,21 +314,25 @@ automation:
         {% endif %}
     action:
       - action: select.select_option
+        continue_on_error: true
         target:
           entity_id: select.hourly_ev_charging
         data:
           option: "{{ ev_tariff }}"
       - action: select.select_option
+        continue_on_error: true
         target:
           entity_id: select.daily_ev_charging
         data:
           option: "{{ ev_tariff }}"
       - action: select.select_option
+        continue_on_error: true
         target:
           entity_id: select.monthly_ev_charging
         data:
           option: "{{ ev_tariff }}"
       - action: input_number.set_value
+        continue_on_error: true
         target:
           entity_id: input_number.ev_electrical_rate
         data:

--- a/packages/xiaomi_robot_vacuum.yaml
+++ b/packages/xiaomi_robot_vacuum.yaml
@@ -252,7 +252,7 @@ script:
         data:
           topic: valetudo/upstairs-vacuum/MapSegmentationCapability/clean/set
           payload: >-
-            {"action": "start_segment_action","segment_ids": ["5],"iterations": 4,"customOrder": true}
+            {"action": "start_segment_action","segment_ids": ["5"],"iterations": 4,"customOrder": true}
   vacuum_bathroom:
     alias: "Vacuum Bathroom"
     sequence:


### PR DESCRIPTION
## Summary

- Add `continue_on_error` to independent multi-step sequences in `alerts.yaml`, `utilities.yaml`, `climate.yaml`, and `tv.yaml` so a single unavailable device cannot abort the rest of a sequence
- Extract `watch_basement_tv_startup` and parameterised `watch_plex_show` helper scripts in `tv.yaml`; 8 show-specific Plex scripts collapse to single-call wrappers (~280 lines removed)
- Merge two identical-trigger alarm automations in `alerts.yaml` into one; condense triple light-flash to `repeat: count: 3`
- Fix missing closing quote in `vacuum_guest_room` segment JSON payload

Closes #322

## Changes

| File | What changed |
|---|---|
| `packages/xiaomi_robot_vacuum.yaml` | Fix `"5]` → `"5"]` syntax bug in `vacuum_guest_room` |
| `packages/alerts.yaml` | `continue_on_error` on alarm arm/disarm and alarm-triggered steps; merge `notify_ios_app` into `send_notification_when_alarm_triggered`; condense triple light-flash to `repeat: count: 3` |
| `packages/utilities.yaml` | `continue_on_error` on all tariff `select.select_option` and `input_number.set_value` steps |
| `packages/climate.yaml` | `continue_on_error` on ecobee resume, climate turn_on, and notify clear steps in `window_climate_action_handler` |
| `packages/tv.yaml` | `continue_on_error` on `tv_resumed` and `tv_off_at_night_bed_prep`; extract `watch_basement_tv_startup` and `watch_plex_show` helpers; collapse 8 show scripts |

## Test plan

- [ ] YAML lint passes (CI)
- [ ] HA config validation passes (CI)
- [ ] Verify `watch_letterkenny` (and any other Plex show script) still plays correctly via the new `watch_plex_show` helper
- [ ] Verify alarm arm/disarm automation fires both notify steps when alarm triggers
- [ ] Confirm tariff automations still update all three utility meters on rate change

🤖 Generated with [Claude Code](https://claude.com/claude-code)