### PR TITLE
fix: exclude garden birds sensor from InfluxDB

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -131,6 +131,9 @@ influxdb:
       - vacuum
     entities:
       - sensor.time
+      # The Garden Birds MQTT sensor carries an attribute named "time"; InfluxDB
+      # rejects fields with that reserved name and drops the entire batch.
+      - sensor.garden_birds
 
 cloud:
   alexa:

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -10,6 +10,7 @@ ZIGBEE_ZWAVE_PATH = ROOT / "packages" / "zigbee_zwave.yaml"
 BIRDS_PATH = ROOT / "packages" / "birds.yaml"
 UTILITIES_PATH = ROOT / "packages" / "utilities.yaml"
 HOLIDAYS_PATH = ROOT / "packages" / "holidays.yaml"
+CONFIGURATION_PATH = ROOT / "configuration.yaml"
 
 
 def _read(path: Path) -> str:
@@ -103,6 +104,14 @@ def test_bird_templates_guard_missing_json_fields() -> None:
     assert "payload is mapping and payload.common_name is defined" in text
     assert "value_json is defined and value_json is mapping and value_json.species is defined and value_json.species | count > 0" in text
     assert "value_json is defined and value_json is mapping and value_json.detections is defined and value_json.detections | length > 0" in text
+
+
+def test_garden_birds_sensor_is_excluded_from_influxdb() -> None:
+    text = _read(CONFIGURATION_PATH)
+
+    influx_block = text.split("influxdb:\n", 1)[1].split("\ncloud:", 1)[0]
+
+    assert "sensor.garden_birds" in influx_block
 
 
 def test_garbage_notifications_use_computed_pickup_date_sensor() -> None:


### PR DESCRIPTION
## Summary
- Exclude `sensor.garden_birds` from the InfluxDB integration because its MQTT payload exposes an attribute named `time`, which InfluxDB rejects as a field name and then drops the whole write batch.
- Add a regression test that keeps the Garden Birds sensor in the InfluxDB exclude block.

## Runtime evidence
- Live Home Assistant logs repeatedly showed InfluxDB write failures for `sensor.garden_birds` with `invalid field name: input field "time" on measurement "°C" is invalid`.
- This was a current live regression because the same entity remained active and not excluded from the live/repo InfluxDB config.

## Validation
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable}}' configuration.yaml`
- `uv run --with pytest pytest tests/test_runtime_log_regressions.py -q`
- `uv run --with pytest pytest`