### PR TITLE
[codex] Replay hall transition LED policy after recovery

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2579,6 +2579,35 @@ script:
                 target:
                   entity_id: script.day_mode_switches_owner_suite_bedroom
 
+  replay_hall_transition_inovelli_led_policy_on_recovery:
+    icon: mdi:light-switch
+    description: >
+      Reapply the current Inovelli LED policy after the hall transition switch
+      recovers from unavailable so a missed write gets replayed once Zigbee2MQTT
+      is back.
+    mode: single
+    trigger:
+      - trigger: state
+        entity_id:
+          - number.hall_transition_switch_ledcolorwhenoff
+          - number.hall_transition_switch_ledcolorwhenon
+          - number.hall_transition_switch_ledintensitywhenoff
+          - number.hall_transition_switch_ledintensitywhenon
+        from: "unavailable"
+    condition:
+      condition: or
+      conditions:
+        - condition: state
+          entity_id: switch.sleep_mode
+          state: "on"
+        - condition: state
+          entity_id: sun.sun
+          state: "below_horizon"
+    action:
+      - action: script.turn_on
+        target:
+          entity_id: script.restore_inovelli_switch_leds_from_trip
+
   turn_off_owner_suite_inovelli_switch_leds:
     icon: mdi:light-switch
     sequence:

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -493,6 +493,30 @@ homeassistant:
 ## Automation
 ################################################
 automation:
+  - alias: replay_inovelli_led_policy_on_recovery
+    id: replay_inovelli_led_policy_on_recovery
+    mode: restart
+    trigger:
+      - trigger: event
+        event_type: state_changed
+    condition:
+      - condition: template
+        value_template: >-
+          {% set entity_id = trigger.event.data.entity_id | default('') %}
+          {% set from_state = trigger.event.data.old_state %}
+          {% set to_state = trigger.event.data.new_state %}
+          {{
+            entity_id is match('^number\\..*_led(?:color|intensity)when(?:on|off)$')
+            and from_state is not none
+            and from_state.state == 'unavailable'
+            and to_state is not none
+            and to_state.state not in ['unavailable', 'unknown']
+          }}
+    action:
+      - action: script.turn_on
+        target:
+          entity_id: script.replay_inovelli_led_policy_after_recovery
+
   - alias: basement_bathroom_switch_actions
     id: basement_bathroom_switch_actions
     trigger:
@@ -2579,34 +2603,39 @@ script:
                 target:
                   entity_id: script.day_mode_switches_owner_suite_bedroom
 
-  replay_hall_transition_inovelli_led_policy_on_recovery:
+  replay_inovelli_led_policy_after_recovery:
     icon: mdi:light-switch
     description: >
