### PR TITLE
[codex] Fix TV resume outside-light exclusions

### DIFF
--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -337,8 +337,10 @@ automation:
         continue_on_error: true
         data:
           exclude_lights:
-            - light.outside_front_lights
-            - light.deck_all
+            - light.outside_front_hue
+            - light.outside_north_west_garage
+            - light.outside_south_west_garage
+            - light.outside_front_door
             - light.basement_tv_bias
           transition: 15
       - action: script.turn_on

--- a/tests/test_tv_package.py
+++ b/tests/test_tv_package.py
@@ -115,10 +115,14 @@ def test_tv_resumed_preserves_outside_groups_when_playback_starts() -> None:
 
     for token in (
         "action: script.lights_off_except",
-        "light.outside_front_lights",
-        "light.deck_all",
+        "light.outside_front_hue",
+        "light.outside_north_west_garage",
+        "light.outside_south_west_garage",
+        "light.outside_front_door",
         "light.basement_tv_bias",
         'after: "19:30:00"',
         'before: "23:59:00"',
     ):
         assert token in block
+
+    assert "light.deck_all" not in block


### PR DESCRIPTION
## Summary
- restore concrete front-light exclusions in `tv_resumed` so overlapping holiday groups stay protected
- stop excluding `light.deck_all` so deck lighting can turn off with the rest of the house during TV resume
- update the TV-package regression to match the intended front-vs-deck behavior

## Root Cause
The April 13 outside-light preservation change switched `tv_resumed` from concrete front bulbs to aggregate groups. That allowed overlapping holiday front groups to be swept off indirectly while explicitly preserving deck lighting that should still turn off during TV playback.

Closes #451

## Validation
- `uv run --with pytest pytest tests/test_tv_package.py tests/test_runtime_log_regressions.py`
- `uv run --with pytest pytest`