### PR TITLE
[codex] Ignore home-region named flights in trip detection

### DIFF
--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -1408,7 +1408,7 @@ template:
               {% if named_destination != '' %}
                 {% set destination_code = named_destination.split(' (', 1)[0].split(' •', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
               {% endif %}
-              {% if looks_like_flight and not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL'] and start_dt is not none and end_dt is not none %}
+              {% if looks_like_flight and not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'MINNESOTA'] and start_dt is not none and end_dt is not none %}
                 {% set start_ts = as_timestamp(start_dt) %}
                 {% set end_ts = as_timestamp(end_dt) %}
                 {% if end_ts > now_ts %}
@@ -1709,7 +1709,7 @@ template:
                   {% set destination_name = named_destination.split(' (', 1)[0].split(' •', 1)[0].strip() %}
                   {% set destination_code = destination_name | regex_replace('[^A-Za-z]', '') | upper %}
                 {% endif %}
-                {% if destination_name == '' and destination_code not in ['', 'MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER', 'MINNESOTA'] %}
+                {% if destination_name == '' and destination_code not in ([''] + home_codes) %}
                   {% set destination_name = destination_code %}
                 {% endif %}
                 {% set is_home_origin = origin_code in ['MSP', 'RST'] %}

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -471,7 +471,7 @@ automation:
                   {{
                     looks_like_flight
                     and is_msp_departure
-                    and destination_code not in ["", "MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "ROCHESTER"]
+                    and destination_code not in ["", "MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "ROCHESTER", "MINNESOTA"]
                     and "friend" not in trip_text
                   }}
             sequence:
@@ -1560,7 +1560,7 @@ template:
           vacation_plan_json: >-
             {% set now_ts = as_timestamp(now()) %}
             {% set future_cutoff_ts = now_ts + (180 * 86400) %}
-            {% set home_codes = ['MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER'] %}
+            {% set home_codes = ['MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER', 'MINNESOTA'] %}
             {% set curling_events_list = (curling_events | default('[]', true) | string | trim | from_json) %}
             {% set personal_events_list = (personal_events | default('[]', true) | string | trim | from_json) %}
             {% set work_trip_events_list = (work_trip_events | default('[]', true) | string | trim | from_json) %}
@@ -1709,7 +1709,7 @@ template:
                   {% set destination_name = named_destination.split(' (', 1)[0].split(' •', 1)[0].strip() %}
                   {% set destination_code = destination_name | regex_replace('[^A-Za-z]', '') | upper %}
                 {% endif %}
-                {% if destination_name == '' and destination_code not in ['', 'MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER'] %}
+                {% if destination_name == '' and destination_code not in ['', 'MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER', 'MINNESOTA'] %}
                   {% set destination_name = destination_code %}
                 {% endif %}
                 {% set is_home_origin = origin_code in ['MSP', 'RST'] %}

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -68,6 +68,14 @@ def test_time_to_home_template_handles_unavailable_source_state() -> None:
     assert "'%02d:%02d:00' | format(hours, minutes)" in text
 
 
+def test_trip_templates_treat_minnesota_as_home_destination() -> None:
+    text = _read(TRIPS_PATH)
+
+    assert '"MINNESOTA"' in text
+    assert 'destination_code not in ["", "MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "ROCHESTER", "MINNESOTA"]' in text
+    assert "{% set home_codes = ['MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER', 'MINNESOTA'] %}" in text
+
+
 def test_bedroom_hour_of_day_remains_numeric() -> None:
     text = _read(ZIGBEE_ZWAVE_PATH)
 

--- a/tests/test_trips_flight_classification.py
+++ b/tests/test_trips_flight_classification.py
@@ -402,11 +402,15 @@ def test_route_summaries_keep_departure_and_return_directions_distinct() -> None
 def test_named_flights_extract_clean_destination_codes() -> None:
     direct = parse_flight_signals("flight to CLT (DL 2819)")
     verbose = parse_flight_signals("Flight: MSP TO CLT (DL 2819)")
+    homebound = parse_flight_signals("Flight to Minnesota (DL 2819)")
 
     assert direct.destination_name == "CLT"
     assert direct.destination_code == "CLT"
     assert verbose.destination_name == "CLT"
     assert verbose.destination_code == "CLT"
+    assert homebound.destination_name == "Minnesota"
+    assert homebound.destination_code == "MINNESOTA"
+    assert homebound.destination_code in HOME_CODES
 
 
 def test_trips_package_avoids_case_sensitive_named_flight_splits() -> None:
@@ -427,7 +431,7 @@ def test_trips_package_exposes_vacation_plan_diagnostics_and_logging() -> None:
     assert "alias: log_calendar_vacation_plan_diagnostics" in text
     assert "name: Travel detection" in text
     assert "attribute: decision_code" in text
-    assert "not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL']" in text
+    assert "not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'MINNESOTA']" in text
     assert "not is_friend_itinerary and destination_code in ['RST', 'ROCHESTER']" in text
 
 

--- a/tests/test_trips_flight_classification.py
+++ b/tests/test_trips_flight_classification.py
@@ -10,7 +10,7 @@ import pytest
 
 
 CENTRAL = ZoneInfo("America/Chicago")
-HOME_CODES = {"MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "ROCHESTER"}
+HOME_CODES = {"MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "ROCHESTER", "MINNESOTA"}
 TRIPS_PATH = Path(__file__).resolve().parents[1] / "packages" / "trips.yaml"
 MATRIX_PATH = Path(__file__).resolve().parents[1] / "docs" / "travel_detection_regression_matrix.md"
 
@@ -568,6 +568,34 @@ def test_friend_itineraries_to_home_are_ignored() -> None:
     assert plan["reason"] == "off"
     assert plan["decision_code"] == "off_no_candidate"
     assert "friend itinerary" in plan["ignored_reason"].lower()
+
+
+def test_home_region_named_flight_does_not_override_curling_trip_block() -> None:
+    now = iso("2026-04-11T08:00:00-05:00")
+    personal_events = [
+        {
+            "summary": "Flight to Minnesota (DL 2819)",
+            "description": "Created from an email you received in Gmail",
+            "start": "2026-04-12T17:47:00-05:00",
+            "end": "2026-04-12T20:00:00-05:00",
+        }
+    ]
+    curling_events = [
+        {
+            "summary": "Arena play down",
+            "start": "2026-04-10",
+            "end": "2026-04-13",
+            "location": "Brookings\nUnited States",
+        }
+    ]
+
+    plan = build_vacation_plan(personal_events, now, curling_events=curling_events)
+
+    assert plan["reason"] == "calendar"
+    assert plan["decision_code"] == "calendar_curling_block"
+    assert plan["summary"] == "Arena play down"
+    assert plan["outbound_summary"] == ""
+    assert plan["fallback_source"] == "curling block"
 
 
 def test_local_rochester_appointments_do_not_create_trip_window() -> None:


### PR DESCRIPTION
## Summary
- treat `Flight to Minnesota (...)` as a home-region itinerary instead of a qualifying outbound trip
- keep the existing standalone fallback behavior so real calendar trip windows can still drive trip mode and Ecobee vacation sync
- add regression coverage for the live `Flight to Minnesota` plus curling-block trace and for the YAML home-region guard

## Trace Evidence
During the 2026-04-12 trace sweep for #314, live Home Assistant logged this travel decision from `automation.log_calendar_vacation_plan_diagnostics`:

- `Using outbound flight and curling block because no return flight is booked.`
- outbound: `Flight to Minnesota (DL 2819)`
- fallback: `Arena play down`
- destination: `Minnesota`

That route is home-region travel and should not win the outbound-flight slot. It was causing trip detection to prefer `flight_curling_block` over the intended standalone calendar fallback.

Closes #421.
Refs #314.

## Validation
- `uv run --with pytest pytest tests/test_trips_flight_classification.py tests/test_runtime_log_regressions.py -q`
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/trips.yaml`
- `uv run --with pyyaml python /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/trips.yaml --strict` (reports pre-existing duplicate-condition/action groups elsewhere in `packages/trips.yaml`; no new findings from this fix)
- `uv run --with homeassistant==2026.3.4 python -m homeassistant --config '/Users/rtclauss/.codex/worktrees/0ac0/New project' --script check_config` could not complete because local secret `home_latitude` is unavailable in this worktree

## Test Cases
- a named `Flight to Minnesota` does not override a real standalone curling trip block
- the trips package keeps `MINNESOTA` in the home-region exclusion lists used by trip mode and vacation-plan detection