### PR TITLE
[codex] Decouple owner-suite bathroom wake-up paths

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1711,7 +1711,7 @@ automation:
 
   - alias: enable_owner_suite_bedroom_switch_day_mode_after_morning_activity
     id: enable_owner_suite_bedroom_switch_day_mode_after_morning_activity
-    description: Apply owner suite bedroom switch day mode after 8 AM once bed occupancy clears and both the bathroom and hallway have seen motion.
+    description: Apply owner suite bedroom switch day mode after 8 AM once bed occupancy clears and both the bedroom and bathroom have seen activity.
     trigger:
       - trigger: time
         at: "08:00:00"
@@ -1722,7 +1722,7 @@ automation:
         entity_id: binary_sensor.owner_suite_bathroom_room_occupancy
         to: "on"
       - trigger: state
-        entity_id: binary_sensor.hall_upstairs_motion_occupancy
+        entity_id: binary_sensor.bedroom_occupancy
         to: "on"
     condition:
       - condition: time
@@ -1735,8 +1735,8 @@ automation:
         {{ is_state('binary_sensor.owner_suite_bathroom_room_occupancy', 'on')
            or states.binary_sensor.owner_suite_bathroom_room_occupancy.last_changed >= today_at('08:00') }}
       - >-
-        {{ is_state('binary_sensor.hall_upstairs_motion_occupancy', 'on')
-           or states.binary_sensor.hall_upstairs_motion_occupancy.last_changed >= today_at('08:00') }}
+        {{ is_state('binary_sensor.bedroom_occupancy', 'on')
+           or states.binary_sensor.bedroom_occupancy.last_changed >= today_at('08:00') }}
     action:
       - action: script.turn_on
         target:

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -400,6 +400,9 @@ automation:
               - "sat"
               - "sun"
     action:
+      - variables:
+          bathroom_was_playing: "{{ is_state('media_player.bathroom_sonos_2', 'playing') }}"
+          bathroom_volume_above_min: "{{ state_attr('media_player.bathroom_sonos_2', 'volume_level') | float(0) > 0.1 }}"
       - action: input_boolean.turn_on
         target:
           entity_id: input_boolean.morning_routine
@@ -413,73 +416,42 @@ automation:
             - number.guest_room_fan_switch_ledintensitywhenoff
         data:
           value: 1
-      - alias: "Stop Playback"
-        action: media_player.media_stop
-        target:
-          entity_id:
-            - media_player.bedroom_sonos_2
-            - media_player.bathroom_sonos_2
-            - media_player.office_sonos_2
       - choose:
-          # If we're already playing music, don't turn down the music.
+          # If the bathroom already had audible playback, skip the long fade-in.
           - conditions:
-              - condition: state
-                entity_id: media_player.bathroom_sonos_2
-                state: "playing"
-              - alias: "check volume above minimal"
-                condition: numeric_state
-                entity_id: media_player.bathroom_sonos_2
-                attribute: volume_level
-                above: 0.1
+              - condition: template
+                value_template: "{{ bathroom_was_playing and bathroom_volume_above_min }}"
             sequence:
-              - action: script.turn_on
-                target:
-                  entity_id: script.spotify_wake_up
+              - action: script.spotify_wake_up
                 data:
-                  variables:
-                    playback_entity_id: media_player.bathroom_sonos_2
+                  playback_entity_id: media_player.bathroom_sonos_2
+                  regroup_after_play: false
               - action: media_player.volume_set
+                target:
+                  entity_id: media_player.bathroom_sonos_2
                 data:
-                  entity_id:
-                    - media_player.bedroom_sonos_2
-                    - media_player.bathroom_sonos_2
-                    - media_player.office_sonos_2
                   volume_level: 0.30
         default:
-          # Nothing is playing so ease up the music
+          # Nothing is playing in the bathroom yet, so ease up the music.
           - alias: "Set Volume 0.1"
             action: media_player.volume_set
+            target:
+              entity_id: media_player.bathroom_sonos_2
             data:
               volume_level: 0.1
-            target:
-              entity_id:
-                - media_player.bedroom_sonos_2
-                - media_player.bathroom_sonos_2
-                - media_player.office_sonos_2
-          - action: script.turn_on
-            target:
-              entity_id: script.spotify_wake_up
+          - action: script.spotify_wake_up
             data:
-              variables:
-                playback_entity_id: media_player.bathroom_sonos_2
-          - alias: "Set Volume 0.09 in office"
-            action: media_player.volume_set
-            data:
-              volume_level: 0.2
-            target:
-              entity_id:
-                - media_player.office_sonos_2
+              playback_entity_id: media_player.bathroom_sonos_2
+              regroup_after_play: false
           - alias: "Repeat until desired volume reached"
             repeat:
               sequence:
                 - alias: "Increase Volume by 0.01"
                   action: media_player.volume_set
