### PR TITLE
[codex] Fix trip mode on scheduled departure

### DIFF
--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -321,6 +321,10 @@ automation:
         to: "off"
         for:
           hours: 20
+      - trigger: state
+        id: depart_for_scheduled_trip
+        entity_id: binary_sensor.bayesian_zeke_home
+        to: "off"
       - trigger: template
         id: away_over_radius_mi
         value_template: >-
@@ -406,12 +410,31 @@ automation:
                   - away_over_radius_mi
                   - planned_work_trip
                   - planned_vacation
+                  - depart_for_scheduled_trip
               - condition: state
                 entity_id: binary_sensor.bayesian_zeke_home
                 state: "off"
               - condition: state
                 entity_id: input_boolean.trip
                 state: "off"
+              - condition: or
+                conditions:
+                  - condition: template
+                    value_template: "{{ trigger.id != 'depart_for_scheduled_trip' }}"
+                  - condition: state
+                    entity_id: binary_sensor.planned_work_trip_calendar
+                    state: "on"
+                  - condition: template
+                    value_template: >-
+                      {% set start_ts = as_timestamp(state_attr('sensor.ecobee_calendar_vacation_schedule', 'start'), default=none) %}
+                      {% set end_ts = as_timestamp(state_attr('sensor.ecobee_calendar_vacation_schedule', 'end'), default=none) %}
+                      {% set now_ts = as_timestamp(now()) %}
+                      {{
+                        start_ts is not none
+                        and end_ts is not none
+                        and now_ts >= (start_ts - 21600)
+                        and now_ts < end_ts
+                      }}
             sequence:
               - action: input_boolean.turn_on
                 target:

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -429,10 +429,11 @@ automation:
                       {% set start_ts = as_timestamp(state_attr('sensor.ecobee_calendar_vacation_schedule', 'start'), default=none) %}
                       {% set end_ts = as_timestamp(state_attr('sensor.ecobee_calendar_vacation_schedule', 'end'), default=none) %}
                       {% set now_ts = as_timestamp(now()) %}
+                      {% set scheduled_departure_lead_seconds = 6 * 3600 %}
                       {{
                         start_ts is not none
                         and end_ts is not none
-                        and now_ts >= (start_ts - 21600)
+                        and now_ts >= (start_ts - scheduled_departure_lead_seconds)
                         and now_ts < end_ts
                       }}
             sequence:

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -82,7 +82,8 @@ def test_trip_mode_manager_can_enable_trip_mode_when_departing_for_scheduled_tra
     assert "trigger.id != 'depart_for_scheduled_trip'" in block
     assert "entity_id: binary_sensor.planned_work_trip_calendar" in block
     assert "sensor.ecobee_calendar_vacation_schedule" in block
-    assert "start_ts - 21600" in block
+    assert "scheduled_departure_lead_seconds = 6 * 3600" in block
+    assert "start_ts - scheduled_departure_lead_seconds" in block
 
 
 def test_bedroom_hour_of_day_remains_numeric() -> None:

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -75,6 +75,15 @@ def test_trip_templates_treat_minnesota_as_home_destination() -> None:
     assert 'destination_code not in ["", "MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "ROCHESTER", "MINNESOTA"]' in text
     assert "{% set home_codes = ['MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER', 'MINNESOTA'] %}" in text
 
+def test_trip_mode_manager_can_enable_trip_mode_when_departing_for_scheduled_travel() -> None:
+    block = _automation_block(TRIPS_PATH, "trip_mode_manager")
+
+    assert "id: depart_for_scheduled_trip" in block
+    assert "trigger.id != 'depart_for_scheduled_trip'" in block
+    assert "entity_id: binary_sensor.planned_work_trip_calendar" in block
+    assert "sensor.ecobee_calendar_vacation_schedule" in block
+    assert "start_ts - 21600" in block
+
 
 def test_bedroom_hour_of_day_remains_numeric() -> None:
     text = _read(ZIGBEE_ZWAVE_PATH)


### PR DESCRIPTION
## Summary
- enable `trip_mode_manager` when `binary_sensor.bayesian_zeke_home` leaves home during the pre-departure window of a scheduled travel plan
- keep the existing vacation-day sensor semantics intact so departure-day wake routines are not suppressed
- add regression coverage for the new scheduled-departure trigger path

## Trace evidence
On April 9, 2026 (America/Chicago), `device_tracker.bayesian_zeke_home` left home at 12:00 PM CDT, but `input_boolean.trip` did not turn on until 1:30 PM CDT from the `calendar_trip` offset trigger. The later `trip_mode_manager` traces were benign no-ops because trip mode was already on by then.

## Validation
- `uv run --with pytest pytest tests/test_runtime_log_regressions.py tests/test_trips_flight_classification.py -q`
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/trips.yaml`

## Notes
- `uv run --with pyyaml python3 /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/trips.yaml --strict` still reports pre-existing duplication in `packages/trips.yaml`; this patch did not introduce new duplicate groups.
- `uv run --with homeassistant python -m homeassistant --config . --script check_config` stops on missing local secret `home_latitude`, so config validation could not complete in this worktree.

Closes #417