### PR TITLE
Fix IKEA PARASOLL battery drain and network drop-off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 ########################################
 !*.yaml
 !*.yml
+!zigbee2mqtt/ext_converter.js
 !AGENTS.md
 !esphome/tikiroom_effects.h
 !.python-version

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -1,0 +1,106 @@
+# IKEA PARASOLL (E2013) — battery drain & drop-off fix
+#
+# Root cause (github.com/Koenkk/zigbee2mqtt/issues/22579):
+#   1. Battery drain: Z2M writes an aggressive genPollCtrl check-in interval.
+#   2. Drop off: a regression removed the ssIasZone cluster binding, so the
+#      device stops sending contact-state changes after a few hours.
+#
+# This package pairs with zigbee2mqtt/ext_converter.js.
+# Deployment order:
+#   1. Put ext_converter.js in the zigbee2mqtt config directory.
+#   2. Add `external_converters: [ext_converter.js]` to zigbee2mqtt/configuration.yaml
+#      (already done — see the top of that file).
+#   3. Restart Zigbee2MQTT.  Devices should show "PARASOLL door/window sensor (patched)".
+#   4. Run script.parasoll_reconfigure_all from Developer Tools or the UI.
+#   5. For sensors that are fully unresponsive: pull the battery, reinsert, then
+#      the automation below handles them automatically as they re-join.
+
+################################################################
+## Scripts
+################################################################
+
+script:
+  parasoll_reconfigure_all:
+    alias: "PARASOLL - Reconfigure All"
+    description: >
+      Sends a Z2M reconfigure command to every joined PARASOLL sensor so the
+      patched converter settings (ssIasZone binding, no genPollCtrl) are applied
+      without requiring a factory reset.  Sensors that are completely dead need
+      a battery pull first so Z2M can actually reach them.
+    mode: single
+    sequence:
+      - variables:
+          parasoll_ieee_list: >
+            {% set ns = namespace(devices=[]) %}
+            {% for entity in states.binary_sensor %}
+              {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor' %}
+                {% set ids = device_attr(entity.entity_id, 'identifiers') | list %}
+                {% for id_tuple in ids %}
+                  {% if id_tuple[0] == 'mqtt' %}
+                    {% set ieee = id_tuple[1] | replace('zigbee2mqtt_', '') %}
+                    {% if ieee not in ns.devices %}
+                      {% set ns.devices = ns.devices + [ieee] %}
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.devices }}
+      - repeat:
+          for_each: "{{ parasoll_ieee_list }}"
+          sequence:
+            - action: mqtt.publish
+              data:
+                topic: zigbee2mqtt/bridge/request/device/configure
+                payload: '{"id": "{{ repeat.item }}"}'
+            - delay:
+                milliseconds: 1500
+
+################################################################
+## Automations
+################################################################
+
+automation:
+  - alias: "PARASOLL - Auto-Reconfigure on Join or Announce"
+    id: parasoll_auto_reconfigure_on_join
+    description: >
+      Watches Z2M bridge events and sends a reconfigure request when:
+        • A brand-new PARASOLL joins (device_interview event, model E2013).
+        • A known PARASOLL re-announces after a battery pull or reconnect
+          (device_announce event, cross-checked against HA device registry).
+      The 5-second delay gives Z2M time to finish its own setup first.
+    mode: queued
+    max: 10
+    trigger:
+      - platform: mqtt
+        topic: zigbee2mqtt/bridge/event
+    condition:
+      - condition: template
+        value_template: >
+          {% set type = trigger.payload_json.type %}
+          {% set ieee = trigger.payload_json.data.ieee_address %}
+          {% if type == 'device_interview' %}
+            {{ trigger.payload_json.data.get('definition', {}).get('model', '') == 'E2013' }}
+          {% elif type == 'device_announce' %}
+            {% set ns = namespace(found=false) %}
+            {% for entity in states.binary_sensor %}
+              {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor' %}
+                {% set ids = device_attr(entity.entity_id, 'identifiers') | list %}
+                {% for id_tuple in ids %}
+                  {% if id_tuple[0] == 'mqtt' and id_tuple[1] == 'zigbee2mqtt_' ~ ieee %}
+                    {% set ns.found = true %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.found }}
+          {% else %}
+            {{ false }}
+          {% endif %}
+    action:
+      - delay:
+          seconds: 5
+      - action: mqtt.publish
+        data:
+          topic: zigbee2mqtt/bridge/request/device/configure
+          payload: '{"id": "{{ trigger.payload_json.data.ieee_address }}"}'

--- a/zigbee2mqtt/configuration.yaml
+++ b/zigbee2mqtt/configuration.yaml
@@ -1,3 +1,6 @@
+external_converters:
+  - ext_converter.js
+
 homeassistant:
   enabled: true
   legacy_action_sensor: true

