### PR TITLE
feat: arrival adaptive lighting + morning light ramp spec

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -87,16 +87,20 @@ automation:
       turn on as part of home-arrival automations. Fires for all transport
       modes (car, Uber, Lyft, walking) via the Bayesian presence sensor.
       A 2-second delay lets arrival-scene transitions begin before the
-      adaptive apply fires. turn_on_lights=false ensures only lights that
-      are already transitioning on receive the correction; lights that remain
-      off are not disturbed. Resolves #486.
+      adaptive apply fires. Empty-house arrivals can apply across all
+      configured arrival switches; occupied-house arrivals only apply to
+      configured lights that Adaptive Lighting has not marked as manually
+      controlled. turn_on_lights=false keeps off lights undisturbed. Resolves
+      #486.
     mode: single
     trigger:
       - trigger: zone
+        id: bayesian-device-entered-home
         entity_id: device_tracker.bayesian_zeke_home
         zone: zone.home
         event: enter
       - trigger: state
+        id: bayesian-presence-turned-on
         entity_id: binary_sensor.bayesian_zeke_home
         from: "off"
         to: "on"
@@ -105,19 +109,68 @@ automation:
         entity_id: binary_sensor.bayesian_bed_occupancy
         state: "off"
     action:
-      - delay:
-          seconds: 2
-      - action: adaptive_lighting.apply
-        data:
-          entity_id:
+      - variables:
+          arrival_home_was_empty: >-
+            {{
+              (
+                trigger.id == 'bayesian-presence-turned-on'
+                and trigger.from_state is not none
+                and trigger.from_state.state == 'off'
+              )
+              or
+              (
+                trigger.id == 'bayesian-device-entered-home'
+                and is_state('binary_sensor.bayesian_zeke_home', 'off')
+              )
+            }}
+          arrival_adaptive_switches:
             - switch.adaptive_lighting_kitchen
             - switch.adaptive_lighting_den
             - switch.adaptive_lighting_hallway
             - switch.adaptive_lighting_owner_suite
-          adapt_brightness: true
-          adapt_color: true
-          turn_on_lights: false
-          transition: 1
+      - delay:
+          seconds: 2
+      - choose:
+          - alias: "Apply globally when this arrival starts from an empty house"
+            conditions:
+              - condition: template
+                value_template: "{{ arrival_home_was_empty }}"
+            sequence:
+              - action: adaptive_lighting.apply
+                data:
+                  entity_id: "{{ arrival_adaptive_switches }}"
+                  adapt_brightness: true
+                  adapt_color: true
+                  turn_on_lights: false
+                  transition: 1
+        default:
+          - repeat:
+              for_each: "{{ arrival_adaptive_switches }}"
+              sequence:
+                - variables:
+                    configured_arrival_lights: >-
+                      {% set configuration = state_attr(repeat.item, 'configuration') or {} %}
+                      {{ configuration.get('lights', []) }}
+                    manual_controlled_lights: >-
+                      {{ state_attr(repeat.item, 'manual_control') or [] }}
+                    eligible_arrival_lights: >-
+                      {{
+                        configured_arrival_lights
+                        | reject('in', manual_controlled_lights)
+                        | list
+                      }}
+                - if:
+                    - condition: template
+                      value_template: "{{ eligible_arrival_lights | count > 0 }}"
+                  then:
+                    - action: adaptive_lighting.apply
+                      data:
+                        entity_id: "{{ repeat.item }}"
+                        lights: "{{ eligible_arrival_lights }}"
+                        adapt_brightness: true
+                        adapt_color: true
+                        turn_on_lights: false
+                        transition: 1
 
   - id: sync_selected_inovelli_led_bars_to_adaptive_lighting
     alias: sync_selected_inovelli_led_bars_to_adaptive_lighting

--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -80,6 +80,45 @@ automation:
           detect_non_ha_changes: false
       - event: adaptive_lighting_startup_reconciled
 
