### PR TITLE
fix(#472): fix off-by-one in playlist and shuffle random selection

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1236,7 +1236,7 @@ script:
           "spotify:playlist:6z6y5fEt0QIUuC64w1VOw4",
           "spotify:playlist:7gU7Ul8SuSReUTGYJMv9jr"
           ] -%}
-          {% set pindex =  (range(0, (plists | length - 1 ) )|random) -%}
+          {% set pindex =  (range(0, (plists | length))|random) -%}
           {{ plists[pindex] }}
     sequence:
       - action: logbook.log
@@ -1266,7 +1266,7 @@ script:
           "spotify:playlist:3ebHKSjHujS4Tyt2KKP97R",
           "spotify:playlist:4sgUux9hmykyWYmVoe4W6p"
           ] -%}
-          {% set pindex =  (range(0, (plists | length - 1 ) )|random) -%}
+          {% set pindex =  (range(0, (plists | length))|random) -%}
           {{ plists[pindex] }}
     sequence:
       - action: logbook.log
@@ -1310,7 +1310,7 @@ script:
           "spotify:user:gorillagoat:playlist:7aX5kvEDdre0kHNCvQ9sbr",
           "spotify:playlist:37i9dQZF1DZ06evO3VghcA"
           ] -%}
-          {% set pindex =  (range(0, (plists | length - 1 ) )|random) -%}
+          {% set pindex =  (range(0, (plists | length))|random) -%}
           {{ plists[pindex] }}
     sequence:
       - action: logbook.log
@@ -1346,7 +1346,7 @@ script:
           "spotify:playlist:1Iowhep08Kl9MJ0XOwsBMp",
           "spotify:playlist:37i9dQZF1DX4nNmLlb3JR2"
           ] -%}
-          {% set pindex =  (range(0, (plists | length - 1 ) )|random) -%}
+          {% set pindex =  (range(0, (plists | length))|random) -%}
           {{ plists[pindex] }}
     sequence:
       - action: logbook.log
@@ -1484,7 +1484,7 @@ script:
           "spotify:playlist:37i9dQZF1CAqqQ5eUaE9tb",
           "spotify:playlist:4gmNQHup10wDckuwWL3IFZ"
           ] -%}
-          {% set pindex =  (range(0, (plists | length - 1 ) )|random) -%}
+          {% set pindex =  (range(0, (plists | length))|random) -%}
           {{ plists[pindex] }}
       playback_entity: >-
         {{ 'media_player.den_sonos_2' if is_state('input_boolean.guest_mode', 'off')
@@ -1500,7 +1500,7 @@ script:
         data:
           shuffle: >-
             {%- set shuffle = [true, false] -%}
-            {% set sindex =  (range(0, (shuffle | length - 1 ) )|random) -%}
+            {% set sindex =  (range(0, (shuffle | length))|random) -%}
             {{ shuffle[sindex] }}
       - delay:
           seconds: 2
@@ -1665,7 +1665,7 @@ script:
         data:
           shuffle: >-
             {%- set shuffle = [true, false] -%}
-            {% set sindex =  (range(0, (shuffle | length - 1 ) )|random) -%}
+            {% set sindex =  (range(0, (shuffle | length))|random) -%}
             {{ shuffle[sindex] }}
       - action: media_player.repeat_set
         continue_on_error: true
@@ -1885,7 +1885,7 @@ script:
           "spotify:playlist:5dPSsspVwjaoU7Nf6itkUZ",
           "spotify:playlist:37i9dQZF1EIg42NGihn0NZ"
           ] -%}
-          {% set pindex =  (range(0, (plists | length - 1 ) )|random) -%}
+          {% set pindex =  (range(0, (plists | length))|random) -%}
           {{ plists[pindex] }}
     sequence:
       - if:
@@ -1915,7 +1915,7 @@ script:
         data:
           shuffle: >-
             {%- set shuffle = [true, false] -%}
-            {% set sindex =  (range(0, (shuffle | length - 1 ) )|random) -%}
+            {% set sindex =  (range(0, (shuffle | length))|random) -%}
             {{ shuffle[sindex] }}
       - action: media_player.repeat_set
         continue_on_error: true


### PR DESCRIPTION
Closes #472 (partial — this PR addresses root causes #2 and #3)

## Problem

Six scripts use `range(0, (plists | length - 1))` when selecting a random playlist index. `range(0, n)` in Python generates `[0, 1, ..., n-1]`, so `range(0, length-1)` generates `[0, ..., length-2]` — the **last item is never reachable**.

Two scripts additionally use the same pattern on a `[true, false]` shuffle list, making `false` (shuffle off) permanently unreachable — shuffle is always `true`.

## Affected scripts

| Script | Bug | Item never played |
|--------|-----|-------------------|
| `spotify_arrival` | playlist off-by-one + always-shuffle | `spotify:playlist:4gmNQHup10wDckuwWL3IFZ` (Guster w/ Utah) |
| `spotify_wake_up` | playlist off-by-one | `spotify:playlist:37i9dQZF1EIg42NGihn0NZ` (Anti-anxiety mix) |
| `bedroom_playlist_2` | playlist off-by-one | `spotify:playlist:7gU7Ul8SuSReUTGYJMv9jr` (Holland Patent Public Radio) |
| `bedroom_playlist_3` | playlist off-by-one | `spotify:playlist:4sgUux9hmykyWYmVoe4W6p` (Synthwave from Space) |
| `bedroom_playlist_4` | playlist off-by-one | `spotify:playlist:37i9dQZF1DZ06evO3VghcA` (This is Walk the Moon) |
| `bedroom_playlist_5` | playlist off-by-one | `spotify:playlist:37i9dQZF1DX4nNmLlb3JR2` (Lowfi Covers) |
| `spotify_bedtime` | always-shuffle only | shuffle=false never set |
| `spotify_arrival` | always-shuffle | shuffle=false never set |

## Fix

Remove the `- 1` from all affected `range()` calls:

```jinja2
# Before
{% set pindex = (range(0, (plists | length - 1))|random) -%}

# After  
{% set pindex = (range(0, (plists | length))|random) -%}
```

## Test plan

- [ ] Trigger each bedroom cube playlist several times, confirm all entries are reachable over time
- [ ] Confirm `spotify_arrival` occasionally plays without shuffle