### PR TITLE
fix(#472): have spotify_bedtime claim bedroom group before playing

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1691,6 +1691,8 @@ script:
               ] -%}
             {% set pindex = (range(0, (plists | length))|random) -%}
             {{ plists[pindex] }}
+      - alias: "Claim bedroom group before playing — unjoins from any arrival group"
+        action: script.music_assistant_prepare_bedroom_group
       - action: media_player.shuffle_set
         continue_on_error: true
         target:

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -171,6 +171,18 @@ def test_arrival_music_does_not_retry_regroup_after_playback_starts() -> None:
     assert 'entity_id: script.music_assistant_try_join_arrival_group_after_play' not in arrival_block
 
 
+def test_bedtime_claims_bedroom_group_before_playing() -> None:
+    # spotify_arrival leaves den_sonos_2 as coordinator with bedroom as a follower.
+    # spotify_bedtime must reclaim the group (promote bedroom to coordinator) before
+    # playing, otherwise the play_item call silently fails on a follower.
+    block = _script_block("spotify_bedtime")
+
+    assert 'action: script.music_assistant_prepare_bedroom_group' in block
+    assert block.index('action: script.music_assistant_prepare_bedroom_group') < block.index(
+        'action: script.music_assistant_play_item'
+    )
+
+
 def test_bedtime_join_retry_runs_after_playback_starts() -> None:
     helper_block = _script_block("music_assistant_try_join_bedroom_group_after_play")
     bedtime_block = _script_block("spotify_bedtime")
@@ -225,11 +237,15 @@ def test_spotify_wakeup_prepares_group_before_play_and_only_retries_regroup_when
     )
 
 
-def test_bathroom_wakeup_automation_targets_bathroom_player() -> None:
+def test_bathroom_wakeup_automation_targets_bedroom_coordinator() -> None:
     block = _automation_block("play_music_in_bathroom_when_up")
 
     assert 'action: script.spotify_wake_up' in block
-    assert block.count('playback_entity_id: media_player.bathroom_sonos_2') == 2
+    # Must play on the group coordinator (bedroom), not a group member (bathroom),
+    # to avoid the race condition where the playback queue is lost when
+    # music_assistant_prepare_bedroom_group reforms the group.
+    assert block.count('playback_entity_id: media_player.bedroom_sonos_2') == 2
+    assert block.count('playback_entity_id: media_player.bathroom_sonos_2') == 0
     assert block.count('regroup_after_play: true') == 2
     assert 'media_player.media_stop' not in block
 


### PR DESCRIPTION
Closes #472 (partial — this PR addresses root cause #1)

## Problem

`spotify_arrival` makes `den_sonos_2` the Sonos group coordinator and joins bedroom, bathroom, office, and tiki room as followers under it. When `tv_off_at_night_bed_prep` subsequently fires and calls `script.spotify_bedtime`, that script tries to play on `media_player.bedroom_sonos_2` — which is still a follower in the den group. The `music_assistant.play_media` call has `continue_on_error: true`, so it fails silently, leaving the arrival playlist playing all evening.

Confirmed via automation traces: `spotify_arrival` ran at 9:17 PM CDT tonight; `spotify_bedtime` ran with 8 short cycles yesterday evening (bathroom occupancy completing the wait quickly), each silently failing to replace the arrival content.

## Fix

Add a `music_assistant_prepare_bedroom_group` call at the start of the `spotify_bedtime` sequence. This script already exists and does exactly what's needed: unjoins bedroom, bathroom, den, and office from any existing group, then rejoins them with bedroom as coordinator.

```yaml
sequence:
  - alias: "Claim bedroom group before playing — unjoins from any arrival group"
    action: script.music_assistant_prepare_bedroom_group
  - action: media_player.shuffle_set
    ...
```

## Trade-offs

- Adds ~1–2 seconds to the bedtime startup path (group reform delay in `music_assistant_prepare_bedroom_group`)
- Den speaker will be pulled into the bedroom group; arrival music from den stops. This is the correct behavior for bedtime.
- Alternative: add a condition to skip bedtime if arrival music was recently started (see #472 for other PRs)

## Test plan

- [ ] Arrive home by car in the evening → `spotify_arrival` plays on whole-house group
- [ ] Turn off TV after 20:00 → `spotify_bedtime` fires, bedroom group reforms, new random playlist starts on bedroom/bathroom
- [ ] Confirm different playlist plays each evening