### PR TITLE
[codex] Fix owner suite LED bar night sync

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1685,6 +1685,7 @@ automation:
     condition:
       - condition: time
         after: "07:59:59"
+        before: "12:00:00"
       - condition: state
         entity_id: binary_sensor.bayesian_bed_occupancy
         state: "off"
@@ -1698,6 +1699,22 @@ automation:
       - action: script.turn_on
         target:
           entity_id: script.day_mode_switches_owner_suite_bedroom
+
+  - alias: owner_suite_switch_leds_red_when_lamps_on_at_night
+    id: owner_suite_switch_leds_red_when_lamps_on_at_night
+    description: Restore the owner suite Inovelli LED bars to the nighttime red state whenever the owner suite lamps come back on overnight.
+    trigger:
+      - trigger: state
+        entity_id: light.owner_suite_lamps
+        to: "on"
+    condition:
+      - condition: time
+        after: "22:00:00"
+        before: "06:00:00"
+    action:
+      - action: script.turn_on
+        target:
+          entity_id: script.night_mode_switches_owner_suite
 
   - alias: button_reset_basement
     id: button_reset_basement
@@ -1773,6 +1790,12 @@ automation:
       - action: light.turn_off
         target:
           entity_id: light.bed_lightstrip
+      - if:
+          - condition: time
+            after: "22:00:00"
+            before: "06:00:00"
+        then:
+          - action: script.turn_off_owner_suite_inovelli_switch_leds
 
   - id: turn_on_bedroom_light_when_leave_bathroom
     alias: turn_on_bedroom_light_when_leave_bathroom

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2160,6 +2160,49 @@ script:
             {{owner_suite_bedroom_on_led_switches}}
           value: "170"
 
+  night_mode_switches_owner_suite:
+    icon: mdi:light-switch
+    sequence:
+      - *trip_led_updates_allowed
+      - action: logbook.log
+        data:
+          entity_id: script.night_mode_switches_owner_suite
+          name: Exclude log
+          message: "Setting owner suite switch LED colors to nighttime red"
+          domain: script
+      - action: number.set_value
+        target:
+          entity_id:
+            - number.owner_suite_closet_ledcolorwhenoff
+            - number.owner_suite_fan_switch_ledcolorwhenoff
+            - number.owner_suite_bathroom_vanity_ledcolorwhenoff
+        data:
+          value: "0"
+      - action: number.set_value
+        target:
+          entity_id:
+            - number.owner_suite_closet_ledintensitywhenoff
+            - number.owner_suite_fan_switch_ledintensitywhenoff
+            - number.owner_suite_bathroom_vanity_ledintensitywhenoff
+        data:
+          value: "1"
+      - action: number.set_value
+        target:
+          entity_id:
+            - number.owner_suite_closet_ledintensitywhenon
+            - number.owner_suite_fan_switch_ledintensitywhenon
+            - number.owner_suite_bathroom_vanity_ledintensitywhenon
+        data:
+          value: "50"
+      - action: number.set_value
+        target:
+          entity_id:
+            - number.owner_suite_closet_ledcolorwhenon
+            - number.owner_suite_fan_switch_ledcolorwhenon
+            - number.owner_suite_bathroom_vanity_ledcolorwhenon
+        data:
+          value: "0"
+
   day_mode_switches_office_guest_room:
     icon: mdi:light-switch
     variables:

--- a/tests/test_inovelli_day_mode_switches.py
+++ b/tests/test_inovelli_day_mode_switches.py
@@ -35,11 +35,10 @@ def _script_block(path: Path, script_id: str) -> str:
 
 def _automation_block(path: Path, automation_id: str) -> str:
     lines = path.read_text(encoding="utf-8").splitlines()
-    id_line = f"    id: {automation_id}"
     start = None
 
     for index, line in enumerate(lines):
-        if line != id_line:
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
             continue
 
         for candidate in range(index, -1, -1):
