### PR TITLE
feat: nightly adaptive lighting cycle reset at 4 AM

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -176,14 +176,20 @@ automation:
     alias: nightly_adaptive_lighting_cycle_reset
     description: >
       Nightly at 4 AM, cycle every main adaptive lighting switch off then back on
-      to unstick color or brightness matching that has drifted. Control switches
-      (sleep_mode, adapt_brightness, adapt_color) are excluded to preserve their
-      settings. At 4 AM nearly all lights are off so no downstream on/off
-      transitions occur when the switches are re-enabled.
+      to unstick color or brightness matching that has drifted. A startup trigger
+      acts as a recovery path: if HA restarts during the 10-second off window the
+      next boot immediately re-enables all switches so they are never stranded off.
+      Control switches (sleep_mode, adapt_brightness, adapt_color) are excluded to
+      preserve their settings. At 4 AM nearly all lights are off so no downstream
+      on/off transitions occur when the switches are re-enabled.
     mode: single
     trigger:
       - trigger: time
+        id: nightly-cycle
         at: "04:00:00"
+      - trigger: homeassistant
+        id: ha-start
+        event: start
     variables:
       main_adaptive_switches:
         - switch.adaptive_lighting_basement
@@ -194,10 +200,14 @@ automation:
         - switch.adaptive_lighting_owner_suite
         - switch.dining_room_adaptive_lighting_dining_room
     action:
-      - action: switch.turn_off
-        target:
-          entity_id: "{{ main_adaptive_switches }}"
-      - delay: "00:00:10"
+      - if:
+          - condition: trigger
+            id: nightly-cycle
+        then:
+          - action: switch.turn_off
+            target:
+              entity_id: "{{ main_adaptive_switches }}"
+          - delay: "00:00:10"
       - action: switch.turn_on
         target:
           entity_id: "{{ main_adaptive_switches }}"

--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -172,6 +172,36 @@ automation:
                         turn_on_lights: false
                         transition: 1
 
+  - id: nightly_adaptive_lighting_cycle_reset
+    alias: nightly_adaptive_lighting_cycle_reset
+    description: >
+      Nightly at 4 AM, cycle every main adaptive lighting switch off then back on
+      to unstick color or brightness matching that has drifted. Control switches
+      (sleep_mode, adapt_brightness, adapt_color) are excluded to preserve their
+      settings. At 4 AM nearly all lights are off so no downstream on/off
+      transitions occur when the switches are re-enabled.
+    mode: single
+    trigger:
+      - trigger: time
+        at: "04:00:00"
+    variables:
+      main_adaptive_switches:
+        - switch.adaptive_lighting_basement
+        - switch.adaptive_lighting_den
+        - switch.adaptive_lighting_hallway
+        - switch.adaptive_lighting_kitchen
+        - switch.adaptive_lighting_office
+        - switch.adaptive_lighting_owner_suite
+        - switch.dining_room_adaptive_lighting_dining_room
+    action:
+      - action: switch.turn_off
+        target:
+          entity_id: "{{ main_adaptive_switches }}"
+      - delay: "00:00:10"
+      - action: switch.turn_on
+        target:
+          entity_id: "{{ main_adaptive_switches }}"
+
   - id: sync_selected_inovelli_led_bars_to_adaptive_lighting
     alias: sync_selected_inovelli_led_bars_to_adaptive_lighting
     description: >


### PR DESCRIPTION
## Summary

- Adds `nightly_adaptive_lighting_cycle_reset` automation to `packages/adaptive_lighting.yaml`
- Cycles all 7 main adaptive lighting switches off → 10 s delay → on at 4:00 AM daily
- Control switches (`sleep_mode`, `adapt_brightness`, `adapt_color`) are excluded so their settings survive the reset

## Design decisions

- **Native `trigger: time`** — no template trigger needed
- **`variables` block** defines the switch list once; both the `switch.turn_off` and `switch.turn_on` actions reference `{{ main_adaptive_switches }}` to stay DRY (verifier: 0 findings)
- **`mode: single`** — one-shot nightly operation, no re-entry needed
- **4 AM timing** — virtually all lights are off, so no downstream on/off transitions occur when switches are re-enabled
- **10 s delay** — gives the integration time to fully detach before re-attaching

Closes #499

## Test plan

- [ ] Config check passes (`ha config check` / `check_config`)
- [ ] Automation appears in HA with correct trigger time
- [ ] Manual trigger at night: lights stay at current state, adaptive control resumes after 10 s
- [ ] Confirm no lights are turned on or off during the cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)