### PR TITLE
[codex] Stop alarm wake-up audio from being interrupted by regroup retry

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1064,16 +1064,20 @@ script:
         description: "Optional delay before playback starts"
       playback_entity_id:
         description: "Preferred Music Assistant player for wake-up playback"
+      prepare_group_before_play:
+        description: "Whether to prepare the bedroom wake-up zone before playback starts"
       regroup_after_play:
         description: "Whether to regroup the bedroom wake-up zone after playback starts"
     variables:
       playback_player: "{{ playback_entity_id | default('media_player.bedroom_sonos_2') }}"
+      should_prepare_group_before_play: >-
+        {{ prepare_group_before_play | default(playback_player == 'media_player.bedroom_sonos_2') | bool }}
       should_regroup_after_play: >-
-        {{ regroup_after_play | default(playback_player == 'media_player.bedroom_sonos_2') | bool }}
+        {{ regroup_after_play | default(false) | bool }}
     sequence:
       - if:
           - condition: template
-            value_template: "{{ should_regroup_after_play }}"
+            value_template: "{{ should_prepare_group_before_play }}"
         then:
           - action: script.turn_on
             target:
@@ -1085,7 +1089,7 @@ script:
               entity_id: "{{ playback_player }}"
       - if:
           - condition: template
-            value_template: "{{ should_regroup_after_play }}"
+            value_template: "{{ should_prepare_group_before_play }}"
         then:
           - action: media_player.volume_set
             continue_on_error: true
@@ -1126,7 +1130,7 @@ script:
             - choose:
                 - conditions:
                     - condition: template
-                      value_template: "{{ should_regroup_after_play }}"
+                      value_template: "{{ should_prepare_group_before_play }}"
                   sequence:
                     - alias: "Increase grouped wake-up volume by 0.01"
                       continue_on_error: true
@@ -1778,12 +1782,16 @@ script:
     fields:
       playback_entity_id:
         description: "Preferred Music Assistant player for wake-up playback"
+      prepare_group_before_play:
+        description: "Whether to prepare the bedroom wake-up zone before playback starts"
       regroup_after_play:
         description: "Whether to regroup the bedroom wake-up zone after playback starts"
     variables:
       playback_player: "{{ playback_entity_id | default('media_player.bedroom_sonos_2') }}"
+      should_prepare_group_before_play: >-
+        {{ prepare_group_before_play | default(playback_player == 'media_player.bedroom_sonos_2') | bool }}
       should_regroup_after_play: >-
