### PR TITLE
Guard owner suite overnight LED sync

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -143,10 +143,20 @@ script:
                   {% else %}
                     {{ '' }}
                   {% endif %}
+                room_specific_sync_blocked: >-
+                  {{
+                    repeat.item == 'owner_suite'
+                    and is_state('light.owner_suite_lamps', 'on')
+                    and (now().hour >= 22 or now().hour < 6)
+                  }}
             - if:
                 - condition: template
                   value_template: >-
-                    {{ not guest_mode_blocks_room and adaptive_lighting_entity != '' }}
+                    {{
+                      not guest_mode_blocks_room
+                      and not room_specific_sync_blocked
+                      and adaptive_lighting_entity != ''
+                    }}
               then:
                 - variables:
                     adaptive_brightness_pct: >-

--- a/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
+++ b/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
@@ -102,6 +102,10 @@ def test_led_bar_sync_script_uses_privacy_and_sleep_guards_with_office_fallback(
     assert "entity_id: switch.sleep_mode" in block
     assert "guest_mode_blocks_sync: true" in block
     assert "fallback_adaptive_switch: switch.adaptive_lighting_owner_suite" in block
+    assert "light.owner_suite_lamps" in block
+    assert "repeat.item == 'owner_suite'" in block
+    assert "now().hour >= 22 or now().hour < 6" in block
+    assert "room_specific_sync_blocked" in block
     assert "min_color_temp" in block
     assert "max_color_temp" in block
     assert "* 170" in block


### PR DESCRIPTION
## Summary
- stop the adaptive LED sync script from overwriting the owner-suite overnight red LED state
- keep the room-based sync behavior for the configured rooms outside that overnight owner-suite window
- cover the guard with adaptive lighting sync test assertions

## Review Context
- addresses the unresolved Codex review thread on PR #408 about nighttime red LEDs being overwritten

## Testing
- uv run --with pytest pytest tests/test_adaptive_lighting_inovelli_led_bar_sync.py -q
- uv run --with pytest pytest tests/test_inovelli_day_mode_switches.py -q
- uv run --with pytest pytest