### PR TITLE
Tune kitchen Adaptive Lighting startup baseline

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -3,7 +3,8 @@ automation:
     alias: reconcile_owner_suite_adaptive_lighting
     description: >
       Reapply the Adaptive Lighting baselines after Home Assistant starts so
-      owner suite wake transitions and dining-room tuning survive restarts.
+      kitchen, dining-room, and owner-suite tuning survive restarts while
+      preserving each room's intended scene and task-lighting behavior.
       The runtime dining-room Adaptive Lighting switch now uses the current dining-room entity id.
     mode: single
     trigger:
@@ -24,6 +25,17 @@ automation:
           detect_non_ha_changes: false
       - action: adaptive_lighting.change_switch_settings
         data:
+          entity_id: switch.adaptive_lighting_kitchen
+          use_defaults: current
+          include_config_in_attributes: true
+          take_over_control: true
+          adapt_only_on_bare_turn_on: true
+          only_once: true
+          initial_transition: 1
+          transition: 3
+          detect_non_ha_changes: false
+      - action: adaptive_lighting.change_switch_settings
+        data:
           entity_id: switch.adaptive_lighting_owner_suite
           use_defaults: current
           include_config_in_attributes: true
@@ -36,18 +48,21 @@ automation:
           sleep_brightness: 1
           sleep_color_temp: 1000
           detect_non_ha_changes: false
+      - event: adaptive_lighting_startup_reconciled
 
   - id: sync_selected_inovelli_led_bars_to_adaptive_lighting
     alias: sync_selected_inovelli_led_bars_to_adaptive_lighting
     description: >
       Keep the owner suite and office Inovelli LED bars aligned with Adaptive
       Lighting while still yielding to trip mode, sleep mode, and office guest
-      privacy overrides. The shared script accepts room or rooms so additional
-      rooms can opt in without duplicating the LED-bar mapping logic.
+      privacy overrides. Startup sync waits for Adaptive Lighting baseline
+      reconciliation so the shared script runs after room settings are
+      restored. The shared script accepts room or rooms so additional rooms
+      can opt in without duplicating the LED-bar mapping logic.
     mode: restart
     trigger:
-      - trigger: homeassistant
-        event: start
+      - trigger: event
+        event_type: adaptive_lighting_startup_reconciled
       - trigger: state
         entity_id:
           - switch.sleep_mode
@@ -57,11 +72,6 @@ automation:
       - trigger: time_pattern
         minutes: "/2"
     action:
-      - if:
-          - condition: template
-            value_template: "{{ trigger.platform == 'homeassistant' }}"
-        then:
-          - delay: "00:00:30"
       - action: script.turn_on
         target:
           entity_id: script.sync_inovelli_led_bars_to_adaptive_lighting

--- a/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
+++ b/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
@@ -59,18 +59,17 @@ def _script_block(script_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
-def test_default_led_bar_sync_automation_updates_owner_suite_and_office() -> None:
+def test_default_led_bar_sync_automation_updates_owner_suite_and_office_after_reconcile() -> None:
     block = _automation_block("sync_selected_inovelli_led_bars_to_adaptive_lighting")
 
     assert "owner suite and office Inovelli LED bars" in block
-    assert "trigger: homeassistant" in block
-    assert "event: start" in block
+    assert "trigger: event" in block
+    assert "event_type: adaptive_lighting_startup_reconciled" in block
     assert 'minutes: "/2"' in block
     assert "switch.sleep_mode" in block
     assert "input_boolean.guest_mode" in block
     assert "switch.adaptive_lighting_owner_suite" in block
     assert "switch.adaptive_lighting_sleep_mode_owner_suite" in block
-    assert 'delay: "00:00:30"' in block
     assert "action: script.turn_on" in block
     assert "entity_id: script.sync_inovelli_led_bars_to_adaptive_lighting" in block
     assert "variables:" in block

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -42,7 +42,7 @@ def test_owner_suite_adaptive_lighting_reconciles_supported_scene_safe_settings(
     assert "event: start" in block
     assert 'delay: "00:00:30"' in block
     assert "action: adaptive_lighting.change_switch_settings" in block
-    assert "owner suite wake transitions and dining-room tuning survive restarts" in block
+    assert "kitchen, dining-room, and owner-suite tuning survive restarts" in block
     assert "entity_id: switch.adaptive_lighting_owner_suite" in block
     assert "use_defaults: current" in block
     assert "include_config_in_attributes: true" in block
@@ -55,6 +55,7 @@ def test_owner_suite_adaptive_lighting_reconciles_supported_scene_safe_settings(
     assert "sleep_brightness: 1" in block
     assert "sleep_color_temp: 1000" in block
     assert "detect_non_ha_changes: false" in block
+    assert "event: adaptive_lighting_startup_reconciled" in block
 
 
 def test_dining_room_adaptive_lighting_reconciles_current_switch_to_scene_safe_settings() -> None:
@@ -73,4 +74,20 @@ def test_dining_room_adaptive_lighting_reconciles_current_switch_to_scene_safe_s
     assert "only_once: true" in block
     assert "initial_transition: 1" in block
     assert "transition: 5" in block
+    assert "detect_non_ha_changes: false" in block
+
+
+def test_kitchen_adaptive_lighting_reconciles_bright_scene_safe_settings() -> None:
+    block = _automation_block("reconcile_owner_suite_adaptive_lighting")
+
+    assert "preserving each room's intended scene and task-lighting behavior" in block
+    assert "action: adaptive_lighting.change_switch_settings" in block
+    assert "entity_id: switch.adaptive_lighting_kitchen" in block
+    assert "use_defaults: current" in block
+    assert "include_config_in_attributes: true" in block
+    assert "take_over_control: true" in block
+    assert "adapt_only_on_bare_turn_on: true" in block
+    assert "only_once: true" in block
+    assert "initial_transition: 1" in block
+    assert "transition: 3" in block
     assert "detect_non_ha_changes: false" in block


### PR DESCRIPTION
## Summary
- persist the kitchen Adaptive Lighting baseline at Home Assistant startup using the repo-managed reconcile automation
- keep the kitchen bright-range behavior intact by using `use_defaults: current` while switching to scene-safe startup settings
- remove the duplicate startup trigger in `packages/adaptive_lighting.yaml` by handing LED-bar startup sync off from reconcile completion

## Issue
- Fixes #98

## Validation
- `uv run --with pyyaml python /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/adaptive_lighting.yaml --strict`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/adaptive_lighting.yaml`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt`
- `uv run --with pytest pytest tests/test_adaptive_lighting_reconcile.py tests/test_adaptive_lighting_inovelli_led_bar_sync.py`
- `uv run --with pytest pytest`
- `uv run --with homeassistant==2026.3.4 python -m homeassistant --config /tmp/hass-config-issue-98 --script check_config`

## Test Cases
- startup reconcile reapplies kitchen scene-safe Adaptive Lighting settings without disturbing its fixed bright kitchen defaults
- startup LED-bar sync waits for Adaptive Lighting baseline reconciliation instead of racing Home Assistant startup
- full repo test suite and Home Assistant config validation stay green