### PR TITLE
Fix laundry leak dry transition

### DIFF
--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -123,8 +123,8 @@ automation:
         id: wet
       - trigger: state
         entity_id: binary_sensor.laundry_room_leak_water_leak
-        from: "off"
-        to: "on"
+        from: "on"
+        to: "off"
         id: dry
 
     action:
@@ -439,11 +439,13 @@ script:
         action: light.turn_on
         target:
           entity_id: all
-      - delay:
+      - alias: Hold lights on
+        delay:
           seconds: 1
       - alias: Lights Off
         action: light.turn_off
         target:
           entity_id: all
-      - delay:
+      - alias: Hold lights off
+        delay:
           seconds: 1

--- a/tests/test_alerts_notify_groups.py
+++ b/tests/test_alerts_notify_groups.py
@@ -37,3 +37,21 @@ def test_shared_notifications_mirror_defaults_optional_payload_fields() -> None:
 
     assert "notify_title: \"{{ notify_payload.title | default('', true) }}\"" in mirror
     assert "notify_data: \"{{ notify_payload.data | default({}, true) }}\"" in mirror
+
+
+def test_laundry_leak_dry_trigger_uses_on_to_off_transition() -> None:
+    text = ALERTS_PATH.read_text(encoding="utf-8")
+    laundry_triggers = text.split(
+        "entity_id: binary_sensor.laundry_room_leak_water_leak", maxsplit=1
+    )[1]
+
+    assert 'from: "off"\n        to: "on"\n        id: wet' in laundry_triggers
+    assert 'from: "on"\n        to: "off"\n        id: dry' in laundry_triggers
+
+
+def test_flash_lights_keeps_distinct_on_and_off_hold_steps() -> None:
+    text = ALERTS_PATH.read_text(encoding="utf-8")
+    script = text.split("  flash_lights:", maxsplit=1)[1]
+
+    assert "alias: Hold lights on\n        delay:\n          seconds: 1" in script
+    assert "alias: Hold lights off\n        delay:\n          seconds: 1" in script


### PR DESCRIPTION
## Summary
- Rewrite the stale nightly-sweep branch as a single-defect fix from current `origin/develop`.
- Correct the laundry-room leak sensor dry transition from the duplicated `off -> on` wet edge to `on -> off`.
- Label the two existing flash-light hold delays distinctly so strict HA YAML DRY validation remains clean without changing timing.
- Add focused regression coverage.

## Why
The old PR bundled LG TV notification and flash-loop work that has since landed through later fixes. The remaining live regression was the laundry dry edge, which could never fire after the floor dried.

## Validation
- `uv run --with pytest pytest` (`472 passed`)
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/alerts.yaml`
- `uv run --with pyyaml python /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/alerts.yaml --strict`
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `uv run --with homeassistant==2026.5.4 python -m homeassistant --config . --script check_config`
- `git diff --check`