+  - id: apply_adaptive_lighting_on_arrival
+    alias: apply_adaptive_lighting_on_arrival
+    description: >
+      Instantly correct color temperature and brightness for any lights that
+      turn on as part of home-arrival automations. Fires for all transport
+      modes (car, Uber, Lyft, walking) via the Bayesian presence sensor.
+      A 2-second delay lets arrival-scene transitions begin before the
+      adaptive apply fires. turn_on_lights=false ensures only lights that
+      are already transitioning on receive the correction; lights that remain
+      off are not disturbed. Resolves #486.
+    mode: single
+    trigger:
+      - trigger: zone
+        entity_id: device_tracker.bayesian_zeke_home
+        zone: zone.home
+        event: enter
+      - trigger: state
+        entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
+        to: "on"
+    condition:
+      - condition: state
+        entity_id: binary_sensor.bayesian_bed_occupancy
+        state: "off"
+    action:
+      - delay:
+          seconds: 2
+      - action: adaptive_lighting.apply
+        data:
+          entity_id:
+            - switch.adaptive_lighting_kitchen
+            - switch.adaptive_lighting_den
+            - switch.adaptive_lighting_hallway
+            - switch.adaptive_lighting_owner_suite
+          adapt_brightness: true
+          adapt_color: true
+          turn_on_lights: false
+          transition: 1
+
   - id: sync_selected_inovelli_led_bars_to_adaptive_lighting
     alias: sync_selected_inovelli_led_bars_to_adaptive_lighting
     description: >

--- a/specs/alarm_wakeup.allium
+++ b/specs/alarm_wakeup.allium
@@ -85,6 +85,7 @@ config {
     special_meeting_lead: Duration = 5.minutes
     snooze_duration: Duration = 8.minutes
     morning_blinds_delay: Duration = 175.seconds
+    morning_light_ramp_duration: Duration = 3.minutes
 }
 
 ------------------------------------------------------------
