### PR TITLE
fix: re-enable bedroom suite grouping during bathroom morning wake-up

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -425,7 +425,7 @@ automation:
               - action: script.spotify_wake_up
                 data:
                   playback_entity_id: media_player.bathroom_sonos_2
-                  regroup_after_play: false
+                  regroup_after_play: true
               - action: media_player.volume_set
                 target:
                   entity_id: media_player.bathroom_sonos_2
@@ -442,7 +442,7 @@ automation:
           - action: script.spotify_wake_up
             data:
               playback_entity_id: media_player.bathroom_sonos_2
-              regroup_after_play: false
+              regroup_after_play: true
           - alias: "Repeat until desired volume reached"
             repeat:
               sequence:

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -230,7 +230,7 @@ def test_bathroom_wakeup_automation_targets_bathroom_player() -> None:
 
     assert 'action: script.spotify_wake_up' in block
     assert block.count('playback_entity_id: media_player.bathroom_sonos_2') == 2
-    assert block.count('regroup_after_play: false') == 2
+    assert block.count('regroup_after_play: true') == 2
     assert 'media_player.media_stop' not in block
 
 


### PR DESCRIPTION
## Summary

- PR #439 decoupled the bathroom wake-up path and hardcoded `regroup_after_play: false` in both branches of the `choose` block in `play_music_in_bathroom_when_up`
- This caused bedroom, office, and den Sonos speakers to stop joining when bathroom morning music starts
- Fixes by setting `regroup_after_play: true` in both the "already playing" and default branches

## Root cause

Traced via automation trace from this morning (run `83f7e79c`): `spotify_wake_up` was called with `regroup_after_play: false`, so `should_regroup_after_play` evaluated to `false` and the `music_assistant_try_join_bedroom_group_after_play` call was skipped entirely.

Reverts grouping behavior changed in #439.

## Test plan

- [ ] Trigger `binary_sensor.owner_suite_bathroom_room_occupancy` during morning time window with `morning_routine` off
- [ ] Confirm bedroom, office, and den Sonos speakers join the bathroom speaker group
- [ ] Confirm the volume fade-in still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)