+                  target:
+                    entity_id: media_player.bathroom_sonos_2
                   data:
                     volume_level: "{{ 0.01 * repeat.index }}"
-                  target:
-                    entity_id:
-                      - media_player.bedroom_sonos_2
-                      - media_player.bathroom_sonos_2
                 - delay:
                     # As time passes, the delay gets smaller and smaller. 60, 30s, 20s, 15s, 12s,..., 2s
                     seconds: "{{ (1/(tan(repeat.index/60))) | round(0, 'ceil', 5)}}"
@@ -1092,19 +1064,42 @@ script:
         description: "Optional delay before playback starts"
       playback_entity_id:
         description: "Preferred Music Assistant player for wake-up playback"
+      regroup_after_play:
+        description: "Whether to regroup the bedroom wake-up zone after playback starts"
     variables:
       playback_player: "{{ playback_entity_id | default('media_player.bedroom_sonos_2') }}"
+      should_regroup_after_play: >-
+        {{ regroup_after_play | default(playback_player == 'media_player.bedroom_sonos_2') | bool }}
     sequence:
-      - action: script.turn_on
-        target:
-          entity_id: script.music_assistant_prepare_bedroom_group
-      - action: media_player.volume_set
-        continue_on_error: true
-        data:
-          entity_id:
-            - media_player.bedroom_sonos_2
-            - media_player.bathroom_sonos_2
-          volume_level: 0.01
+      - if:
+          - condition: template
+            value_template: "{{ should_regroup_after_play }}"
+        then:
+          - action: script.turn_on
+            target:
+              entity_id: script.music_assistant_prepare_bedroom_group
+        else:
+          - action: media_player.unjoin
+            continue_on_error: true
+            data:
+              entity_id: "{{ playback_player }}"
+      - if:
+          - condition: template
+            value_template: "{{ should_regroup_after_play }}"
+        then:
+          - action: media_player.volume_set
+            continue_on_error: true
+            data:
+              entity_id:
+                - media_player.bedroom_sonos_2
+                - media_player.bathroom_sonos_2
+              volume_level: 0.01
+        else:
+          - action: media_player.volume_set
+            continue_on_error: true
+            data:
+              entity_id: "{{ playback_player }}"
+              volume_level: 0.01
       - if:
           - condition: template
             value_template: "{{ (initial_delay | default(0) | int(0)) > 0 }}"
@@ -1119,20 +1114,35 @@ script:
           media_id: "{{ radio_uri }}"
           media_type: radio
           enqueue: replace
-      - action: script.turn_on
-        target:
-          entity_id: script.music_assistant_try_join_bedroom_group_after_play
+      - if:
+          - condition: template
+            value_template: "{{ should_regroup_after_play }}"
+        then:
+          - action: script.turn_on
+            target:
+              entity_id: script.music_assistant_try_join_bedroom_group_after_play
       - repeat:
           sequence:
-            - alias: "Increase Volume by 0.01"
-              continue_on_error: true
-              action: media_player.volume_set
-              data:
-                volume_level: "{{ 0.01 * repeat.index }}"
-              target:
-                entity_id:
-                  - media_player.bedroom_sonos_2
-                  - media_player.bathroom_sonos_2
+            - choose:
+                - conditions:
+                    - condition: template
+                      value_template: "{{ should_regroup_after_play }}"
+                  sequence:
+                    - alias: "Increase grouped wake-up volume by 0.01"
+                      continue_on_error: true
+                      action: media_player.volume_set
+                      data:
+                        entity_id:
+                          - media_player.bedroom_sonos_2
+                          - media_player.bathroom_sonos_2
+                        volume_level: "{{ 0.01 * repeat.index }}"
+              default:
+                - alias: "Increase standalone wake-up volume by 0.01"
+                  continue_on_error: true
+                  action: media_player.volume_set
+                  data:
+                    entity_id: "{{ playback_player }}"
+                    volume_level: "{{ 0.01 * repeat.index }}"
             - delay:
                 seconds: "{{ (1/(tan(repeat.index/120))) | round(0, 'ceil', 5)}}"
           until: "{{ repeat.index == 30 }}"
@@ -1768,8 +1778,12 @@ script:
     fields:
       playback_entity_id:
         description: "Preferred Music Assistant player for wake-up playback"