--- a/zigbee2mqtt/ext_converter.js
+++ b/zigbee2mqtt/ext_converter.js
@@ -1,0 +1,52 @@
+/**
+ * IKEA PARASOLL (E2013) — patched external converter
+ *
+ * Fixes two issues tracked in https://github.com/Koenkk/zigbee2mqtt/issues/22579:
+ *  1. Battery drain: genPollCtrl cluster is intentionally excluded; the stock
+ *     converter sets aggressive check-in intervals that drain the battery.
+ *  2. Dropping off-network / not reporting: explicitly binds the ssIasZone
+ *     cluster on endpoint 2, which a regression removed from the built-in
+ *     converter, causing the device to stop sending contact state changes.
+ *
+ * After installing this file:
+ *   1. Restart Zigbee2MQTT (it will show "PARASOLL door/window sensor (patched)"
+ *      in the device description once loaded correctly).
+ *   2. Run the HA script "PARASOLL - Reconfigure All" to push the new config to
+ *      every already-joined sensor.  Sensors that are completely unresponsive
+ *      need a battery pull to wake them before reconfigure will reach them.
+ */
+
+const {
+  deviceEndpoints,
+  battery,
+  identify,
+  iasZoneAlarm,
+  bindCluster,
+} = require("zigbee-herdsman-converters/lib/modernExtend");
+
+const {
+  addCustomClusterManuSpecificIkeaUnknown,
+  ikeaOta,
+} = require("zigbee-herdsman-converters/lib/ikea");
+
+const definition = {
+  zigbeeModel: ["PARASOLL Door/Window Sensor"],
+  model: "E2013",
+  vendor: "IKEA of Sweden",
+  description: "PARASOLL door/window sensor (patched)",
+  extend: [
+    addCustomClusterManuSpecificIkeaUnknown(),
+    deviceEndpoints({ endpoints: { "1": 1, "2": 2 } }),
+    // Explicitly bind ssIasZone — the missing binding is the root cause of
+    // sensors silently stopping state reports after a few hours.
+    bindCluster({ cluster: "ssIasZone", clusterType: "input", endpointNames: ["2"] }),
+    iasZoneAlarm({ zoneType: "contact", zoneAttributes: ["alarm_1"] }),
+    identify({ isSleepy: true }),
+    battery(),
+    ikeaOta(),
+    // genPollCtrl is deliberately omitted — binding it causes Z2M to write an
+    // aggressive check-in interval that drains the AAA battery in days/weeks.
+  ],
+};
+
+module.exports = definition;


### PR DESCRIPTION
## Summary

- Add `zigbee2mqtt/ext_converter.js` — overrides the built-in PARASOLL converter to fix two cluster binding issues
- Add `external_converters` entry to `zigbee2mqtt/configuration.yaml`
- Add `packages/parasoll_fix.yaml` — HA script + automation for one-time and ongoing reconfiguration
- Allow `zigbee2mqtt/ext_converter.js` in `.gitignore`

Closes #429

## Root cause

[Koenkk/zigbee2mqtt#22579](https://github.com/Koenkk/zigbee2mqtt/issues/22579) identifies two bugs in the stock Z2M PARASOLL converter:

1. **Battery drain** — `genPollCtrl` cluster binding causes Z2M to write an aggressive check-in interval, waking the radio constantly and draining batteries in days.
2. **Drops off-network** — a regression removed the explicit `ssIasZone` binding on endpoint 2; without it the device stops sending contact-state reports after its first check-in cycle.

## Changes

### `zigbee2mqtt/ext_converter.js` (new)
- Inherits all the standard PARASOLL extends (iasZoneAlarm, battery, identify, ikeaOta, custom IKEA cluster)
- Adds `bindCluster({ cluster: 'ssIasZone', endpoint: '2' })` — the missing binding
- Omits `genPollCtrl` entirely

### `packages/parasoll_fix.yaml` (new)
- **`script.parasoll_reconfigure_all`**: iterates all HA entities with model `PARASOLL door/window sensor`, extracts IEEE addresses, and publishes `zigbee2mqtt/bridge/request/device/configure` for each. No factory reset required.
- **`automation.parasoll_auto_reconfigure_on_join`**: MQTT trigger on `zigbee2mqtt/bridge/event`; fires reconfigure after 5 s for:
  - `device_interview` events where `definition.model == E2013` (new sensor)
  - `device_announce` events where the IEEE address matches a known PARASOLL in HA device registry (battery-pull reconnect)

## Test plan

- [ ] Restart Zigbee2MQTT — device descriptions update to "PARASOLL door/window sensor (patched)"
- [ ] Reload HA config — `script.parasoll_reconfigure_all` and automation appear
- [ ] Run `script.parasoll_reconfigure_all` — Z2M logs show configure requests for all 19 sensors
- [ ] Open/close a window — contact state updates correctly in HA
- [ ] Pull battery on one sensor, reinsert — automation fires reconfigure within ~10 s of re-announce
- [ ] Monitor battery levels over 2–4 weeks for improvement

🤖 Generated with [Claude Code](https://claude.ai/claude-code)