### PR TITLE
Protect outside front lights from grouped shutdowns

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -2416,11 +2416,21 @@ script:
       exclude_lights:
         description: "Excluded lights as list"
     variables:
+      protected_lights: >-
+        {% set excluded = exclude_lights | default([], true) | list %}
+        {% set ns = namespace(entities=excluded) %}
+        {% for light in states.light %}
+          {% set members = state_attr(light.entity_id, 'entity_id') %}
+          {% if members is iterable and members is not string and (members | select('in', excluded) | list | count > 0) %}
+            {% set ns.entities = ns.entities + [light.entity_id] %}
+          {% endif %}
+        {% endfor %}
+        {{ ns.entities | unique | list }}
       # Builds a comma-separated string of all currently-on lights, excluding
-      # the lights listed in exclude_lights (e.g. outdoor/porch lights that
-      # should stay on overnight).
+      # the protected lights and any light groups that would turn those
+      # protected members off indirectly.
       all_other_lights: >
-        {%- for device in states.light | rejectattr('entity_id', 'in', exclude_lights) | selectattr('state', 'eq', 'on') %}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.light | rejectattr('entity_id', 'in', protected_lights) | selectattr('state', 'eq', 'on') %}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
     sequence:
       # Fixed: guard the entire sequence so that when all non-excluded lights
       # are already off (all_other_lights resolves to an empty string), the

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -475,6 +475,10 @@ automation:
       - condition: state
         entity_id: input_boolean.guest_mode
         state: "off"
+      - alias: "Primary tracker confirms departure"
+        condition: template
+        value_template: >-
+          {{ not is_state('device_tracker.bayesian_zeke_home', 'home') }}
       - alias: "I'm driving away"
         enabled: false
         condition: state

--- a/tests/test_house_mode_zone.py
+++ b/tests/test_house_mode_zone.py
@@ -75,3 +75,11 @@ def test_departure_house_transition_runs_in_parallel_without_embedding_vacuum_lo
     assert "action: mqtt.publish" not in transition_block
     assert "action: script.vacuum_main_and_upstairs_levels" not in transition_block
     assert "action: script.vacuum_main_and_upstairs_levels" in vacuum_block
+
+
+def test_departure_waits_for_primary_tracker_to_leave_home() -> None:
+    block = _automation_block(ZONE_PATH, "turn_off_lights_when_i_leave")
+
+    assert "Primary tracker confirms departure" in block
+    assert "device_tracker.bayesian_zeke_home" in block
+    assert "not is_state('device_tracker.bayesian_zeke_home', 'home')" in block

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -172,3 +172,17 @@ def test_lights_off_except_only_targets_currently_on_lights() -> None:
 
     assert "selectattr('state', 'eq', 'on')" in block
     assert "rejectattr('state','in','off')" not in block
+
+
+def test_lights_off_except_skips_light_groups_that_contain_protected_members() -> None:
+    text = _read(ROOT / "packages" / "light.yaml")
+
+    block = text.split("lights_off_except:\n", 1)[1].split(
+        "\n########################\n# Sensor",
+        1,
+    )[0]
+
+    assert "protected_lights:" in block
+    assert "state_attr(light.entity_id, 'entity_id')" in block
+    assert "members | select('in', excluded)" in block
+    assert "rejectattr('entity_id', 'in', protected_lights)" in block


### PR DESCRIPTION
## Summary
- prevent `script.lights_off_except` from shutting off protected lights indirectly through light groups that contain excluded members
- require the primary `device_tracker.bayesian_zeke_home` to confirm departure before the away transition runs from the bayesian binary sensor
- add regression tests for both the grouped-light protection and the departure confirmation guard

## Validation
- `uv run --with pytest pytest` (`260 passed`)

## Coverage
- added regression coverage in `tests/test_runtime_log_regressions.py`
- added regression coverage in `tests/test_house_mode_zone.py`