+      regroup_after_play:
+        description: "Whether to regroup the bedroom wake-up zone after playback starts"
     variables:
       playback_player: "{{ playback_entity_id | default('media_player.bedroom_sonos_2') }}"
+      should_regroup_after_play: >-
+        {{ regroup_after_play | default(playback_player == 'media_player.bedroom_sonos_2') | bool }}
       playlist: >-
         {#
         ## Your Top Songs 2017 : spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW
@@ -1881,9 +1895,18 @@ script:
           {% set pindex =  (range(0, (plists | length - 1 ) )|random) -%}
           {{ plists[pindex] }}
     sequence:
-      - action: script.turn_on
-        target:
-          entity_id: script.music_assistant_prepare_bedroom_group
+      - if:
+          - condition: template
+            value_template: "{{ should_regroup_after_play }}"
+        then:
+          - action: script.turn_on
+            target:
+              entity_id: script.music_assistant_prepare_bedroom_group
+        else:
+          - action: media_player.unjoin
+            continue_on_error: true
+            data:
+              entity_id: "{{ playback_player }}"
       - delay:
           seconds: 2
       - alias: "Pause currently playing media"
@@ -1912,19 +1935,29 @@ script:
       - delay:
           seconds: 2
       - alias: "Set volume low"
-        continue_on_error: true
-        action: media_player.volume_set
-        data:
-          entity_id:
-            - media_player.bedroom_sonos_2
-            - media_player.bathroom_sonos_2
-            - media_player.office_sonos_2
-          volume_level: 0.05
+        if:
+          - condition: template
+            value_template: "{{ should_regroup_after_play }}"
+        then:
+          - continue_on_error: true
+            action: media_player.volume_set
+            data:
+              entity_id:
+                - media_player.bedroom_sonos_2
+                - media_player.bathroom_sonos_2
+                - media_player.office_sonos_2
+              volume_level: 0.05
+        else:
+          - continue_on_error: true
+            action: media_player.volume_set
+            data:
+              entity_id: "{{ playback_player }}"
+              volume_level: 0.05
       - delay:
           seconds: 2
       - action: logbook.log
         data:
-          entity_id: media_player.bedroom_sonos_2
+          entity_id: "{{ playback_player }}"
           domain: media_player
           name: Spotify Wake Up is
           message: " playing wakeup playlist: {{ playlist }}"
@@ -1933,9 +1966,13 @@ script:
         data:
           entity_id: "{{ playback_player }}"
           spotify_uri: "{{ playlist }}"
-      - action: script.turn_on
-        target:
-          entity_id: script.music_assistant_try_join_bedroom_group_after_play
+      - if:
+          - condition: template
+            value_template: "{{ should_regroup_after_play }}"
+        then:
+          - action: script.turn_on
+            target:
+              entity_id: script.music_assistant_try_join_bedroom_group_after_play
 
 ########################
 # Sensor

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -310,7 +310,7 @@ automation:
     alias: workday_owner_suite_wake_transition_from_morning_activity
     description: >
       Start the owner suite workday wake transition when bed occupancy clears
-      and both the bathroom and upstairs hall show fresh wake-up activity.
+      and both the bedroom and bathroom show fresh wake-up activity.
     mode: single
     trigger:
       - trigger: state
@@ -320,7 +320,7 @@ automation:
         entity_id: binary_sensor.owner_suite_bathroom_room_occupancy
         to: "on"
       - trigger: state
-        entity_id: binary_sensor.hall_upstairs_motion_occupancy
+        entity_id: binary_sensor.bedroom_occupancy
         to: "on"
     condition:
       - condition: time
@@ -356,8 +356,8 @@ automation:
              or as_timestamp(now()) - as_timestamp(states.binary_sensor.owner_suite_bathroom_room_occupancy.last_changed) <= 900 }}
       - condition: template
         value_template: >-
-          {{ is_state('binary_sensor.hall_upstairs_motion_occupancy', 'on')
-             or as_timestamp(now()) - as_timestamp(states.binary_sensor.hall_upstairs_motion_occupancy.last_changed) <= 900 }}
+          {{ is_state('binary_sensor.bedroom_occupancy', 'on')
+             or as_timestamp(now()) - as_timestamp(states.binary_sensor.bedroom_occupancy.last_changed) <= 900 }}
     action:
       - action: script.turn_on
         target:

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2854,8 +2854,8 @@ script:
             or states.binary_sensor.owner_suite_bathroom_room_occupancy.last_changed >= today_at('08:00')
           )
           and (
-            is_state('binary_sensor.hall_upstairs_motion_occupancy', 'on')
-            or states.binary_sensor.hall_upstairs_motion_occupancy.last_changed >= today_at('08:00')
+            is_state('binary_sensor.bedroom_occupancy', 'on')
+            or states.binary_sensor.bedroom_occupancy.last_changed >= today_at('08:00')
           )
         }}
     sequence:

