### PR TITLE
fix: reduce media player YAML DRY findings

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -782,6 +782,26 @@ script:
           media_item: "{{ normalized_uri }}"
           enqueue: "{{ enqueue | default('replace') }}"
 
+  music_assistant_play_bedroom_playlist_choice:
+    alias: "Play bedroom playlist choice via Music Assistant"
+    fields:
+      playlist:
+        description: "Spotify URI selected by a bedroom playlist script"
+      playlist_name:
+        description: "Human-readable playlist group name for logbook"
+    sequence:
+      - action: logbook.log
+        data:
+          entity_id: media_player.bedroom_sonos_2
+          domain: media_player
+          name: Cube Playlist is
+          message: " playing {{ playlist_name }} playlist: {{ playlist }}"
+      - alias: "Play playlist via Music Assistant"
+        action: script.music_assistant_play_spotify_uri
+        data:
+          entity_id: media_player.bedroom_sonos_2
+          spotify_uri: "{{ playlist }}"
+
   music_assistant_search_music:
     alias: "Search Music Assistant"
     sequence:
@@ -1067,17 +1087,10 @@ script:
                 ] -%}
               {% set pindex =  (range(0, (plists | length) )|random) -%}
               {{ plists[pindex] }}
-      - action: logbook.log
+      - action: script.music_assistant_play_bedroom_playlist_choice
         data:
-          entity_id: media_player.bedroom_sonos_2
-          domain: media_player
-          name: Cube Playlist is
-          message: " playing Lowfi playlist: {{ playlist }}"
-      - alias: "Play playlist via Music Assistant"
-        action: script.music_assistant_play_spotify_uri
-        data:
-          entity_id: media_player.bedroom_sonos_2
-          spotify_uri: "{{ playlist }}"
+          playlist_name: Lowfi
+          playlist: "{{ playlist }}"
 
   bedroom_playlist_1:
     alias: "Play Guster"
@@ -1111,17 +1124,10 @@ script:
             ] -%}
               {% set pindex =  (range(0, (plists | length))|random) -%}
               {{ plists[pindex] }}
-      - action: logbook.log
+      - action: script.music_assistant_play_bedroom_playlist_choice
         data:
-          entity_id: media_player.bedroom_sonos_2
-          domain: media_player
-          name: Cube Playlist is
-          message: " playing Guster playlist: {{ playlist }}"
-      - alias: "Play playlist via Music Assistant"
-        action: script.music_assistant_play_spotify_uri
-        data:
-          entity_id: media_player.bedroom_sonos_2
-          spotify_uri: "{{ playlist }}"
+          playlist_name: Guster
+          playlist: "{{ playlist }}"
 
   bedroom_playlist_2:
     alias: "Play Joe Pera"
@@ -1141,17 +1147,10 @@ script:
               ] -%}
               {% set pindex =  (range(0, (plists | length))|random) -%}
               {{ plists[pindex] }}
-      - action: logbook.log
+      - action: script.music_assistant_play_bedroom_playlist_choice
         data:
-          entity_id: media_player.bedroom_sonos_2
-          domain: media_player
-          name: Cube Playlist is
-          message: " playing Joe Pera playlist: {{ playlist }}"
-      - alias: "Play playlist via Music Assistant"
-        action: script.music_assistant_play_spotify_uri
-        data:
-          entity_id: media_player.bedroom_sonos_2
-          spotify_uri: "{{ playlist }}"
+          playlist_name: Joe Pera
+          playlist: "{{ playlist }}"
 
   bedroom_playlist_3:
     alias: "Play VaporWave and Retro"
@@ -1171,17 +1170,10 @@ script:
               ] -%}
               {% set pindex =  (range(0, (plists | length))|random) -%}
               {{ plists[pindex] }}
-      - action: logbook.log
+      - action: script.music_assistant_play_bedroom_playlist_choice
         data:
