### PR TITLE
fix: add from: to bayesian_zeke_home state triggers to prevent startup race

### DIFF
--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -324,6 +324,7 @@ automation:
       - trigger: state
         id: depart_for_scheduled_trip
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "on"
         to: "off"
       - trigger: template
         id: away_over_radius_mi
@@ -362,6 +363,7 @@ automation:
       - trigger: state
         id: return_home
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
         to: "on"
     action:
       - choose:
@@ -657,6 +659,7 @@ automation:
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
         to: "on"
         for:
           hours: 1

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -169,6 +169,7 @@ automation:
         event: enter
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
         to: "on"
     condition:
       condition: and
@@ -199,6 +200,7 @@ automation:
         event: enter
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
         to: "on"
     condition:
       and:
@@ -230,6 +232,7 @@ automation:
         event: leave
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "on"
         to: "off"
     variables:
       open_egress_points: >-
@@ -253,6 +256,7 @@ automation:
         event: leave
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "on"
         to: "off"
     condition:
       - condition: state
@@ -271,6 +275,7 @@ automation:
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
         to: "on"
     action:
       - action: input_boolean.turn_on
@@ -282,6 +287,7 @@ automation:
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "on"
         to: "off"
     action:
       - action: input_boolean.turn_off
@@ -297,6 +303,7 @@ automation:
         event: enter
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
         to: "on"
     condition:
       - condition: state
@@ -330,6 +337,7 @@ automation:
         event: enter
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
         to: "on"
     condition:
       condition: and
@@ -368,6 +376,7 @@ automation:
         event: enter
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
         to: "on"
     condition:
       condition: and
@@ -470,6 +479,7 @@ automation:
         event: leave
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "on"
         to: "off"
     condition:
       - condition: state
@@ -579,6 +589,7 @@ automation:
         event: enter
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
         to: "on"
     action:
       - action: vacuum.return_to_base


### PR DESCRIPTION
## Summary

Fixes #462 — HA Repairs flagging automations with \"unknown action: script.house_transition\".

- **Root cause**: State triggers on `binary_sensor.bayesian_zeke_home` with only `to:` (no `from:`) fire during HA startup when the entity transitions `unavailable` → `on`. At that moment, `script.house_transition` may not yet be registered as a service, causing the error.
- **Evidence**: Automation trace shows failure at 00:49 UTC (\"Action script.house_transition not found\") during a restart, success at 04:23 UTC (fully running system).
- **Fix**: Add `from: "off"` to all arrival triggers and `from: "on"` to all departure triggers — the same pattern `vacuum_leave_home` already uses correctly. 14 triggers fixed across `zone.yaml` (11) and `trips.yaml` (3).

## Changed files

| File | Triggers fixed |
|---|---|
| `packages/zone.yaml` | `cloudy_home_arrival`, `default_arrive_home`, `doors_open_when_leaving_home`, `garage_door_open_when_leaving_home`, `input_boolean_tracker_on/off`, `play_spotify_when_i_get_home`, `turn_on_lights_at_night_when_i_get_home`, `turn_on_bedroom_lights_at_night_when_i_get_home`, `turn_off_lights_when_i_leave`, `vacuum_return_home` |
| `packages/trips.yaml` | `trip_mode_manager` (`depart_for_scheduled_trip`, `return_home`), `trip_mode_watchdog_home_1h` |

## Test plan

- [ ] Reload automations — no HA Repairs notifications for `script.house_transition`
- [ ] Restart HA — verify none of the arrival/departure automations fire spuriously on startup
- [ ] Arrive home — confirm `cloudy_home_arrival` and `default_arrive_home` still fire correctly
- [ ] Leave home — confirm `turn_off_lights_when_i_leave` still fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)