### PR TITLE
[codex] Re-enable kitchen motion lighting

### DIFF
--- a/docs/room_intent.yaml
+++ b/docs/room_intent.yaml
@@ -3,7 +3,7 @@
 # consume it directly, but automations and docs should stay aligned with it.
 
 version: 1
-last_updated: "2026-03-29"
+last_updated: "2026-04-13"
 owner: rtclauss
 summary: >
   Treat room purpose as durable context, not chat memory. Guest-capable rooms
@@ -160,8 +160,9 @@ rooms:
       baseline: shared-use room
       priority: low
     automation_guidance:
-      disabled_automations:
-        - kitchen motion lighting
+      safe_defaults:
+        - motion-activated lighting is acceptable when guest mode is off
+        - keep motion lighting practical and low-friction for food prep
 
   outside:
     primary_purpose: exterior circulation and outdoor use

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -987,8 +987,7 @@ automation:
 
   - id: kitchen_lights_toggle
     alias: kitchen_lights_toggle
-    description: Disabled pending a new kitchen policy; broad guest mode should not rely on this automation.
-    initial_state: false
+    description: Kitchen motion lighting; enabled when guest mode is off.
     mode: restart
     trigger:
       - trigger: state

--- a/tests/test_kitchen_motion_policy.py
+++ b/tests/test_kitchen_motion_policy.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOM_INTENT_PATH = ROOT / "docs" / "room_intent.yaml"
+LIGHT_PATH = ROOT / "packages" / "light.yaml"
+
+
+def _kitchen_room_block() -> str:
+    text = ROOM_INTENT_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        r"^  kitchen:\n(?P<body>.*?)(?=^  [a-z_]+:\n|^decision_rules:\n|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError("Could not find kitchen block in docs/room_intent.yaml")
+    return match.group(0)
+
+
+def _automation_block(automation_id: str) -> str:
+    text = LIGHT_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^  - id: {re.escape(automation_id)}\n(.*?)(?=^  - (?:id|alias): |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in packages/light.yaml")
+    return match.group(0)
+
+
+def test_kitchen_room_intent_allows_motion_lighting_when_guest_mode_is_off() -> None:
+    block = _kitchen_room_block()
+
+    assert "disabled_automations" not in block
+    assert "motion-activated lighting is acceptable when guest mode is off" in block
+    assert "keep motion lighting practical and low-friction for food prep" in block
+
+
+def test_kitchen_motion_automation_is_enabled_and_remains_restart_mode() -> None:
+    block = _automation_block("kitchen_lights_toggle")
+
+    assert "Disabled pending a new kitchen policy" not in block
+    assert "initial_state: false" not in block
+    assert "mode: restart" in block
+    assert "binary_sensor.kitchen_motion_occupancy" in block
+    assert "input_boolean.guest_mode" in block


### PR DESCRIPTION
## Summary
- update the kitchen room-intent policy so motion lighting is allowed when guest mode is off
- re-enable `kitchen_lights_toggle` instead of leaving it hard-disabled in YAML
- add focused regression coverage for the room-intent and automation policy

## Root Cause
The kitchen motion sensor is still functioning. The real blocker was repository policy: `docs/room_intent.yaml` marked kitchen motion lighting as disabled, and `automation.kitchen_lights_toggle` was forced off with `initial_state: false`.

Closes #452

## Validation
- `uv run --with pytest pytest tests/test_kitchen_motion_policy.py tests/test_goodnight_integrity.py`
- `uv run --with pytest pytest`