### PR TITLE
[codex] Preserve outside lights during overnight shutdown and TV playback

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -2492,11 +2492,37 @@ script:
     variables:
       protected_lights: >-
         {% set excluded = exclude_lights | default([], true) | list %}
+        {% set opaque_group_members = {
+          'light.outside_front_lights': [
+            'light.outside_front_hue',
+            'light.outside_north_west_garage',
+            'light.outside_south_west_garage',
+            'light.outside_front_door'
+          ],
+          'light.deck_all': [
+            'light.deck_kitchen_door_light',
+            'light.deck_tiki_room_door',
+            'light.deck_flood_lights',
+            'light.deck_string',
+            'light.deck_kitchen_door',
+            'light.deck_hue'
+          ]
+        } %}
         {% set ns = namespace(entities=excluded) %}
         {% for light in states.light %}
-          {% set members = state_attr(light.entity_id, 'entity_id') %}
-          {% if members is iterable and members is not string and (members | select('in', excluded) | list | count > 0) %}
-            {% set ns.entities = ns.entities + [light.entity_id] %}
+          {# Zigbee2MQTT aggregate lights such as light.outside_front_lights do
+             not expose member lists via state attributes, so keep a small
+             explicit fallback map for the opaque groups we preserve overnight. #}
+          {% set runtime_members = state_attr(light.entity_id, 'entity_id') %}
+          {% if runtime_members is iterable and runtime_members is not string %}
+            {% set members = runtime_members | list %}
+          {% elif light.entity_id in opaque_group_members %}
+            {% set members = opaque_group_members[light.entity_id] %}
+          {% else %}
+            {% set members = [] %}
+          {% endif %}
+          {% if light.entity_id in excluded or (members | select('in', excluded) | list | count > 0) %}
+            {% set ns.entities = ns.entities + [light.entity_id] + members %}
           {% endif %}
         {% endfor %}
         {{ ns.entities | unique | list }}

--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -337,10 +337,8 @@ automation:
         continue_on_error: true
         data:
           exclude_lights:
-            - light.outside_front_hue
-            - light.outside_north_west_garage
-            - light.outside_south_west_garage
-            - light.outside_front_door
+            - light.outside_front_lights
+            - light.deck_all
             - light.basement_tv_bias
           transition: 15
       - action: script.turn_on

--- a/specs/night_routines.allium
+++ b/specs/night_routines.allium
@@ -48,6 +48,7 @@ entity BedtimeEnvironment {
 
 entity HouseSleepSafety {
     common_area_lights_off: Boolean
+    overnight_exterior_lighting_preserved: Boolean
     preserved_guest_lighting: none | dedicated_guest_room | all_guest_capable_rooms
     preserved_guest_fans: none | dedicated_guest_room | office_and_guest_room
     decorative_lamps_off: Boolean
@@ -106,10 +107,12 @@ rule EnterInBedHouseMode {
     when: ResidentSettledInBed()
     requires: house_mode.mode = night
     ensures: house_mode.mode = in_bed
+    ensures: house.overnight_exterior_lighting_preserved = true
     @guidance
         -- The live implementation derives this from sustained owner-suite bed
         -- occupancy, then turns off unrelated house lights while preserving
-        -- the bedside lights and overnight exterior lighting.
+        -- the bedside lights and overnight exterior lighting until the
+        -- dedicated sunrise schedule takes over.
 }
 
 rule ScheduleBedtimeAudioRampdown {
@@ -147,6 +150,7 @@ rule ApplyGoodnightIntegrity {
     let guest_context_enabled = night.guest_mode_enabled or night.guest_room_occupied
     ensures: house_mode.mode = asleep
     ensures: house.common_area_lights_off = true
+    ensures: house.overnight_exterior_lighting_preserved = true
     ensures:
         if night.guest_mode_enabled:
             house.preserved_guest_lighting = all_guest_capable_rooms

--- a/tests/test_allium_specs.py
+++ b/tests/test_allium_specs.py
@@ -23,9 +23,11 @@ def test_behavioral_allium_specs_exist_and_are_versioned() -> None:
         "night_routines.allium": [
             "-- allium: 3",
             "entity HouseModeStateMachine",
+            "overnight_exterior_lighting_preserved: Boolean",
             "rule StartBedtimePreparation",
             "rule ScheduleBedtimeAudioRampdown",
             "rule EnterInBedHouseMode",
+            "ensures: house.overnight_exterior_lighting_preserved = true",
             "rule ChooseBedtimeAudioFromConfiguredPool",
             "rule TriggerGoodnightFromCPAPSleep",
             "rule EnterAsleepHouseModeFromBedsideShutdown",

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -202,5 +202,11 @@ def test_lights_off_except_skips_light_groups_that_contain_protected_members() -
 
     assert "protected_lights:" in block
     assert "state_attr(light.entity_id, 'entity_id')" in block
+    assert "opaque_group_members" in block
+    assert "'light.outside_front_lights': [" in block
+    assert "'light.outside_front_door'" in block
+    assert "'light.deck_all': [" in block
+    assert "'light.deck_string'" in block
+    assert "light.entity_id in excluded or (members | select('in', excluded)" in block
     assert "members | select('in', excluded)" in block
     assert "rejectattr('entity_id', 'in', protected_lights)" in block

--- a/tests/test_tv_package.py
+++ b/tests/test_tv_package.py
@@ -53,6 +53,28 @@ def _script_block(script_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
+def _automation_block(automation_id: str) -> str:
+    lines = TV_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line != f"  - id: {automation_id}":
+            continue
+        start = index
+        break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation id {automation_id!r} in {TV_PATH.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - id: "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
 def test_all_watch_scripts_are_exposed_to_siri_and_voice_integrations() -> None:
     package = TV_PATH.read_text(encoding="utf-8")
     watch_scripts = set(re.findall(r"^  (watch_[a-z0-9_]+):$", package, flags=re.MULTILINE))
@@ -86,3 +108,17 @@ def test_watch_f1_script_uses_basement_apple_tv_path() -> None:
     else:
         assert 'source: "HDMI 3"' in f1_block
         assert "action: script.wait_for_basement_media_player_ready" in f1_block
+
+
+def test_tv_resumed_preserves_outside_groups_when_playback_starts() -> None:
+    block = _automation_block("tv_resumed")
+
+    for token in (
+        "action: script.lights_off_except",
+        "light.outside_front_lights",
+        "light.deck_all",
+        "light.basement_tv_bias",
+        'after: "19:30:00"',
+        'before: "23:59:00"',
+    ):
+        assert token in block


### PR DESCRIPTION
## Summary
- preserve exterior light groups when bedtime and TV playback automations call `script.lights_off_except`
- harden `lights_off_except` for Zigbee2MQTT aggregate lights that do not expose runtime member lists
- make the overnight exterior-light preservation explicit in the night routines Allium spec and extend regression coverage

## Root Cause
`script.lights_off_except` excluded the individual exterior lights, but it could still turn them off indirectly through opaque aggregate lights like `light.outside_front_lights`. Sunday night traces showed `automation.in_bed_turn_off_other_lights` calling `script.lights_off_except`, which then shut off the outside group at 11:39 PM CDT.

## Impact
- outside front and deck lights stay preserved during bedtime shutdown flows
- outside lights also stay preserved when basement TV playback starts at night
- regression coverage now protects the group-preservation behavior

## Validation
- `uv run --with pytest pytest`
- `allium check specs/night_routines.allium` (`0 error(s)`, existing external-entity warning only)

## Coverage
- added/updated regression tests in `tests/test_runtime_log_regressions.py`
- added TV automation coverage in `tests/test_tv_package.py`
- updated spec smoke coverage in `tests/test_allium_specs.py`

Fixes #434