### PR TITLE
[codex] Prevent arrival music from stopping after regroup

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -758,16 +758,6 @@ script:
               group_members:
                 - media_player.bathroom_sonos_2
 
-  music_assistant_try_join_arrival_group_after_play:
-    alias: "Try joining arrival Music Assistant followers after playback"
-    mode: restart
-    sequence:
-      - delay:
-          seconds: 2
-      - action: script.turn_on
-        target:
-          entity_id: script.music_assistant_prepare_arrival_group
-
   music_assistant_prepare_house_party_group:
     alias: "Prepare house party Music Assistant group"
     sequence:
@@ -1527,9 +1517,6 @@ script:
         data:
           entity_id: "{{ playback_entity }}"
           spotify_uri: "{{ playlist }}"
-      - action: script.turn_on
-        target:
-          entity_id: script.music_assistant_try_join_arrival_group_after_play
       - action: logbook.log
         data:
           entity_id: "{{ playback_entity }}"

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -163,18 +163,12 @@ def test_arrival_group_helper_resets_players_before_regrouping() -> None:
         assert media_player in block
 
 
-def test_arrival_join_retry_runs_after_playback_starts() -> None:
-    helper_block = _script_block("music_assistant_try_join_arrival_group_after_play")
+def test_arrival_music_does_not_retry_regroup_after_playback_starts() -> None:
     arrival_block = _script_block("spotify_arrival")
 
-    assert 'mode: restart' in helper_block
-    assert 'seconds: 2' in helper_block
-    assert 'action: script.turn_on' in helper_block
-    assert 'entity_id: script.music_assistant_prepare_arrival_group' in helper_block
-    assert 'entity_id: script.music_assistant_try_join_arrival_group_after_play' in arrival_block
-    assert arrival_block.index('action: script.music_assistant_play_spotify_uri') < arrival_block.index(
-        'entity_id: script.music_assistant_try_join_arrival_group_after_play'
-    )
+    assert 'action: script.music_assistant_prepare_arrival_group' in arrival_block
+    assert 'action: script.music_assistant_play_spotify_uri' in arrival_block
+    assert 'entity_id: script.music_assistant_try_join_arrival_group_after_play' not in arrival_block
 
 
 def test_bedtime_join_retry_runs_after_playback_starts() -> None:


### PR DESCRIPTION
## Summary
- remove the arrival-only post-play regroup that was interrupting already-started Music Assistant playback
- keep the pre-play arrival group preparation intact
- update the regression test to require that arrival playback no longer retries regroup after start

Fixes #444.
Related to #438 and merged PR #439, which addressed the same regroup-after-start failure mode for bathroom wake-up playback.

## Tests
- `uv run --with pytest pytest`

## Coverage
- `tests/test_media_player_music_assistant.py::test_arrival_music_does_not_retry_regroup_after_playback_starts`
