### PR TITLE
fix(#472): stop playback after bedtime rampdown; remove duplicate playlists

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1618,8 +1618,6 @@ script:
           "spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq",
           "spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP",
           "spotify:user:126202651:playlist:3D3gu4wURrZfR813RTh5M8",
-          "spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu",
-          "spotify:playlist:37i9dQZEVXcMDffrPenJPl",
           "spotify:user:spotify:playlist:37i9dQZF1DX0YKekzl0blG",
           "spotify:user:spotify:playlist:37i9dQZF1E4lDVOWeZX2IT",
           "spotify:user:spotify:playlist:37i9dQZF1E4pBKIU2s8AX1",
@@ -1759,6 +1757,16 @@ script:
             - media_player.bathroom_sonos_2
             - media_player.office_sonos_2
           volume_level: 0.01
+      - delay:
+          minutes: 1
+      - alias: "Stop playback so the same track does not resume the next evening"
+        continue_on_error: true
+        action: media_player.media_stop
+        target:
+          entity_id:
+            - media_player.bedroom_sonos_2
+            - media_player.bathroom_sonos_2
+            - media_player.office_sonos_2
 
   spotify_wake_up:
     alias: "Spotify Wake Up"


### PR DESCRIPTION
Closes #472 (partial — this PR addresses root causes #4 and #5)

## Problem 1: Music never stops after bedtime

`spotify_bedtime_volume` fades all bedroom/bathroom/office speakers from 0.20 → 0.1 → 0.07 → 0.05 → 0.01 over ~6 minutes, but never calls `media_player.media_stop`. The players remain in `playing` state indefinitely. Confirmed via the HA recorder: `media_player.bedroom_sonos_2` and `media_player.bathroom_sonos_2` have been in `playing` state continuously since the last HA restart (5 days). When `spotify_bedtime` silently fails to start new content (e.g., due to the arrival group conflict in #473), the indefinitely-playing stale track is what you hear.

## Problem 2: Duplicate entries in `spotify_bedtime`

The `spotify_bedtime` playlist list contains two entries that appear twice:
- `spotify:playlist:37i9dQZEVXcMDffrPenJPl` (Discover Weekly) — index 4 **and** 25
- `spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu` (This is Passion Pit) — index 6 **and** 24

Doubles their selection probability relative to every other entry.

## Fix

1. Add `media_player.media_stop` at the end of `spotify_bedtime_volume`, after a 1-minute settle at 0.01 volume:

```yaml
- delay:
    minutes: 1
- alias: "Stop playback so the same track does not resume the next evening"
  continue_on_error: true
  action: media_player.media_stop
  target:
    entity_id:
      - media_player.bedroom_sonos_2
      - media_player.bathroom_sonos_2
      - media_player.office_sonos_2
```

2. Remove the two duplicate URIs from the `spotify_bedtime` playlist list.

## Trade-offs

- The stop happens ~7 minutes after bedtime sequence begins. If something wakes you up and you want to resume, the speaker will be idle rather than paused. You'd need to restart manually.
- If you prefer pause-instead-of-stop, swap `media_player.media_stop` for `media_player.media_pause`.

## Test plan

- [ ] Run `spotify_bedtime` manually, confirm music stops ~7 minutes after start
- [ ] Next evening, confirm bedroom speaker is idle (not auto-resuming old content)