### PR TITLE
Fix Inovelli LED sync script validation

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -84,9 +84,7 @@ script:
         example: owner suite
       rooms:
         description: List of rooms to sync.
-        example:
-          - owner suite
-          - office
+        example: "owner suite, office"
     variables:
       room_configs:
         owner_suite:

--- a/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
+++ b/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
@@ -82,6 +82,7 @@ def test_led_bar_sync_script_accepts_room_inputs_and_maps_owner_suite_and_office
     assert "fields:" in block
     assert "room:" in block
     assert "rooms:" in block
+    assert 'example: "owner suite, office"' in block
     assert "owner_suite:" in block
     assert "office:" in block
     assert "switch.adaptive_lighting_owner_suite" in block


### PR DESCRIPTION
## Summary
- fix the new Inovelli LED sync script field metadata so Home Assistant will register the script
- keep the room/rooms interface intact by using a string example value that matches HA validation rules
- lock the regression with the existing adaptive lighting sync test

## Testing
- uv run --with pytest pytest tests/test_adaptive_lighting_inovelli_led_bar_sync.py -q
- uv run --with pytest pytest