-          entity_id: media_player.bedroom_sonos_2
-          domain: media_player
-          name: Cube Playlist is
-          message: " playing RetroWave playlist: {{ playlist }}"
-      - alias: "Play playlist via Music Assistant"
-        action: script.music_assistant_play_spotify_uri
-        data:
-          entity_id: media_player.bedroom_sonos_2
-          spotify_uri: "{{ playlist }}"
+          playlist_name: RetroWave
+          playlist: "{{ playlist }}"
 
   bedroom_playlist_4:
     alias: "Play Alt/Independent"
@@ -1215,17 +1207,10 @@ script:
               ] -%}
               {% set pindex =  (range(0, (plists | length))|random) -%}
               {{ plists[pindex] }}
-      - action: logbook.log
+      - action: script.music_assistant_play_bedroom_playlist_choice
         data:
-          entity_id: media_player.bedroom_sonos_2
-          domain: media_player
-          name: Cube Playlist is
-          message: " playing Alt/Independent playlist: {{ playlist }}"
-      - alias: "Play playlist via Music Assistant"
-        action: script.music_assistant_play_spotify_uri
-        data:
-          entity_id: media_player.bedroom_sonos_2
-          spotify_uri: "{{ playlist }}"
+          playlist_name: Alt/Independent
+          playlist: "{{ playlist }}"
 
   bedroom_playlist_5:
     alias: "Play LoFi"
@@ -1251,17 +1236,10 @@ script:
               ] -%}
               {% set pindex =  (range(0, (plists | length))|random) -%}
               {{ plists[pindex] }}
-      - action: logbook.log
+      - action: script.music_assistant_play_bedroom_playlist_choice
         data:
-          entity_id: media_player.bedroom_sonos_2
-          domain: media_player
-          name: Cube Playlist is
-          message: " playing Lowfi playlist: {{ playlist }}"
-      - alias: "Play playlist via Music Assistant"
-        action: script.music_assistant_play_spotify_uri
-        data:
-          entity_id: media_player.bedroom_sonos_2
-          spotify_uri: "{{ playlist }}"
+          playlist_name: Lowfi
+          playlist: "{{ playlist }}"
 
   play_video_games:
     alias: "Play Video Games"
@@ -1560,12 +1538,15 @@ script:
               ] -%}
             {% set pindex = (range(0, (plists | length))|random) -%}
             {{ plists[pindex] }}
+      - variables:
+          bedtime_playback_entity: >-
+            {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
+               else 'media_player.everywhere_sonos' }}
+          bedtime_media_type: "{{ 'radio' if playlist.startswith('https://somafm.com/') else '' }}"
       - action: media_player.shuffle_set
         continue_on_error: true
         target:
-          entity_id: >-
-            {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
-               else 'media_player.everywhere_sonos' }}
+          entity_id: "{{ bedtime_playback_entity }}"
         data:
           shuffle: >-
             {%- set shuffle = [true, false] -%}
@@ -1576,9 +1557,7 @@ script:
         data:
           repeat: all
         target:
-          entity_id: >-
-            {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
-               else 'media_player.everywhere_sonos' }}
+          entity_id: "{{ bedtime_playback_entity }}"
       - delay:
           seconds: 2
       - action: media_player.volume_set
@@ -1594,20 +1573,16 @@ script:
           seconds: 2
       - action: logbook.log
         data:
-          entity_id: >-
-            {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
-               else 'media_player.everywhere_sonos' }}
+          entity_id: "{{ bedtime_playback_entity }}"
           domain: media_player
           name: Spotify Bedtime is
           message: " playing Bedtime playlist: {{ playlist }}"
       - alias: "Play bedtime music on sync group"
         action: script.music_assistant_play_item
         data:
-          entity_id: >-
-            {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
-               else 'media_player.everywhere_sonos' }}
+          entity_id: "{{ bedtime_playback_entity }}"
           media_item: "{{ playlist }}"
-          media_type: "{{ 'radio' if playlist.startswith('https://somafm.com/') else '' }}"
+          media_type: "{{ bedtime_media_type }}"
       - wait_for_trigger:
           - trigger: state
             entity_id: binary_sensor.owner_suite_bathroom_room_occupancy
@@ -1628,44 +1603,61 @@ script:
   spotify_bedtime_volume:
     alias: "Spotify Bedtime Rampdown"
     sequence:
