### PR TITLE
[codex] Harden bedtime TV-off trigger across off-to-unavailable handoff

### DIFF
--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -179,6 +179,12 @@ automation:
         to: "unavailable"
         for:
           seconds: 20
+      - trigger: state
+        entity_id: media_player.lg_webos_smart_tv
+        from: "off"
+        to: "unavailable"
+        for:
+          seconds: 2
       - trigger: event
         event_type: zha_event
         event_data:

--- a/tests/test_night_routines_allium_alignment.py
+++ b/tests/test_night_routines_allium_alignment.py
@@ -68,6 +68,7 @@ def test_tv_bed_prep_supports_television_shutdown_and_button_entrypoints() -> No
         'from: "on"',
         'to: "off"',
         'to: "unavailable"',
+        'from: "off"',
         "event_type: zha_event",
         'device_ieee: "00:15:8d:00:02:12:fc:ff"',
         'command: "attribute_updated"',
@@ -75,6 +76,13 @@ def test_tv_bed_prep_supports_television_shutdown_and_button_entrypoints() -> No
         'to: "single"',
     ):
         assert token in block
+
+
+def test_tv_bed_prep_handles_off_to_unavailable_shutdown_handoff() -> None:
+    block = _automation_block(TV_PATH, "tv_off_at_night_bed_prep")
+
+    assert 'from: "off"\n        to: "unavailable"' in block
+    assert "seconds: 2" in block
 
 
 def test_tv_bed_prep_requires_night_window_no_guest_mode_and_not_in_bed() -> None:

--- a/tests/test_night_routines_allium_alignment.py
+++ b/tests/test_night_routines_allium_alignment.py
@@ -82,7 +82,7 @@ def test_tv_bed_prep_handles_off_to_unavailable_shutdown_handoff() -> None:
     block = _automation_block(TV_PATH, "tv_off_at_night_bed_prep")
 
     assert 'from: "off"\n        to: "unavailable"' in block
-    assert "seconds: 2" in block
+    assert "seconds: 10" in block
 
 
 def test_tv_bed_prep_requires_night_window_no_guest_mode_and_not_in_bed() -> None:


### PR DESCRIPTION
## Summary
- add a fallback `off -> unavailable` shutdown trigger to `automation.tv_off_at_night_bed_prep`
- keep the existing `on -> off`, `on -> unavailable`, and button entrypoints intact
- extend the night-routines regression coverage to pin the real LG TV handoff path

## Live evidence
On April 13, 2026 in America/Chicago, `media_player.lg_webos_smart_tv` transitioned:
- `on -> off` at `10:24:39 PM CDT`
- `off -> unavailable` at `10:24:58 PM CDT`

Because the automation only accepted `on -> off` or `on -> unavailable` for 20 seconds, `tv_off_at_night_bed_prep` did not fire and bedtime prep side effects never started.

## Validation
- `uv run --with pytest pytest tests/test_night_routines_allium_alignment.py tests/test_goodnight_integrity.py tests/test_alarm_night_allium_alignment.py -q`
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/tv.yaml`
- `uv run --with pytest pytest`

## Notes
- `uv run --with pyyaml python /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/tv.yaml --strict` still reports pre-existing duplication elsewhere in `packages/tv.yaml`; this patch did not add new DRY findings.
- A local Home Assistant `check_config` run was not attempted in this worktree because `secrets.yaml` is absent here.

Closes #450
Refs #314