### PR TITLE
Fix musty notification: replace fragile boolean with input_select gate

### DIFF
--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -156,16 +156,12 @@ alarm_control_panel: []
 automation:
   - id: washer_started
     alias: washer_started
-    description: Mark the washer as actively running and clear any stale wet-load reminder from a prior load.
+    description: Mark the washer as actively running.
     trigger:
       - trigger: state
         entity_id: binary_sensor.washing_machine_running
-        from: "off"
         to: "on"
     action:
-      - action: input_boolean.turn_off
-        target:
-          entity_id: input_boolean.washer_wet_load_pending
       - action: input_select.select_option
         target:
           entity_id: input_select.washer_state
@@ -186,9 +182,6 @@ automation:
           entity_id: input_datetime.washer_finished_at
         data:
           datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
-      - action: input_boolean.turn_on
-        target:
-          entity_id: input_boolean.washer_wet_load_pending
       - action: input_select.select_option
         target:
           entity_id: input_select.washer_state
@@ -221,17 +214,14 @@ automation:
         event: start
     condition:
       - condition: state
-        entity_id: input_boolean.washer_wet_load_pending
-        state: "on"
+        entity_id: input_select.washer_state
+        state: "CLEAN"
       - condition: state
         entity_id: binary_sensor.washing_machine_running
         state: "off"
       - condition: state
         entity_id: binary_sensor.laundry_room_washing_machine_door_contact
         state: "off"
-      - condition: state
-        entity_id: input_select.washer_state
-        state: "CLEAN"
       - condition: template
         value_template: >-
           {% set finished = states('input_datetime.washer_finished_at') %}
@@ -258,13 +248,15 @@ automation:
       - condition: state
         entity_id: binary_sensor.washing_machine_running
         state: "off"
-      - condition: state
-        entity_id: input_boolean.washer_wet_load_pending
-        state: "on"
+      - condition: or
+        conditions:
+          - condition: state
+            entity_id: input_select.washer_state
+            state: "CLEAN"
+          - condition: state
+            entity_id: input_select.washer_state
+            state: "MUSTY"
     action:
-      - action: input_boolean.turn_off
-        target:
-          entity_id: input_boolean.washer_wet_load_pending
       - action: input_select.select_option
         target:
           entity_id: input_select.washer_state
@@ -299,10 +291,7 @@ group: {}
 ########################
 # Input Booleans
 ########################
-input_boolean:
-  washer_wet_load_pending:
-    name: Washer Wet Load Pending
-    icon: mdi:tshirt-crew
+input_boolean: {}
 
 ########################
 # Input Datetime

--- a/tests/test_laundry_plug_monitoring.py
+++ b/tests/test_laundry_plug_monitoring.py
@@ -87,16 +87,16 @@ def test_cleaning_package_notifies_from_power_based_running_sensors() -> None:
     washer_cleared = _automation_block(CLEANING_PATH, "washer_cleared")
 
     assert "entity_id: binary_sensor.washing_machine_running" in washer_started
-    assert 'from: "off"' in washer_started
     assert 'to: "on"' in washer_started
-    assert "input_boolean.washer_wet_load_pending" in washer_started
+    assert 'from: "off"' not in washer_started  # must fire even after unavailable→on
+    assert "input_boolean.washer_wet_load_pending" not in washer_started
     assert "option: CLEANING" in washer_started
 
     assert "entity_id: binary_sensor.washing_machine_running" in wash_finished
     assert 'from: "on"' in wash_finished
     assert 'to: "off"' in wash_finished
     assert "input_datetime.washer_finished_at" in wash_finished
-    assert "input_boolean.washer_wet_load_pending" in wash_finished
+    assert "input_boolean.washer_wet_load_pending" not in wash_finished
     assert "option: CLEAN" in wash_finished
     assert "binary_sensor.front_load_washer_wash_completed" not in wash_finished
 
@@ -108,7 +108,8 @@ def test_cleaning_package_notifies_from_power_based_running_sensors() -> None:
     assert 'trigger: time_pattern' in washer_reminder
     assert 'minutes: "/10"' in washer_reminder
     assert 'trigger: homeassistant' in washer_reminder
-    assert "input_boolean.washer_wet_load_pending" in washer_reminder
+    assert "input_boolean.washer_wet_load_pending" not in washer_reminder
+    assert 'state: "CLEAN"' in washer_reminder  # input_select gates the reminder
     assert "binary_sensor.laundry_room_washing_machine_door_contact" in washer_reminder
     assert "input_datetime.washer_finished_at" in washer_reminder
     assert "24 * 60 * 60" in washer_reminder
@@ -117,14 +118,16 @@ def test_cleaning_package_notifies_from_power_based_running_sensors() -> None:
 
     assert "binary_sensor.laundry_room_washing_machine_door_contact" in washer_cleared
     assert 'to: "on"' in washer_cleared
-    assert "input_boolean.washer_wet_load_pending" in washer_cleared
+    assert "input_boolean.washer_wet_load_pending" not in washer_cleared
+    assert 'state: "CLEAN"' in washer_cleared
+    assert 'state: "MUSTY"' in washer_cleared
     assert "option: IDLE" in washer_cleared
 
 
 def test_cleaning_package_tracks_wet_load_helpers() -> None:
     config = CLEANING_PATH.read_text(encoding="utf-8")
 
-    assert "washer_wet_load_pending:" in config
+    assert "washer_wet_load_pending" not in config  # removed; state machine uses input_select
     assert "input_datetime:" in config
     assert "washer_finished_at:" in config
     assert "binary_sensor.laundry_room_washing_machine_door_contact:" in config


### PR DESCRIPTION
## Root cause

Three rapid HA restarts on Apr 4 at 05:09/05:18/05:26 UTC reset `input_boolean.washer_wet_load_pending` to its default `off` state after the Apr 3 wash. Every subsequent `washer_reminder` run failed on `condition/0` (the boolean check) — the automation never reached the 24-hour timer, so the musty notification was silently suppressed indefinitely.

`input_select.washer_state` correctly survived those same restarts as `CLEAN` because `input_select` entities are restored from `.storage`. The boolean is not.

**Secondary issues also fixed:**
- `washer_started` had `last_triggered: null` (never fired) — the `from: "off"` constraint blocked it whenever the power sensor came back `unavailable → on` across a restart
- `washer_cleared` conditioned on the boolean, so it also couldn't clear a MUSTY load after a restart

## Changes

- **Remove `input_boolean.washer_wet_load_pending` entirely** — `input_select.washer_state == CLEAN` encodes the same information and survives restarts
- **`washer_reminder`** — gates on `state == CLEAN` (first condition, restart-resilient) instead of the boolean
- **`washer_started`** — drops `from: "off"` constraint so it fires on `unavailable → on` transitions
- **`wash_finished`** — drops the now-removed boolean `turn_on` action
- **`washer_cleared`** — drops boolean condition; resets to IDLE when state is `CLEAN` or `MUSTY`
- **Tests updated** to assert the boolean is gone and the new state-machine-only behavior

## Test plan

- [ ] All 5 laundry/washer tests pass (`uv run --with pytest pytest tests/test_laundry_plug_monitoring.py tests/test_appdaemon_washer_config.py`)
- [ ] Run a wash cycle — confirm `washer_state` transitions IDLE → CLEANING → CLEAN and finish notification fires
- [ ] Leave clothes in washer 24h — confirm musty notification fires even after an HA restart in between
- [ ] Open washer door after cycle — confirm `washer_state` resets to IDLE

🤖 Generated with [Claude Code](https://claude.com/claude-code)