-      - action: media_player.volume_set
-        continue_on_error: true
-        data:
-          entity_id:
-            - media_player.bedroom_sonos
-            - media_player.office_sonos
-            - media_player.bathroom_sonos
-            - media_player.den_sonos
-          volume_level: 0.1
-      - delay:
-          minutes: 2
-      - action: media_player.volume_set
-        continue_on_error: true
-        data:
-          entity_id:
-            - media_player.bedroom_sonos
-            - media_player.bathroom_sonos
-            - media_player.office_sonos
-          volume_level: 0.07
-      - delay:
-          minutes: 2
-      - action: media_player.volume_set
-        data:
-          entity_id:
-            - media_player.bedroom_sonos
-            - media_player.bathroom_sonos
-            - media_player.office_sonos
-          volume_level: 0.05
-      - delay:
-          minutes: 2
-      - action: media_player.volume_set
-        continue_on_error: true
-        data:
-          entity_id:
-            - media_player.bedroom_sonos
-            - media_player.bathroom_sonos
-            - media_player.office_sonos
-          volume_level: 0.01
+      - variables:
+          bedtime_rampdown_steps:
+            - delay_minutes: 0
+              continue_on_error: true
+              entity_id:
+                - media_player.bedroom_sonos
+                - media_player.office_sonos
+                - media_player.bathroom_sonos
+                - media_player.den_sonos
+              volume_level: 0.1
+            - delay_minutes: 2
+              continue_on_error: true
+              entity_id:
+                - media_player.bedroom_sonos
+                - media_player.bathroom_sonos
+                - media_player.office_sonos
+              volume_level: 0.07
+            - delay_minutes: 2
+              continue_on_error: false
+              entity_id:
+                - media_player.bedroom_sonos
+                - media_player.bathroom_sonos
+                - media_player.office_sonos
+              volume_level: 0.05
+            - delay_minutes: 2
+              continue_on_error: true
+              entity_id:
+                - media_player.bedroom_sonos
+                - media_player.bathroom_sonos
+                - media_player.office_sonos
+              volume_level: 0.01
+      - repeat:
+          for_each: "{{ bedtime_rampdown_steps }}"
+          sequence:
+            - if:
+                - condition: template
+                  value_template: "{{ repeat.item.delay_minutes | int(0) > 0 }}"
+              then:
+                - delay:
+                    minutes: "{{ repeat.item.delay_minutes }}"
+            - choose:
+                - conditions:
+                    - condition: template
+                      value_template: "{{ repeat.item.continue_on_error }}"
+                  sequence:
+                    - action: media_player.volume_set
+                      continue_on_error: true
+                      data:
+                        entity_id: "{{ repeat.item.entity_id }}"
+                        volume_level: "{{ repeat.item.volume_level }}"
+              default:
+                - action: media_player.volume_set
+                  data:
+                    entity_id: "{{ repeat.item.entity_id }}"
+                    volume_level: "{{ repeat.item.volume_level }}"
 
   spotify_wake_up:
     alias: "Spotify Wake Up"

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -120,6 +120,20 @@ def test_spotify_wrapper_delegates_to_generic_music_assistant_helper() -> None:
     assert 'media_item: "{{ normalized_uri }}"' in block
 
 
+def test_bedroom_playlist_helper_logs_and_plays_selected_playlist() -> None:
+    block = _script_block("music_assistant_play_bedroom_playlist_choice")
+
+    for token in (
+        "playlist:",
+        "playlist_name:",
+        "Cube Playlist is",
+        "media_player.bedroom_sonos_2",
+        "script.music_assistant_play_spotify_uri",
+        'spotify_uri: "{{ playlist }}"',
+    ):
+        assert token in block
+
+
 def test_house_party_helper_is_stubbed_after_sync_group_migration() -> None:
     block = _script_block("music_assistant_prepare_house_party_group")
     common_block = _script_block("music_assistant_sync_group_migration_stub")
@@ -168,6 +182,7 @@ def test_arrival_music_targets_guest_aware_sync_group_without_regroup_retry() ->
 def test_bedtime_targets_guest_aware_sync_group_before_playing() -> None:
     block = _script_block("spotify_bedtime")
 
