### PR TITLE
feat(#203): add dining room confidence occupancy

### DIFF
--- a/packages/room_confidence.yaml
+++ b/packages/room_confidence.yaml
@@ -39,6 +39,10 @@ homeassistant:
       <<: *customize
       friendly_name: Den confidently occupied
       icon: mdi:sofa
+    binary_sensor.dining_room_confident_occupancy:
+      <<: *customize
+      friendly_name: Dining room confidently occupied
+      icon: mdi:silverware-fork-knife
     binary_sensor.office_confident_occupancy:
       <<: *customize
       friendly_name: Office confidently occupied
@@ -58,6 +62,10 @@ homeassistant:
     sensor.den_room_confidence:
       <<: *customize
       friendly_name: Den room confidence
+      icon: mdi:signal-distance-variant
+    sensor.dining_room_room_confidence:
+      <<: *customize
+      friendly_name: Dining room room confidence
       icon: mdi:signal-distance-variant
     sensor.office_room_confidence:
       <<: *customize
@@ -91,6 +99,7 @@ template:
           - binary_sensor.bayesian_bed_occupancy
           - binary_sensor.bedroom_occupancy
           - binary_sensor.den_occupancy_2
+          - binary_sensor.dining_room_bt_proxy_dining_room_bluetooth_proxy_status
           - binary_sensor.office_occupancy_2
           - binary_sensor.office_motion_occupancy
           - binary_sensor.ryan_office_presence
@@ -245,6 +254,46 @@ template:
           phone_area: "{{ states('sensor.iphone_17_pro_area') }}"
           watch_area: "{{ states('sensor.apple_watch_ultra_2_area') }}"
 
+      - name: dining_room_room_confidence
+        unique_id: dining_room_room_confidence
+        unit_of_measurement: "%"
+        state: >-
+          {% set home_present = is_state('person.ryan', 'home') or is_state('binary_sensor.bayesian_zeke_home', 'on') %}
+          {% set unknown_states = ['unknown', 'unavailable', 'none', ''] %}
+          {% set dining_area_names = ['dining room'] %}
+          {% set phone_area = states('sensor.iphone_17_pro_area') | lower %}
+          {% set watch_area = states('sensor.apple_watch_ultra_2_area') | lower %}
+          {% set score = namespace(value=0) %}
+          {% if not home_present %}
+            0
+          {% else %}
+            {% if phone_area in dining_area_names %}
+              {% set score.value = score.value + 45 %}
+            {% elif phone_area not in unknown_states %}
+              {% set score.value = score.value - 25 %}
+            {% endif %}
+            {% if watch_area in dining_area_names %}
+              {% set score.value = score.value + 10 %}
+            {% elif watch_area not in unknown_states %}
+              {% set score.value = score.value - 5 %}
+            {% endif %}
+            {% if phone_area in dining_area_names and watch_area in dining_area_names %}
+              {% set score.value = score.value + 5 %}
+            {% endif %}
+            {{ [[score.value, 0] | max, 100] | min }}
+          {% endif %}
+        attributes:
+          band: >-
+            {% set score = states('sensor.dining_room_room_confidence') | int(0) %}
+            {% if score >= 80 %}certain
+            {% elif score >= 50 %}likely
+            {% elif score >= 25 %}possible
+            {% else %}clear
+            {% endif %}
+          phone_area: "{{ states('sensor.iphone_17_pro_area') }}"
+          watch_area: "{{ states('sensor.apple_watch_ultra_2_area') }}"
+          bluetooth_proxy_status: "{{ states('binary_sensor.dining_room_bt_proxy_dining_room_bluetooth_proxy_status') }}"
+
       - name: basement_room_confidence
         unique_id: basement_room_confidence
         unit_of_measurement: "%"
@@ -380,6 +429,11 @@ template:
         unique_id: den_confident_occupancy
         device_class: occupancy
         state: "{{ states('sensor.den_room_confidence') | int(0) >= 50 }}"
+
+      - name: dining_room_confident_occupancy
+        unique_id: dining_room_confident_occupancy
+        device_class: occupancy
+        state: "{{ states('sensor.dining_room_room_confidence') | int(0) >= 50 }}"
 
       - name: basement_confident_occupancy
         unique_id: basement_confident_occupancy

--- a/packages/room_confidence.yaml
+++ b/packages/room_confidence.yaml
@@ -260,7 +260,7 @@ template:
         state: >-
           {% set home_present = is_state('person.ryan', 'home') or is_state('binary_sensor.bayesian_zeke_home', 'on') %}
           {% set unknown_states = ['unknown', 'unavailable', 'none', ''] %}
-          {% set dining_area_names = ['dining room', 'living room'] %}
+          {% set dining_area_names = ['dining room'] %}
           {% set phone_area = states('sensor.iphone_17_pro_area') | lower %}
           {% set watch_area = states('sensor.apple_watch_ultra_2_area') | lower %}
           {% set score = namespace(value=0) %}

--- a/packages/room_confidence.yaml
+++ b/packages/room_confidence.yaml
@@ -260,7 +260,7 @@ template:
         state: >-
           {% set home_present = is_state('person.ryan', 'home') or is_state('binary_sensor.bayesian_zeke_home', 'on') %}
           {% set unknown_states = ['unknown', 'unavailable', 'none', ''] %}
-          {% set dining_area_names = ['dining room'] %}
+          {% set dining_area_names = ['dining room', 'living room'] %}
           {% set phone_area = states('sensor.iphone_17_pro_area') | lower %}
           {% set watch_area = states('sensor.apple_watch_ultra_2_area') | lower %}
           {% set score = namespace(value=0) %}

--- a/tests/test_room_confidence.py
+++ b/tests/test_room_confidence.py
@@ -35,13 +35,13 @@ def test_dining_room_confidence_uses_bermuda_area_without_local_motion_weight() 
 
     assert "sensor.iphone_17_pro_area" in block
     assert "sensor.apple_watch_ultra_2_area" in block
-    assert "dining_area_names = ['dining room']" in block
+    assert "dining_area_names = ['dining room', 'living room']" in block
     assert "score.value = score.value + 45" in block
     assert "score.value = score.value + 10" in block
     assert "score.value = score.value + 5" in block
     assert "binary_sensor.dining_room_bt_proxy_dining_room_bluetooth_proxy_status" in block
     assert "_occupancy" not in block
-    assert "living room" not in block
+    assert "living room" in block
 
 
 def test_dining_room_confident_occupancy_threshold_matches_other_rooms() -> None:

--- a/tests/test_room_confidence.py
+++ b/tests/test_room_confidence.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOM_CONFIDENCE_PATH = Path(__file__).resolve().parents[1] / "packages" / "room_confidence.yaml"
+
+
+def _room_confidence_text() -> str:
+    return ROOM_CONFIDENCE_PATH.read_text(encoding="utf-8")
+
+
+def _sensor_block(text: str, sensor_name: str) -> str:
+    marker = f"      - name: {sensor_name}\n"
+    start = text.index(marker)
+    next_sensor = text.find("\n      - name:", start + len(marker))
+    if next_sensor == -1:
+        return text[start:]
+    return text[start:next_sensor]
+
+
+def test_dining_room_confidence_entities_are_registered() -> None:
+    text = _room_confidence_text()
+
+    assert "binary_sensor.dining_room_confident_occupancy:" in text
+    assert "friendly_name: Dining room confidently occupied" in text
+    assert "sensor.dining_room_room_confidence:" in text
+    assert "friendly_name: Dining room room confidence" in text
+    assert "icon: mdi:silverware-fork-knife" in text
+
+
+def test_dining_room_confidence_uses_bermuda_area_without_local_motion_weight() -> None:
+    text = _room_confidence_text()
+    block = _sensor_block(text, "dining_room_room_confidence")
+
+    assert "sensor.iphone_17_pro_area" in block
+    assert "sensor.apple_watch_ultra_2_area" in block
+    assert "dining_area_names = ['dining room']" in block
+    assert "score.value = score.value + 45" in block
+    assert "score.value = score.value + 10" in block
+    assert "score.value = score.value + 5" in block
+    assert "binary_sensor.dining_room_bt_proxy_dining_room_bluetooth_proxy_status" in block
+    assert "_occupancy" not in block
+    assert "living room" not in block
+
+
+def test_dining_room_confident_occupancy_threshold_matches_other_rooms() -> None:
+    text = _room_confidence_text()
+    block = _sensor_block(text, "dining_room_confident_occupancy")
+
+    assert "device_class: occupancy" in block
+    assert 'state: "{{ states(\'sensor.dining_room_room_confidence\') | int(0) >= 50 }}"' in block
+
+
+def test_dining_room_confidence_recomputes_when_proxy_status_changes() -> None:
+    text = _room_confidence_text()
+    trigger_block = text.split("    sensor:", 1)[0]
+
+    assert "binary_sensor.dining_room_bt_proxy_dining_room_bluetooth_proxy_status" in trigger_block

--- a/tests/test_room_confidence.py
+++ b/tests/test_room_confidence.py
@@ -35,13 +35,13 @@ def test_dining_room_confidence_uses_bermuda_area_without_local_motion_weight() 
 
     assert "sensor.iphone_17_pro_area" in block
     assert "sensor.apple_watch_ultra_2_area" in block
-    assert "dining_area_names = ['dining room', 'living room']" in block
+    assert "dining_area_names = ['dining room']" in block
     assert "score.value = score.value + 45" in block
     assert "score.value = score.value + 10" in block
     assert "score.value = score.value + 5" in block
     assert "binary_sensor.dining_room_bt_proxy_dining_room_bluetooth_proxy_status" in block
     assert "_occupancy" not in block
-    assert "living room" in block
+    assert "living room" not in block
 
 
 def test_dining_room_confident_occupancy_threshold_matches_other_rooms() -> None:


### PR DESCRIPTION
## Summary

- Add `sensor.dining_room_room_confidence` and `binary_sensor.dining_room_confident_occupancy` to `packages/room_confidence.yaml`.
- Use Bermuda area sensors from `sensor.iphone_17_pro_area` and `sensor.apple_watch_ultra_2_area` to score dining-room occupancy confidence.
- Require the canonical `Dining Room` area label for this dining-room confidence sensor; do not accept the legacy `Living Room` label here.
- Include the Dining Room BT Proxy status as a trigger and diagnostic attribute so the confidence entity updates when that proxy changes availability.
- Add focused regression coverage in `tests/test_room_confidence.py`.

## ESP32/Bermuda notes

- Live Home Assistant currently reports Bermuda at 6 total proxies / 5 active proxies.
- Den contributes: live entities include `sensor.iphone_17_pro_distance_to_denbluetoothproxy`, and `binary_sensor.denbluetoothproxy_den_bluetooth_proxy_status` is online.
- Dining Room contributes: live entities include `sensor.iphone_17_pro_distance_to_livingroombtproxy`, and `binary_sensor.dining_room_bt_proxy_dining_room_bluetooth_proxy_status` is online.
- Other visible contributing proxies include Office, Basement, and Under Bed. Not every ESPHome device should be assumed to contribute; only ESP32 devices with BLE tracking/proxy enabled and proper HA/Bermuda area placement should be treated as room-location inputs.

References #203.

## Validation

- `uv run --with pytest pytest tests/test_room_confidence.py tests/test_room_name_registry.py` -> 12 passed
- `uv run --with pytest pytest tests/test_room_confidence.py tests/test_esphome_proxy_packages.py` -> 8 passed
- `python3 /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/room_confidence.yaml --strict` -> 0 findings
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/room_confidence.yaml` -> passed
- `git diff --check` -> passed
- Home Assistant `check_config` -> valid

## Known baseline issue

- `uv run --with pytest pytest` on current `origin/develop` fails in unrelated media-player/Tiki Time expectations: 11 failed, 296 passed. The new room-confidence tests pass and the failures do not touch this PR's files.