### PR TITLE
Fix PARASOLL converter: move to external_converters/ subdirectory for Z2M 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 ########################################
 !*.yaml
 !*.yml
-!zigbee2mqtt/ext_converter.js
+!zigbee2mqtt/external_converters/parasoll.js
 !AGENTS.md
 !esphome/tikiroom_effects.h
 !.python-version

--- a/zigbee2mqtt/configuration.yaml
+++ b/zigbee2mqtt/configuration.yaml
@@ -1,6 +1,3 @@
-external_converters:
-  - ext_converter.js
-
 homeassistant:
   enabled: true
   legacy_action_sensor: true

--- a/zigbee2mqtt/external_converters/parasoll.js
+++ b/zigbee2mqtt/external_converters/parasoll.js
@@ -1,18 +1,15 @@
 /**
- * IKEA PARASOLL (E2013) — patched external converter
+ * IKEA PARASOLL (E2013) — patched external converter for Z2M 2.x
  *
  * Fixes two issues tracked in https://github.com/Koenkk/zigbee2mqtt/issues/22579:
  *  1. Battery drain: genPollCtrl cluster is intentionally excluded; the stock
  *     converter sets aggressive check-in intervals that drain the battery.
- *  2. Dropping off-network / not reporting: explicitly binds the ssIasZone
- *     cluster on endpoint 2, which a regression removed from the built-in
- *     converter, causing the device to stop sending contact state changes.
+ *  2. Dropping off-network: explicitly binds the ssIasZone cluster so the
+ *     device doesn't silently stop sending contact state changes after hours.
  *
- * NOTE: Only imports from modernExtend (not lib/ikea) so this works with
- * Z2M 2.x where the IKEA-specific lib paths changed. OTA is handled by
- * Z2M natively; losing the addCustomClusterManuSpecificIkeaUnknown() call
- * is acceptable — it only affects IKEA-proprietary cluster binding which is
- * not needed for contact + battery reporting.
+ * Placement: /config/zigbee2mqtt/external_converters/parasoll.js
+ * Z2M 2.x scans this folder automatically — no configuration.yaml entry needed.
+ * Z2M symlinks node_modules into this folder so require() works correctly.
  */
 
 const {
@@ -28,8 +25,8 @@ module.exports = {
   vendor: "IKEA of Sweden",
   description: "PARASOLL door/window sensor (patched)",
   extend: [
-    // Explicitly bind ssIasZone on endpoint 1 — the missing binding is the
-    // root cause of sensors silently stopping state reports after a few hours.
+    // Explicitly bind ssIasZone — the missing binding is the root cause of
+    // sensors silently stopping state reports after a few hours.
     bindCluster({ cluster: "ssIasZone", clusterType: "input" }),
     iasZoneAlarm({ zoneType: "contact", zoneAttributes: ["alarm_1"] }),
     identify({ isSleepy: true }),


### PR DESCRIPTION
## Summary

- Move `zigbee2mqtt/ext_converter.js` → `zigbee2mqtt/external_converters/parasoll.js`
- Remove stale `external_converters:` list from `zigbee2mqtt/configuration.yaml`
- Update `.gitignore` to track the new path

Third attempt — this one identifies the actual root cause.

## Root cause

Z2M 2.x changed how external converters are loaded. The `external_converters:` key in `configuration.yaml` was a Z2M 1.x feature. In Z2M 2.x, the [`ExternalJSExtension`](https://github.com/Koenkk/zigbee2mqtt/blob/main/lib/extension/externalJS.ts) class sets `basePath = data.joinPath('external_converters')` and scans that subdirectory automatically — the config key is ignored entirely.

Because the file was sitting in `/config/zigbee2mqtt/ext_converter.js` (the root), Z2M never found it and silently fell back to the native (broken) converter.

## How Z2M 2.x `require()` works for external converters

Z2M detects that the external_converters folder is outside its install dir and creates a `node_modules` symlink inside it pointing to `/app/node_modules`. This makes `require('zigbee-herdsman-converters/...')` work correctly from converter files.

## Test plan

- [ ] Restart Z2M → devices show **"PARASOLL door/window sensor (patched)"**
- [ ] Run `script.parasoll_reconfigure_all` → all 19 sensors reconfigured
- [ ] Open/close window → contact state updates in HA

🤖 Generated with [Claude Code](https://claude.ai/claude-code)