### PR TITLE
[codex] Use explicit SomaFM URLs for bedtime audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Accepted playlist values:
 - `https://open.spotify.com/album/...`
 - `https://open.spotify.com/artist/...`
 - `https://open.spotify.com/track/...`
+- Permanent internet radio playlist URLs, such as `https://somafm.com/groovesalad.pls`
 - Music Assistant URIs or plain item names, for mixed lists that call `script.music_assistant_play_item`
 
 If you are creating a brand new script, prefer calling the helper instead of using `media_player.play_media` directly:
@@ -85,6 +86,7 @@ If you are creating a brand new script, prefer calling the helper instead of usi
 Notes:
 
 - The generic helper now passes Music Assistant URIs and plain item names through directly. Use `media_type` when a name is ambiguous.
+- Prefer explicit URLs or Music Assistant URIs for radio entries so automations do not depend on name search resolution.
 - `script.music_assistant_play_spotify_uri` remains as a compatibility wrapper for Spotify URLs and URIs.
 
 ### Searching and Queuing Music Assistant Items

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1589,11 +1589,11 @@ script:
         ## Pachuca Sunrise Radio: spotify:playlist:37i9dQZF1E8T1k2ZTHYNkV
         ##  Darksynth | Synthwave: spotify:playlist:1Iowhep08Kl9MJ0XOwsBMp
         ##  Lowfi Covers: spotify:playlist:37i9dQZF1DX4nNmLlb3JR2
-        ## SomaFM Groove Salad
-        ## SomaFM Deep Space One
-        ## SomaFM Mission Control
-        ## SomaFM Space Station Soma
-        ## SomaFM Vaporwaves
+        ## SomaFM Groove Salad: https://somafm.com/groovesalad.pls
+        ## SomaFM Deep Space One: https://somafm.com/deepspaceone.pls
+        ## SomaFM Mission Control: https://somafm.com/missioncontrol.pls
+        ## SomaFM Space Station Soma: https://somafm.com/spacestation.pls
+        ## SomaFM Vaporwaves: https://somafm.com/vaporwaves.pls
         #}
         {%- set plists = ["spotify:album:78bpIziExqiI9qztvNFlQu",
           "spotify:user:spotify:playlist:37i9dQZF1DXbTxeAdrVG2l",
@@ -1649,11 +1649,11 @@ script:
           "spotify:playlist:37i9dQZF1E8T1k2ZTHYNkV",
           "spotify:playlist:1Iowhep08Kl9MJ0XOwsBMp",
           "spotify:playlist:37i9dQZF1DX4nNmLlb3JR2",
-          "Groove Salad",
-          "Deep Space One",
-          "Mission Control",
-          "Space Station Soma",
-          "Vaporwaves",
+          "https://somafm.com/groovesalad.pls",
+          "https://somafm.com/deepspaceone.pls",
+          "https://somafm.com/missioncontrol.pls",
+          "https://somafm.com/spacestation.pls",
+          "https://somafm.com/vaporwaves.pls",
           "spotify--Tviw9k66://playlist/2I2cwYxeuLbIXaNRccMViZ"
           ] -%}
           {% set pindex =  (range(0, (plists | length))|random) -%}
@@ -1698,6 +1698,7 @@ script:
         data:
           entity_id: media_player.bedroom_sonos_2
           media_item: "{{ playlist }}"
+          media_type: "{{ 'radio' if playlist.startswith('https://somafm.com/') else '' }}"
       - action: script.turn_on
         target:
           entity_id: script.music_assistant_try_join_bedroom_group_after_play

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -242,21 +242,31 @@ def test_stuck_morning_audio_scripts_are_recovered() -> None:
     assert 'entity_id: input_boolean.morning_routine' in block
 
 
-def test_bedtime_playlist_includes_somafm_station_names() -> None:
+def test_bedtime_playlist_includes_explicit_somafm_station_urls() -> None:
     block = _script_block("spotify_bedtime")
 
-    for station in (
+    for station_url in (
+        "https://somafm.com/groovesalad.pls",
+        "https://somafm.com/deepspaceone.pls",
+        "https://somafm.com/missioncontrol.pls",
+        "https://somafm.com/spacestation.pls",
+        "https://somafm.com/vaporwaves.pls",
+    ):
+        assert f'"{station_url}"' in block
+
+    for station_name in (
         "Groove Salad",
         "Deep Space One",
         "Mission Control",
         "Space Station Soma",
         "Vaporwaves",
     ):
-        assert f'"{station}"' in block
+        assert f'"{station_name}"' not in block
 
     assert "range(0, (plists | length))" in block
     assert "action: script.music_assistant_play_item" in block
     assert 'media_item: "{{ playlist }}"' in block
+    assert "playlist.startswith('https://somafm.com/')" in block
 
 
 def test_music_assistant_dashboard_exposes_player_card() -> None:

--- a/tests/test_update_music_assistant_playlist.py
+++ b/tests/test_update_music_assistant_playlist.py
@@ -54,7 +54,7 @@ def test_append_item_to_playlist_config_deduplicates(media_player_config_text: s
     updated, changed = append_item_to_playlist_config(
         media_player_config_text,
         "spotify_bedtime",
-        "Groove Salad",
+        "https://somafm.com/groovesalad.pls",
     )
 
     assert changed is False


### PR DESCRIPTION
## Summary
- Replace ambiguous SomaFM bedtime station names with explicit permanent SomaFM `.pls` URLs.
- Pass `media_type: radio` for SomaFM URL selections so Music Assistant does not rely on name search resolution.
- Update README guidance and tests to cover URL-based bedtime radio entries.

## Validation
- `uv run --with pytest pytest tests/test_update_music_assistant_playlist.py tests/test_media_player_music_assistant.py`
- `uv run --with pytest pytest`
- `git diff --check`