### PR TITLE
fix: broaden Spotify URI normalization + correct tiki_room entity ID

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -725,7 +725,7 @@ script:
       raw_media_type: "{{ media_type | default('') | trim }}"
       raw_enqueue: "{{ enqueue | default('replace') }}"
       normalized_item: >-
-        {{ 'spotify:' ~ raw_item.split('spotify:user:spotify:')[1] if raw_item.startswith('spotify:user:spotify:') else raw_item }}
+        {{ ('spotify:' ~ raw_item.split(':')[3] ~ ':' ~ raw_item.split(':')[4]) if (raw_item.startswith('spotify:user:') and (raw_item.split(':') | length) == 5) else raw_item }}
     sequence:
       - choose:
           - conditions:
@@ -1406,7 +1406,7 @@ script:
             - media_player.bathroom_sonos
             - media_player.den_sonos
             - media_player.office_sonos
-            - media_player.tiki_room
+            - media_player.tiki_room_3
           volume_level: 0.30
       - alias: "Play arrival music via Music Assistant"
         action: script.music_assistant_play_spotify_uri
@@ -1794,7 +1794,7 @@ script:
             - media_player.bedroom_sonos
             - media_player.office_sonos
             - media_player.den_sonos
-            - media_player.tiki_room
+            - media_player.tiki_room_3
           volume_level: 0.05
       - alias: "Enable Shuffle"
         continue_on_error: true

--- a/packages/tiki_time.yaml
+++ b/packages/tiki_time.yaml
@@ -338,7 +338,7 @@ script:
                     - media_player.bathroom_sonos
                     - media_player.office_sonos
                     - media_player.den_sonos
-                    - media_player.tiki_room
+                    - media_player.tiki_room_3
                 data:
                   volume_level: 0.30
               - action: script.music_assistant_play_item


### PR DESCRIPTION
Closes #493 (broadens the partial fix — personal user playlist URIs like `spotify:user:126202651:playlist:…` were still being misresolved)

## Summary

- **Broader Spotify URI normalization**: The previous fix only caught `spotify:user:spotify:` legacy URIs. Any personal user playlist (e.g. `spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP`) was still being misresolved by Music Assistant to wrong content. The `normalized_item` variable in `music_assistant_play_item` now matches any `spotify:user:<anything>:<type>:<id>` URI with exactly 5 colon-separated parts and rewrites it to the modern `spotify:<type>:<id>` format.
- **Correct tiki_room entity ID**: `media_player.tiki_room` does not exist — the native Sonos entity is `media_player.tiki_room_3`. Fixed in both `packages/media_player.yaml` (volume_set calls) and `packages/tiki_time.yaml`.

## Test plan

- [ ] Play a personal user playlist (e.g. `spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP`) via `music_assistant_play_item` — verify the correct playlist plays, not "Spotify Playlist" by Valeria von Seen
- [ ] Trigger `script.tiki_time` — verify no "entity not found" errors for tiki_room volume_set
- [ ] Verify morning bathroom wake-up plays expected playlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)