-        {{ regroup_after_play | default(playback_player == 'media_player.bedroom_sonos_2') | bool }}
+        {{ regroup_after_play | default(false) | bool }}
       playlist: >-
         {#
         ## Your Top Songs 2017 : spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW
@@ -1897,7 +1905,7 @@ script:
     sequence:
       - if:
           - condition: template
-            value_template: "{{ should_regroup_after_play }}"
+            value_template: "{{ should_prepare_group_before_play }}"
         then:
           - action: script.turn_on
             target:
@@ -1937,7 +1945,7 @@ script:
       - alias: "Set volume low"
         if:
           - condition: template
-            value_template: "{{ should_regroup_after_play }}"
+            value_template: "{{ should_prepare_group_before_play }}"
         then:
           - continue_on_error: true
             action: media_player.volume_set

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1079,9 +1079,7 @@ script:
           - condition: template
             value_template: "{{ should_prepare_group_before_play }}"
         then:
-          - action: script.turn_on
-            target:
-              entity_id: script.music_assistant_prepare_bedroom_group
+          - action: script.music_assistant_prepare_bedroom_group
         else:
           - action: media_player.unjoin
             continue_on_error: true
@@ -1907,9 +1905,7 @@ script:
           - condition: template
             value_template: "{{ should_prepare_group_before_play }}"
         then:
-          - action: script.turn_on
-            target:
-              entity_id: script.music_assistant_prepare_bedroom_group
+          - action: script.music_assistant_prepare_bedroom_group
         else:
           - action: media_player.unjoin
             continue_on_error: true

--- a/specs/alarm_wakeup.allium
+++ b/specs/alarm_wakeup.allium
@@ -236,6 +236,9 @@ rule PrepareMorningAudioGroup {
             else:
                 WakeupAudioGroupPrepared(bedroom_bathroom_office_den)
     @guidance
+        -- Bedroom-suite wake-up audio should prepare its intended speaker group
+        -- before playback begins and should not trigger a second regroup once
+        -- playback is already underway unless an explicit recovery path needs it.
         -- Bathroom-triggered follow-up audio should stay independent from the
         -- owner-suite light ramp and should not depend on regrouping the wider
         -- bedroom wake-up audio zone.

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -200,12 +200,10 @@ def test_radio_wakeup_prepares_group_before_play_and_only_retries_regroup_when_r
     assert 'playback_player' in block
     assert 'should_prepare_group_before_play' in block
     assert 'should_regroup_after_play' in block
-    assert 'action: script.music_assistant_prepare_bedroom_group' not in block
     assert 'action: media_player.unjoin' in block
-    assert 'action: script.turn_on' in block
+    assert 'action: script.music_assistant_prepare_bedroom_group' in block
     assert "{{ prepare_group_before_play | default(playback_player == 'media_player.bedroom_sonos_2') | bool }}" in block
     assert "{{ regroup_after_play | default(false) | bool }}" in block
-    assert 'entity_id: script.music_assistant_prepare_bedroom_group' in block
     assert 'entity_id: "{{ playback_player }}"' in block
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in block
     assert block.index('action: music_assistant.play_media') < block.index(
@@ -222,12 +220,10 @@ def test_spotify_wakeup_prepares_group_before_play_and_only_retries_regroup_when
     assert 'playback_player' in block
     assert 'should_prepare_group_before_play' in block
     assert 'should_regroup_after_play' in block
-    assert 'action: script.music_assistant_prepare_bedroom_group' not in block
     assert 'action: media_player.unjoin' in block
-    assert 'action: script.turn_on' in block
+    assert 'action: script.music_assistant_prepare_bedroom_group' in block
     assert "{{ prepare_group_before_play | default(playback_player == 'media_player.bedroom_sonos_2') | bool }}" in block
     assert "{{ regroup_after_play | default(false) | bool }}" in block
-    assert 'entity_id: script.music_assistant_prepare_bedroom_group' in block
     assert 'entity_id: "{{ playback_player }}"' in block
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in block
     assert block.index('action: script.music_assistant_play_spotify_uri') < block.index(

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -191,16 +191,20 @@ def test_bedtime_join_retry_runs_after_playback_starts() -> None:
     )
 
 
-def test_radio_wakeup_join_retry_runs_after_playback_starts() -> None:
+def test_radio_wakeup_prepares_group_before_play_and_only_retries_regroup_when_requested() -> None:
     block = _script_block("music_assistant_radio_wake_up")
 
     assert 'playback_entity_id:' in block
+    assert 'prepare_group_before_play:' in block
     assert 'regroup_after_play:' in block
     assert 'playback_player' in block
+    assert 'should_prepare_group_before_play' in block
     assert 'should_regroup_after_play' in block
     assert 'action: script.music_assistant_prepare_bedroom_group' not in block
     assert 'action: media_player.unjoin' in block
     assert 'action: script.turn_on' in block
+    assert "{{ prepare_group_before_play | default(playback_player == 'media_player.bedroom_sonos_2') | bool }}" in block
+    assert "{{ regroup_after_play | default(false) | bool }}" in block
     assert 'entity_id: script.music_assistant_prepare_bedroom_group' in block
     assert 'entity_id: "{{ playback_player }}"' in block
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in block
@@ -209,16 +213,20 @@ def test_radio_wakeup_join_retry_runs_after_playback_starts() -> None:
     )
 
 
-def test_spotify_wakeup_join_retry_runs_after_playback_starts() -> None:
+def test_spotify_wakeup_prepares_group_before_play_and_only_retries_regroup_when_requested() -> None:
     block = _script_block("spotify_wake_up")
 
     assert 'playback_entity_id:' in block
+    assert 'prepare_group_before_play:' in block
     assert 'regroup_after_play:' in block
     assert 'playback_player' in block
+    assert 'should_prepare_group_before_play' in block
     assert 'should_regroup_after_play' in block
     assert 'action: script.music_assistant_prepare_bedroom_group' not in block
     assert 'action: media_player.unjoin' in block
     assert 'action: script.turn_on' in block
+    assert "{{ prepare_group_before_play | default(playback_player == 'media_player.bedroom_sonos_2') | bool }}" in block
+    assert "{{ regroup_after_play | default(false) | bool }}" in block
     assert 'entity_id: script.music_assistant_prepare_bedroom_group' in block
     assert 'entity_id: "{{ playback_player }}"' in block
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' in block


### PR DESCRIPTION
## Summary
- separate pre-play wake-up grouping from the delayed post-play regroup retry in the morning audio helpers
- keep bedroom-suite alarm audio grouped before playback starts while making the retry regroup opt-in instead of the default
- align the alarm wake-up spec and regression tests with the new behavior

Fixes #446.
Related to #438, #444, #439, and #445.

## Tests
- `uv run --with pytest pytest tests/test_media_player_music_assistant.py tests/test_alarm_night_allium_alignment.py`
- `uv run --with pytest pytest`

## Coverage
- `packages/media_player.yaml`
- `specs/alarm_wakeup.allium`
- `tests/test_media_player_music_assistant.py`