-      Reapply the current Inovelli LED policy after the hall transition switch
-      recovers from unavailable so a missed write gets replayed once Zigbee2MQTT
-      is back.
-    mode: single
-    trigger:
-      - trigger: state
-        entity_id:
-          - number.hall_transition_switch_ledcolorwhenoff
-          - number.hall_transition_switch_ledcolorwhenon
-          - number.hall_transition_switch_ledintensitywhenoff
-          - number.hall_transition_switch_ledintensitywhenon
-        from: "unavailable"
-    condition:
-      condition: or
-      conditions:
-        - condition: state
-          entity_id: switch.sleep_mode
-          state: "on"
-        - condition: state
-          entity_id: sun.sun
-          state: "below_horizon"
-    action:
-      - action: script.turn_on
-        target:
-          entity_id: script.restore_inovelli_switch_leds_from_trip
+      Reapply the current Inovelli LED policy after any LED number entity
+      recovers from unavailable so missed Zigbee2MQTT writes are replayed.
+    mode: queued
+    variables:
+      owner_suite_leds_should_be_dark: >-
+        {{
+          (now() >= today_at('22:00') or now() < today_at('06:00'))
+          and (
+            is_state('binary_sensor.bayesian_bed_occupancy', 'on')
+            or is_state('light.owner_suite_lamps', 'off')
+          )
+        }}
+    sequence:
+      - if:
+          - condition: state
+            entity_id: input_boolean.trip
+            state: "on"
+        then:
+          - action: script.turn_on
+            target:
+              entity_id: script.turn_off_all_inovelli_switch_leds
+        else:
+          - action: script.turn_on
+            target:
+              entity_id: script.restore_inovelli_switch_leds_from_trip
+          - if:
+              - condition: template
+                value_template: "{{ owner_suite_leds_should_be_dark }}"
+            then:
+              - action: script.turn_off_owner_suite_inovelli_switch_leds
 
   turn_off_owner_suite_inovelli_switch_leds:
     icon: mdi:light-switch

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -309,6 +309,30 @@ def test_reset_script_replays_endpoint_1_membership_for_group_bound_switch_sync(
         assert (group, device, 2) not in memberships
 
 
+def test_hall_transition_recovery_replays_led_policy_after_unavailable() -> None:
+    text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
+
+    block = text.split(
+        "replay_hall_transition_inovelli_led_policy_on_recovery:\n",
+        1,
+    )[1].split(
+        "\n  turn_off_owner_suite_inovelli_switch_leds:\n",
+        1,
+    )[0]
+
+    for token in (
+        'from: "unavailable"',
+        "number.hall_transition_switch_ledcolorwhenoff",
+        "number.hall_transition_switch_ledcolorwhenon",
+        "number.hall_transition_switch_ledintensitywhenoff",
+        "number.hall_transition_switch_ledintensitywhenon",
+        "switch.sleep_mode",
+        "sun.sun",
+        "script.restore_inovelli_switch_leds_from_trip",
+    ):
+        assert token in block
+
+
 def test_reset_script_finishes_with_the_issue_aurora_led_effect() -> None:
     block = _script_block("reset_inovelli_switches")
 

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -309,11 +309,30 @@ def test_reset_script_replays_endpoint_1_membership_for_group_bound_switch_sync(
         assert (group, device, 2) not in memberships
 
 
-def test_hall_transition_recovery_replays_led_policy_after_unavailable() -> None:
+def test_inovelli_led_recovery_automation_watches_all_led_number_entities() -> None:
+    text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
+
+    block = text.split("automation:\n", 1)[1].split(
+        "\n  - alias: basement_bathroom_switch_actions\n",
+        1,
+    )[0]
+
+    for token in (
+        "replay_inovelli_led_policy_on_recovery",
+        "event_type: state_changed",
+        "entity_id is match('^number\\\\..*_led(?:color|intensity)when(?:on|off)$')",
+        "from_state.state == 'unavailable'",
+        "to_state.state not in ['unavailable', 'unknown']",
+        "entity_id: script.replay_inovelli_led_policy_after_recovery",
+    ):
+        assert token in block
+
+
+def test_inovelli_led_recovery_replays_trip_day_night_and_owner_suite_darkening() -> None:
     text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
 
     block = text.split(
-        "replay_hall_transition_inovelli_led_policy_on_recovery:\n",
+        "replay_inovelli_led_policy_after_recovery:\n",
         1,
     )[1].split(
         "\n  turn_off_owner_suite_inovelli_switch_leds:\n",
@@ -321,14 +340,13 @@ def test_hall_transition_recovery_replays_led_policy_after_unavailable() -> None
     )[0]
 
     for token in (
-        'from: "unavailable"',
-        "number.hall_transition_switch_ledcolorwhenoff",
-        "number.hall_transition_switch_ledcolorwhenon",
-        "number.hall_transition_switch_ledintensitywhenoff",
-        "number.hall_transition_switch_ledintensitywhenon",
-        "switch.sleep_mode",
-        "sun.sun",
-        "script.restore_inovelli_switch_leds_from_trip",
+        "entity_id: input_boolean.trip",
+        "entity_id: script.turn_off_all_inovelli_switch_leds",
+        "entity_id: script.restore_inovelli_switch_leds_from_trip",
+        "owner_suite_leds_should_be_dark",
+        "binary_sensor.bayesian_bed_occupancy",
+        "light.owner_suite_lamps",
+        "script.turn_off_owner_suite_inovelli_switch_leds",
     ):
         assert token in block
 


### PR DESCRIPTION
## Summary
- replay the hall transition Inovelli LED policy when its Zigbee2MQTT number entities recover from `unavailable`
- reuse `script.restore_inovelli_switch_leds_from_trip` so the fix stays aligned with the existing day/night/trip policy
- add regression coverage for the recovery automation

## Root Cause
On April 13, 2026, the hall transition switch LED entities were already unavailable when `script.night_tv_mode_switches` ran. The LED policy write was missed, and there was no replay path once the switch recovered.

Closes #448

## Validation
- `uv run --with pytest pytest tests/test_zigbee_zwave_inovelli_reset_replay.py`
- `uv run --with pytest pytest`