### PR TITLE
[codex] Disable AppDaemon bed side predictor

### DIFF
--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -16,21 +16,23 @@ auto_fan_speed_owner_suite:
     turn_off_at_end_time: True
   debug: true
 
-bed_side_predictor:
-  module: bed_side_predictor
-  class: BedSidePredictor
-  east_sensor: sensor.east_bed_occupied_num
-  west_sensor: sensor.west_bed_occupied_num
-  presence_sensor: person.ryan
-  guest_mode: input_boolean.guest_mode
-  train_hour: 16
-  update_every_minutes: 60
-  lookback_days: 56
-  min_dwell_minutes: 5
-  min_positive_minutes: 300
-  min_negative_minutes: 600
-  timezone: America/Chicago
-  debug: true
+# Disabled because it pulls in scikit-learn, which currently prevents the
+# AppDaemon add-on from bootstrapping on Alpine without a working toolchain.
+# bed_side_predictor:
+#   module: bed_side_predictor
+#   class: BedSidePredictor
+#   east_sensor: sensor.east_bed_occupied_num
+#   west_sensor: sensor.west_bed_occupied_num
+#   presence_sensor: person.ryan
+#   guest_mode: input_boolean.guest_mode
+#   train_hour: 16
+#   update_every_minutes: 60
+#   lookback_days: 56
+#   min_dwell_minutes: 5
+#   min_positive_minutes: 300
+#   min_negative_minutes: 600
+#   timezone: America/Chicago
+#   debug: true
 
 # bed_fusion_detector:
 #   module: bed_fusion


### PR DESCRIPTION
## Summary
- disable the `bed_side_predictor` AppDaemon app entry
- document that it is disabled because it pulls in `scikit-learn`
- keep the AppDaemon app registry aligned with the runtime decision to stop using this predictor

## Why
AppDaemon was failing to start after Alpine system-package conflicts were removed because `pip` fell back to building `scikit-learn` from source on musl/Python 3.12. The enabled `bed_side_predictor` app was the active AppDaemon dependency requiring `scikit-learn`, so disabling it removes the startup blocker without affecting active automation paths.

## Validation
- `uv run --with pytest pytest`
