### PR TITLE
Add room-based Inovelli adaptive LED sync

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -33,3 +33,161 @@ automation:
           initial_transition: 2
           transition: 5
           detect_non_ha_changes: false
+
+  - id: sync_selected_inovelli_led_bars_to_adaptive_lighting
+    alias: sync_selected_inovelli_led_bars_to_adaptive_lighting
+    description: >
+      Keep the owner suite and office Inovelli LED bars aligned with Adaptive
+      Lighting while still yielding to trip mode, sleep mode, and office guest
+      privacy overrides. The shared script accepts room or rooms so additional
+      rooms can opt in without duplicating the LED-bar mapping logic.
+    mode: restart
+    trigger:
+      - trigger: homeassistant
+        event: start
+      - trigger: state
+        entity_id:
+          - switch.sleep_mode
+          - input_boolean.guest_mode
+          - switch.adaptive_lighting_owner_suite
+          - switch.adaptive_lighting_sleep_mode_owner_suite
+      - trigger: time_pattern
+        minutes: "/2"
+    action:
+      - if:
+          - condition: template
+            value_template: "{{ trigger.platform == 'homeassistant' }}"
+        then:
+          - delay: "00:00:30"
+      - action: script.sync_inovelli_led_bars_to_adaptive_lighting
+        data:
+          rooms:
+            - owner suite
+            - office
+
+script:
+  sync_inovelli_led_bars_to_adaptive_lighting:
+    alias: sync_inovelli_led_bars_to_adaptive_lighting
+    description: >
+      Mirror Adaptive Lighting color temperature and brightness onto selected
+      Inovelli LED bars. Rooms may provide a preferred Adaptive Lighting
+      switch plus a fallback so guest-sensitive rooms can opt in gradually
+      without breaking when a dedicated switch has not been created yet.
+    icon: mdi:led-strip-variant
+    mode: queued
+    fields:
+      room:
+        description: Single room to sync.
+        example: owner suite
+      rooms:
+        description: List of rooms to sync.
+        example:
+          - owner suite
+          - office
+    variables:
+      room_configs:
+        owner_suite:
+          preferred_adaptive_switch: switch.adaptive_lighting_owner_suite
+          fallback_adaptive_switch: switch.adaptive_lighting_owner_suite
+          led_color_on: number.owner_suite_fan_switch_ledcolorwhenon
+          led_color_off: number.owner_suite_fan_switch_ledcolorwhenoff
+          led_intensity_on: number.owner_suite_fan_switch_ledintensitywhenon
+          led_intensity_off: number.owner_suite_fan_switch_ledintensitywhenoff
+          guest_mode_blocks_sync: false
+        office:
+          preferred_adaptive_switch: switch.adaptive_lighting_office
+          fallback_adaptive_switch: switch.adaptive_lighting_owner_suite
+          led_color_on: number.office_fan_switch_ledcolorwhenon
+          led_color_off: number.office_fan_switch_ledcolorwhenoff
+          led_intensity_on: number.office_fan_switch_ledintensitywhenon
+          led_intensity_off: number.office_fan_switch_ledintensitywhenoff
+          guest_mode_blocks_sync: true
+      requested_rooms: >-
+        {% set raw_rooms = rooms if rooms is defined else room if room is defined else [] %}
+        {% set items = raw_rooms.split(',') if raw_rooms is string else raw_rooms %}
+        {% set ns = namespace(values=[]) %}
+        {% for item in items %}
+          {% set normalized = item | string | lower | replace('-', '_') | replace(' ', '_') %}
+          {% if normalized == 'owner_suite_bedroom' %}
+            {% set normalized = 'owner_suite' %}
+          {% endif %}
+          {% if normalized in room_configs and normalized not in ns.values %}
+            {% set ns.values = ns.values + [normalized] %}
+          {% endif %}
+        {% endfor %}
+        {{ ns.values }}
+    sequence:
+      - condition: state
+        entity_id: input_boolean.trip
+        state: "off"
+      - condition: state
+        entity_id: switch.sleep_mode
+        state: "off"
+      - repeat:
+          for_each: "{{ requested_rooms }}"
+          sequence:
+            - variables:
+                guest_mode_blocks_room: >-
+                  {{
+                    room_configs[repeat.item]['guest_mode_blocks_sync']
+                    and is_state('input_boolean.guest_mode', 'on')
+                  }}
+                adaptive_lighting_entity: >-
+                  {% set preferred = room_configs[repeat.item]['preferred_adaptive_switch'] %}
+                  {% set fallback = room_configs[repeat.item]['fallback_adaptive_switch'] %}
+                  {% if has_value(preferred) %}
+                    {{ preferred }}
+                  {% elif has_value(fallback) %}
+                    {{ fallback }}
+                  {% else %}
+                    {{ '' }}
+                  {% endif %}
+            - if:
+                - condition: template
+                  value_template: >-
+                    {{ not guest_mode_blocks_room and adaptive_lighting_entity != '' }}
+              then:
+                - variables:
+                    adaptive_brightness_pct: >-
+                      {{ state_attr(adaptive_lighting_entity, 'brightness_pct') | int(75) }}
+                    adaptive_current_kelvin: >-
+                      {{ state_attr(adaptive_lighting_entity, 'color_temp_kelvin') | int(3000) }}
+                    adaptive_min_kelvin: >-
+                      {{
+                        (state_attr(adaptive_lighting_entity, 'configuration') or {})
+                        .get('min_color_temp', 2000)
+                        | int(2000)
+                      }}
+                    adaptive_max_kelvin: >-
+                      {{
+                        (state_attr(adaptive_lighting_entity, 'configuration') or {})
+                        .get('max_color_temp', 5500)
+                        | int(5500)
+                      }}
+                    adaptive_led_color: >-
+                      {% set current_kelvin = adaptive_current_kelvin | int(3000) %}
+                      {% set min_kelvin = adaptive_min_kelvin | int(2000) %}
+                      {% set max_kelvin = adaptive_max_kelvin | int(5500) %}
+                      {% set clamped_kelvin = [[current_kelvin, min_kelvin] | max, max_kelvin] | min %}
+                      {% if max_kelvin <= min_kelvin %}
+                        170
+                      {% else %}
+                        {{ (((clamped_kelvin - min_kelvin) / (max_kelvin - min_kelvin)) * 170) | round(0) | int }}
+                      {% endif %}
+                    adaptive_led_intensity_on: >-
+                      {% set brightness_pct = adaptive_brightness_pct | int(75) %}
+                      {{ [[brightness_pct, 1] | max, 100] | min }}
+                - action: number.set_value
+                  data:
+                    entity_id: >-
+                      {{ room_configs[repeat.item]['led_color_on'] }},
+                      {{ room_configs[repeat.item]['led_color_off'] }}
+                    value: "{{ adaptive_led_color }}"
+                - action: number.set_value
+                  data:
+                    entity_id: "{{ room_configs[repeat.item]['led_intensity_on'] }}"
+                    value: "{{ adaptive_led_intensity_on }}"
+                - action: number.set_value
+                  data:
+                    entity_id: "{{ room_configs[repeat.item]['led_intensity_off'] }}"
+                    value: 1

