### PR TITLE
[codex] Fix AppDaemon vacuum stall monitor sync churn

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,6 +7,13 @@ fi
 
 repo_root="$(git rev-parse --show-toplevel)"
 
+# Only auto-sync from the primary checkout. Worktrees are often pinned to older
+# feature branches, and pulling the live add-on tree into them creates
+# unrelated AppDaemon restore commits.
+if [ ! -d "$repo_root/.git" ]; then
+  exit 0
+fi
+
 # Only auto-sync when the repo copy is clean. If the user is already editing
 # appdaemon/ locally, leave their work alone and let them sync deliberately.
 if [ -n "$(git diff --name-only -- appdaemon)" ]; then

--- a/appdaemon/apps/vacuum_stall_monitor.py
+++ b/appdaemon/apps/vacuum_stall_monitor.py
@@ -138,7 +138,7 @@ def normalize_service(service_name: str) -> str:
 
 
 def slug_from_vacuum_entity(entity_id: str) -> str:
-    return entity_id.split(".", 1)[-1]
+    return entity_id.split(".", 1)[-1].removeprefix("valetudo_")
 
 
 def is_active_vacuum_state(state: str | None, active_states: tuple[str, ...] = ("cleaning", "returning")) -> bool:

--- a/docs/appdaemon_sync.md
+++ b/docs/appdaemon_sync.md
@@ -14,6 +14,17 @@ Pull the live add-on tree into the repo and stage it:
 python3 scripts/appdaemon_sync.py pull --stage
 ```
 
+Routine pulls are additive/update-only: files missing from the live add-on are
+left intact in the repo copy so custom apps do not disappear from feature
+branches after an HA-side reset or reinstall.
+
+Use `--delete` only when you intentionally want the repo copy pruned to match
+the live add-on exactly:
+
+```sh
+python3 scripts/appdaemon_sync.py pull --stage --delete
+```
+
 Check whether the repo copy differs from the live add-on tree:
 
 ```sh
