### PR TITLE
fix: Sonos group coordinator race condition and unconditional unjoin collateral damage

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -424,7 +424,7 @@ automation:
             sequence:
               - action: script.spotify_wake_up
                 data:
-                  playback_entity_id: media_player.bathroom_sonos_2
+                  playback_entity_id: media_player.bedroom_sonos_2
                   regroup_after_play: true
               - action: media_player.volume_set
                 target:
@@ -441,7 +441,7 @@ automation:
               volume_level: 0.1
           - action: script.spotify_wake_up
             data:
-              playback_entity_id: media_player.bathroom_sonos_2
+              playback_entity_id: media_player.bedroom_sonos_2
               regroup_after_play: true
           - alias: "Repeat until desired volume reached"
             repeat:
@@ -669,6 +669,22 @@ script:
     alias: "Prepare bedroom Music Assistant group"
     mode: restart
     sequence:
+      - alias: "Skip unjoin/rejoin if bedroom group is already correctly formed"
+        if:
+          - condition: template
+            value_template: >
+              {% set members = state_attr('media_player.bedroom_sonos_2', 'group_members') | default([]) %}
+              {% if is_state('input_boolean.guest_mode', 'off') %}
+                {{ 'media_player.bathroom_sonos_2' in members and
+                   'media_player.den_sonos_2' in members and
+                   'media_player.office_sonos_2' in members }}
+              {% else %}
+                {{ 'media_player.bathroom_sonos_2' in members and
+                   'media_player.den_sonos_2' not in members and
+                   'media_player.office_sonos_2' not in members }}
+              {% endif %}
+        then:
+          - stop: "Bedroom group already correctly formed"
       - alias: "Split bedroom wake-up players before regrouping"
         continue_on_error: true
         action: media_player.unjoin
@@ -719,6 +735,23 @@ script:
   music_assistant_prepare_arrival_group:
     alias: "Prepare arrival Music Assistant group"
     sequence:
+      - alias: "Skip unjoin/rejoin if arrival group is already correctly formed"
+        if:
+          - condition: template
+            value_template: >
+              {% if is_state('input_boolean.guest_mode', 'off') %}
+                {% set members = state_attr('media_player.den_sonos_2', 'group_members') | default([]) %}
+                {{ 'media_player.bedroom_sonos_2' in members and
+                   'media_player.bathroom_sonos_2' in members and
+                   'media_player.office_sonos_2' in members and
+                   'media_player.tiki_room_2' in members }}
+              {% else %}
+                {% set members = state_attr('media_player.bedroom_sonos_2', 'group_members') | default([]) %}
+                {{ 'media_player.bathroom_sonos_2' in members and
+                   'media_player.den_sonos_2' not in members }}
+              {% endif %}
+        then:
+          - stop: "Arrival group already correctly formed"
       - alias: "Split arrival players before regrouping"
         continue_on_error: true
         action: media_player.unjoin


### PR DESCRIPTION
Closes #477

## Summary

- **Fix race condition** in `play_music_in_bathroom_when_up`: stop passing `bathroom_sonos_2` as `playback_entity_id` — play on the group coordinator (`bedroom_sonos_2`) instead, so the group forms cleanly before music starts
- **Add idempotency guard** to `music_assistant_prepare_bedroom_group`: skip unjoin/rejoin entirely if `bedroom_sonos_2` already has the correct group members
- **Same guard** for `music_assistant_prepare_arrival_group`

## Root cause

`play_music_in_bathroom_when_up` was passing `playback_entity_id: media_player.bathroom_sonos_2` to `script.spotify_wake_up`. The script would then:
1. Start playback on `bathroom_sonos_2`
2. Call `music_assistant_prepare_bedroom_group`, which unjoins all speakers then reforms with `bedroom_sonos_2` as coordinator and `bathroom_sonos_2` as a subordinate member
3. `bedroom_sonos_2` (the new coordinator) has no active MA content → group goes idle

The fix plays directly on the coordinator so there's nothing to hand off.

The idempotency guards prevent the unconditional unjoin from killing the Den Turntable pairing and other unrelated groups on every morning automation trigger.

## Test plan

- [ ] Trigger `play_music_in_bathroom_when_up` manually with bathroom occupancy sensor — verify all 4 speakers play and volume ramps up
- [ ] Trigger again while already in correct group state — verify `music_assistant_prepare_bedroom_group` exits early (check trace, should show `stop` action)
- [ ] Verify Den Turntable is not disrupted when morning automation fires while den is playing from turntable

🤖 Generated with [Claude Code](https://claude.com/claude-code)