+    assert "bedtime_playback_entity" in block
     assert "media_player.guest_sonos" in block
     assert "media_player.everywhere_sonos" in block
     assert "input_boolean.guest_mode" in block
@@ -276,6 +291,7 @@ def test_bedtime_playlist_includes_explicit_somafm_station_urls() -> None:
     assert "range(0, (plists | length))" in block
     assert "action: script.music_assistant_play_item" in block
     assert 'media_item: "{{ playlist }}"' in block
+    assert 'media_type: "{{ bedtime_media_type }}"' in block
     assert "playlist.startswith('https://somafm.com/')" in block
 
 
@@ -338,6 +354,37 @@ def test_bedroom_playlist_scripts_use_sequence_level_random_selection() -> None:
         # Sequence must begin with a variables action containing playlist
         assert "      - variables:" in block, f"{script_id}: missing sequence-level variables action"
         assert "          playlist: >-" in block, f"{script_id}: missing sequence-level playlist"
+        assert (
+            "action: script.music_assistant_play_bedroom_playlist_choice" in block
+        ), f"{script_id}: missing shared bedroom playlist playback helper"
+        assert "action: logbook.log" not in block, f"{script_id}: should delegate logging"
+        assert (
+            "action: script.music_assistant_play_spotify_uri" not in block
+        ), f"{script_id}: should delegate Music Assistant playback"
+
+
+def test_bedtime_volume_rampdown_is_data_driven_without_repeating_delay_actions() -> None:
+    block = _script_block("spotify_bedtime_volume")
+
+    for token in (
+        "bedtime_rampdown_steps:",
+        "delay_minutes: 0",
+        "delay_minutes: 2",
+        "volume_level: 0.1",
+        "volume_level: 0.07",
+        "volume_level: 0.05",
+        "volume_level: 0.01",
+        "repeat:",
+        'for_each: "{{ bedtime_rampdown_steps }}"',
+        'minutes: "{{ repeat.item.delay_minutes }}"',
+        'entity_id: "{{ repeat.item.entity_id }}"',
+        'volume_level: "{{ repeat.item.volume_level }}"',
+    ):
+        assert token in block
+
+    assert block.count("- delay:") == 1
+    assert block.count("action: media_player.volume_set") == 2
+    assert "continue_on_error: false" in block
 
 
 def test_arrival_and_wakeup_scripts_use_sequence_level_playlist_selection() -> None:


### PR DESCRIPTION
Refs #508
Related: #504
Follows #509

## Summary

- Add `music_assistant_play_bedroom_playlist_choice` so the bedroom playlist scripts share their logbook + Music Assistant playback tail while keeping sequence-level random playlist selection.
- Hoist the bedtime guest-aware playback target and SomaFM media-type decision into runtime variables before the playback actions.
- Convert `spotify_bedtime_volume` into a data-driven rampdown loop that preserves the immediate first volume set, the 2-minute step delays, and the one strict `volume_set` step without `continue_on_error`.

## DRY verifier movement

Post-#509 baseline from `origin/develop` for the five #508 files was:

- Duplicate full-block groups: 1
- Duplicate entry groups: 18
- Intra-block duplicates: 3

This PR reports:

- Duplicate full-block groups: 1
- Duplicate entry groups: 16
- Intra-block duplicates: 2

Remaining findings are intentionally left for follow-up slices: the cross-package startup trigger, light/zigbee Inovelli patterns, the generic media 2-second delays, and the two Lowfi playlist helper calls that are semantically identical because both scripts still log as `Lowfi`.

## Coverage and tests

- `python3 - <<'PY' ... yaml.safe_load(packages/media_player.yaml) ... PY`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/media_player.yaml`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/media_player.yaml --min-occurrences 2`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/adaptive_lighting.yaml packages/light.yaml packages/media_player.yaml packages/zigbee_zwave.yaml packages/house_mode.yaml --min-occurrences 2`
- `uv run --with pytest pytest tests/test_media_player_music_assistant.py tests/test_alarm_night_allium_alignment.py tests/test_night_routines_allium_alignment.py` (`42 passed`)
- `uv run --with pytest pytest` (`320 passed`)