### PR TITLE
Fix Spook unknown Inovelli LED sync action

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -62,11 +62,14 @@ automation:
             value_template: "{{ trigger.platform == 'homeassistant' }}"
         then:
           - delay: "00:00:30"
-      - action: script.sync_inovelli_led_bars_to_adaptive_lighting
+      - action: script.turn_on
+        target:
+          entity_id: script.sync_inovelli_led_bars_to_adaptive_lighting
         data:
-          rooms:
-            - owner suite
-            - office
+          variables:
+            rooms:
+              - owner suite
+              - office
 
 script:
   sync_inovelli_led_bars_to_adaptive_lighting:

--- a/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
+++ b/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
@@ -71,7 +71,10 @@ def test_default_led_bar_sync_automation_updates_owner_suite_and_office() -> Non
     assert "switch.adaptive_lighting_owner_suite" in block
     assert "switch.adaptive_lighting_sleep_mode_owner_suite" in block
     assert 'delay: "00:00:30"' in block
-    assert "action: script.sync_inovelli_led_bars_to_adaptive_lighting" in block
+    assert "action: script.turn_on" in block
+    assert "entity_id: script.sync_inovelli_led_bars_to_adaptive_lighting" in block
+    assert "variables:" in block
+    assert "action: script.sync_inovelli_led_bars_to_adaptive_lighting" not in block
     assert "- owner suite" in block
     assert "- office" in block
 


### PR DESCRIPTION
## Summary
- replace the generated `script.sync_inovelli_led_bars_to_adaptive_lighting` action call with the stable `script.turn_on` service
- pass the configured rooms through `data.variables` so the script still receives `owner suite` and `office`
- add regression coverage so the automation does not reintroduce the generated script service action

## Why
Spook reports the automation action as unknown when it references the generated script service directly. `script.turn_on` is a stable built-in service and avoids that repair while preserving the script call.

## Testing
- `uv run --with pytest pytest tests/test_adaptive_lighting_inovelli_led_bar_sync.py -q`
- `uv run --with pytest pytest`