### PR TITLE
Keep owner suite Adaptive Lighting in control during wake transitions

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -2,8 +2,8 @@ automation:
   - id: reconcile_owner_suite_adaptive_lighting
     alias: reconcile_owner_suite_adaptive_lighting
     description: >
-      Reapply the scene-friendly Adaptive Lighting baselines after Home
-      Assistant starts so owner suite and dining-room tuning survive restarts.
+      Reapply the Adaptive Lighting baselines after Home Assistant starts so
+      owner suite wake transitions and dining-room tuning survive restarts.
       The runtime dining-room Adaptive Lighting switch now uses the current dining-room entity id.
     mode: single
     trigger:
@@ -29,7 +29,10 @@ automation:
           include_config_in_attributes: true
           take_over_control: true
           adapt_only_on_bare_turn_on: true
-          only_once: true
+          only_once: false
           initial_transition: 2
+          sleep_transition: 2
           transition: 5
+          sleep_brightness: 1
+          sleep_color_temp: 1000
           detect_non_ha_changes: false

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1292,16 +1292,29 @@ automation:
           state: "off"
           # enabled: false
     action:
-      - action: light.turn_on
-        data:
+      - action: switch.turn_on
+        target:
           entity_id:
+            - switch.adaptive_lighting_owner_suite
+            - switch.adaptive_lighting_adapt_brightness_owner_suite
+            - switch.adaptive_lighting_adapt_color_owner_suite
+      - action: adaptive_lighting.apply
+        data:
+          entity_id: switch.adaptive_lighting_owner_suite
+          lights:
             - light.owner_suite_lamps
             - light.bed_lightstrip
-          brightness_pct: >-
-            {{ state_attr('switch.adaptive_lighting_owner_suite', 'brightness_pct') | int(100) }}
-          color_temp_kelvin: >-
-            {{ state_attr('switch.adaptive_lighting_owner_suite', 'color_temp_kelvin') | int(4000) }}
+          adapt_brightness: true
+          adapt_color: true
+          turn_on_lights: true
           transition: 45
+      - action: adaptive_lighting.set_manual_control
+        data:
+          entity_id: switch.adaptive_lighting_owner_suite
+          lights:
+            - light.owner_suite_lamps
+            - light.bed_lightstrip
+          manual_control: false
       - action: input_boolean.turn_on
         data:
           entity_id: input_boolean.owner_suite_bedroom_auto_on

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -306,6 +306,57 @@ automation:
                   entity_id: media_player.bedroom_sonos_2
                   spotify_uri: "https://open.spotify.com/track/2Mik4RyMTMGXscX9QGiDoX?si=TBH_9RezQA6d1Y1w5iahHQ"
 
+  - id: workday_owner_suite_wake_transition_from_morning_activity
+    alias: workday_owner_suite_wake_transition_from_morning_activity
+    description: >
+      Start the owner suite workday wake transition when bed occupancy clears
+      and both the bathroom and upstairs hall show fresh wake-up activity.
+    mode: single
+    trigger:
+      - trigger: state
+        entity_id: binary_sensor.bayesian_bed_occupancy
+        to: "off"
+      - trigger: state
+        entity_id: binary_sensor.owner_suite_bathroom_room_occupancy
+        to: "on"
+      - trigger: state
+        entity_id: binary_sensor.hall_upstairs_motion_occupancy
+        to: "on"
+    condition:
+      - condition: time
+        after: "04:30:00"
+        before: "12:00:00"
+      - condition: state
+        entity_id: binary_sensor.workday_sensor
+        state: "on"
+      - condition: state
+        entity_id: binary_sensor.bayesian_zeke_home
+        state: "on"
+      - condition: state
+        entity_id: binary_sensor.planned_vacation_calendar
+        state: "off"
+      - condition: state
+        entity_id: binary_sensor.bayesian_bed_occupancy
+        state: "off"
+      - condition: state
+        entity_id: input_boolean.wakeup_alarm_firing
+        state: "off"
+      - condition: state
+        entity_id: light.owner_suite_lamps
+        state: "off"
+      - condition: template
+        value_template: >-
+          {{ is_state('binary_sensor.owner_suite_bathroom_room_occupancy', 'on')
+             or as_timestamp(now()) - as_timestamp(states.binary_sensor.owner_suite_bathroom_room_occupancy.last_changed) <= 900 }}
+      - condition: template
+        value_template: >-
+          {{ is_state('binary_sensor.hall_upstairs_motion_occupancy', 'on')
+             or as_timestamp(now()) - as_timestamp(states.binary_sensor.hall_upstairs_motion_occupancy.last_changed) <= 900 }}
+    action:
+      - action: script.turn_on
+        target:
+          entity_id: script.owner_suite_morning_transition
+
   - id: toggle_lava_lamp_workday
     alias: toggle_lava_lamp_workday
     trigger:
@@ -622,6 +673,92 @@ script:
         data:
           radio_uri: "tunein--S3NwgspV://radio/s20620"
 
+  owner_suite_morning_transition:
+    alias: Owner Suite Morning Transition
+    mode: single
+    sequence:
+      - alias: "Start from the owner suite adaptive sleep target"
+        continue_on_error: true
+        action: switch.turn_on
+        target:
+          entity_id:
+            - switch.adaptive_lighting_owner_suite
+            - switch.adaptive_lighting_adapt_brightness_owner_suite
+            - switch.adaptive_lighting_adapt_color_owner_suite
+            - switch.sleep_mode
+      - alias: "Clear any stale owner suite manual control before the wake ramp"
+        continue_on_error: true
+        action: adaptive_lighting.set_manual_control
+        data:
+          entity_id: switch.adaptive_lighting_owner_suite
+          lights:
+            - light.owner_suite_lamps
+            - light.bed_lightstrip
+          manual_control: false
+      - alias: "Apply the owner suite adaptive sleep target"
+        continue_on_error: true
+        action: adaptive_lighting.apply
+        data:
+          entity_id: switch.adaptive_lighting_owner_suite
+          lights:
+            - light.owner_suite_lamps
+            - light.bed_lightstrip
+          adapt_brightness: true
+          adapt_color: true
+          turn_on_lights: true
+          transition: 2
+      - delay:
+          seconds: 1
+      - parallel:
+          - sequence:
+              - alias: "Ramp the owner suite lights to the current adaptive daytime target"
+                continue_on_error: true
+                action: switch.turn_off
+                data:
+                  entity_id:
+                    - switch.sleep_mode
+              - alias: "Apply the daytime adaptive target over three minutes"
+                continue_on_error: true
+                action: adaptive_lighting.apply
+                data:
+                  entity_id: switch.adaptive_lighting_owner_suite
+                  lights:
+                    - light.owner_suite_lamps
+                    - light.bed_lightstrip
+                  adapt_brightness: true
+                  adapt_color: true
+                  turn_on_lights: true
+                  transition: 180
+              - alias: "Keep owner suite adaptive lighting in control after the wake ramp"
+                continue_on_error: true
+                action: switch.turn_on
+                target:
+                  entity_id:
+                    - switch.adaptive_lighting_owner_suite
+                    - switch.adaptive_lighting_adapt_brightness_owner_suite
+                    - switch.adaptive_lighting_adapt_color_owner_suite
+              - alias: "Clear owner suite adaptive-lighting manual control after the wake ramp"
+                continue_on_error: true
+                action: adaptive_lighting.set_manual_control
+                data:
+                  entity_id: switch.adaptive_lighting_owner_suite
+                  lights:
+                    - light.owner_suite_lamps
+                    - light.bed_lightstrip
+                  manual_control: false
+          - sequence:
+              - alias: "Start raising the owner suite blinds during the wake ramp"
+                continue_on_error: true
+                repeat:
+                  until: "{{ (repeat.index * 2) == 80 }}"
+                  sequence:
+                    - action: cover.set_cover_position
+                      data:
+                        entity_id: cover.owner_suite_blinds_ha
+                        position: "{{ repeat.index * 2 }}"
+                    - delay:
+                        seconds: "{{ (75/(log(repeat.index + 1, 5))) | round(0, 'ceil', 5) }}"
+
   wake_up_script:
     alias: Common Wake Up Tasks
     sequence:
@@ -633,50 +770,7 @@ script:
       - action: input_boolean.turn_on
         data:
           entity_id: input_boolean.wakeup_alarm_firing
