### PR TITLE
[codex] Retry basement lights after media players stop

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -378,24 +378,20 @@ automation:
         to: "on"
       - trigger: state
         entity_id: media_player.basement
-        from: "playing"
+        to: "idle"
         for:
           seconds: 3
       - trigger: state
         entity_id: media_player.basement
-        from: "paused"
+        to: "off"
         for:
           seconds: 3
       - trigger: state
-        entity_id: media_player.plex_basement_apple_tv
-        from: "playing"
+        entity_id: media_player.lg_webos_smart_tv
+        from: "on"
+        to: "off"
         for:
-          seconds: 3
-      - trigger: state
-        entity_id: media_player.plex_basement_apple_tv
-        from: "paused"
-        for:
-          seconds: 3
+          seconds: 10
     condition:
       - alias: "Not in bed"
         condition: state

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -376,6 +376,26 @@ automation:
       - trigger: state
         entity_id: binary_sensor.basement_landing_occupancy
         to: "on"
+      - trigger: state
+        entity_id: media_player.basement
+        from: "playing"
+        for:
+          seconds: 3
+      - trigger: state
+        entity_id: media_player.basement
+        from: "paused"
+        for:
+          seconds: 3
+      - trigger: state
+        entity_id: media_player.plex_basement_apple_tv
+        from: "playing"
+        for:
+          seconds: 3
+      - trigger: state
+        entity_id: media_player.plex_basement_apple_tv
+        from: "paused"
+        for:
+          seconds: 3
     condition:
       - alias: "Not in bed"
         condition: state
@@ -383,6 +403,10 @@ automation:
           - binary_sensor.bayesian_bed_occupancy
           # - input_boolean.chatgpt_bed_occupied
         state: "off"
+      - alias: "Basement landing still occupied"
+        condition: state
+        entity_id: binary_sensor.basement_landing_occupancy
+        state: "on"
       - condition: not
         conditions:
           - condition: or
@@ -391,10 +415,18 @@ automation:
                 condition: state
                 entity_id: media_player.basement
                 state: "playing"
+              - alias: "paused something"
+                condition: state
+                entity_id: media_player.basement
+                state: "paused"
               - alias: "watching Apple TV"
                 condition: state
                 entity_id: media_player.plex_basement_apple_tv
                 state: "playing"
+              - alias: "paused Apple TV"
+                condition: state
+                entity_id: media_player.plex_basement_apple_tv
+                state: "paused"
       - condition: state
         entity_id:
           - input_boolean.bayesian_zeke_home

--- a/tests/test_basement_media_handoff.py
+++ b/tests/test_basement_media_handoff.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIGHT_PATH = ROOT / "packages" / "light.yaml"
+
+
+def _automation_block(automation_id: str) -> str:
+    text = LIGHT_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^  - id: {re.escape(automation_id)}\n(.*?)(?=^  - (?:id|alias): |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in packages/light.yaml")
+    return match.group(0)
+
+
+def test_basement_lights_auto_on_retries_after_media_shutdown_handoffs() -> None:
+    block = _automation_block("basement_lights_auto_on")
+
+    for token in (
+        'entity_id: binary_sensor.basement_landing_occupancy',
+        'entity_id: media_player.basement\n        from: "playing"',
+        'entity_id: media_player.basement\n        from: "paused"',
+        'entity_id: media_player.plex_basement_apple_tv\n        from: "playing"',
+        'entity_id: media_player.plex_basement_apple_tv\n        from: "paused"',
+        "seconds: 3",
+    ):
+        assert token in block
+
+
+def test_basement_lights_auto_on_requires_occupancy_and_non_playback_states() -> None:
+    block = _automation_block("basement_lights_auto_on")
+
+    for token in (
+        'alias: "Basement landing still occupied"',
+        'entity_id: binary_sensor.basement_landing_occupancy\n        state: "on"',
+        'entity_id: media_player.basement\n                state: "playing"',
+        'entity_id: media_player.basement\n                state: "paused"',
+        'entity_id: media_player.plex_basement_apple_tv\n                state: "playing"',
+        'entity_id: media_player.plex_basement_apple_tv\n                state: "paused"',
+        "light.basement_great_room",
+    ):
+        assert token in block

--- a/tests/test_basement_media_handoff.py
+++ b/tests/test_basement_media_handoff.py
@@ -25,11 +25,11 @@ def test_basement_lights_auto_on_retries_after_media_shutdown_handoffs() -> None
 
     for token in (
         'entity_id: binary_sensor.basement_landing_occupancy',
-        'entity_id: media_player.basement\n        from: "playing"',
-        'entity_id: media_player.basement\n        from: "paused"',
-        'entity_id: media_player.plex_basement_apple_tv\n        from: "playing"',
-        'entity_id: media_player.plex_basement_apple_tv\n        from: "paused"',
+        'entity_id: media_player.basement\n        to: "idle"',
+        'entity_id: media_player.basement\n        to: "off"',
+        'entity_id: media_player.lg_webos_smart_tv\n        from: "on"\n        to: "off"',
         "seconds: 3",
+        "seconds: 10",
     ):
         assert token in block
 


### PR DESCRIPTION
## Summary
- let `basement_lights_auto_on` re-evaluate after basement media players leave `playing` or finish a paused handoff
- require basement landing occupancy explicitly now that media-state transitions can trigger the automation
- add focused regression coverage for the playback handoff path

## Root Cause
On April 13, 2026, basement occupancy arrived before the Apple TV had fully left playback. The automation only triggered on occupancy, so the one failed evaluation never retried after the media players actually settled.

Closes #449

## Validation
- `uv run --with pytest pytest tests/test_basement_media_handoff.py tests/test_goodnight_integrity.py`
- `uv run --with pytest pytest`