### PR TITLE
fix: keep bathroom wake audio on bathroom sonos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,12 @@
 - Read it before changing guest mode, occupancy, lighting, media, vacuum, climate, dashboards, or other room-targeted logic.
 - If convenience behavior conflicts with room intent, preserve privacy-first behavior.
 
+## Media Playback Targets
+- Music playback, Music Assistant, and Sonos grouping logic must target Sonos speakers only.
+- Do not retarget music playback to HomePods, Apple TVs, TVs, receivers, or other non-Sonos media players as a substitute for an unavailable Sonos entity.
+- Before debugging or updating music playback targets, inspect the live media player integration/device type and confirm the entity is a Sonos speaker.
+- The Den turntable is an input source only and is not a valid output target for any music playback, grouping, volume, or pause automation.
+
 ## Behavioral Specs
 - Use `specs/alarm_wakeup.allium` as the source of truth for alarm, wake-up, snooze, and morning audio behavior.
 - Use `specs/night_routines.allium` as the source of truth for bedtime preparation and overnight goodnight behavior.

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -424,8 +424,9 @@ automation:
             sequence:
               - action: script.spotify_wake_up
                 data:
-                  playback_entity_id: media_player.bedroom_sonos_2
-                  regroup_after_play: true
+                  playback_entity_id: media_player.bathroom_sonos_2
+                  prepare_group_before_play: false
+                  regroup_after_play: false
               - action: media_player.volume_set
                 target:
                   entity_id: media_player.bathroom_sonos_2
@@ -441,8 +442,9 @@ automation:
               volume_level: 0.1
           - action: script.spotify_wake_up
             data:
-              playback_entity_id: media_player.bedroom_sonos_2
-              regroup_after_play: true
+              playback_entity_id: media_player.bathroom_sonos_2
+              prepare_group_before_play: false
+              regroup_after_play: false
           - alias: "Repeat until desired volume reached"
             repeat:
               sequence:

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -225,12 +225,15 @@ def test_spotify_wakeup_prepares_group_before_play_and_only_retries_regroup_when
     )
 
 
-def test_bathroom_wakeup_automation_targets_bathroom_player() -> None:
+def test_bathroom_wakeup_automation_targets_bathroom_sonos_only() -> None:
     block = _automation_block("play_music_in_bathroom_when_up")
 
     assert 'action: script.spotify_wake_up' in block
     assert block.count('playback_entity_id: media_player.bathroom_sonos_2') == 2
-    assert block.count('regroup_after_play: true') == 2
+    assert 'playback_entity_id: media_player.bedroom_sonos_2' not in block
+    assert block.count('prepare_group_before_play: false') == 2
+    assert block.count('regroup_after_play: false') == 2
+    assert 'regroup_after_play: true' not in block
     assert 'media_player.media_stop' not in block
 
 


### PR DESCRIPTION
## Summary
- Document that music playback targets must stay on Sonos speakers only, never HomePods or other media players, and that the Den turntable is not an output target.
- Fix bathroom-triggered wake audio to play on `media_player.bathroom_sonos_2` instead of starting on the bedroom Sonos and regrouping.
- Update the Music Assistant test to assert bathroom-only Sonos playback and no post-play regrouping for that path.

## Runtime evidence
- Nightly trace review found the required full pytest run failing on `test_bathroom_wakeup_automation_targets_bathroom_player` because the current package was using `media_player.bedroom_sonos_2` for bathroom wake-up audio.
- `specs/alarm_wakeup.allium` requires `MorningAudioRequested(morning_playlist, bathroom)` to prepare bathroom-only wake audio, so this was a Logic/Behavior Mismatch (Allium).
- User clarified that unavailable Tiki Room Sonos must not be replaced with the HomePod-style `media_player.tiki_room` target; the earlier local retarget was backed out before commit.

## Validation
- `uv run --with pytest pytest tests/test_media_player_music_assistant.py tests/test_alarm_night_allium_alignment.py -q` - 27 passed
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/media_player.yaml` - passed
- `uv run --with pytest pytest` - 296 passed

## Notes
- `uv run --with pyyaml python /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/media_player.yaml --strict` still reports pre-existing duplicate sequence patterns in the large media package; no new duplicate block was added by this change.
