### PR TITLE
fix: replace 9 dead Spotify playlist IDs + correct stale album ID

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1181,10 +1181,10 @@ script:
       - variables:
           playlist: >-
             {#
-            ##  This is The Wombats: spotify:playlist:37i9dQZF1DWVK4jhlkcOzu
+            ##  This is The Wombats: spotify:playlist:37i9dQZF1DZ06evO0vIZz2
             ##  This is Passion Pit: spotify:playlist:37i9dQZF1DZ06evO4iu5hu
             ##  Arctic Monkeys - AM : spotify:album:78bpIziExqiI9qztvNFlQu
-            ##  This is The Mountain Goats : spotify:playlist:37i9dQZF1DWTmUQ5ZV8Wa1
+            ##  This is The Mountain Goats : spotify:playlist:37i9dQZF1DZ06evO1U0vAp
             ##  This is The Griswolds : spotify:playlist:37i9dQZF1DZ06evO1XPrLQ
             ##  This is Band of Horses : spotify:user:spotify:playlist:37i9dQZF1DZ06evO0pK2Aw
             ##  Henry Jamison Radio : spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY
@@ -1193,10 +1193,10 @@ script:
             ## MGMT Kids Playlist: spotify:user:gorillagoat:playlist:7aX5kvEDdre0kHNCvQ9sbr
             ## This is Walk the Moon: spotify:playlist:37i9dQZF1DZ06evO3VghcA
             #}
-            {%- set plists = ["spotify:playlist:37i9dQZF1DWVK4jhlkcOzu",
+            {%- set plists = ["spotify:playlist:37i9dQZF1DZ06evO0vIZz2",
               "spotify:playlist:37i9dQZF1DZ06evO4iu5hu",
               "spotify:album:78bpIziExqiI9qztvNFlQu",
-              "spotify:playlist:37i9dQZF1DWTmUQ5ZV8Wa1",
+              "spotify:playlist:37i9dQZF1DZ06evO1U0vAp",
               "spotify:playlist:37i9dQZF1DZ06evO1XPrLQ",
               "spotify:user:spotify:playlist:37i9dQZF1DZ06evO0pK2Aw",
               "spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY",
@@ -1294,19 +1294,19 @@ script:
             ## 90s Acoustic: spotify:user:spotify:playlist:37i9dQZF1DXb9LIXaj5WhL
             ## This is Passion Pit: spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu
             ## Panic! at the Disco Pretty. Odd. : spotify:album:7Hk9WbjPbN1n2GXaK7aldw
-            ## This is The Mountain Goats : spotify:playlist:37i9dQZF1DWTmUQ5ZV8Wa1
+            ## This is The Mountain Goats : spotify:playlist:37i9dQZF1DZ06evO1U0vAp
             ## It's ALT Good! : spotify:user:spotify:playlist:37i9dQZF1DX2SK4ytI2KAZ
             ## This is The Griswolds : spotify:playlist:37i9dQZF1DZ06evO1XPrLQ
             ## The Wombats : spotify:artist:0Ya43ZKWHTKkAbkoJJkwIB
             ## The Decemberists @ Palace 2018 : spotify:user:126202651:playlist:4CIBhwpAL598munofpCu6i
-            ## This is Jimmy Eat World : spotify:user:spotify:playlist:37i9dQZF1DX4wNVWmoZ4FM
+            ## This is Jimmy Eat World : spotify:playlist:37i9dQZF1DZ06evO25r82I
             ## David Bowie Legacy : spotify:album:4JEgSaokMH5mMRClx9wp3S
             ## This is Cake: spotify:user:spotify:playlist:37i9dQZF1DZ06evO3T3SWA
             ## SDSU : spotify:user:126202651:playlist:56WlVUutx91MElxdsbtzj1
             ## Your Top Songs 2018 : spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf
             ## Your Top Songs 2017 : spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW
             ## Your Time Capsule : spotify:user:spotify:playlist:37i9dQZF1E4YuevTvB5WHT
-            ## This is The Lumineers : spotify:user:spotify:playlist:37i9dQZF1DXdxZQJxjFMLO
+            ## This is The Lumineers : spotify:playlist:37i9dQZF1DZ06evO0AGqf6
             ## Guster @ Showbox Seattle 2/16/2019 spotify:user:126202651:playlist:65fTj3YJl4jvFmXxru7BfO
             ## Guster @ First Ave MSP 2/9/2019 spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq
             ## Coheed & Cambria @ The Armory MSP 7/26/2018 spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP
@@ -1324,8 +1324,8 @@ script:
             ## Henry Jamison Radio : spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY
             ## Happier Radio : spotify:playlist:37i9dQZF1E8DMpUzqgcOJh
             ## Guster @ Weesner Family Ampitheater (MN Zoo), Jul 22, 2019
-            ## This is Tool : spotify:playlist:37i9dQZF1DX0GDEVNHvE3h
-            ## Best of the Decade 2011-2019: spotify:playlist:37i9dQZF1DXaMu9xyX1HzK
+            ## This is Tool : spotify:playlist:37i9dQZF1DZ06evO1sZyol
+            ## Best of the Decade 2011-2019: spotify:playlist:37i9dQZF1DX5Ejj0EkURtP
             ## Top Songs of 2019: spotify:playlist:37i9dQZF1EtiMc33WI4nNn
             ## Daily Mix 1: spotify:playlist:37i9dQZF1E37INBdbw9l8Q
             ## Daily Mix 2: spotify:playlist:37i9dQZF1E38mQjeIPb1EL
@@ -1344,18 +1344,18 @@ script:
               "spotify:user:spotify:playlist:37i9dQZF1DXb9LIXaj5WhL",
               "spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu",
               "spotify:album:7Hk9WbjPbN1n2GXaK7aldw",
-              "spotify:playlist:37i9dQZF1DWTmUQ5ZV8Wa1",
+              "spotify:playlist:37i9dQZF1DZ06evO1U0vAp",
               "spotify:user:spotify:playlist:37i9dQZF1DX2SK4ytI2KAZ",
               "spotify:playlist:37i9dQZF1DZ06evO1XPrLQ",
               "spotify:artist:0Ya43ZKWHTKkAbkoJJkwIB",
               "spotify:user:126202651:playlist:4CIBhwpAL598munofpCu6i",
-              "spotify:user:spotify:playlist:37i9dQZF1DX4wNVWmoZ4FM",
+              "spotify:playlist:37i9dQZF1DZ06evO25r82I",
               "spotify:album:4JEgSaokMH5mMRClx9wp3S",
               "spotify:user:126202651:playlist:56WlVUutx91MElxdsbtzj1",
               "spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf",
               "spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW",
               "spotify:user:spotify:playlist:37i9dQZF1E4YuevTvB5WHT",
-              "spotify:user:spotify:playlist:37i9dQZF1DXdxZQJxjFMLO",
+              "spotify:playlist:37i9dQZF1DZ06evO0AGqf6",
               "spotify:user:126202651:playlist:65fTj3YJl4jvFmXxru7BfO",
               "spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq",
               "spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP",
@@ -1371,8 +1371,8 @@ script:
               "spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY",
               "spotify:playlist:37i9dQZF1E8DMpUzqgcOJh",
               "spotify:playlist:3dj3AYHFe2RKKjdQsaOWYl",
-              "spotify:playlist:37i9dQZF1DX0GDEVNHvE3h",
-              "spotify:playlist:37i9dQZF1DXaMu9xyX1HzK",
+              "spotify:playlist:37i9dQZF1DZ06evO1sZyol",
+              "spotify:playlist:37i9dQZF1DX5Ejj0EkURtP",
               "spotify:playlist:37i9dQZF1EtiMc33WI4nNn",
               "spotify:playlist:37i9dQZF1E354DBk6AJ16Y",
               "spotify:playlist:37i9dQZF1E38mQjeIPb1EL",
@@ -1434,19 +1434,19 @@ script:
             ## 90s Acoustic: spotify:user:spotify:playlist:37i9dQZF1DXb9LIXaj5WhL
             ## This is Passion Pit: spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu
             ## Panic! at the Disco Pretty. Odd. : spotify:album:7Hk9WbjPbN1n2GXaK7aldw
-            ## This is The Mountain Goats : spotify:playlist:37i9dQZF1DWTmUQ5ZV8Wa1
+            ## This is The Mountain Goats : spotify:playlist:37i9dQZF1DZ06evO1U0vAp
             ## It's ALT Good! : spotify:user:spotify:playlist:37i9dQZF1DX2SK4ytI2KAZ
             ## The Griswolds : spotify:playlist:37i9dQZF1DZ06evO1XPrLQ
             ## The Wombats : spotify:artist:0Ya43ZKWHTKkAbkoJJkwIB
             ## The Decemberists @ Palace 2018 : spotify:user:126202651:playlist:4CIBhwpAL598munofpCu6i
-            ## This is Jimmy Eat World : spotify:user:spotify:playlist:37i9dQZF1DX4wNVWmoZ4FM
+            ## This is Jimmy Eat World : spotify:playlist:37i9dQZF1DZ06evO25r82I
             ## David Bowie Legacy : spotify:album:4JEgSaokMH5mMRClx9wp3S
             ## This is Cake: spotify:user:spotify:playlist:37i9dQZF1DZ06evO3T3SWA
             ## SDSU : spotify:user:126202651:playlist:56WlVUutx91MElxdsbtzj1
             ## Your Top Songs 2018 : spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf
             ## Your Top Songs 2017 : spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW
             ## Your Time Capsule : spotify:user:spotify:playlist:37i9dQZF1E4YuevTvB5WHT
-            ## This is The Lumineers : spotify:user:spotify:playlist:37i9dQZF1DXdxZQJxjFMLO
+            ## This is The Lumineers : spotify:playlist:37i9dQZF1DZ06evO0AGqf6
             ## Guster @ Showbox Seattle 2/16/2019 spotify:user:126202651:playlist:65fTj3YJl4jvFmXxru7BfO
             ## Guster @ First Ave MSP 2/9/2019 spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq
             ## Coheed & Cambria @ The Armory MSP 7/26/2018 spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP
@@ -1464,8 +1464,8 @@ script:
             ## Henry Jamison Radio : spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY
             ## Happier Radio : spotify:playlist:37i9dQZF1E8DMpUzqgcOJh
             ## Guster @ Weesner Family Ampitheater (MN Zoo), Jul 22, 2019
-            ## This is Tool : spotify:playlist:37i9dQZF1DX0GDEVNHvE3h
-            ## Best of the Decade 2011-2019: spotify:playlist:37i9dQZF1DXaMu9xyX1HzK
+            ## This is Tool : spotify:playlist:37i9dQZF1DZ06evO1sZyol
+            ## Best of the Decade 2011-2019: spotify:playlist:37i9dQZF1DX5Ejj0EkURtP
             ## Top Songs of 2019: spotify:playlist:37i9dQZF1EtiMc33WI4nNn
             ## Daily Mix 1: spotify:playlist:37i9dQZF1E37INBdbw9l8Q
             ## Daily Mix 2: spotify:playlist:37i9dQZF1E38mQjeIPb1EL
@@ -1497,18 +1497,18 @@ script:
               "spotify:user:spotify:playlist:37i9dQZF1DXb9LIXaj5WhL",
               "spotify:user:spotify:playlist:37i9dQZF1DZ06evO4iu5hu",
               "spotify:album:7Hk9WbjPbN1n2GXaK7aldw",
-              "spotify:playlist:37i9dQZF1DWTmUQ5ZV8Wa1",
+              "spotify:playlist:37i9dQZF1DZ06evO1U0vAp",
               "spotify:user:spotify:playlist:37i9dQZF1DX2SK4ytI2KAZ",
               "spotify:playlist:37i9dQZF1DZ06evO1XPrLQ",
               "spotify:artist:0Ya43ZKWHTKkAbkoJJkwIB",
               "spotify:user:126202651:playlist:4CIBhwpAL598munofpCu6i",
-              "spotify:user:spotify:playlist:37i9dQZF1DX4wNVWmoZ4FM",
+              "spotify:playlist:37i9dQZF1DZ06evO25r82I",
               "spotify:album:4JEgSaokMH5mMRClx9wp3S",
               "spotify:user:126202651:playlist:56WlVUutx91MElxdsbtzj1",
               "spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf",
               "spotify:user:spotify:playlist:37i9dQZF1E9G2yMdYA64HW",
               "spotify:user:spotify:playlist:37i9dQZF1E4YuevTvB5WHT",
-              "spotify:user:spotify:playlist:37i9dQZF1DXdxZQJxjFMLO",
+              "spotify:playlist:37i9dQZF1DZ06evO0AGqf6",
               "spotify:user:126202651:playlist:65fTj3YJl4jvFmXxru7BfO",
               "spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq",
               "spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP",
@@ -1524,8 +1524,8 @@ script:
               "spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY",
               "spotify:playlist:37i9dQZF1E8DMpUzqgcOJh",
               "spotify:playlist:3dj3AYHFe2RKKjdQsaOWYl",
-              "spotify:playlist:37i9dQZF1DX0GDEVNHvE3h",
-              "spotify:playlist:37i9dQZF1DXaMu9xyX1HzK",
+              "spotify:playlist:37i9dQZF1DZ06evO1sZyol",
+              "spotify:playlist:37i9dQZF1DX5Ejj0EkURtP",
               "spotify:playlist:37i9dQZF1EtiMc33WI4nNn",
               "spotify:playlist:37i9dQZF1E354DBk6AJ16Y",
               "spotify:playlist:37i9dQZF1E38mQjeIPb1EL",
@@ -1682,10 +1682,10 @@ script:
             ## Alternative Nation: spotify:user:topsify:playlist:1uBI8icgYcUED3T1W1X6dB
             ## Matt & Kim Daylight Playlist: spotify:user:127725734:playlist:1tpH6e8WmMkWZNKv9HFvGK
             ## MGMT Kids Playlist: spotify:user:gorillagoat:playlist:7aX5kvEDdre0kHNCvQ9sbr
-            ## Guardians of the Galaxy Vols 1 & 2 : spotify:user:hollywdrecrds:playlist:1xY6msLHX1W34EzB0UkkbU
+            ## Guardians of the Galaxy Vols 1 & 2 : spotify:playlist:37i9dQZF1DXatoD1BSWRau
             ## Walk the Moon Talking is Hard: spotify:album:3mNoFlD1wsoXfkljfFzExT
-            ## This is Fall Out Boy: spotify:user:spotify:playlist:37i9dQZF1DX4JbuQ72y8Ek
-            ## This is Panic! at the Disco : spotify:user:spotify:playlist:37i9dQZF1DX5C8bjZ5YDv7
+            ## This is Fall Out Boy: spotify:playlist:37i9dQZF1DZ06evO2T19Mk
+            ## This is Panic! at the Disco : spotify:playlist:37i9dQZF1DZ06evO18A72E
             ## Coheed & Cambria Good Apollo: spotify:album:4nYsnQpTAQaPzrPc6rOsBN
             ## APC Mer De Noms: spotify:album:0GeWd0yUKXHbCXVag1mJvO
             ## Matt and Kim : Lightning : spotify:album:0ByuPWOUIKAgMZGWneqO9O
@@ -1693,7 +1693,7 @@ script:
             ## 90s Rock Anthems: spotify:user:spotify:playlist:37i9dQZF1DX1rVvRgjX59F
             ## Your Top Songs 2018 : spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf
             ## Your Time Capsule : spotify:user:spotify:playlist:37i9dQZF1E4YuevTvB5WHT
-            ## This is The Lumineers : spotify:user:spotify:playlist:37i9dQZF1DXdxZQJxjFMLO
+            ## This is The Lumineers : spotify:playlist:37i9dQZF1DZ06evO0AGqf6
             ## Guster @ Showbox Seattle 2/16/2019 spotify:user:126202651:playlist:65fTj3YJl4jvFmXxru7BfO
             ## Guster @ First Ave MSP 2/9/2019 spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq
             ## Coheed & Cambria @ The Armory MSP 7/26/2018 spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP
@@ -1711,8 +1711,8 @@ script:
             ## Henry Jamison Radio : spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY
             ## Happier Radio : spotify:playlist:37i9dQZF1E8DMpUzqgcOJh
             ## Guster @ Weesner Family Ampitheater (MN Zoo), Jul 22, 2019
-            ## This is Tool : spotify:playlist:37i9dQZF1DX0GDEVNHvE3h
-            ## Best of the Decade 2011-2019: spotify:playlist:37i9dQZF1DXaMu9xyX1HzK
+            ## This is Tool : spotify:playlist:37i9dQZF1DZ06evO1sZyol
+            ## Best of the Decade 2011-2019: spotify:playlist:37i9dQZF1DX5Ejj0EkURtP
             ## Top Songs of 2019: spotify:playlist:37i9dQZF1EtiMc33WI4nNn
             ## Daily Mix 1: spotify:playlist:37i9dQZF1E37INBdbw9l8Q
             ## Daily Mix 2: spotify:playlist:37i9dQZF1E38mQjeIPb1EL
@@ -1736,10 +1736,10 @@ script:
               "spotify:user:topsify:playlist:1uBI8icgYcUED3T1W1X6dB",
               "spotify:user:127725734:playlist:1tpH6e8WmMkWZNKv9HFvGK",
               "spotify:user:gorillagoat:playlist:7aX5kvEDdre0kHNCvQ9sbr",
-              "spotify:user:hollywdrecrds:playlist:1xY6msLHX1W34EzB0UkkbU",
+              "spotify:playlist:37i9dQZF1DXatoD1BSWRau",
               "spotify:album:3mNoFlD1wsoXfkljfFzExT",
-              "spotify:user:spotify:playlist:37i9dQZF1DX4JbuQ72y8Ek",
-              "spotify:user:spotify:playlist:37i9dQZF1DX5C8bjZ5YDv7",
+              "spotify:playlist:37i9dQZF1DZ06evO2T19Mk",
+              "spotify:playlist:37i9dQZF1DZ06evO18A72E",
               "spotify:album:4nYsnQpTAQaPzrPc6rOsBN",
               "spotify:album:0GeWd0yUKXHbCXVag1mJvO",
               "spotify:album:0ByuPWOUIKAgMZGWneqO9O",
@@ -1747,7 +1747,7 @@ script:
               "spotify:user:spotify:playlist:37i9dQZF1DX1rVvRgjX59F",
               "spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf",
               "spotify:user:spotify:playlist:37i9dQZF1E4YuevTvB5WHT",
-              "spotify:user:spotify:playlist:37i9dQZF1DXdxZQJxjFMLO",
+              "spotify:playlist:37i9dQZF1DZ06evO0AGqf6",
               "spotify:user:126202651:playlist:65fTj3YJl4jvFmXxru7BfO",
               "spotify:user:126202651:playlist:4jmwGUvZ8XI9DmWa3NthVq",
               "spotify:user:126202651:playlist:5wO8RqOaWT9PDJNMnktftP",
@@ -1763,8 +1763,8 @@ script:
               "spotify:user:spotify:playlist:37i9dQZF1E4xIBgPnPOnGY",
               "spotify:playlist:37i9dQZF1E8DMpUzqgcOJh",
               "spotify:playlist:3dj3AYHFe2RKKjdQsaOWYl",
-              "spotify:playlist:37i9dQZF1DX0GDEVNHvE3h",
-              "spotify:playlist:37i9dQZF1DXaMu9xyX1HzK",
+              "spotify:playlist:37i9dQZF1DZ06evO1sZyol",
+              "spotify:playlist:37i9dQZF1DX5Ejj0EkURtP",
               "spotify:playlist:37i9dQZF1EtiMc33WI4nNn",
               "spotify:playlist:37i9dQZF1E354DBk6AJ16Y",
               "spotify:playlist:37i9dQZF1E38mQjeIPb1EL",

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1688,7 +1688,7 @@ script:
             ## This is Panic! at the Disco : spotify:user:spotify:playlist:37i9dQZF1DX5C8bjZ5YDv7
             ## Coheed & Cambria Good Apollo: spotify:album:4nYsnQpTAQaPzrPc6rOsBN
             ## APC Mer De Noms: spotify:album:0GeWd0yUKXHbCXVag1mJvO
-            ## Matt and Kim : Lightning : spotify:album:2MbpbHn31Luzr8G3uDsSUH
+            ## Matt and Kim : Lightning : spotify:album:0ByuPWOUIKAgMZGWneqO9O
             ## '90s Pop Rock Essentials : spotify:user:spotify:playlist:37i9dQZF1DX3YMp9n8fkNx
             ## 90s Rock Anthems: spotify:user:spotify:playlist:37i9dQZF1DX1rVvRgjX59F
             ## Your Top Songs 2018 : spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf
@@ -1742,7 +1742,7 @@ script:
               "spotify:user:spotify:playlist:37i9dQZF1DX5C8bjZ5YDv7",
               "spotify:album:4nYsnQpTAQaPzrPc6rOsBN",
               "spotify:album:0GeWd0yUKXHbCXVag1mJvO",
-              "spotify:album:2MbpbHn31Luzr8G3uDsSUH",
+              "spotify:album:0ByuPWOUIKAgMZGWneqO9O",
               "spotify:user:spotify:playlist:37i9dQZF1DX3YMp9n8fkNx",
               "spotify:user:spotify:playlist:37i9dQZF1DX1rVvRgjX59F",
               "spotify:user:spotify:playlist:37i9dQZF1Ejutsu6U8IhOf",


### PR DESCRIPTION
## Summary

Audited all 93 unique Spotify URIs in the config via the oEmbed API. Found and replaced 10 dead/invalid URIs:

### Dead playlists → replacements (all verified via oEmbed API)

| Old label | Old ID | New URI |
|---|---|---|
| This Is The Wombats | `37i9dQZF1DWVK4jhlkcOzu` | `spotify:playlist:37i9dQZF1DZ06evO0vIZz2` |
| This Is The Mountain Goats | `37i9dQZF1DWTmUQ5ZV8Wa1` | `spotify:playlist:37i9dQZF1DZ06evO1U0vAp` |
| This Is Jimmy Eat World | `37i9dQZF1DX4wNVWmoZ4FM` | `spotify:playlist:37i9dQZF1DZ06evO25r82I` |
| This Is The Lumineers | `37i9dQZF1DXdxZQJxjFMLO` | `spotify:playlist:37i9dQZF1DZ06evO0AGqf6` |
| This Is TOOL | `37i9dQZF1DX0GDEVNHvE3h` | `spotify:playlist:37i9dQZF1DZ06evO1sZyol` |
| Best of the Decade 2011-2019 | `37i9dQZF1DXaMu9xyX1HzK` | `spotify:playlist:37i9dQZF1DX5Ejj0EkURtP` (All Out 2010s) |
| Guardians of the Galaxy Vols 1&2 | `1xY6msLHX1W34EzB0UkkbU` | `spotify:playlist:37i9dQZF1DXatoD1BSWRau` (Official Mixtape) |
| This Is Fall Out Boy | `37i9dQZF1DX4JbuQ72y8Ek` | `spotify:playlist:37i9dQZF1DZ06evO2T19Mk` |
| This Is Panic! at the Disco | `37i9dQZF1DX5C8bjZ5YDv7` | `spotify:playlist:37i9dQZF1DZ06evO18A72E` |
| Matt and Kim — Lightning (album) | `2MbpbHn31Luzr8G3uDsSUH` | `spotify:album:0ByuPWOUIKAgMZGWneqO9O` |

The replacements for "Best of the Decade" and "Guardians" are the closest surviving Spotify editorial equivalents — the originals no longer exist.

Note: `Your Time Capsule` (`37i9dQZF1E4YuevTvB5WHT`) returns 404 from the unauthenticated oEmbed API but is a personalized playlist that may still resolve at runtime with the authenticated Spotify account. Left in place.

## Test plan
- [ ] Trigger `script.spotify_wake_up` — verify it plays successfully (no "No playable items found" error)
- [ ] Trigger `script.spotify_arrive_home` — verify it plays
- [ ] Trigger `script.spotify_bedtime` — verify it plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)