-      - alias: "Turn on light at dimmest setting. Adaptive Lighting will apply"
-        continue_on_error: true
-        action: light.turn_on
-        data:
-          entity_id:
-            - light.owner_suite_lamps
-            - light.bed_lightstrip
-          color_temp_kelvin: 2700
-          brightness_pct: 1
-      - delay:
-          seconds: 5
-      - alias: "Ramp bedroom lights up to full wake-up brightness"
-        continue_on_error: true
-        action: light.turn_on
-        data:
-          entity_id:
-            - light.owner_suite_lamps
-            - light.bed_lightstrip
-          color_temp_kelvin: 6500
-          brightness_pct: 100
-          transition: 300
-      - delay:
-          minutes: 1
-      - action: switch.turn_off
-        data:
-          entity_id:
-            - switch.sleep_mode
-      - alias: "Slowly Open Blinds"
-        continue_on_error: true
-        repeat:
-          until: "{{ (repeat.index * 2) == 80 }}"
-          sequence:
-            - action: cover.set_cover_position
-              data:
-                entity_id: cover.owner_suite_blinds_ha
-                position: "{{ repeat.index * 2 }}"
-            - delay:
-                seconds: "{{ (75/(log(repeat.index + 1, 5))) | round(0, 'ceil', 5) }}"
-      - alias: "Turn on Adaptive Brightness for bedroom"
-        continue_on_error: true
-        action: switch.turn_on
-        entity_id:
-          - switch.adaptive_lighting_adapt_brightness_owner_suite
-          - switch.adaptive_lighting_adapt_color_owner_suite
+      - action: script.owner_suite_morning_transition
 
 ########################
 # Binary Sensors

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -42,15 +42,18 @@ def test_owner_suite_adaptive_lighting_reconciles_supported_scene_safe_settings(
     assert "event: start" in block
     assert 'delay: "00:00:30"' in block
     assert "action: adaptive_lighting.change_switch_settings" in block
-    assert "scene-friendly Adaptive Lighting baselines" in block
+    assert "owner suite wake transitions and dining-room tuning survive restarts" in block
     assert "entity_id: switch.adaptive_lighting_owner_suite" in block
     assert "use_defaults: current" in block
     assert "include_config_in_attributes: true" in block
     assert "take_over_control: true" in block
     assert "adapt_only_on_bare_turn_on: true" in block
-    assert "only_once: true" in block
+    assert "only_once: false" in block
     assert "initial_transition: 2" in block
+    assert "sleep_transition: 2" in block
     assert "transition: 5" in block
+    assert "sleep_brightness: 1" in block
+    assert "sleep_color_temp: 1000" in block
     assert "detect_non_ha_changes: false" in block
 
 

--- a/tests/test_inovelli_day_mode_switches.py
+++ b/tests/test_inovelli_day_mode_switches.py
@@ -124,6 +124,14 @@ def test_owner_suite_bedroom_day_mode_waits_for_bed_bathroom_and_hallway_activit
     assert 'before: "12:00:00"' in block
     assert "today_at('08:00')" in block
     assert "script.day_mode_switches_owner_suite_bedroom" in block
+    assert "script.owner_suite_morning_transition" not in block
+
+
+def test_wake_up_script_no_longer_forces_day_mode_before_eight_am() -> None:
+    block = _script_block(WORKDAY_PATH, "wake_up_script")
+
+    assert "script.owner_suite_morning_transition" in block
+    assert "script.day_mode_switches" not in block
 
 
 def test_owner_suite_night_mode_script_sets_suite_led_bars_to_red() -> None:
@@ -175,5 +183,5 @@ def test_owner_suite_night_lamp_shutdown_turns_off_switch_leds_with_bed_strip() 
 def test_wake_up_script_no_longer_forces_day_mode_before_eight_am() -> None:
     block = _script_block(WORKDAY_PATH, "wake_up_script")
 
-    assert "switch.sleep_mode" in block
+    assert "script.owner_suite_morning_transition" in block
     assert "script.day_mode_switches" not in block

--- a/tests/test_issue_owner_suite_home_condition.py
+++ b/tests/test_issue_owner_suite_home_condition.py
@@ -42,3 +42,12 @@ def test_owner_suite_light_auto_on_uses_home_presence_sensor() -> None:
     assert "zone: zone.home" not in block
     assert "light.owner_suite_lamps" in block
     assert "binary_sensor.bayesian_bed_occupancy" in block
+    assert "action: switch.turn_on" in block
+    assert "switch.adaptive_lighting_owner_suite" in block
+    assert "action: adaptive_lighting.apply" in block
+    assert "entity_id: switch.adaptive_lighting_owner_suite" in block
+    assert "turn_on_lights: true" in block
+    assert "transition: 45" in block
+    assert "manual_control: false" in block
+    assert "\n          brightness_pct:" not in block
+    assert "\n          color_temp_kelvin:" not in block

--- a/tests/test_owner_suite_blinds_automation.py
+++ b/tests/test_owner_suite_blinds_automation.py
@@ -57,14 +57,52 @@ def _automation_block(path: Path, automation_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
-def test_wake_up_script_uses_supported_color_temperature_fields_and_keeps_running() -> None:
+def test_owner_suite_morning_transition_keeps_adaptive_lighting_in_control_while_blinds_start_raising() -> None:
+    block = _script_block(WORKDAY_PATH, "owner_suite_morning_transition")
+
+    for token in (
+        "switch.sleep_mode",
+        "switch.adaptive_lighting_owner_suite",
+        "action: adaptive_lighting.apply",
+        "entity_id: switch.adaptive_lighting_owner_suite",
+        "manual_control: false",
+        "transition: 2",
+        "transition: 180",
+        "cover.owner_suite_blinds_ha",
+        "position: \"{{ repeat.index * 2 }}\"",
+        "switch.adaptive_lighting_adapt_brightness_owner_suite",
+        "switch.adaptive_lighting_adapt_color_owner_suite",
+    ):
+        assert token in block
+
+
+def test_wake_up_script_uses_shared_owner_suite_morning_transition() -> None:
     block = _script_block(WORKDAY_PATH, "wake_up_script")
 
-    assert "cover.owner_suite_blinds_ha" in block
-    assert "color_temp_kelvin: 2700" in block
-    assert "color_temp_kelvin: 6500" in block
-    assert "\n          kelvin:" not in block
-    assert block.count("continue_on_error: true") >= 3
+    assert "script.owner_suite_morning_transition" in block
+    assert "cover.owner_suite_blinds_ha" not in block
+    assert "transition: 180" not in block
+
+
+def test_workday_morning_activity_can_start_owner_suite_wake_transition() -> None:
+    block = _automation_block(WORKDAY_PATH, "workday_owner_suite_wake_transition_from_morning_activity")
+
+    for token in (
+        'after: "04:30:00"',
+        'before: "12:00:00"',
+        "binary_sensor.workday_sensor",
+        "binary_sensor.bayesian_zeke_home",
+        "binary_sensor.planned_vacation_calendar",
+        "binary_sensor.bayesian_bed_occupancy",
+        "binary_sensor.owner_suite_bathroom_room_occupancy",
+        "binary_sensor.hall_upstairs_motion_occupancy",
+        "input_boolean.wakeup_alarm_firing",
+        "light.owner_suite_lamps",
+        "script.owner_suite_morning_transition",
+        "as_timestamp(now()) - as_timestamp(states.binary_sensor.owner_suite_bathroom_room_occupancy.last_changed) <= 900",
+        "as_timestamp(now()) - as_timestamp(states.binary_sensor.hall_upstairs_motion_occupancy.last_changed) <= 900",
+    ):
+        assert token in block
 
 
 def test_close_owner_suite_blinds_catches_evening_recovery_after_missed_sunset() -> None:


### PR DESCRIPTION
## Summary
- keep owner suite Adaptive Lighting authoritative during bedroom auto-on and morning wake-up flows
- introduce a shared owner-suite morning transition that starts at the adaptive sleep target, ramps to the current adaptive target over three minutes, and starts raising the blinds in parallel
- add a workday morning-activity trigger so the same wake transition can start when wakefulness is detected without an alarm
- reconcile owner-suite Adaptive Lighting settings so continuous control survives restarts

## Review focus
- confirm the owner-suite morning transition should always start from the Adaptive Lighting sleep target and hand off to the current adaptive target over 180 seconds
- confirm the workday wake-from-activity conditions are the right signal for non-alarm wake-ups
- confirm `only_once: false` is the desired owner-suite Adaptive Lighting behavior

## Validation
- `uv run --with pytest pytest tests/test_adaptive_lighting_reconcile.py tests/test_owner_suite_blinds_automation.py tests/test_inovelli_day_mode_switches.py tests/test_issue_owner_suite_home_condition.py`
- `uv run --with pytest pytest`
- `ha_check_config`