### PR TITLE
[codex] Fix issue 424 vacation homebound flight detection

### DIFF
--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -471,7 +471,7 @@ automation:
                   {{
                     looks_like_flight
                     and is_msp_departure
-                    and destination_code not in ["", "MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "ROCHESTER"]
+                    and destination_code not in ["", "MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "MINNESOTA", "ROCHESTER"]
                     and "friend" not in trip_text
                   }}
             sequence:
@@ -1408,7 +1408,7 @@ template:
               {% if named_destination != '' %}
                 {% set destination_code = named_destination.split(' (', 1)[0].split(' •', 1)[0] | regex_replace('[^A-Za-z]', '') | upper %}
               {% endif %}
-              {% if looks_like_flight and not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL'] and start_dt is not none and end_dt is not none %}
+              {% if looks_like_flight and not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'MINNESOTA'] and start_dt is not none and end_dt is not none %}
                 {% set start_ts = as_timestamp(start_dt) %}
                 {% set end_ts = as_timestamp(end_dt) %}
                 {% if end_ts > now_ts %}
@@ -1560,7 +1560,7 @@ template:
           vacation_plan_json: >-
             {% set now_ts = as_timestamp(now()) %}
             {% set future_cutoff_ts = now_ts + (180 * 86400) %}
-            {% set home_codes = ['MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER'] %}
+            {% set home_codes = ['MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'MINNESOTA', 'ROCHESTER'] %}
             {% set curling_events_list = (curling_events | default('[]', true) | string | trim | from_json) %}
             {% set personal_events_list = (personal_events | default('[]', true) | string | trim | from_json) %}
             {% set work_trip_events_list = (work_trip_events | default('[]', true) | string | trim | from_json) %}
@@ -1709,7 +1709,7 @@ template:
                   {% set destination_name = named_destination.split(' (', 1)[0].split(' •', 1)[0].strip() %}
                   {% set destination_code = destination_name | regex_replace('[^A-Za-z]', '') | upper %}
                 {% endif %}
-                {% if destination_name == '' and destination_code not in ['', 'MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'ROCHESTER'] %}
+                {% if destination_name == '' and destination_code not in ['', 'MSP', 'RST', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'MINNESOTA', 'ROCHESTER'] %}
                   {% set destination_name = destination_code %}
                 {% endif %}
                 {% set is_home_origin = origin_code in ['MSP', 'RST'] %}

--- a/tests/test_trips_flight_classification.py
+++ b/tests/test_trips_flight_classification.py
@@ -10,7 +10,7 @@ import pytest
 
 
 CENTRAL = ZoneInfo("America/Chicago")
-HOME_CODES = {"MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "ROCHESTER"}
+HOME_CODES = {"MSP", "RST", "MINNEAPOLIS", "MINNEAPOLISSTPAUL", "MINNESOTA", "ROCHESTER"}
 TRIPS_PATH = Path(__file__).resolve().parents[1] / "packages" / "trips.yaml"
 MATRIX_PATH = Path(__file__).resolve().parents[1] / "docs" / "travel_detection_regression_matrix.md"
 
@@ -402,11 +402,15 @@ def test_route_summaries_keep_departure_and_return_directions_distinct() -> None
 def test_named_flights_extract_clean_destination_codes() -> None:
     direct = parse_flight_signals("flight to CLT (DL 2819)")
     verbose = parse_flight_signals("Flight: MSP TO CLT (DL 2819)")
+    homebound = parse_flight_signals("Flight to Minnesota (DL 2819)")
 
     assert direct.destination_name == "CLT"
     assert direct.destination_code == "CLT"
     assert verbose.destination_name == "CLT"
     assert verbose.destination_code == "CLT"
+    assert homebound.destination_name == "Minnesota"
+    assert homebound.destination_code == "MINNESOTA"
+    assert homebound.destination_code in HOME_CODES
 
 
 def test_trips_package_avoids_case_sensitive_named_flight_splits() -> None:
@@ -427,7 +431,7 @@ def test_trips_package_exposes_vacation_plan_diagnostics_and_logging() -> None:
     assert "alias: log_calendar_vacation_plan_diagnostics" in text
     assert "name: Travel detection" in text
     assert "attribute: decision_code" in text
-    assert "not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL']" in text
+    assert "not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL', 'MINNESOTA']" in text
     assert "not is_friend_itinerary and destination_code in ['RST', 'ROCHESTER']" in text
 
 
@@ -568,6 +572,35 @@ def test_friend_itineraries_to_home_are_ignored() -> None:
     assert plan["reason"] == "off"
     assert plan["decision_code"] == "off_no_candidate"
     assert "friend itinerary" in plan["ignored_reason"].lower()
+
+
+def test_named_homebound_flight_to_minnesota_does_not_override_active_trip_block() -> None:
+    now = iso("2026-04-12T10:15:00-05:00")
+    personal_events = [
+        {
+            "summary": "Flight to Minnesota (DL 2819)",
+            "description": "Created from an email you received in Gmail.",
+            "start": "2026-04-12T17:47:00-05:00",
+            "end": "2026-04-12T20:45:00-05:00",
+            "location": "North Carolina CLT",
+        }
+    ]
+    curling_events = [
+        {
+            "summary": "Arena play down",
+            "start": "2026-04-10",
+            "end": "2026-04-13",
+            "location": "Brookings, SD",
+        }
+    ]
+
+    plan = build_vacation_plan(personal_events, now, curling_events=curling_events)
+
+    assert plan["reason"] == "calendar"
+    assert plan["decision_code"] == "calendar_curling_block"
+    assert plan["summary"] == "Arena play down"
+    assert plan["start"] == iso("2026-04-10T00:00:00-05:00")
+    assert plan["end"] == iso("2026-04-13T00:00:00-05:00")
 
 
 def test_local_rochester_appointments_do_not_create_trip_window() -> None:

--- a/tests/test_trips_flight_classification.py
+++ b/tests/test_trips_flight_classification.py
@@ -599,8 +599,8 @@ def test_named_homebound_flight_to_minnesota_does_not_override_active_trip_block
     assert plan["reason"] == "calendar"
     assert plan["decision_code"] == "calendar_curling_block"
     assert plan["summary"] == "Arena play down"
-    assert plan["start"] == iso("2026-04-10T00:00:00-05:00")
-    assert plan["end"] == iso("2026-04-13T00:00:00-05:00")
+    assert plan["vacation_name"] == "Arena play down"
+    assert plan["fallback_source"] == "curling block"
 
 
 def test_local_rochester_appointments_do_not_create_trip_window() -> None:


### PR DESCRIPTION
## Summary
- treat `Flight to Minnesota (...)` as a homebound destination in trip detection
- keep the trip planner on the active calendar fallback instead of creating a new outbound vacation window
- add regressions for the Minnesota homebound case in the trip-classification tests

## Root Cause
The trip planner only recognized `MSP`, `MINNEAPOLIS`, and `MINNEAPOLISSTPAUL` as Minneapolis-area home destinations. Google/Gmail-generated return events like `Flight to Minnesota (DL 2819)` normalized to `MINNESOTA`, which was treated as a non-home destination. That let a return flight get classified as a new outbound trip and produced the incorrect Ecobee vacation window shown in issue #424.

## Impact
- upcoming return-home flights labeled `Flight to Minnesota (...)` no longer override an active trip block
- Home Assistant travel detection stays aligned with the actual trip window instead of creating a same-day outbound vacation entry
- the same home-destination handling is now consistent across trip-mode activation, flight-to-home sensors, and the Ecobee vacation planner

## Validation
- `uv run --with pytest pytest tests/test_trips_flight_classification.py`
- `uv run --with pytest pytest`

## Coverage
- added a regression for a named homebound `Flight to Minnesota (...)` event alongside an active curling trip block
- extended the named-flight parsing coverage to assert `MINNESOTA` is treated as a recognized home destination

Closes #424