### PR TITLE
[codex] Reconcile owner suite morning transition

### DIFF
--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -747,6 +747,10 @@ script:
                     - light.bed_lightstrip
                   manual_control: false
           - sequence:
+              - alias: "Let the adaptive wake ramp settle before opening blinds"
+                continue_on_error: true
+                delay:
+                  seconds: 175
               - alias: "Start raising the owner suite blinds during the wake ramp"
                 continue_on_error: true
                 repeat:

--- a/specs/alarm_wakeup.allium
+++ b/specs/alarm_wakeup.allium
@@ -40,8 +40,12 @@ external entity WakeupContext {
     resident_in_bed: Boolean
     bathroom_occupied: Boolean
     guest_mode_enabled: Boolean
+    within_workday_owner_suite_wake_window: Boolean
     within_weekday_bathroom_window: Boolean
     within_weekend_bathroom_window: Boolean
+    owner_suite_lamps_on: Boolean
+    owner_suite_recent_bathroom_activity: Boolean
+    owner_suite_recent_hall_activity: Boolean
 }
 
 ------------------------------------------------------------
@@ -75,6 +79,7 @@ entity OwnerSuiteWakeEnvironment {
 config {
     special_meeting_lead: Duration = 5.minutes
     snooze_duration: Duration = 8.minutes
+    morning_blinds_delay: Duration = 175.seconds
 }
 
 ------------------------------------------------------------
@@ -165,26 +170,52 @@ rule TriggerSpecialMeetingWakeup {
     ensures: MorningAudioRequested(meeting_track, bedroom_suite)
 }
 
+rule TriggerWorkdayOwnerSuiteWakeTransitionFromMorningActivity {
+    when: context.resident_in_bed becomes false
+    or context.bathroom_occupied becomes true
+    or context.owner_suite_recent_hall_activity becomes true
+    requires: calendar.today_is_workday
+    requires: context.within_workday_owner_suite_wake_window
+    requires: context.resident_home
+    requires: not context.planned_vacation_active
+    requires: not wakeup.wakeup_alarm_firing
+    requires: not context.owner_suite_lamps_on
+    requires: not context.resident_in_bed
+    requires: context.owner_suite_recent_bathroom_activity
+    requires: context.owner_suite_recent_hall_activity
+    ensures: WakeupSequenceRequested(workday_morning_activity)
+}
+
 rule BeginWakeupSequence {
     when: WakeupSequenceRequested(kind)
     requires: not wakeup.wakeup_alarm_firing
     ensures: wakeup.wakeup_alarm_firing = true
-    ensures: owner_suite.lighting_state = dim_warm
-    ensures: owner_suite.blinds_state = opening
+    ensures: owner_suite.adaptive_lighting_enabled = true
+    ensures: owner_suite.lighting_state = daylight_ramp
     ensures: WakeupRampRequested(kind)
+    ensures: WakeupBlindTransitionRequested(kind)
     @guidance
-        -- The current wake-up flow no longer suspends adaptive lighting at the
-        -- start of the sequence. It applies the light ramp while adaptive
-        -- lighting remains in effect and explicitly re-enables the bedroom
-        -- adaptive-lighting switches at the end.
+        -- The live owner-suite morning transition immediately hands brightness
+        -- and color back to adaptive lighting. It starts with a short apply
+        -- from the current owner-suite sleep target and then settles into a
+        -- longer adaptive daytime ramp instead of forcing an explicit 2700K to
+        -- 6500K sequence in the wake-up script itself.
 }
 
 rule FinishWakeupSequence {
     when: WakeupRampRequested(kind)
     ensures: owner_suite.lighting_state = daytime
     ensures: owner_suite.sleep_mode_enabled = false
-    ensures: owner_suite.blinds_state = mostly_open
     ensures: owner_suite.adaptive_lighting_enabled = true
+}
+
+rule OpenBlindsDuringWakeupTransition {
+    when: WakeupBlindTransitionRequested(kind)
+    ensures: owner_suite.blinds_state = mostly_open
+    @guidance
+        -- The owner-suite morning transition delays blind movement by
+        -- config.morning_blinds_delay and then opens the blinds gradually in
+        -- small steps while the adaptive lighting ramp continues.
 }
 
 rule PrepareMorningAudioGroup {

--- a/tests/test_allium_specs.py
+++ b/tests/test_allium_specs.py
@@ -14,6 +14,8 @@ def test_behavioral_allium_specs_exist_and_are_versioned() -> None:
             "rule NormalizePhoneWakeupPayload",
             "rule SyncPhoneWakeupAlarm",
             "rule TriggerWeekdayWakeup",
+            "rule TriggerWorkdayOwnerSuiteWakeTransitionFromMorningActivity",
+            "rule OpenBlindsDuringWakeupTransition",
             "rule StartBathroomMorningRoutine",
         ],
         "night_routines.allium": [

--- a/tests/test_owner_suite_blinds_automation.py
+++ b/tests/test_owner_suite_blinds_automation.py
@@ -57,7 +57,7 @@ def _automation_block(path: Path, automation_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
-def test_owner_suite_morning_transition_keeps_adaptive_lighting_in_control_while_blinds_start_raising() -> None:
+def test_owner_suite_morning_transition_keeps_adaptive_lighting_in_control_and_delays_blind_ramp() -> None:
     block = _script_block(WORKDAY_PATH, "owner_suite_morning_transition")
 
     for token in (
@@ -68,6 +68,7 @@ def test_owner_suite_morning_transition_keeps_adaptive_lighting_in_control_while
         "manual_control: false",
         "transition: 2",
         "transition: 180",
+        "seconds: 175",
         "cover.owner_suite_blinds_ha",
         "position: \"{{ repeat.index * 2 }}\"",
         "switch.adaptive_lighting_adapt_brightness_owner_suite",


### PR DESCRIPTION
## Summary

- reconcile `owner_suite_morning_transition` with the live April 9 wake-up trace by adding the delayed blind-open phase
- update `specs/alarm_wakeup.allium` to model the delegated adaptive-lighting wake transition and delayed blind movement
- tighten regression coverage around the owner-suite morning transition and spec obligations

## Issue

Refs #410

## Test Coverage

Added or updated coverage in:

- `tests/test_owner_suite_blinds_automation.py`
- `tests/test_allium_specs.py`

Existing alignment coverage exercised in:

- `tests/test_alarm_night_allium_alignment.py`
- `tests/test_inovelli_day_mode_switches.py`

## Test Cases

- `owner_suite_morning_transition` keeps adaptive lighting in control and delays the blind ramp by `175s`
- `wake_up_script` delegates to `script.owner_suite_morning_transition`
- the Allium wake-up spec contains the workday owner-suite morning-activity trigger and delayed blind-transition rules

## Validation

- `uv run --with pytest pytest tests/test_allium_specs.py tests/test_owner_suite_blinds_automation.py tests/test_alarm_night_allium_alignment.py tests/test_inovelli_day_mode_switches.py`
- `uv run --with pytest pytest`
