### PR TITLE
fix(#493): normalize legacy spotify:user:spotify: URIs in music_assistant_play_item

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -822,6 +822,12 @@ script:
       raw_item: "{{ media_item | trim }}"
       raw_media_type: "{{ media_type | default('') | trim }}"
       raw_enqueue: "{{ enqueue | default('replace') }}"
+      normalized_item: >-
+        {% if raw_item.startswith('spotify:user:spotify:') %}
+          {{ 'spotify:' ~ raw_item.split('spotify:user:spotify:')[1] }}
+        {% else %}
+          {{ raw_item }}
+        {% endif %}
     sequence:
       - choose:
           - conditions:
@@ -833,7 +839,7 @@ script:
                 target:
                   entity_id: "{{ entity_id }}"
                 data:
-                  media_id: "{{ raw_item }}"
+                  media_id: "{{ normalized_item }}"
                   media_type: "{{ raw_media_type }}"
                   enqueue: "{{ raw_enqueue }}"
         default:
@@ -842,7 +848,7 @@ script:
             target:
               entity_id: "{{ entity_id }}"
             data:
-              media_id: "{{ raw_item }}"
+              media_id: "{{ normalized_item }}"
               enqueue: "{{ raw_enqueue }}"
 
   music_assistant_play_spotify_uri:


### PR DESCRIPTION
## Summary

- Adds URI normalization in `script.music_assistant_play_item` to rewrite legacy `spotify:user:spotify:<type>:<id>` → `spotify:<type>:<id>` before passing to Music Assistant
- Fixes misresolution of ~30+ playlist entries across `spotify_wake_up`, `spotify_bedtime`, `spotify_arrive_home`, and cube playlist scripts
- Chosen location (`music_assistant_play_item`) ensures all callers are covered, including `spotify_bedtime` which bypasses `music_assistant_play_spotify_uri`

Closes #493

## Test plan

- [x] Trigger bathroom morning music automation — verify it plays from "Your Top Songs 2017" (Jimmy Eat World, Arctic Monkeys, Decemberists) and not "Spotify Playlist" by Valeria von Seen
- [ ] Check `media_content_id` in `media_player.bathroom_sonos_2` state — should show a playlist URI, not a single track ID
- [ ] Trigger bedtime music — verify correct playlist plays
- [ ] Check logbook for `playing wakeup playlist:` entries to confirm normalized URI is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)