--- a/specs/alarm_wakeup.allium
+++ b/specs/alarm_wakeup.allium
@@ -46,7 +46,7 @@ external entity WakeupContext {
     within_weekend_bathroom_window: Boolean
     owner_suite_lamps_on: Boolean
     owner_suite_recent_bathroom_activity: Boolean
-    owner_suite_recent_hall_activity: Boolean
+    owner_suite_recent_bedroom_activity: Boolean
 }
 
 ------------------------------------------------------------
@@ -178,7 +178,7 @@ rule TriggerSpecialMeetingWakeup {
 rule TriggerWorkdayOwnerSuiteWakeTransitionFromMorningActivity {
     when: context.resident_in_bed becomes false
     or context.bathroom_occupied becomes true
-    or context.owner_suite_recent_hall_activity becomes true
+    or context.owner_suite_recent_bedroom_activity becomes true
     requires: calendar.today_is_workday
     requires: context.within_workday_owner_suite_wake_window
     requires: context.resident_home
@@ -188,7 +188,7 @@ rule TriggerWorkdayOwnerSuiteWakeTransitionFromMorningActivity {
     requires: not context.owner_suite_lamps_on
     requires: not context.resident_in_bed
     requires: context.owner_suite_recent_bathroom_activity
-    requires: context.owner_suite_recent_hall_activity
+    requires: context.owner_suite_recent_bedroom_activity
     ensures: WakeupSequenceRequested(workday_morning_activity)
 }
 
@@ -228,10 +228,17 @@ rule OpenBlindsDuringWakeupTransition {
 rule PrepareMorningAudioGroup {
     when: MorningAudioRequested(program, target_room)
     ensures:
-        if context.guest_mode_enabled:
-            WakeupAudioGroupPrepared(bedroom_and_bathroom)
+        if target_room == bathroom:
+            WakeupAudioGroupPrepared(bathroom_only)
         else:
-            WakeupAudioGroupPrepared(bedroom_bathroom_office_den)
+            if context.guest_mode_enabled:
+                WakeupAudioGroupPrepared(bedroom_and_bathroom)
+            else:
+                WakeupAudioGroupPrepared(bedroom_bathroom_office_den)
+    @guidance
+        -- Bathroom-triggered follow-up audio should stay independent from the
+        -- owner-suite light ramp and should not depend on regrouping the wider
+        -- bedroom wake-up audio zone.
 }
 
 rule ChooseWakeupPlaylistFromConfiguredPool {

--- a/tests/test_inovelli_day_mode_switches.py
+++ b/tests/test_inovelli_day_mode_switches.py
@@ -114,13 +114,13 @@ def test_guest_mode_keeps_office_and_guest_room_switches_delayed_until_noon() ->
     assert "script.day_mode_switches_office_guest_room" in block
 
 
-def test_owner_suite_bedroom_day_mode_waits_for_bed_bathroom_and_hallway_activity() -> None:
+def test_owner_suite_bedroom_day_mode_waits_for_bed_bedroom_and_bathroom_activity() -> None:
     block = _automation_block(LIGHT_PATH, "enable_owner_suite_bedroom_switch_day_mode_after_morning_activity")
 
     for entity_id in (
         "binary_sensor.bayesian_bed_occupancy",
+        "binary_sensor.bedroom_occupancy",
         "binary_sensor.owner_suite_bathroom_room_occupancy",
-        "binary_sensor.hall_upstairs_motion_occupancy",
     ):
         assert entity_id in block
 

--- a/tests/test_issue_trip_led_suspend.py
+++ b/tests/test_issue_trip_led_suspend.py
@@ -95,8 +95,8 @@ def test_trip_restore_script_reuses_existing_day_and_night_profiles() -> None:
         "is_state('input_boolean.guest_mode', 'off')",
         "today_at('12:00')",
         "binary_sensor.bayesian_bed_occupancy",
+        "binary_sensor.bedroom_occupancy",
         "binary_sensor.owner_suite_bathroom_room_occupancy",
-        "binary_sensor.hall_upstairs_motion_occupancy",
         "today_at('08:00')",
     ):
         assert token in block

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -195,8 +195,11 @@ def test_radio_wakeup_join_retry_runs_after_playback_starts() -> None:
     block = _script_block("music_assistant_radio_wake_up")
 
     assert 'playback_entity_id:' in block
+    assert 'regroup_after_play:' in block
     assert 'playback_player' in block
+    assert 'should_regroup_after_play' in block
     assert 'action: script.music_assistant_prepare_bedroom_group' not in block
+    assert 'action: media_player.unjoin' in block
     assert 'action: script.turn_on' in block
     assert 'entity_id: script.music_assistant_prepare_bedroom_group' in block
     assert 'entity_id: "{{ playback_player }}"' in block
@@ -210,8 +213,11 @@ def test_spotify_wakeup_join_retry_runs_after_playback_starts() -> None:
     block = _script_block("spotify_wake_up")
 
     assert 'playback_entity_id:' in block
+    assert 'regroup_after_play:' in block
     assert 'playback_player' in block
+    assert 'should_regroup_after_play' in block
     assert 'action: script.music_assistant_prepare_bedroom_group' not in block
+    assert 'action: media_player.unjoin' in block
     assert 'action: script.turn_on' in block
     assert 'entity_id: script.music_assistant_prepare_bedroom_group' in block
     assert 'entity_id: "{{ playback_player }}"' in block
@@ -224,8 +230,10 @@ def test_spotify_wakeup_join_retry_runs_after_playback_starts() -> None:
 def test_bathroom_wakeup_automation_targets_bathroom_player() -> None:
     block = _automation_block("play_music_in_bathroom_when_up")
 
-    assert 'entity_id: script.spotify_wake_up' in block
+    assert 'action: script.spotify_wake_up' in block
     assert block.count('playback_entity_id: media_player.bathroom_sonos_2') == 2
+    assert block.count('regroup_after_play: false') == 2
+    assert 'media_player.media_stop' not in block
 
 
 def test_stuck_morning_audio_scripts_are_recovered() -> None:

--- a/tests/test_owner_suite_blinds_automation.py
+++ b/tests/test_owner_suite_blinds_automation.py
@@ -101,13 +101,13 @@ def test_workday_morning_activity_can_start_owner_suite_wake_transition() -> Non
         "binary_sensor.bayesian_zeke_home",
         "binary_sensor.planned_vacation_calendar",
         "binary_sensor.bayesian_bed_occupancy",
+        "binary_sensor.bedroom_occupancy",
         "binary_sensor.owner_suite_bathroom_room_occupancy",
-        "binary_sensor.hall_upstairs_motion_occupancy",
         "input_boolean.wakeup_alarm_firing",
         "light.owner_suite_lamps",
         "script.owner_suite_morning_transition",
+        "as_timestamp(now()) - as_timestamp(states.binary_sensor.bedroom_occupancy.last_changed) <= 900",
         "as_timestamp(now()) - as_timestamp(states.binary_sensor.owner_suite_bathroom_room_occupancy.last_changed) <= 900",
-        "as_timestamp(now()) - as_timestamp(states.binary_sensor.hall_upstairs_motion_occupancy.last_changed) <= 900",
     ):
         assert token in block
 


### PR DESCRIPTION
## Summary
Decouple the owner-suite bathroom wake-up flows so bathroom-triggered music stays reliable on its own speaker and the owner-suite light ramp depends only on owner-suite bedroom/bathroom activity.

## Why
On April 13, 2026, entering the owner-suite bathroom stopped the existing bedroom/office playback, briefly started replacement bathroom wake-up music, and then left the room silent. The owner-suite light ramp also never started because the wake-transition automation still depended on upstairs hallway motion and on the owner-suite lamps remaining off.

## What Changed
- removed upstairs hallway motion from the owner-suite morning wake-transition and day-mode readiness logic
- replaced that dependency with owner-suite bedroom occupancy freshness alongside owner-suite bathroom activity
- made bathroom-triggered wake-up audio independent from the owner-suite light-ramp path
- let the wake-up scripts skip bedroom regroup-after-play when playback is intentionally targeted at the bathroom speaker
- updated `specs/alarm_wakeup.allium` so the wake-up boundary stays owner-suite-local and the bathroom audio path stays decoupled from the light ramp
- updated regression coverage for the YAML/spec expectations

## Root Cause
Two independent wake-up paths had become coupled:

1. the light transition logic required hallway motion outside the owner suite
2. the bathroom wake-up audio path always rejoined the wider bedroom group after playback started, which could immediately tear down standalone bathroom playback

## Validation
- `uv run --with pytest pytest`
- result: `274 passed`

## Tracking
- Fixes #438
- Context added to #392 documenting that wake-up behavior should not intertwine other-room lighting/motion such as the hallway with owner-suite waking semantics.