### PR TITLE
Fix bedtime audio rampdown timeout fallback

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1707,11 +1707,16 @@ script:
             to: "on"
         timeout:
           minutes: 10 # TODO this as a variable that is passed by the caller. Different timeouts for tv off and for laying in bed automation
-        continue_on_timeout: false
-      - delay:
-          minutes: 3
+        continue_on_timeout: true
+      - if:
+          - condition: template
+            value_template: "{{ wait.completed }}"
+        then:
+          - delay:
+              minutes: 3
       - action: script.turn_on
-        entity_id: script.spotify_bedtime_volume
+        target:
+          entity_id: script.spotify_bedtime_volume
 
   spotify_bedtime_volume:
     alias: "Spotify Bedtime Rampdown"

--- a/specs/night_routines.allium
+++ b/specs/night_routines.allium
@@ -87,7 +87,11 @@ rule StartBedtimePreparation {
 rule ScheduleBedtimeAudioRampdown {
     when: BedtimeAudioRequested(zone)
     ensures: bedtime.bedtime_audio_rampdown_active = true
-    ensures: BedtimeAudioRampdownScheduled(wait_for_bathroom_visit, config.bedtime_audio_timeout, config.bedtime_audio_rampdown_delay)
+    ensures: BedtimeAudioRampdownScheduled(wait_for_bathroom_visit_or_timeout, config.bedtime_audio_timeout, config.bedtime_audio_rampdown_delay)
+    @guidance
+        -- A bathroom occupancy event starts the additional rampdown delay.
+        -- If no bathroom visit is detected within config.bedtime_audio_timeout,
+        -- the rampdown still begins at the timeout instead of aborting.
 }
 
 rule ChooseBedtimeAudioFromConfiguredPool {

--- a/tests/test_alarm_night_allium_alignment.py
+++ b/tests/test_alarm_night_allium_alignment.py
@@ -194,7 +194,7 @@ def test_tv_bed_prep_is_guest_suppressed_and_defers_sleep_mode_shutdown() -> Non
         assert token in block
 
 
-def test_bedtime_audio_waits_for_bathroom_then_ramps_down() -> None:
+def test_bedtime_audio_uses_bathroom_visit_or_timeout_before_rampdown() -> None:
     block = _script_block(MEDIA_PLAYER_PATH, "spotify_bedtime")
 
     for token in (
@@ -202,8 +202,10 @@ def test_bedtime_audio_waits_for_bathroom_then_ramps_down() -> None:
         "entity_id: binary_sensor.owner_suite_bathroom_room_occupancy",
         'to: "on"',
         "minutes: 10",
-        "continue_on_timeout: false",
+        "continue_on_timeout: true",
+        'value_template: "{{ wait.completed }}"',
         "minutes: 3",
+        "target:\n          entity_id: script.spotify_bedtime_volume",
         "entity_id: script.spotify_bedtime_volume",
     ):
         assert token in block

--- a/tests/test_allium_specs.py
+++ b/tests/test_allium_specs.py
@@ -21,9 +21,11 @@ def test_behavioral_allium_specs_exist_and_are_versioned() -> None:
         "night_routines.allium": [
             "-- allium: 3",
             "rule StartBedtimePreparation",
+            "rule ScheduleBedtimeAudioRampdown",
             "rule ChooseBedtimeAudioFromConfiguredPool",
             "rule TriggerGoodnightFromCPAPSleep",
             "rule ApplyGoodnightIntegrity",
+            "wait_for_bathroom_visit_or_timeout",
         ],
     }
 

--- a/tests/test_night_routines_allium_alignment.py
+++ b/tests/test_night_routines_allium_alignment.py
@@ -104,7 +104,7 @@ def test_tv_bed_prep_starts_low_volume_bedroom_prep_and_delayed_sleep_mode_relea
         assert token in block
 
 
-def test_spotify_bedtime_waits_for_bathroom_and_then_ramps_down() -> None:
+def test_spotify_bedtime_uses_bathroom_visit_or_timeout_before_rampdown() -> None:
     block = _script_block(MEDIA_PLAYER_PATH, "spotify_bedtime")
 
     for token in (
@@ -112,8 +112,10 @@ def test_spotify_bedtime_waits_for_bathroom_and_then_ramps_down() -> None:
         "entity_id: binary_sensor.owner_suite_bathroom_room_occupancy",
         'to: "on"',
         "minutes: 10",
-        "continue_on_timeout: false",
+        "continue_on_timeout: true",
+        'value_template: "{{ wait.completed }}"',
         "minutes: 3",
+        "target:\n          entity_id: script.spotify_bedtime_volume",
         "entity_id: script.spotify_bedtime_volume",
     ):
         assert token in block


### PR DESCRIPTION
## Summary
- keep `script.spotify_bedtime` alive when the bathroom occupancy wait times out so bedtime rampdown still starts
- only apply the extra 3 minute delay when the bathroom occupancy trigger actually fires
- update the night routines Allium spec and alignment tests to document the bathroom-visit-or-timeout behavior

## Verification
- `uv run --with pytest pytest`

Closes #407.