@@ -58,7 +69,7 @@ scripts/install_appdaemon_hooks.sh
 ```
 
 The pre-commit hook auto-pulls live AppDaemon changes only when `appdaemon/` is
-clean locally. That keeps accidental hook-driven overwrites away from intentional
-local edits.
+clean locally, and only from the primary checkout. Worktrees skip the hook so
+older feature branches do not absorb unrelated AppDaemon drift.
 
 Set `APPDAEMON_SYNC_SKIP=1` to bypass the hook for a single commit.

--- a/scripts/appdaemon_sync.py
+++ b/scripts/appdaemon_sync.py
@@ -228,7 +228,7 @@ def pull(root: Path, args: argparse.Namespace) -> int:
         cmd = build_rsync_command(
             remote_dir,
             local_dir,
-            delete=True,
+            delete=args.delete,
             dry_run=args.dry_run,
             itemize=not args.quiet or args.dry_run,
         )
@@ -319,6 +319,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Pull the live add-on tree into repo/appdaemon and optionally stage it.",
     )
     pull_parser.add_argument("--dry-run", action="store_true")
+    pull_parser.add_argument(
+        "--delete",
+        action="store_true",
+        help="Delete repo files missing from the live AppDaemon add-on",
+    )
     pull_parser.add_argument("--stage", action="store_true")
     pull_parser.add_argument("--quiet", action="store_true")
     pull_parser.set_defaults(func=pull)

--- a/tests/test_appdaemon_pre_commit_hook.py
+++ b/tests/test_appdaemon_pre_commit_hook.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_pre_commit_skips_worktrees_before_appdaemon_sync() -> None:
+    hook_path = Path(__file__).resolve().parents[1] / ".githooks" / "pre-commit"
+    hook_text = hook_path.read_text(encoding="utf-8")
+
+    assert 'if [ ! -d "$repo_root/.git" ]; then' in hook_text
+    assert "Worktrees are often pinned to older" in hook_text

--- a/tests/test_appdaemon_sync.py
+++ b/tests/test_appdaemon_sync.py
@@ -64,3 +64,27 @@ def test_build_rsync_command_includes_delete_and_excludes() -> None:
     assert "__pycache__/" in command
     assert "compiled/" in command
     assert command[-2:] == ["/source/", "/dest/"]
+
+
+def test_build_rsync_command_omits_delete_by_default() -> None:
+    command = MODULE.build_rsync_command(
+        Path("/source"),
+        Path("/dest"),
+        delete=False,
+        dry_run=False,
+        itemize=False,
+    )
+
+    assert command[:2] == ["rsync", "-a"]
+    assert "--delete" not in command
+    assert command[-2:] == ["/source/", "/dest/"]
+
+
+def test_pull_parser_requires_explicit_delete_flag() -> None:
+    parser = MODULE.build_parser()
+
+    default_args = parser.parse_args(["pull"])
+    delete_args = parser.parse_args(["pull", "--delete"])
+
+    assert default_args.delete is False
+    assert delete_args.delete is True

--- a/tests/test_issue_343_vacuum_stall_monitor.py
+++ b/tests/test_issue_343_vacuum_stall_monitor.py
@@ -105,6 +105,14 @@ def test_monitor_only_counts_cleaning_and_returning_states() -> None:
     assert module.is_active_vacuum_state("unavailable") is False
 
 
+def test_slug_from_vacuum_entity_drops_duplicate_valetudo_prefix() -> None:
+    module = _load_module()
+
+    assert module.slug_from_vacuum_entity("vacuum.valetudo_mainlevel") == "mainlevel"
+    assert module.slug_from_vacuum_entity("vacuum.valetudo_den") == "den"
+    assert module.slug_from_vacuum_entity("vacuum.valetudo_upstairs_vacuum") == "upstairs_vacuum"
+
+
 def test_extract_valetudo_map_and_render_png(tmp_path: Path) -> None:
     module = _load_module()
     map_data = {


### PR DESCRIPTION
Fixes #399

## What changed
- make `scripts/appdaemon_sync.py pull` non-destructive by default and require explicit `--delete` to prune the repo copy
- skip the AppDaemon auto-pull pre-commit hook in worktrees so feature branches do not absorb unrelated live add-on drift
- normalize the vacuum stall monitor slug so the published runtime entities match the dashboard IDs
- add regression coverage for sync defaults, worktree hook behavior, and vacuum slug normalization

## Why
The live AppDaemon add-on had lost `vacuum_stall_monitor.py` and `vacuum_stall_monitor.yaml` after an HA-side reset/reinstall. Because routine AppDaemon pulls used `--delete`, that live-side loss kept propagating back into git and produced repeated "restore vacuum stall monitor files" commits on unrelated branches. The vacuum stall monitor also published duplicate `valetudo_valetudo_*` entity IDs, which drifted from the dashboard and expected entity names.

## Impact
- AppDaemon routine pulls no longer delete custom repo files unless pruning is explicitly requested
- worktree commits no longer churn on unrelated AppDaemon restore noise
- HA now uses the expected vacuum stall monitor entity IDs

## Validation
- `uv run --with pytest pytest`
- `uv run --with pytest pytest tests/test_appdaemon_sync.py tests/test_appdaemon_pre_commit_hook.py tests/test_issue_343_vacuum_stall_monitor.py`
- pushed the tracked `appdaemon/` tree back to the live AppDaemon add-on
- restarted the `a0d7b954_appdaemon` add-on and verified:
  - `sensor.valetudo_mainlevel_stall_status`
  - `sensor.valetudo_den_stall_status`
  - `sensor.valetudo_upstairs_vacuum_stall_status`
  - `binary_sensor.valetudo_mainlevel_stalled`
  - `binary_sensor.valetudo_den_stalled`
  - `binary_sensor.valetudo_upstairs_vacuum_stalled`

## Notes
The old double-prefixed `valetudo_valetudo_*` synthetic states may still linger as stale runtime leftovers from the prior code path, but the corrected IDs are the active ones after the AppDaemon restart.