@@ -122,8 +121,55 @@ def test_owner_suite_bedroom_day_mode_waits_for_bed_bathroom_and_hallway_activit
         assert entity_id in block
 
     assert 'after: "07:59:59"' in block
+    assert 'before: "12:00:00"' in block
     assert "today_at('08:00')" in block
     assert "script.day_mode_switches_owner_suite_bedroom" in block
+
+
+def test_owner_suite_night_mode_script_sets_suite_led_bars_to_red() -> None:
+    block = _script_block(ZIGBEE_ZWAVE_PATH, "night_mode_switches_owner_suite")
+
+    for entity_id in (
+        "number.owner_suite_closet_ledcolorwhenoff",
+        "number.owner_suite_fan_switch_ledcolorwhenoff",
+        "number.owner_suite_bathroom_vanity_ledcolorwhenoff",
+        "number.owner_suite_closet_ledintensitywhenoff",
+        "number.owner_suite_fan_switch_ledintensitywhenoff",
+        "number.owner_suite_bathroom_vanity_ledintensitywhenoff",
+        "number.owner_suite_closet_ledintensitywhenon",
+        "number.owner_suite_fan_switch_ledintensitywhenon",
+        "number.owner_suite_bathroom_vanity_ledintensitywhenon",
+        "number.owner_suite_closet_ledcolorwhenon",
+        "number.owner_suite_fan_switch_ledcolorwhenon",
+        "number.owner_suite_bathroom_vanity_ledcolorwhenon",
+    ):
+        assert entity_id in block
+
+    assert 'value: "0"' in block
+    assert 'value: "1"' in block
+    assert 'value: "50"' in block
+    assert "Setting owner suite switch LED colors to nighttime red" in block
+
+
+def test_owner_suite_switch_leds_return_to_night_red_when_lamps_turn_on_overnight() -> None:
+    block = _automation_block(LIGHT_PATH, "owner_suite_switch_leds_red_when_lamps_on_at_night")
+
+    assert "entity_id: light.owner_suite_lamps" in block
+    assert 'to: "on"' in block
+    assert 'after: "22:00:00"' in block
+    assert 'before: "06:00:00"' in block
+    assert "script.night_mode_switches_owner_suite" in block
+
+
+def test_owner_suite_night_lamp_shutdown_turns_off_switch_leds_with_bed_strip() -> None:
+    block = _automation_block(LIGHT_PATH, "owner_suite_bed_strip_off_when_lamps_off")
+
+    assert "entity_id: light.owner_suite_lamps" in block
+    assert 'to: "off"' in block
+    assert "entity_id: light.bed_lightstrip" in block
+    assert 'after: "22:00:00"' in block
+    assert 'before: "06:00:00"' in block
+    assert "script.turn_off_owner_suite_inovelli_switch_leds" in block
 
 
 def test_wake_up_script_no_longer_forces_day_mode_before_eight_am() -> None:


### PR DESCRIPTION
Fixes #403.

## What changed
- keep the delayed owner-suite bedroom switch day-mode automation inside a morning-only window
- add an owner-suite nighttime switch LED script that restores the suite bars to the nighttime red state when the lamps come on overnight
- turn the owner-suite switch LED bars off when the owner-suite lamps turn off overnight
- add regression coverage for the new owner-suite night sync behavior

## Why
The owner suite bedroom day-mode automation could still fire late at night from bathroom or hallway motion and repaint the bedroom switch LED bar away from the nighttime state. The overnight lamp-off path also did not guarantee that the owner-suite Inovelli LED bars turned off with the lamps.

## Impact
- owner-suite switch LED bars stay aligned with the nighttime lamp behavior
- late-night motion no longer flips the owner-suite bedroom switch bar back to the daytime color
- overnight lamp-off now turns off the owner-suite switch LED bars as well as the bed lightstrip

## Validation
- `uv run --with pytest pytest`
- `uv run --with pytest pytest tests/test_inovelli_day_mode_switches.py tests/test_goodnight_integrity.py tests/test_runtime_log_regressions.py`