--- a/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
+++ b/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ADAPTIVE_LIGHTING_PATH = (
+    Path(__file__).resolve().parents[1] / "packages" / "adaptive_lighting.yaml"
+)
+
+
+def _automation_block(automation_id: str) -> str:
+    lines = ADAPTIVE_LIGHTING_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _script_block(script_id: str) -> str:
+    lines = ADAPTIVE_LIGHTING_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r}")
+
+    end = len(lines)
+    next_script = re.compile(r"^  [A-Za-z0-9_]+:$")
+    for index in range(start + 1, len(lines)):
+        if next_script.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_default_led_bar_sync_automation_updates_owner_suite_and_office() -> None:
+    block = _automation_block("sync_selected_inovelli_led_bars_to_adaptive_lighting")
+
+    assert "owner suite and office Inovelli LED bars" in block
+    assert "trigger: homeassistant" in block
+    assert "event: start" in block
+    assert 'minutes: "/2"' in block
+    assert "switch.sleep_mode" in block
+    assert "input_boolean.guest_mode" in block
+    assert "switch.adaptive_lighting_owner_suite" in block
+    assert "switch.adaptive_lighting_sleep_mode_owner_suite" in block
+    assert 'delay: "00:00:30"' in block
+    assert "action: script.sync_inovelli_led_bars_to_adaptive_lighting" in block
+    assert "- owner suite" in block
+    assert "- office" in block
+
+
+def test_led_bar_sync_script_accepts_room_inputs_and_maps_owner_suite_and_office() -> None:
+    block = _script_block("sync_inovelli_led_bars_to_adaptive_lighting")
+
+    assert "fields:" in block
+    assert "room:" in block
+    assert "rooms:" in block
+    assert "owner_suite:" in block
+    assert "office:" in block
+    assert "switch.adaptive_lighting_owner_suite" in block
+    assert "switch.adaptive_lighting_office" in block
+    assert "number.owner_suite_fan_switch_ledcolorwhenon" in block
+    assert "number.owner_suite_fan_switch_ledintensitywhenoff" in block
+    assert "number.office_fan_switch_ledcolorwhenon" in block
+    assert "number.office_fan_switch_ledintensitywhenoff" in block
+    assert "owner_suite_bedroom" in block
+
+
+def test_led_bar_sync_script_uses_privacy_and_sleep_guards_with_office_fallback() -> None:
+    block = _script_block("sync_inovelli_led_bars_to_adaptive_lighting")
+
+    assert "entity_id: input_boolean.trip" in block
+    assert 'state: "off"' in block
+    assert "entity_id: switch.sleep_mode" in block
+    assert "guest_mode_blocks_sync: true" in block
+    assert "fallback_adaptive_switch: switch.adaptive_lighting_owner_suite" in block
+    assert "min_color_temp" in block
+    assert "max_color_temp" in block
+    assert "* 170" in block
+    assert "value: 1" in block


### PR DESCRIPTION
## Summary
- add a reusable script that syncs selected Inovelli LED bars from Adaptive Lighting using `room` or `rooms`
- add a default automation that keeps the owner suite and office switch LED bars aligned while respecting trip mode, sleep mode, and office guest-mode privacy
- add regression tests for the new room mapping, office fallback behavior, and automation wiring

## Testing
- `uv run --with pytest pytest`