### PR TITLE
fix: harden nightly runtime sweep follow-ups

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -209,7 +209,7 @@ automation:
         id: ha-start
         event: start
     variables:
-      main_adaptive_switches:
+      candidate_main_adaptive_switches:
         - switch.adaptive_lighting_basement
         - switch.adaptive_lighting_den
         - switch.adaptive_lighting_hallway
@@ -217,18 +217,34 @@ automation:
         - switch.adaptive_lighting_office
         - switch.adaptive_lighting_owner_suite
         - switch.dining_room_adaptive_lighting_dining_room
+      main_adaptive_switches: >-
+        {% set ns = namespace(items=[]) %}
+        {% for entity_id in candidate_main_adaptive_switches %}
+          {% if states(entity_id) not in ['unknown', 'unavailable'] %}
+            {% set ns.items = ns.items + [entity_id] %}
+          {% endif %}
+        {% endfor %}
+        {{ ns.items }}
     action:
       - if:
           - condition: trigger
             id: nightly-cycle
         then:
-          - action: switch.turn_off
+          - if:
+              - condition: template
+                value_template: "{{ main_adaptive_switches | count > 0 }}"
+            then:
+              - action: switch.turn_off
+                target:
+                  entity_id: "{{ main_adaptive_switches }}"
+          - delay: "00:00:10"
+      - if:
+          - condition: template
+            value_template: "{{ main_adaptive_switches | count > 0 }}"
+        then:
+          - action: switch.turn_on
             target:
               entity_id: "{{ main_adaptive_switches }}"
-          - delay: "00:00:10"
-      - action: switch.turn_on
-        target:
-          entity_id: "{{ main_adaptive_switches }}"
 
   - id: sync_selected_inovelli_led_bars_to_adaptive_lighting
     alias: sync_selected_inovelli_led_bars_to_adaptive_lighting

--- a/packages/z2m_lifecycle.yaml
+++ b/packages/z2m_lifecycle.yaml
@@ -66,8 +66,7 @@ automation:
 
   - id: notify_z2m_lifecycle_issues
     alias: notify_z2m_lifecycle_issues
-    mode: queued
-    max: 10
+    mode: restart
     trigger:
       - trigger: state
         id: summary_change
@@ -1009,7 +1008,6 @@ template:
           coordinator_missing_routers: "{{ z2m_lifecycle_stats.get('coordinator_missing_routers', []) }}"
           coordinator_missing_routers_pending: "{{ z2m_lifecycle_stats.get('coordinator_missing_routers_pending', []) }}"
           coordinator_missing_routers_pending_since: "{{ z2m_lifecycle_stats.get('coordinator_missing_routers_pending_since') }}"
-          devices: "{{ z2m_lifecycle_stats.get('devices', {}) }}"
 
   - trigger:
       - trigger: homeassistant

--- a/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
+++ b/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
@@ -78,6 +78,16 @@ def test_default_led_bar_sync_automation_updates_owner_suite_and_office_after_re
     assert "- office" in block
 
 
+def test_nightly_adaptive_lighting_cycle_filters_missing_candidate_switches() -> None:
+    block = _automation_block("nightly_adaptive_lighting_cycle_reset")
+
+    assert "candidate_main_adaptive_switches:" in block
+    assert "switch.adaptive_lighting_office" in block
+    assert "states(entity_id) not in ['unknown', 'unavailable']" in block
+    assert "main_adaptive_switches | count > 0" in block
+    assert block.count('entity_id: "{{ main_adaptive_switches }}"') == 2
+
+
 def test_led_bar_sync_script_accepts_room_inputs_and_maps_owner_suite_and_office() -> None:
     block = _script_block("sync_inovelli_led_bars_to_adaptive_lighting")
 

--- a/tests/test_z2m_lifecycle_package.py
+++ b/tests/test_z2m_lifecycle_package.py
@@ -40,6 +40,16 @@ def test_z2m_lifecycle_package_tracks_join_drop_leave_and_mesh_health() -> None:
         assert token in text
 
 
+def test_z2m_lifecycle_notification_uses_latest_state_and_bounded_attributes() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    block = _automation_block("notify_z2m_lifecycle_issues")
+
+    assert "mode: restart" in block
+    assert "mode: queued" not in block
+    assert "max: 10" not in block
+    assert "devices: \"{{ z2m_lifecycle_stats.get('devices', {}) }}\"" not in text
+
+
 def test_z2m_lifecycle_package_debounces_transient_coordinator_router_alerts() -> None:
     text = PACKAGE_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #182

## Summary

- Filter the nightly Adaptive Lighting reset candidate list to only switches that currently exist and have a value before calling `switch.turn_off` / `switch.turn_on`.
- Keep `switch.adaptive_lighting_office` as a future candidate, but prevent the live runtime warning caused by targeting it while the Office Adaptive Lighting switch does not exist.
- Change `notify_z2m_lifecycle_issues` to `mode: restart` so rapid startup/flapping transitions let the latest lifecycle state win, preventing stale persistent notifications.
- Remove the raw `devices` map from `sensor.z2m_lifecycle_issues` attributes because live recorder warnings show that attribute can exceed Home Assistant's 16 KB state-attribute limit.

## Runtime evidence

- Live Home Assistant 2026.4.3 reported repeated `Referenced entities ... switch.adaptive_lighting_office are missing or not currently available` warnings from the adaptive lighting reset path.
- Live template evaluation for the new filter returns the six existing switches and excludes missing `switch.adaptive_lighting_office`.
- Live `automation.notify_z2m_lifecycle_issues` traces showed four queued notification runs followed by `failed_max_runs` during a rapid `sensor.z2m_lifecycle_issues` 1 -> 0 transition, while the persistent notification still showed a stale affected device even though the sensor state was 0.
- Live logs also showed repeated recorder warnings for `sensor.z2m_lifecycle_issues` attributes exceeding 16384 bytes.

## Validation

- `uv run --with pytest pytest tests/test_adaptive_lighting_inovelli_led_bar_sync.py tests/test_z2m_lifecycle_package.py` -> 10 passed
- `uv run --with pytest pytest` -> 322 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/adaptive_lighting.yaml packages/z2m_lifecycle.yaml` -> passed
- PyYAML parse for touched packages -> passed
- HA live `ha_check_config` -> valid
- DRY verifier on touched packages -> existing duplicate groups only, 0 parse errors, 0 central-script findings
- `allium check specs/alarm_wakeup.allium specs/night_routines.allium specs/arrival_lighting.allium specs/z2m_lifecycle.allium` -> 0 errors, existing warnings/info diagnostics; CLI returned non-zero for diagnostics
- `git diff --check` -> passed

## Sweep notes

- PR #513 / issue #512 bed-lamp CPAP gating appears to be a historical trace: latest live traces predate the merge, and the current repo config includes the CPAP power gate.
- Issue #502 garage opener ESP restart endpoint needs no repo change from this run: the latest live trace on 2026-04-19 completed without the prior timeout error.
- Current Zigbee2MQTT app and Music Assistant app are started; Zigbee bridge state is online.
