### PR TITLE
Update parasoll_fix.yaml: correct converter path reference

### DIFF
--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -5,14 +5,14 @@
 #   2. Drop off: a regression removed the ssIasZone cluster binding, so the
 #      device stops sending contact-state changes after a few hours.
 #
-# This package pairs with zigbee2mqtt/ext_converter.js.
+# This package pairs with zigbee2mqtt/external_converters/parasoll.js.
+# Z2M 2.x auto-scans the external_converters/ subdirectory — no configuration.yaml
+# entry is needed.
 # Deployment order:
-#   1. Put ext_converter.js in the zigbee2mqtt config directory.
-#   2. Add `external_converters: [ext_converter.js]` to zigbee2mqtt/configuration.yaml
-#      (already done — see the top of that file).
-#   3. Restart Zigbee2MQTT.  Devices should show "PARASOLL door/window sensor (patched)".
-#   4. Run script.parasoll_reconfigure_all from Developer Tools or the UI.
-#   5. For sensors that are fully unresponsive: pull the battery, reinsert, then
+#   1. Ensure zigbee2mqtt/external_converters/parasoll.js is present.
+#   2. Restart Zigbee2MQTT.  Devices should show "PARASOLL door/window sensor (patched)".
+#   3. Run script.parasoll_reconfigure_all from Developer Tools or the UI.
+#   4. For sensors that are fully unresponsive: pull the battery, reinsert, then
 #      the automation below handles them automatically as they re-join.
 
 ################################################################


### PR DESCRIPTION
Fixes stale comments left from the Z2M 2.x location fix (#436). No functional change — updates the deployment instructions to reference `zigbee2mqtt/external_converters/parasoll.js` instead of the old `ext_converter.js` root path.