### PR TITLE
[codex] Guard logbook diagnostics during outages

### DIFF
--- a/packages/house_mode.yaml
+++ b/packages/house_mode.yaml
@@ -170,7 +170,8 @@ script:
           Guest Day
         {% endif %}
     sequence:
-      - action: logbook.log
+      - continue_on_error: true
+        action: logbook.log
         data:
           name: House Transition
           entity_id: script.house_transition

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -619,7 +619,8 @@ automation:
       destination_name: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'destination_name') | default('', true) | string | trim }}"
       ignored_reason: "{{ state_attr('sensor.ecobee_calendar_vacation_schedule', 'ignored_reason') | default('', true) | string | trim }}"
     action:
-      - action: logbook.log
+      - continue_on_error: true
+        action: logbook.log
         data:
           entity_id: sensor.ecobee_calendar_vacation_schedule
           domain: sensor

--- a/tests/test_house_mode_zone.py
+++ b/tests/test_house_mode_zone.py
@@ -64,6 +64,7 @@ def test_house_transition_no_longer_queues_later_mode_changes() -> None:
     assert "house_transition:" in text
     assert "mode: restart" in text
     assert "script.lights_off_except" in text
+    assert "continue_on_error: true\n        action: logbook.log" in text
 
 
 def test_house_transition_supports_in_bed_and_asleep_without_forcing_night_scene_defaults() -> None:

--- a/tests/test_trips_flight_classification.py
+++ b/tests/test_trips_flight_classification.py
@@ -427,6 +427,7 @@ def test_trips_package_exposes_vacation_plan_diagnostics_and_logging() -> None:
     assert "alias: log_calendar_vacation_plan_diagnostics" in text
     assert "name: Travel detection" in text
     assert "attribute: decision_code" in text
+    assert "continue_on_error: true\n        action: logbook.log" in text
     assert "not is_friend_itinerary and destination_code in ['MSP', 'MINNEAPOLIS', 'MINNEAPOLISSTPAUL']" in text
     assert "not is_friend_itinerary and destination_code in ['RST', 'ROCHESTER']" in text
 


### PR DESCRIPTION
## Summary
- guard the shared `logbook.log` diagnostics in `script.house_transition` and `automation.log_calendar_vacation_plan_diagnostics`
- keep the diagnostic entries when the `logbook` integration is healthy, but stop these traces from failing when `logbook` is unavailable
- add regression assertions so the guarded logbook actions stay in `packages/house_mode.yaml` and `packages/trips.yaml`

## Trace Evidence
During the 2026-04-12/2026-04-13 nightly trace sweep for #314, live Home Assistant produced new runtime errors after the recent restart:

- `automation.log_calendar_vacation_plan_diagnostics` run `fb0db789c82d5b6c8b18e2653c1eb7b1` failed with `Action logbook.log not found`
- `automation.trip_mode_manager` run `71a807d01db45ff75461eb5cacd7e1f3` failed through `script.house_transition`, which also showed recent error traces (`01d1a89e03e0fca3511d8c7237920f4f`, `12eb180381d21551a85ec94bd4417ef5`, `c1362f820f87b609bc5814c483a142f7`, `a8b634c23a49a4ed43472350c3481b54`, `582a8ca12dbe4e402a7ad8e8bed61db9`) with the same missing `logbook.log` action
- live HA also has active persistent notifications that `recorder`, `history`, `logbook`, and related integrations failed to set up, so this patch hardens the YAML against that operational outage instead of trying to fix the underlying runtime stack in the same PR

## Validation
- `uv run --with pytest pytest tests/test_house_mode_zone.py tests/test_trips_flight_classification.py -q`
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/house_mode.yaml packages/trips.yaml`
- `uv run --with pyyaml python /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/house_mode.yaml packages/trips.yaml --strict` still reports pre-existing duplicate-condition/action groups elsewhere in `packages/trips.yaml`; this patch did not add new duplication
- `uv run --with homeassistant==2026.4.2 python -m homeassistant --config /Users/rtclauss/.codex/worktrees/review-ha-traces-logbook-guard --script check_config` could not complete because local secret `home_latitude` is unavailable in this worktree

## Test Cases
- `script.house_transition` tolerates a missing `logbook` service instead of failing the parent automation trace
- `automation.log_calendar_vacation_plan_diagnostics` keeps its travel-diagnostic payload but does not error when `logbook` is unavailable

Closes #427.
Refs #314.