### PR TITLE
fix(#385): replace defunct way.com gas price scrape with EIA v2 API

### DIFF
--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -743,21 +743,30 @@ rest_command:
 # REST
 ########################
 rest:
-  - resource: https://www.way.com/gas/prices/minnesota/woodbury
+  # EIA (US Energy Information Administration) weekly Minnesota Regular Conventional
+  # Retail Gasoline Prices. Free API key required — register at https://www.eia.gov/opendata/
+  # Store the full URL (with your key) in secrets.yaml as a single entry so the key
+  # stays out of version control:
+  #
+  #   eia_gas_price_mn_url: >-
+  #     https://api.eia.gov/v2/petroleum/pri/gnd/data/?api_key=YOUR_EIA_KEY_HERE
+  #     &frequency=weekly&data[0]=value&facets[product][]=EPMRU&facets[duoarea][]=SMN
+  #     &sort[0][column]=period&sort[0][direction]=desc&length=1
+  #
+  # Series: EMM_EPMRU_PTE_SMN_DPG  (MN Regular Conventional, $/gal, weekly)
+  # Falls back to input_number.weekly_regular_gas_price_55125_fallback when unavailable.
+  - resource: !secret eia_gas_price_mn_url
     scan_interval: 43200
     timeout: 30
-    headers:
-      Accept: text/html
-      User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:146.0) Gecko/20100101 Firefox/146.0
     sensor:
       - name: Woodbury Weekly Regular Gas Price Live
         unique_id: woodbury_weekly_regular_gas_price_live
         icon: mdi:gas-station
         unit_of_measurement: USD/gal
         value_template: >-
-          {% set matches = value | regex_findall('Week Ago Avg\\.\\s*\\$([0-9]+\\.[0-9]+)') %}
-          {% if matches | count > 0 %}
-            {{ matches[0] | float(default=0) | round(2) }}
+          {% set data = value_json.get('response', {}).get('data', []) %}
+          {% if data | count > 0 and data[0].get('value') is not none %}
+            {{ data[0]['value'] | float(default=0) | round(2) }}
           {% else %}
             {{ none }}
           {% endif %}

--- a/tests/test_ev_cost_comparison.py
+++ b/tests/test_ev_cost_comparison.py
@@ -15,10 +15,12 @@ def test_utilities_package_defines_weekly_gas_price_and_ev_comparison_sensors() 
     for token in (
         "weekly_regular_gas_price_55125_fallback:",
         "initial: 3.76",
-        "resource: https://www.way.com/gas/prices/minnesota/woodbury",
+        # EIA API replaces the defunct way.com scrape (issue #385)
+        "resource: !secret eia_gas_price_mn_url",
+        "api.eia.gov/v2/petroleum/pri/gnd/data/",
+        "EMM_EPMRU_PTE_SMN_DPG",
         "woodbury_weekly_regular_gas_price_live",
-        "Week Ago Avg.",
-        "regex_findall(",
+        "value_json.get('response'",
         "weekly_regular_gas_price_55125",
         "average_daily_ev_charging_cost",
         "average_daily_vehicle_miles",

--- a/tests/test_issue_gas_price_live_sensor.py
+++ b/tests/test_issue_gas_price_live_sensor.py
@@ -6,11 +6,24 @@ from pathlib import Path
 UTILITIES_PATH = Path(__file__).resolve().parents[1] / "packages" / "utilities.yaml"
 
 
-def test_gas_price_live_sensor_guards_missing_scraped_matches() -> None:
+def test_gas_price_live_sensor_uses_eia_api_and_guards_missing_data() -> None:
+    """Sensor must use the EIA v2 API (issue #385 — way.com returned 403).
+
+    The resource URL is stored in secrets.yaml via !secret eia_gas_price_mn_url so
+    the API key is never committed to git. The value_template must gracefully return
+    none when the EIA response contains no data rows.
+    """
     text = UTILITIES_PATH.read_text(encoding="utf-8")
 
     assert "name: Woodbury Weekly Regular Gas Price Live" in text
-    assert "regex_findall_index(" not in text
-    assert "regex_findall('Week Ago Avg\\\\.\\\\s*\\\\$([0-9]+\\\\.[0-9]+)')" in text
-    assert "{{ matches[0] | float(default=0) | round(2) }}" in text
+    # EIA API replaces the defunct way.com HTML scrape
+    assert "resource: !secret eia_gas_price_mn_url" in text
+    assert "api.eia.gov/v2/petroleum/pri/gnd/data/" in text
+    # value_template must parse the JSON response and fall back to none
+    assert "value_json.get('response'" in text
+    assert "data[0]['value'] | float(default=0) | round(2)" in text
     assert "{{ none }}" in text
+    # Old way.com scraper must no longer be the REST resource
+    assert "resource: https://www.way.com" not in text
+    # Old HTML-scrape regex must no longer be in the sensor template
+    assert "regex_findall(" not in text


### PR DESCRIPTION
## Summary

- `sensor.woodbury_weekly_regular_gas_price_live` was returning `unavailable` because `https://www.way.com/gas/prices/minnesota/woodbury` responds with HTTP 403 (blocks automated scraping).
- Replaced the HTML scrape with the free [EIA v2 API](https://www.eia.gov/opendata/) using the Minnesota Regular Conventional weekly series **EMM_EPMRU_PTE_SMN_DPG** (`duoarea=SMN`, `product=EPMRU`). The API returned `$3.717/gal` as of 2026-04-13 — consistent with the current fallback value.
- The `value_template` now parses `value_json` instead of regex-scanning HTML.
- The existing fallback to `input_number.weekly_regular_gas_price_55125_fallback` (3.76 USD/gal) remains active until the EIA secret is configured.

## Secrets setup required

The EIA API key must **never** be committed to git. Add to `secrets.yaml` on the HA host:

```yaml
eia_gas_price_mn_url: >-
  https://api.eia.gov/v2/petroleum/pri/gnd/data/?api_key=YOUR_EIA_KEY_HERE&frequency=weekly&data[0]=value&facets[product][]=EPMRU&facets[duoarea][]=SMN&sort[0][column]=period&sort[0][direction]=desc&length=1
```

Get a free API key at https://www.eia.gov/opendata/ (instant registration, no credit card).

## Files changed

- `packages/utilities.yaml` — replaced `rest:` block; new `value_template` parses JSON response
- `tests/test_ev_cost_comparison.py` — updated token assertions to match EIA endpoint
- `tests/test_issue_gas_price_live_sensor.py` — updated to verify EIA API usage and removal of old scrape patterns

## Test plan

- [x] `uv run --with pytest pytest` — 295 passed, 1 pre-existing unrelated failure (`test_basement_media_handoff`)
- [ ] Add `eia_gas_price_mn_url` secret to HA host `secrets.yaml`
- [ ] Reload HA config / restart to pick up the new REST sensor
- [ ] Verify `sensor.woodbury_weekly_regular_gas_price_live` shows a numeric value (~$3.7x)
- [ ] Verify `sensor.weekly_regular_gas_price_55125` `source` attribute switches from `fallback` to `live`

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)