@@ -198,15 +199,17 @@ rule BeginWakeupSequence {
     ensures: house_mode.mode = home
     ensures: wakeup.wakeup_alarm_firing = true
     ensures: owner_suite.adaptive_lighting_enabled = true
-    ensures: owner_suite.lighting_state = daylight_ramp
+    ensures: owner_suite.lighting_state = dim_warm
     ensures: WakeupRampRequested(kind)
     ensures: WakeupBlindTransitionRequested(kind)
     @guidance
-        -- The live owner-suite morning transition immediately hands brightness
-        -- and color back to adaptive lighting. It starts with a short apply
-        -- from the current owner-suite sleep target and then settles into a
-        -- longer adaptive daytime ramp instead of forcing an explicit 2700K to
-        -- 6500K sequence in the wake-up script itself.
+        -- Implementation enables the adaptive lighting switch and immediately
+        -- applies the sleep target: minimum brightness (1 %) and warmest color
+        -- temperature (sleep_color_temp K) with a short transition (≤ 2 s).
+        -- Sleep mode is left on until the ramp begins so the sleep target values
+        -- remain in effect. WakeupRampRequested then hands control to
+        -- FinishWakeupSequence which performs the full config.morning_light_ramp_duration
+        -- transition to the current adaptive daytime target.
 }
 
 rule FinishWakeupSequence {
@@ -214,6 +217,14 @@ rule FinishWakeupSequence {
     ensures: owner_suite.lighting_state = daytime
     ensures: owner_suite.sleep_mode_enabled = false
     ensures: owner_suite.adaptive_lighting_enabled = true
+    @guidance
+        -- Implementation turns off sleep mode and calls adaptive_lighting.apply
+        -- with transition = config.morning_light_ramp_duration (3 minutes).
+        -- During the ramp, manual-control is locked on the owner-suite lights
+        -- to prevent adaptive lighting's periodic updates from interrupting the
+        -- transition. After config.morning_light_ramp_duration elapses, manual
+        -- control is cleared so adaptive lighting resumes normal periodic
+        -- adjustments without requiring an explicit re-enable.
 }
 
 rule OpenBlindsDuringWakeupTransition {

--- a/specs/arrival_lighting.allium
+++ b/specs/arrival_lighting.allium
@@ -24,6 +24,7 @@ given {
 
 external entity ArrivalContext {
     bed_occupied: Boolean
+    home_was_empty_before_arrival: Boolean
 }
 
 external entity HouseModeStateMachine {
@@ -50,15 +51,32 @@ rule ApplyAdaptiveLightingOnArrival {
     @guidance
         -- A delay of config.arrival_adaptive_delay lets arrival-scene actions
         -- begin turning on lights before the adaptive correction fires.
-        -- The apply targets each room's adaptive lighting switch with
+        -- Rooms in scope: kitchen, den, hallway, owner suite.
+        -- If the house was empty before this arrival, the apply may target
+        -- each room's adaptive lighting switch globally with
         -- adapt_brightness=true, adapt_color=true, turn_on_lights=false, and
         -- transition=config.arrival_adaptive_transition (1 s, near-instant).
-        -- Rooms in scope: kitchen, den, hallway, owner suite.
+        -- If someone was already home, the implementation must apply each
+        -- switch only to configured lights that are not currently present in
+        -- that switch's manual_control attribute, preserving active manual
+        -- brightness or color choices in occupied rooms.
         -- turn_on_lights=false ensures the correction only adjusts lights that
         -- are already on or transitioning on from the arrival scene; lights
         -- that are off are not disturbed.
         -- This rule fires for any transport mode: Tesla, Uber, Lyft, taxi,
         -- drop-off, or walking — presence detection is transport-agnostic.
+}
+
+rule PreserveManualLightingDuringOccupiedArrival {
+    when: ResidentArrivedHome()
+    requires: not arrival.bed_occupied
+    requires: not arrival.home_was_empty_before_arrival
+    ensures: ManualControlledArrivalLightsPreserved()
+    @guidance
+        -- Occupied-house arrivals must not send a broad switch-level
+        -- adaptive_lighting.apply. They derive eligible lights from each
+        -- switch's configured lights minus the current manual_control list
+        -- and apply only to that whitelist.
 }
 
 rule PreserveAdaptiveLightingAfterArrival {

--- a/specs/arrival_lighting.allium
+++ b/specs/arrival_lighting.allium
@@ -1,0 +1,82 @@
+-- allium: 3
+-- arrival_lighting.allium
+--
+-- Scope: Adaptive lighting application on resident home arrival.
+-- Includes:
+--   - instant adaptive lighting correction when arrival lights turn on
+--   - adaptive lighting switch enforcement for all participating rooms after arrival
+-- Excludes:
+--   - which specific lights turn on on arrival (governed by house_transition and scenes)
+--   - transport mode detection and presence-sensor logic
+--   - audio, climate, and security behaviour on arrival
+
+------------------------------------------------------------
+-- Given
+------------------------------------------------------------
+
+given {
+    arrival: ArrivalContext
+}
+
+------------------------------------------------------------
+-- External Entities
+------------------------------------------------------------
+
+external entity ArrivalContext {
+    bed_occupied: Boolean
+}
+
+external entity HouseModeStateMachine {
+    mode: home | away | night | in_bed | asleep
+}
+
+------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    arrival_adaptive_transition: Duration = 1.seconds
+    arrival_adaptive_delay: Duration = 2.seconds
+}
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+rule ApplyAdaptiveLightingOnArrival {
+    when: ResidentArrivedHome()
+    requires: not arrival.bed_occupied
+    ensures: ArrivalAdaptiveLightingApplied()
+    @guidance
+        -- A delay of config.arrival_adaptive_delay lets arrival-scene actions
+        -- begin turning on lights before the adaptive correction fires.
+        -- The apply targets each room's adaptive lighting switch with
+        -- adapt_brightness=true, adapt_color=true, turn_on_lights=false, and
+        -- transition=config.arrival_adaptive_transition (1 s, near-instant).
+        -- Rooms in scope: kitchen, den, hallway, owner suite.
+        -- turn_on_lights=false ensures the correction only adjusts lights that
+        -- are already on or transitioning on from the arrival scene; lights
+        -- that are off are not disturbed.
+        -- This rule fires for any transport mode: Tesla, Uber, Lyft, taxi,
+        -- drop-off, or walking — presence detection is transport-agnostic.
+}
+
+rule PreserveAdaptiveLightingAfterArrival {
+    when: ArrivalAdaptiveLightingApplied()
+    ensures: ArrivalRoomAdaptiveSwitchesEnabled()
+    @guidance
+        -- All room adaptive lighting switches (kitchen, den, hallway, owner
+        -- suite) must remain enabled after arrival so subsequent light events —
+        -- motion triggers, manual presses, and timed automations — receive
+        -- adaptive color and brightness updates without requiring an explicit
+        -- re-enable. The arrival adaptive apply does not disable any switch,
+        -- so this obligation is satisfied as long as no other automation
+        -- disables a switch during the arrival sequence.
+}
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open question "Should the dining room adaptive lighting switch also be included in the arrival apply scope, or only rooms with interior lights in the arrival scenes?"
+open question "If bed_occupied is true on arrival (unusual), should adaptive lighting still be applied to non-bedroom rooms (kitchen, den, hallway)?"

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -6,6 +6,9 @@ from pathlib import Path
 ADAPTIVE_LIGHTING_PATH = (
     Path(__file__).resolve().parents[1] / "packages" / "adaptive_lighting.yaml"
 )
+ARRIVAL_LIGHTING_SPEC_PATH = (
+    Path(__file__).resolve().parents[1] / "specs" / "arrival_lighting.allium"
+)
 
 
 def _automation_block(automation_id: str) -> str:
@@ -128,3 +131,57 @@ def test_basement_adaptive_lighting_reconciles_live_media_safe_settings() -> Non
     assert "sleep_brightness: 1" in block
     assert "sleep_color_temp: 1000" in block
     assert "detect_non_ha_changes: false" in block
+
+
+def test_arrival_adaptive_lighting_scopes_occupied_arrivals_to_non_manual_lights() -> None:
+    block = _automation_block("apply_adaptive_lighting_on_arrival")
+
+    for token in (
+        "id: bayesian-device-entered-home",
+        "id: bayesian-presence-turned-on",
+        "arrival_home_was_empty",
+        "trigger.from_state.state == 'off'",
+        "is_state('binary_sensor.bayesian_zeke_home', 'off')",
+        "arrival_adaptive_switches:",
+        "switch.adaptive_lighting_kitchen",
+        "switch.adaptive_lighting_den",
+        "switch.adaptive_lighting_hallway",
+        "switch.adaptive_lighting_owner_suite",
+        "turn_on_lights: false",
+    ):
+        assert token in block
+
+    empty_house_branch = block.split(
+        'alias: "Apply globally when this arrival starts from an empty house"', maxsplit=1
+    )[1].split("default:", maxsplit=1)[0]
+    assert "entity_id: \"{{ arrival_adaptive_switches }}\"" in empty_house_branch
+    assert not any(line.strip() == "lights:" for line in empty_house_branch.splitlines())
+
+    occupied_house_branch = block.split("default:", maxsplit=1)[1]
+    for token in (
+        'for_each: "{{ arrival_adaptive_switches }}"',
+        "state_attr(repeat.item, 'configuration') or {}",
+        "manual_controlled_lights",
+        "state_attr(repeat.item, 'manual_control') or []",
+        "reject('in', manual_controlled_lights)",
+        "eligible_arrival_lights | count > 0",
+        "entity_id: \"{{ repeat.item }}\"",
+        "lights: \"{{ eligible_arrival_lights }}\"",
+    ):
+        assert token in occupied_house_branch
+
+
+def test_arrival_lighting_spec_documents_empty_house_and_manual_control_gates() -> None:
+    text = ARRIVAL_LIGHTING_SPEC_PATH.read_text(encoding="utf-8")
+
+    for token in (
+        "home_was_empty_before_arrival: Boolean",
+        "If the house was empty before this arrival",
+        "If someone was already home",
+        "manual_control attribute",
+        "rule PreserveManualLightingDuringOccupiedArrival",
+        "requires: not arrival.home_was_empty_before_arrival",
+        "ManualControlledArrivalLightsPreserved",
+        "configured lights minus the current manual_control list",
+    ):
+        assert token in text

--- a/tests/test_allium_specs.py
+++ b/tests/test_allium_specs.py
@@ -34,6 +34,14 @@ def test_behavioral_allium_specs_exist_and_are_versioned() -> None:
             "rule ApplyGoodnightIntegrity",
             "wait_for_bathroom_visit_or_timeout",
         ],
+        "arrival_lighting.allium": [
+            "-- allium: 3",
+            "external entity ArrivalContext",
+            "home_was_empty_before_arrival: Boolean",
+            "rule ApplyAdaptiveLightingOnArrival",
+            "rule PreserveManualLightingDuringOccupiedArrival",
+            "manual_control attribute",
+        ],
         "z2m_lifecycle.allium": [
             "-- allium: 3",
             "entity ZigbeeDeviceLifecycle",


### PR DESCRIPTION
## Summary

- **New spec** `specs/arrival_lighting.allium` — formalises instant adaptive lighting on home arrival (any transport mode)
- **New automation** `apply_adaptive_lighting_on_arrival` in `packages/adaptive_lighting.yaml` — implements the spec
- **Spec alignment** `specs/alarm_wakeup.allium` — adds `morning_light_ramp_duration` config, corrects `BeginWakeupSequence` initial state to `dim_warm`, adds guidance on the 3-minute ramp and post-ramp control release

Closes #486. Partial progress on #410.

---

## Arrival adaptive lighting (closes #486)

**Problem:** Lights turning on during arrival displayed incorrect colors (e.g., cool blue in early morning) because arrival scenes set explicit brightness/color values and adaptive lighting was not re-applied afterward.

**Solution:** A new automation `apply_adaptive_lighting_on_arrival` fires on any home-arrival event (zone enter or Bayesian presence → on). After a 2-second delay to let the arrival scene begin, it calls `adaptive_lighting.apply` for kitchen, den, hallway, and owner-suite switches with:
- `turn_on_lights: false` — corrects lights already transitioning on; does not force off lights on
- `transition: 1` — near-instant (1 s) correction
- Works for Tesla, Uber, Lyft, walking, or any drop-off — transport-mode-agnostic

**Open questions raised in spec** (see `arrival_lighting.allium`):
- Should the dining room switch also be in scope?
- If `bed_occupied` is true on arrival, should non-bedroom rooms still get corrected?

---

## Morning light ramp spec alignment (progress on #410)

The live `owner_suite_morning_transition` already implements the 3-minute ramp correctly. This PR aligns the spec:

| Before | After |
|--------|-------|
| `BeginWakeupSequence` set `lighting_state = daylight_ramp` immediately | Sets `lighting_state = dim_warm` — reflects the actual initial state (1 % brightness, warmest color, sleep target applied instantly) |
| No config for ramp duration | `morning_light_ramp_duration: Duration = 3.minutes` added to config |
| `FinishWakeupSequence` had no guidance | `@guidance` documents the 3-minute adaptive ramp, manual-control lock, and post-ramp control release |

---

## Test plan

- [ ] Arrive home while in an Uber/Lyft (not Tesla) and verify kitchen + den + hallway lights turn on with correct adaptive colors within 3 seconds
- [ ] Arrive home after sunset and verify `night_arrive_home` scene lights (owner suite lamps, bed lightstrip) also receive adaptive correction
- [ ] Arrive home while `binary_sensor.bayesian_bed_occupancy` is `on` — automation should not fire
- [ ] Trigger a morning wakeup sequence and verify lights start at minimum brightness + warmest color before ramping over 3 minutes to daytime adaptive values
- [ ] After the 3-minute ramp completes, verify adaptive lighting continues to update (manual control cleared)
- [ ] `uv run --with pytest pytest` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)