### PR TITLE
fix(#118): centralize trip orchestration cleanup

### DIFF
--- a/docs/house_transition_framework.md
+++ b/docs/house_transition_framework.md
@@ -53,7 +53,16 @@ Common optional fields:
 - `packages/guest.yaml`
   guest-mode enable/disable and guest climate refresh automations
 - `packages/trips.yaml`
-  trip-mode manager enable/disable paths
+  trip-mode manager enable/disable paths, startup reconciliation, and the
+  one-hour home watchdog
+
+## Trip Mode
+
+Trip-mode behavior is documented in `docs/trip_mode_orchestration.md`. The
+important contract is that automated trip resolution delegates to
+`automation.trip_mode_manager`, and the manager calls `script.house_transition`
+with `apply_trip_policy: true` so vacation simulation stays in sync with
+`input_boolean.trip`.
 
 ## Manual Verification
 

--- a/docs/trip_mode_orchestration.md
+++ b/docs/trip_mode_orchestration.md
@@ -1,0 +1,65 @@
+# Trip Mode Orchestration
+
+Issue: `#118`
+
+## Summary
+
+Trip mode is the travel umbrella state for long absences. The canonical state is
+`input_boolean.trip`; all automated trip enable/disable paths should route
+through `automation.trip_mode_manager` so vacation simulation and cleanup stay
+deterministic.
+
+## State Ownership
+
+`automation.trip_mode_manager` owns writes to `input_boolean.trip` for automated
+travel decisions and reconciliation events. Other automations that need to
+resolve trip mode should emit `trip_mode_resolution_requested` with:
+
+- `desired_state`: `on` or `off`
+- `reason`: a concise source such as `startup_reconcile` or
+  `watchdog_home_1h`
+
+The manager then calls `script.house_transition` with `apply_trip_policy: true`.
+That keeps `switch.vacation_simulation` and
+`input_number.random_vacation_light_group` in sync with the trip state.
+
+## Current Inputs
+
+- Manual toggle: `input_boolean.trip`
+- Presence: `binary_sensor.bayesian_zeke_home`
+- Distance threshold: `input_number.trip_trigger_radius_miles`
+- Calendar sensors: `binary_sensor.planned_vacation_calendar`,
+  `binary_sensor.planned_work_trip_calendar`, and
+  `sensor.ecobee_calendar_vacation_schedule`
+- Flight/calendar trigger: `calendar.ryan_claussen`
+- Reconciliation events: `trip_mode_resolution_requested`
+
+## Side Effects
+
+- Trip enable starts vacation simulation through `script.house_transition`.
+- Trip disable stops vacation simulation and resets the random vacation light
+  group through `script.house_transition`.
+- Away lighting remains in `vacation_lights_on` and `vacation_lights_off`.
+- Travel vacuuming remains in `vacuum_on_trip` and `vacuum_flying_home`.
+- Ecobee vacation windows remain in `sync_ecobee_calendar_vacation`.
+
+## Guest And House-Sitter Policy
+
+Guest mode is the current privacy-preserving house-sitter signal. Trip vacuuming
+is suppressed when `input_boolean.guest_mode` is on, matching
+`docs/room_intent.yaml` guidance that automatic vacuuming should not intrude on
+guest-capable rooms. Trip-mode vacation simulation is still allowed because it is
+an exterior/common-area presence signal and is idempotently controlled by
+`script.house_transition`.
+
+## Manual Verification
+
+1. Turn `input_boolean.trip` on and confirm `switch.vacation_simulation` turns on.
+2. Turn `input_boolean.trip` off and confirm `switch.vacation_simulation` turns
+   off and `input_number.random_vacation_light_group` resets to `0`.
+3. Simulate the one-hour home watchdog while trip mode is on and confirm it
+   emits `trip_mode_resolution_requested` instead of directly clearing vacation
+   entities.
+4. Run `vacuum_on_trip` with guest mode on and confirm no vacuum starts.
+5. Run `vacuum_on_trip` with guest mode off, trip mode on, and the house empty;
+   confirm `script.vacuum_main_and_upstairs_levels` starts once.

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -315,6 +315,12 @@ automation:
         event_data:
           desired_state: "off"
           reason: startup_reconcile
+      - trigger: event
+        id: watchdog_home_disable
+        event_type: trip_mode_resolution_requested
+        event_data:
+          desired_state: "off"
+          reason: watchdog_home_1h
       - trigger: state
         id: away_for_20h
         entity_id: binary_sensor.bayesian_zeke_home
@@ -388,8 +394,18 @@ automation:
                   message: "Trip mode enabled."
           - conditions:
               - condition: trigger
-                id: startup_reconcile_disable
+                id:
+                  - startup_reconcile_disable
+                  - watchdog_home_disable
             sequence:
+              - variables:
+                  trip_disable_message: >-
+                    {% if trigger.id == 'watchdog_home_disable' %}
+                      Trip mode watchdog cleared vacation mode after 1 hour
+                      at home.
+                    {% else %}
+                      Back from trip. 💺
+                    {% endif %}
               - action: input_boolean.turn_off
                 target:
                   entity_id: input_boolean.trip
@@ -404,7 +420,7 @@ automation:
                   apply_trip_policy: true
               - action: notify.all
                 data:
-                  message: "Back from trip. \U0001F4BA"
+                  message: "{{ trip_disable_message }}"
           - conditions:
               - condition: trigger
                 id:
@@ -668,19 +684,12 @@ automation:
         entity_id: input_boolean.trip
         state: "on"
     action:
-      - action: switch.turn_off
-        target:
-          entity_id: switch.vacation_simulation
-      - action: input_boolean.turn_off
-        target:
-          entity_id: input_boolean.trip
-      - action: input_number.set_value
-        data:
-          entity_id: input_number.random_vacation_light_group
-          value: "{{ (0|int) }}"
-      - action: notify.all
-        data:
-          message: "Trip mode watchdog cleared vacation mode after 1 hour at home."
+      # Delegate to trip_mode_manager so trip state, vacation simulation, and
+      # related notifications stay on the same reconciliation path.
+      - event: trip_mode_resolution_requested
+        event_data:
+          desired_state: "off"
+          reason: watchdog_home_1h
 
   - id: garage_opened_on_a_trip
     alias: Garage Door Opened while on a Trip
@@ -701,10 +710,12 @@ automation:
     condition:
       condition: and
       conditions:
-        - condition: state
+        - alias: "garage trip mode is active"
+          condition: state
           entity_id: input_boolean.trip
           state: "on"
-        - condition: state
+        - alias: "garage primary resident is away"
+          condition: state
           entity_id: binary_sensor.bayesian_zeke_home
           state: "off"
     action:
@@ -762,6 +773,7 @@ automation:
     alias: random_off_time
     trigger:
       - trigger: homeassistant
+        id: random_off_time_startup
         event: start
       - trigger: time
         at: "12:00:00"
@@ -769,7 +781,8 @@ automation:
         entity_id: input_boolean.trip
         to: "on"
     condition:
-      - condition: state
+      - alias: "random vacation group only while trip mode is active"
+        condition: state
         entity_id: input_boolean.trip
         state: "on"
     action:
@@ -809,10 +822,9 @@ automation:
       #   entity_id: climate.my_ecobee
       #   data:
       #     preset_mode: "Away"
-      - action: ecobee.resume_program
+      - action: script.resume_ecobee_program_for_return_home
         data:
-          resume_all: true
-          entity_id: climate.my_ecobee
+          reason: return_home_from_parents
       - action: notify.all
         data:
           data:
@@ -840,10 +852,9 @@ automation:
       #   entity_id: climate.my_ecobee
       #   data:
       #     preset_mode: "Home"
-      - action: ecobee.resume_program
+      - action: script.resume_ecobee_program_for_return_home
         data:
-          resume_all: true
-          entity_id: climate.my_ecobee
+          reason: send_nest_airport_home_eta
       - action: notify.all
         data:
           data: url:"/ryan-new-mushroom/climate"
@@ -859,10 +870,12 @@ automation:
     condition:
       condition: and
       conditions:
-        - condition: state
+        - alias: "vacation lights on while trip mode is active"
+          condition: state
           entity_id: input_boolean.trip
           state: "on"
-        - condition: state
+        - alias: "vacation lights on while primary resident is away"
+          condition: state
           entity_id: binary_sensor.bayesian_zeke_home
           state: "off"
     action:
@@ -884,10 +897,12 @@ automation:
     condition:
       condition: and
       conditions:
-        - condition: state
+        - alias: "vacation lights off while trip mode is active"
+          condition: state
           entity_id: input_boolean.trip
           state: "on"
-        - condition: state
+        - alias: "vacation lights off while primary resident is away"
+          condition: state
           entity_id: binary_sensor.bayesian_zeke_home
           state: "off"
     action:
@@ -914,7 +929,8 @@ automation:
 
   - id: vacuum_on_trip
     alias: vacuum_on_trip
-    description: Run one full-floor pass on the main and upstairs levels during trips.
+    description: >-
+      Run one full-floor pass on the main and upstairs levels during trips.
     trigger:
       - trigger: time
         at: "13:00:00"
@@ -934,16 +950,16 @@ automation:
           entity_id: input_boolean.guest_mode
           state: "off"
     action:
-      - action: script.vacuum_main_and_upstairs_levels
-      - action: notify.all
+      - action: script.trip_vacuum_main_and_upstairs_levels
         data:
-          data:
-            url: "/ryan-new-mushroom/cleaning"
-          message: "Vacuuming the main and upstairs levels while you're away \U0001F4BA"
+          notify_message: >-
+            Vacuuming the main and upstairs levels while you're away 💺
 
   - id: vacuum_flying_home
     alias: vacuum_flying_home
-    description: Run one full-floor pass on the main and upstairs levels before Ryan flies home.
+    description: >-
+      Run one full-floor pass on the main and upstairs levels before Ryan flies
+      home.
     trigger:
       - entity_id: binary_sensor.flying_home_today
         from: "off"
@@ -962,12 +978,10 @@ automation:
           entity_id: input_boolean.guest_mode
           state: "off"
     action:
-      - action: script.vacuum_main_and_upstairs_levels
-      - action: notify.all
+      - action: script.trip_vacuum_main_and_upstairs_levels
         data:
-          data:
-            url: "/ryan-new-mushroom/cleaning"
-          message: "Vacuuming the main and upstairs levels while you fly home \U0001F4BA"
+          notify_message: >-
+            Vacuuming the main and upstairs levels while you fly home 💺
 
   # - id: toggle_vacation_tab
   #   alias: toggle_vacation_tab
@@ -1154,7 +1168,48 @@ scene:
 ########################
 # Scripts
 ########################
-script: {}
+script:
+  resume_ecobee_program_for_return_home:
+    alias: resume_ecobee_program_for_return_home
+    description: >-
+      Resume the Ecobee program when a return-home travel signal fires.
+    mode: queued
+    fields:
+      reason:
+        description: Return-home travel source requesting Ecobee resume.
+        example: send_nest_airport_home_eta
+    sequence:
+      - continue_on_error: true
+        action: logbook.log
+        data:
+          name: Travel climate
+          entity_id: script.resume_ecobee_program_for_return_home
+          message: >-
+            Resuming Ecobee program for
+            {{ reason | default('return_home', true) }}.
+          domain: script
+      - action: ecobee.resume_program
+        data:
+          resume_all: true
+          entity_id: climate.my_ecobee
+
+  trip_vacuum_main_and_upstairs_levels:
+    alias: trip_vacuum_main_and_upstairs_levels
+    description: >-
+      Run trip-safe whole-floor vacuuming and send the travel notification.
+    mode: queued
+    fields:
+      notify_message:
+        description: >-
+          Notification text describing why the trip vacuum pass started.
+        example: "Vacuuming the main and upstairs levels while you're away."
+    sequence:
+      - action: script.vacuum_main_and_upstairs_levels
+      - action: notify.all
+        data:
+          data:
+            url: "/ryan-new-mushroom/cleaning"
+          message: "{{ notify_message }}"
   # toggle_automations_showing_house:
   #   sequence:
   #     - action: homeassistant.toggle

--- a/tests/test_trip_mode_orchestration.py
+++ b/tests/test_trip_mode_orchestration.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TRIPS_PATH = ROOT / "packages" / "trips.yaml"
+TRIP_DOC_PATH = ROOT / "docs" / "trip_mode_orchestration.md"
+HOUSE_TRANSITION_DOC_PATH = ROOT / "docs" / "house_transition_framework.md"
+
+
+def _automation_block(path: Path, automation_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_trip_watchdog_delegates_to_trip_mode_manager() -> None:
+    block = _automation_block(TRIPS_PATH, "trip_mode_watchdog_home_1h")
+
+    assert "event: trip_mode_resolution_requested" in block
+    assert "desired_state: \"off\"" in block
+    assert "reason: watchdog_home_1h" in block
+    assert "action: switch.turn_off" not in block
+    assert "action: input_boolean.turn_off" not in block
+    assert "action: input_number.set_value" not in block
+
+
+def test_trip_mode_manager_handles_watchdog_disable_through_house_transition() -> None:
+    block = _automation_block(TRIPS_PATH, "trip_mode_manager")
+
+    assert "id: watchdog_home_disable" in block
+    assert "reason: watchdog_home_1h" in block
+    assert "action: input_boolean.turn_off" in block
+    assert "reason: watchdog_home_1h" in block
+    assert "action: script.house_transition" in block
+    assert "apply_trip_policy: true" in block
+    assert "Trip mode watchdog cleared vacation mode after 1 hour" in block
+    assert "at home." in block
+
+
+def test_trip_orchestration_doc_captures_owner_and_guest_policy() -> None:
+    doc = TRIP_DOC_PATH.read_text(encoding="utf-8")
+    house_doc = HOUSE_TRANSITION_DOC_PATH.read_text(encoding="utf-8")
+
+    for token in (
+        "automation.trip_mode_manager",
+        "trip_mode_resolution_requested",
+        "script.house_transition",
+        "apply_trip_policy: true",
+        "switch.vacation_simulation",
+        "input_number.random_vacation_light_group",
+        "input_boolean.guest_mode",
+        "docs/room_intent.yaml",
+        "vacuum_on_trip",
+        "vacuum_flying_home",
+    ):
+        assert token in doc
+
+    assert "docs/trip_mode_orchestration.md" in house_doc

--- a/tests/test_vacuum_whole_floor_policy.py
+++ b/tests/test_vacuum_whole_floor_policy.py
@@ -90,13 +90,20 @@ def test_away_automations_use_shared_whole_floor_helper() -> None:
     automation_locations = [
         (ZONE_PATH, "vacuum_leave_home"),
         (WORKDAY_PATH, "vacuum_while_working"),
-        (TRIPS_PATH, "vacuum_on_trip"),
-        (TRIPS_PATH, "vacuum_flying_home"),
         (CURLING_PATH, "leave_home_for_curling"),
     ]
 
     for path, automation_id in automation_locations:
         block = _automation_block(path, automation_id)
         assert "action: script.vacuum_main_and_upstairs_levels" in block
+        assert "MapSegmentationCapability/clean/set" not in block
+        assert '"iterations": 4' not in block
+
+    trip_wrapper = _script_block(TRIPS_PATH, "trip_vacuum_main_and_upstairs_levels")
+    assert "action: script.vacuum_main_and_upstairs_levels" in trip_wrapper
+
+    for automation_id in ("vacuum_on_trip", "vacuum_flying_home"):
+        block = _automation_block(TRIPS_PATH, automation_id)
+        assert "action: script.trip_vacuum_main_and_upstairs_levels" in block
         assert "MapSegmentationCapability/clean/set" not in block
         assert '"iterations": 4' not in block


### PR DESCRIPTION
## Summary

- Route the one-hour trip-mode home watchdog through `trip_mode_manager` instead of clearing trip/vacation entities directly.
- Add trip orchestration docs that capture state ownership, current inputs, side effects, and guest/house-sitter policy.
- Extract repeated Ecobee return-home resume and trip-vacuum notification actions into reusable trip package scripts.
- Add regression coverage for the watchdog delegation, trip docs, and trip vacuum wrapper behavior.

Fixes #118.

## Validation

- `python3 /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/trips.yaml --strict`
- `uv run --with pytest pytest tests/test_trip_mode_orchestration.py tests/test_vacuum_whole_floor_policy.py tests/test_runtime_log_regressions.py tests/test_house_mode_zone.py`
- `uv run --with pytest pytest` -> 304 passed
- Home Assistant `check_config` -> valid
- `git diff --check`

## Notes

- `uv run --with yamllint yamllint packages/trips.yaml` still reports existing repo-wide style issues in this file, mostly line-length/comment formatting unrelated to this change.