### PR TITLE
fix(#472): move spotify_bedtime playlist selection into sequence variables

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1528,136 +1528,136 @@ script:
 
   spotify_bedtime:
     alias: "Spotify Bedtime"
-    variables:
-      playlist: >-
-        {#
-        ## Arctic Monkeys - AM : spotify:album:78bpIziExqiI9qztvNFlQu
-        ## All Out 90s : spotify:playlist:37i9dQZF1DXbTxeAdrVG2l
-        ## 2000s Smash Hits : spotify:playlist:2f6tXtN0XesjONxicAzMIw
-        ## 2019 Sealand Invitiational : spotify:playlist:6uNCXLheVaTbfE1HRCIsQ5
-        ## Discover Weekly: spotify:playlist:37i9dQZEVXcMDffrPenJPl
-        ## 90s Acoustic: spotify:user:spotify:playlist:37i9dQZF1DXb9LIXaj5WhL
-        ## This is Passion Pit: spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu
-        ## Panic! at the Disco Pretty. Odd. : spotify:album:7Hk9WbjPbN1n2GXaK7aldw
-        ## This is The Mountain Goats : spotify:playlist:37i9dQZF1DWTmUQ5ZV8Wa1
-        ## It's ALT Good! : spotify:user:spotify:playlist:37i9dQZF1DX2SK4ytI2KAZ
-        ## The Griswolds : spotify:playlist:37i9dQZF1DZ06evO1XPrLQ
-        ## The Wombats : spotify:artist:0Ya43ZKWHTKkAbkoJJkwIB
-        ## The Decemberists @ Palace 2018 : spotify:user:126202651:playlist:4CIBhwpAL598munofpCu6i
-        ## This is Jimmy Eat World : spotify:user:spotify:playlist:37i9dQZF1DX4wNVWmoZ4FM
-        ## David Bowie Legacy : spotify:album:4JEgSaokMH5mMRClx9wp3S
-        ## This is Cake: spotify:user:spotify:playlist:37i9dQZF1DZ06evO3T3SWA
-        ## SDSU : spotify:user:126202651:playlist:56WlVUutx91MElxdsbtzj1
-        ## Your Top Songs 2018 : spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf
-        ## Your Top Songs 2017 : spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW
-        ## Your Time Capsule : spotify:user:spotify:playlist:37i9dQZF1E4YuevTvB5WHT
-        ## This is The Lumineers : spotify:user:spotify:playlist:37i9dQZF1DXdxZQJxjFMLO
-        ## Guster @ Showbox Seattle 2/16/2019 spotify:user:126202651:playlist:65fTj3YJl4jvFmXxru7BfO
-        ## Guster @ First Ave MSP 2/9/2019 spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq
-        ## Coheed & Cambria @ The Armory MSP 7/26/2018 spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP
-        ## Jimmy Eat World @ First Ave Minneapolis 5/9/18 spotify:user:126202651:playlist:3D3gu4wURrZfR813RTh5M8
-        ## This is Passion Pit : spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu
-        ## Your Discovery Weekly : spotify:playlist:37i9dQZEVXcMDffrPenJPl
-        ## Alternative 00s : spotify:user:spotify:playlist:37i9dQZF1DX0YKekzl0blG
-        ## Panic at the Disco Radio : spotify:user:spotify:playlist:37i9dQZF1E4lDVOWeZX2IT
-        ## Decemberists Radio : spotify:user:spotify:playlist:37i9dQZF1E4pBKIU2s8AX1
-        ## Guster Radio : spotify:user:spotify:playlist:37i9dQZF1E4AQ4IdimJyYD
-        ## Jimmy Eat World Radio : spotify:user:spotify:playlist:37i9dQZF1E4tDgdv9Es4ng
-        ## The Lumineers Radio : spotify:user:spotify:playlist:37i9dQZF1E4Cpj7tK5yC6M
-        ## Band of Hourses Radio : spotify:user:spotify:playlist:37i9dQZF1E4tcQYL2Wtnge
-        ## This is Band of Horses : spotify:user:spotify:playlist:37i9dQZF1DZ06evO0pK2Aw
-        ## Henry Jamison Radio : spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY
-        ## Happier Radio : spotify:playlist:37i9dQZF1E8DMpUzqgcOJh
-        ## Guster @ Weesner Family Ampitheater (MN Zoo), Jul 22, 2019
-        ## This is Tool : spotify:playlist:37i9dQZF1DX0GDEVNHvE3h
-        ## Best of the Decade 2011-2019: spotify:playlist:37i9dQZF1DXaMu9xyX1HzK
-        ## Top Songs of 2019: spotify:playlist:37i9dQZF1EtiMc33WI4nNn
-        ## Daily Mix 1: spotify:playlist:37i9dQZF1E37INBdbw9l8Q
-        ## Daily Mix 2: spotify:playlist:37i9dQZF1E38mQjeIPb1EL
-        ## Daily Mix 3: spotify:playlist:37i9dQZF1E354DBk6AJ16Y
-        ## Daily Mix 4: spotify:playlist:37i9dQZF1E38XO0gwAEnvS
-        ## Daily Mix 5: spotify:playlist:37i9dQZF1E37RF0IYL80qo
-        ## Daily Mix 6: spotify:playlist:37i9dQZF1E38hC1b4cOQvA
-        ## Summer Rewind: spotify:playlist:37i9dQZF1CAqqQ5eUaE9tb
-        ## 90s Pop Rock Essentials: spotify:playlist:37i9dQZF1DX3YMp9n8fkNx
-        ## Lo-Fi Beats: spotify:playlist:37i9dQZF1DWWQRwui0ExPn
-        ## RetroWave Outrun: spotify:playlist:37i9dQZF1DXdLEN7aqioXM
-        ## Simpsons Wave: spotify:playlist:0OZV1MvJmJdeShboKpNKC8
-        ## Guster w/Utah Symphone 7/29/22: spotify:playlist:4gmNQHup10wDckuwWL3IFZ
-        ## Sigur Ros @ State Theatre 5/31/2022: spotify:playlist:6NiKjgceymmq3yVzxgb9Uv
-        ## Pachuca Sunrise Radio: spotify:playlist:37i9dQZF1E8T1k2ZTHYNkV
-        ##  Darksynth | Synthwave: spotify:playlist:1Iowhep08Kl9MJ0XOwsBMp
-        ##  Lowfi Covers: spotify:playlist:37i9dQZF1DX4nNmLlb3JR2
-        ## SomaFM Groove Salad: https://somafm.com/groovesalad.pls
-        ## SomaFM Deep Space One: https://somafm.com/deepspaceone.pls
-        ## SomaFM Mission Control: https://somafm.com/missioncontrol.pls
-        ## SomaFM Space Station Soma: https://somafm.com/spacestation.pls
-        ## SomaFM Vaporwaves: https://somafm.com/vaporwaves.pls
-        #}
-        {%- set plists = ["spotify:album:78bpIziExqiI9qztvNFlQu",
-          "spotify:user:spotify:playlist:37i9dQZF1DXbTxeAdrVG2l",
-          "spotify:user:myplay.com:playlist:2f6tXtN0XesjONxicAzMIw",
-          "spotify:user:126202651:playlist:6uNCXLheVaTbfE1HRCIsQ5",
-          "spotify:playlist:37i9dQZEVXcMDffrPenJPl",
-          "spotify:user:spotify:playlist:37i9dQZF1DXb9LIXaj5WhL",
-          "spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu",
-          "spotify:album:7Hk9WbjPbN1n2GXaK7aldw",
-          "spotify:playlist:37i9dQZF1DWTmUQ5ZV8Wa1",
-          "spotify:user:spotify:playlist:37i9dQZF1DX2SK4ytI2KAZ",
-          "spotify:playlist:37i9dQZF1DZ06evO1XPrLQ",
-          "spotify:artist:0Ya43ZKWHTKkAbkoJJkwIB",
-          "spotify:user:126202651:playlist:4CIBhwpAL598munofpCu6i",
-          "spotify:user:spotify:playlist:37i9dQZF1DX4wNVWmoZ4FM",
-          "spotify:album:4JEgSaokMH5mMRClx9wp3S",
-          "spotify:user:126202651:playlist:56WlVUutx91MElxdsbtzj1",
-          "spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf",
-          "spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW",
-          "spotify:user:spotify:playlist:37i9dQZF1E4YuevTvB5WHT",
-          "spotify:user:spotify:playlist:37i9dQZF1DXdxZQJxjFMLO",
-          "spotify:user:126202651:playlist:65fTj3YJl4jvFmXxru7BfO",
-          "spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq",
-          "spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP",
-          "spotify:user:126202651:playlist:3D3gu4wURrZfR813RTh5M8",
-          "spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu",
-          "spotify:playlist:37i9dQZEVXcMDffrPenJPl",
-          "spotify:user:spotify:playlist:37i9dQZF1DX0YKekzl0blG",
-          "spotify:user:spotify:playlist:37i9dQZF1E4lDVOWeZX2IT",
-          "spotify:user:spotify:playlist:37i9dQZF1E4pBKIU2s8AX1",
-          "spotify:user:spotify:playlist:37i9dQZF1E4AQ4IdimJyYD",
-          "spotify:user:spotify:playlist:37i9dQZF1E4Cpj7tK5yC6M",
-          "spotify:user:spotify:playlist:37i9dQZF1E4tcQYL2Wtnge",
-          "spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY",
-          "spotify:playlist:37i9dQZF1E8DMpUzqgcOJh",
-          "spotify:playlist:3dj3AYHFe2RKKjdQsaOWYl",
-          "spotify:playlist:37i9dQZF1DX0GDEVNHvE3h",
-          "spotify:playlist:37i9dQZF1DXaMu9xyX1HzK",
-          "spotify:playlist:37i9dQZF1EtiMc33WI4nNn",
-          "spotify:playlist:37i9dQZF1E354DBk6AJ16Y",
-          "spotify:playlist:37i9dQZF1E38mQjeIPb1EL",
-          "spotify:playlist:37i9dQZF1E37INBdbw9l8Q",
-          "spotify:playlist:37i9dQZF1E38XO0gwAEnvS",
-          "spotify:playlist:37i9dQZF1E37RF0IYL80qo",
-          "spotify:playlist:37i9dQZF1E38hC1b4cOQvA",
-          "spotify:playlist:37i9dQZF1CAqqQ5eUaE9tb",
-          "spotify:playlist:37i9dQZF1DX3YMp9n8fkNx",
-          "spotify:playlist:37i9dQZF1DWWQRwui0ExPn",
-          "spotify:playlist:37i9dQZF1DXdLEN7aqioXM",
-          "spotify:playlist:0OZV1MvJmJdeShboKpNKC8",
-          "spotify:playlist:4gmNQHup10wDckuwWL3IFZ",
-          "spotify:playlist:6NiKjgceymmq3yVzxgb9Uv",
-          "spotify:playlist:37i9dQZF1E8T1k2ZTHYNkV",
-          "spotify:playlist:1Iowhep08Kl9MJ0XOwsBMp",
-          "spotify:playlist:37i9dQZF1DX4nNmLlb3JR2",
-          "https://somafm.com/groovesalad.pls",
-          "https://somafm.com/deepspaceone.pls",
-          "https://somafm.com/missioncontrol.pls",
-          "https://somafm.com/spacestation.pls",
-          "https://somafm.com/vaporwaves.pls",
-          "spotify--Tviw9k66://playlist/2I2cwYxeuLbIXaNRccMViZ"
-          ] -%}
-          {% set pindex =  (range(0, (plists | length))|random) -%}
-          {{ plists[pindex] }}
     sequence:
+      - variables:
+          playlist: >-
+            {#
+            ## Arctic Monkeys - AM : spotify:album:78bpIziExqiI9qztvNFlQu
+            ## All Out 90s : spotify:playlist:37i9dQZF1DXbTxeAdrVG2l
+            ## 2000s Smash Hits : spotify:playlist:2f6tXtN0XesjONxicAzMIw
+            ## 2019 Sealand Invitiational : spotify:playlist:6uNCXLheVaTbfE1HRCIsQ5
+            ## Discover Weekly: spotify:playlist:37i9dQZEVXcMDffrPenJPl
+            ## 90s Acoustic: spotify:user:spotify:playlist:37i9dQZF1DXb9LIXaj5WhL
+            ## This is Passion Pit: spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu
+            ## Panic! at the Disco Pretty. Odd. : spotify:album:7Hk9WbjPbN1n2GXaK7aldw
+            ## This is The Mountain Goats : spotify:playlist:37i9dQZF1DWTmUQ5ZV8Wa1
+            ## It's ALT Good! : spotify:user:spotify:playlist:37i9dQZF1DX2SK4ytI2KAZ
+            ## The Griswolds : spotify:playlist:37i9dQZF1DZ06evO1XPrLQ
+            ## The Wombats : spotify:artist:0Ya43ZKWHTKkAbkoJJkwIB
+            ## The Decemberists @ Palace 2018 : spotify:user:126202651:playlist:4CIBhwpAL598munofpCu6i
+            ## This is Jimmy Eat World : spotify:user:spotify:playlist:37i9dQZF1DX4wNVWmoZ4FM
+            ## David Bowie Legacy : spotify:album:4JEgSaokMH5mMRClx9wp3S
+            ## This is Cake: spotify:user:spotify:playlist:37i9dQZF1DZ06evO3T3SWA
+            ## SDSU : spotify:user:126202651:playlist:56WlVUutx91MElxdsbtzj1
+            ## Your Top Songs 2018 : spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf
+            ## Your Top Songs 2017 : spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW
+            ## Your Time Capsule : spotify:user:spotify:playlist:37i9dQZF1E4YuevTvB5WHT
+            ## This is The Lumineers : spotify:user:spotify:playlist:37i9dQZF1DXdxZQJxjFMLO
+            ## Guster @ Showbox Seattle 2/16/2019 spotify:user:126202651:playlist:65fTj3YJl4jvFmXxru7BfO
+            ## Guster @ First Ave MSP 2/9/2019 spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq
+            ## Coheed & Cambria @ The Armory MSP 7/26/2018 spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP
+            ## Jimmy Eat World @ First Ave Minneapolis 5/9/18 spotify:user:126202651:playlist:3D3gu4wURrZfR813RTh5M8
+            ## This is Passion Pit : spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu
+            ## Your Discovery Weekly : spotify:playlist:37i9dQZEVXcMDffrPenJPl
+            ## Alternative 00s : spotify:user:spotify:playlist:37i9dQZF1DX0YKekzl0blG
+            ## Panic at the Disco Radio : spotify:user:spotify:playlist:37i9dQZF1E4lDVOWeZX2IT
+            ## Decemberists Radio : spotify:user:spotify:playlist:37i9dQZF1E4pBKIU2s8AX1
+            ## Guster Radio : spotify:user:spotify:playlist:37i9dQZF1E4AQ4IdimJyYD
+            ## Jimmy Eat World Radio : spotify:user:spotify:playlist:37i9dQZF1E4tDgdv9Es4ng
+            ## The Lumineers Radio : spotify:user:spotify:playlist:37i9dQZF1E4Cpj7tK5yC6M
+            ## Band of Hourses Radio : spotify:user:spotify:playlist:37i9dQZF1E4tcQYL2Wtnge
+            ## This is Band of Horses : spotify:user:spotify:playlist:37i9dQZF1DZ06evO0pK2Aw
+            ## Henry Jamison Radio : spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY
+            ## Happier Radio : spotify:playlist:37i9dQZF1E8DMpUzqgcOJh
+            ## Guster @ Weesner Family Ampitheater (MN Zoo), Jul 22, 2019
+            ## This is Tool : spotify:playlist:37i9dQZF1DX0GDEVNHvE3h
+            ## Best of the Decade 2011-2019: spotify:playlist:37i9dQZF1DXaMu9xyX1HzK
+            ## Top Songs of 2019: spotify:playlist:37i9dQZF1EtiMc33WI4nNn
+            ## Daily Mix 1: spotify:playlist:37i9dQZF1E37INBdbw9l8Q
+            ## Daily Mix 2: spotify:playlist:37i9dQZF1E38mQjeIPb1EL
+            ## Daily Mix 3: spotify:playlist:37i9dQZF1E354DBk6AJ16Y
+            ## Daily Mix 4: spotify:playlist:37i9dQZF1E38XO0gwAEnvS
+            ## Daily Mix 5: spotify:playlist:37i9dQZF1E37RF0IYL80qo
+            ## Daily Mix 6: spotify:playlist:37i9dQZF1E38hC1b4cOQvA
+            ## Summer Rewind: spotify:playlist:37i9dQZF1CAqqQ5eUaE9tb
+            ## 90s Pop Rock Essentials: spotify:playlist:37i9dQZF1DX3YMp9n8fkNx
+            ## Lo-Fi Beats: spotify:playlist:37i9dQZF1DWWQRwui0ExPn
+            ## RetroWave Outrun: spotify:playlist:37i9dQZF1DXdLEN7aqioXM
+            ## Simpsons Wave: spotify:playlist:0OZV1MvJmJdeShboKpNKC8
+            ## Guster w/Utah Symphone 7/29/22: spotify:playlist:4gmNQHup10wDckuwWL3IFZ
+            ## Sigur Ros @ State Theatre 5/31/2022: spotify:playlist:6NiKjgceymmq3yVzxgb9Uv
+            ## Pachuca Sunrise Radio: spotify:playlist:37i9dQZF1E8T1k2ZTHYNkV
+            ##  Darksynth | Synthwave: spotify:playlist:1Iowhep08Kl9MJ0XOwsBMp
+            ##  Lowfi Covers: spotify:playlist:37i9dQZF1DX4nNmLlb3JR2
+            ## SomaFM Groove Salad: https://somafm.com/groovesalad.pls
+            ## SomaFM Deep Space One: https://somafm.com/deepspaceone.pls
+            ## SomaFM Mission Control: https://somafm.com/missioncontrol.pls
+            ## SomaFM Space Station Soma: https://somafm.com/spacestation.pls
+            ## SomaFM Vaporwaves: https://somafm.com/vaporwaves.pls
+            #}
+            {%- set plists = ["spotify:album:78bpIziExqiI9qztvNFlQu",
+              "spotify:user:spotify:playlist:37i9dQZF1DXbTxeAdrVG2l",
+              "spotify:user:myplay.com:playlist:2f6tXtN0XesjONxicAzMIw",
+              "spotify:user:126202651:playlist:6uNCXLheVaTbfE1HRCIsQ5",
+              "spotify:playlist:37i9dQZEVXcMDffrPenJPl",
+              "spotify:user:spotify:playlist:37i9dQZF1DXb9LIXaj5WhL",
+              "spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu",
+              "spotify:album:7Hk9WbjPbN1n2GXaK7aldw",
+              "spotify:playlist:37i9dQZF1DWTmUQ5ZV8Wa1",
+              "spotify:user:spotify:playlist:37i9dQZF1DX2SK4ytI2KAZ",
+              "spotify:playlist:37i9dQZF1DZ06evO1XPrLQ",
+              "spotify:artist:0Ya43ZKWHTKkAbkoJJkwIB",
+              "spotify:user:126202651:playlist:4CIBhwpAL598munofpCu6i",
+              "spotify:user:spotify:playlist:37i9dQZF1DX4wNVWmoZ4FM",
+              "spotify:album:4JEgSaokMH5mMRClx9wp3S",
+              "spotify:user:126202651:playlist:56WlVUutx91MElxdsbtzj1",
+              "spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf",
+              "spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW",
+              "spotify:user:spotify:playlist:37i9dQZF1E4YuevTvB5WHT",
+              "spotify:user:spotify:playlist:37i9dQZF1DXdxZQJxjFMLO",
+              "spotify:user:126202651:playlist:65fTj3YJl4jvFmXxru7BfO",
+              "spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq",
+              "spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP",
+              "spotify:user:126202651:playlist:3D3gu4wURrZfR813RTh5M8",
+              "spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu",
+              "spotify:playlist:37i9dQZEVXcMDffrPenJPl",
+              "spotify:user:spotify:playlist:37i9dQZF1DX0YKekzl0blG",
+              "spotify:user:spotify:playlist:37i9dQZF1E4lDVOWeZX2IT",
+              "spotify:user:spotify:playlist:37i9dQZF1E4pBKIU2s8AX1",
+              "spotify:user:spotify:playlist:37i9dQZF1E4AQ4IdimJyYD",
+              "spotify:user:spotify:playlist:37i9dQZF1E4Cpj7tK5yC6M",
+              "spotify:user:spotify:playlist:37i9dQZF1E4tcQYL2Wtnge",
+              "spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY",
+              "spotify:playlist:37i9dQZF1E8DMpUzqgcOJh",
+              "spotify:playlist:3dj3AYHFe2RKKjdQsaOWYl",
+              "spotify:playlist:37i9dQZF1DX0GDEVNHvE3h",
+              "spotify:playlist:37i9dQZF1DXaMu9xyX1HzK",
+              "spotify:playlist:37i9dQZF1EtiMc33WI4nNn",
+              "spotify:playlist:37i9dQZF1E354DBk6AJ16Y",
+              "spotify:playlist:37i9dQZF1E38mQjeIPb1EL",
+              "spotify:playlist:37i9dQZF1E37INBdbw9l8Q",
+              "spotify:playlist:37i9dQZF1E38XO0gwAEnvS",
+              "spotify:playlist:37i9dQZF1E37RF0IYL80qo",
+              "spotify:playlist:37i9dQZF1E38hC1b4cOQvA",
+              "spotify:playlist:37i9dQZF1CAqqQ5eUaE9tb",
+              "spotify:playlist:37i9dQZF1DX3YMp9n8fkNx",
+              "spotify:playlist:37i9dQZF1DWWQRwui0ExPn",
+              "spotify:playlist:37i9dQZF1DXdLEN7aqioXM",
+              "spotify:playlist:0OZV1MvJmJdeShboKpNKC8",
+              "spotify:playlist:4gmNQHup10wDckuwWL3IFZ",
+              "spotify:playlist:6NiKjgceymmq3yVzxgb9Uv",
+              "spotify:playlist:37i9dQZF1E8T1k2ZTHYNkV",
+              "spotify:playlist:1Iowhep08Kl9MJ0XOwsBMp",
+              "spotify:playlist:37i9dQZF1DX4nNmLlb3JR2",
+              "https://somafm.com/groovesalad.pls",
+              "https://somafm.com/deepspaceone.pls",
+              "https://somafm.com/missioncontrol.pls",
+              "https://somafm.com/spacestation.pls",
+              "https://somafm.com/vaporwaves.pls",
+              "spotify--Tviw9k66://playlist/2I2cwYxeuLbIXaNRccMViZ"
+              ] -%}
+            {% set pindex = (range(0, (plists | length))|random) -%}
+            {{ plists[pindex] }}
       - action: media_player.shuffle_set
         continue_on_error: true
         target:


### PR DESCRIPTION
Closes #472 (partial — this PR addresses a potential root cause from HA template caching)

## Problem

Script-level `variables:` blocks are evaluated during script initialization. Templates with no state entity subscriptions (like a plain `random` call over a static list) can be pre-compiled by HA's template engine — there are no states to track that would signal a re-render. In practice this *may* cause the same playlist index to be selected on every run if HA's template cache is warm.

Note: direct template evaluation tests did show `random` producing different results, so this may not be the active cause — but the pattern is fragile and worth hardening regardless, since it makes the caching question moot.

## Fix

Move the `playlist:` template from the script-level `variables:` block into a `variables:` action as the **first step of the sequence**. Variables defined inside a `sequence` action are always evaluated fresh at execution time, with no caching pathway:

```yaml
# Before (script-level, potentially cacheable)
spotify_bedtime:
  variables:
    playlist: >-
      {%- set plists = [...] -%}
      {{ plists[(range(0, plists|length)|random)] }}
  sequence:
    - action: media_player.shuffle_set
      ...

# After (sequence-level, always fresh)
spotify_bedtime:
  sequence:
    - variables:
        playlist: >-
          {%- set plists = [...] -%}
          {{ plists[(range(0, plists|length)|random)] }}
    - action: media_player.shuffle_set
      ...
```

## Scope

This PR only migrates `spotify_bedtime`. The same pattern should be applied to `spotify_arrival` and `spotify_wake_up` in a follow-up — they are left separate to keep this PR reviewable.

## Trade-offs

- The `playlist` variable is no longer available as a script-level field (e.g. you can't pass it as an override via `script.turn_on` data). If caller override is needed, add a `fields:` definition and a conditional in the sequence.
- Slightly different YAML indentation for the playlist list (cosmetic only).

## Test plan

- [ ] Run `script.spotify_bedtime` 5 times in developer tools, check logbook — confirm 5 different playlist URIs are logged