### PR TITLE
fix: prevent repeated guest mode notifications when wifi sensor flaps

### DIFF
--- a/packages/guest.yaml
+++ b/packages/guest.yaml
@@ -150,7 +150,10 @@ automation:
         to: "on"
         for:
           minutes: 10
-    #condition:
+    condition:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "off"
     action:
       - action: notify.mobile_app_wethop
         data:
@@ -176,9 +179,16 @@ automation:
             id: enable_guest
             event_data:
               action: ENABLE_GUEST
+          - trigger: event
+            event_type: mobile_app_notification_action
+            id: disable_guest
+            event_data:
+              action: DISABLE_GUEST
         timeout:
           hours: 1
         continue_on_timeout: false
+      - condition: template
+        value_template: "{{ wait.trigger.id == 'enable_guest' }}"
       - action: input_boolean.turn_on
         target:
           entity_id: input_boolean.guest_mode


### PR DESCRIPTION
Closes #466

## Summary

- Add condition: state guard (input_boolean.guest_mode == off) so the automation exits immediately if guest mode is already active - prevents re-notification on every wifi sensor flap
- Add DISABLE_GUEST to wait_for_trigger alongside ENABLE_GUEST, then gate input_boolean.turn_on on wait.trigger.id == 'enable_guest' so tapping "No" exits the automation immediately instead of idling for an hour

## Root cause

binary_sensor.guest_on_wifi was flapping today (off->on 4+ times). Because the automation is mode: restart with no guard condition, each flap cancelled the previous waiting instance and sent a new notification. The lingering 1-hour wait from a "No" tap made the timing worse.

## Test plan

- [ ] Manually trigger binary_sensor.guest_on_wifi on while input_boolean.guest_mode is already on - confirm no notification fires
- [ ] Trigger with guest mode off - confirm notification fires, tapping "No" resolves immediately (trace shows automation exits after disable_guest trigger, not after 1-hour timeout)
- [ ] Trigger with guest mode off - tap "Yes" - confirm guest mode turns on

Generated with Claude Code