### PR TITLE
fix: address PR 463 review and audit all automation action validity

### DIFF
--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -282,6 +282,7 @@ automation:
                 {%- endfor %}
                 {{ ns.found }}
             - alias: "Move the date"
+              continue_on_error: true
               action: garbage_collection.offset_date
               data:
                 entity_id: "{{ trigger.event.data.entity_id }}"
@@ -307,6 +308,7 @@ automation:
                   {% endfor %}
                   {{ ns.offset }}
       - alias: "Update the garbage_collection entity"
+        continue_on_error: true
         action: garbage_collection.update_state
         data:
           entity_id: "{{ trigger.event.data.entity_id }}"

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -275,7 +275,6 @@ automation:
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
-        from: "off"
         to: "on"
     action:
       - action: input_boolean.turn_on
@@ -287,7 +286,6 @@ automation:
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
-        from: "on"
         to: "off"
     action:
       - action: input_boolean.turn_off


### PR DESCRIPTION
## Summary

Two follow-on fixes after #463 merged:

- **Revert \`from:\` guards on \`input_boolean_tracker_on/off\`** — these are sync mirrors that must fire on the \`unavailable→on/off\` startup transition to keep \`input_boolean.bayesian_zeke_home\` aligned with the binary sensor. Adding \`from:\` would leave the boolean stale after a restart, breaking downstream light automations in \`light.yaml\` that gate on it. These automations also don't call \`script.house_transition\` so they were never causing the repair error.
- **Add \`continue_on_error: true\` to \`garbage_collection\` service calls** — \`update.garbage_collection_update\` is currently \`unavailable\` (state restored from cache, integration not loaded). Its services \`garbage_collection.offset_date\` and \`garbage_collection.update_state\` are unregistered, generating HA Repairs "unknown action" errors for \`garbage_holiday_update\`. The defensive fix is \`continue_on_error: true\` so the automation doesn't hard-fail. **Root fix: reinstall/update the \`garbage_collection\` integration via HACS.**

## Full action audit

All service calls across all 39 package files validated against the live HA service registry:

| Domain | Status |
|---|---|
| \`adaptive_lighting.*\` | ✅ |
| \`bond.set_light_power_tracked_state\` | ✅ |
| \`ecobee.resume_program\` | ✅ |
| \`garbage_collection.*\` | ⚠️ integration unavailable — mitigated with \`continue_on_error\` |
| \`hassio.addon_restart\` | ✅ |
| \`notify.all\`, \`notify.notify_all\` | ✅ both registered |
| \`retry.actions\` | ✅ |
| \`tesla_custom.api\` | ✅ |
| All standard HA domains | ✅ |

## DRY verifier findings (touched files, deferred)

The verifier flags 6 arrival automations in \`zone.yaml\` sharing the same \`[zone enter + state from:off to:on]\` trigger pattern. This is intentional — each has distinct conditions and actions. Merging into one branching automation would reduce clarity and debuggability. Deferred as separate cleanup.

## Test plan

- [ ] Restart HA — confirm \`input_boolean.bayesian_zeke_home\` matches \`binary_sensor.bayesian_zeke_home\` after startup
- [ ] Verify \`garbage_holiday_update\` automation no longer hard-fails when \`garbage_collection\` is unavailable
- [ ] Reinstall \`garbage_collection\` integration via HACS to permanently clear its repair errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)