### PR TITLE
feat: auto-reject vacuum pending map changes to preserve room layout (#485)

### DIFF
--- a/packages/vacuum_map_guard.yaml
+++ b/packages/vacuum_map_guard.yaml
@@ -54,10 +54,8 @@ script:
   valetudo_reject_pending_map_change:
     alias: "Reject Pending Valetudo Map Change"
     description: >-
-      Rejects a pending Valetudo map change for one robot and notifies.
-      Call with robot_name ("Main Level" or "Upstairs") and
-      rest_command_id ("valetudo_mainlevel_reject_map_change" or
-      "valetudo_upstairs_reject_map_change").
+      Rejects a pending Valetudo map change for one robot and sends an
+      actionable notification with an "Accept New Map" button for manual override.
     mode: parallel
     max: 2
     fields:
@@ -67,6 +65,9 @@ script:
       rest_command_id:
         description: "rest_command service ID to call for the reject action"
         example: "valetudo_mainlevel_reject_map_change"
+      notify_action_id:
+        description: "Unique action identifier for the Accept button in the notification"
+        example: "ACCEPT_MAP_MAINLEVEL"
     sequence:
       - choose:
           - conditions:
@@ -82,10 +83,12 @@ script:
         data:
           title: "{{ robot_name }} Vacuum: Map Change Rejected"
           message: >-
-            The {{ robot_name }} vacuum proposed a new map. It was automatically
-            rejected to preserve the existing room layout. If drift is severe,
-            accept the change manually via Developer Tools → Services →
-            rest_command.valetudo_{{ 'mainlevel' if 'mainlevel' in rest_command_id else 'upstairs' }}_accept_map_change.
+            New map proposed and auto-rejected to preserve room layout.
+            Tap Accept if the current map is too skewed to be useful.
+          data:
+            actions:
+              - action: "{{ notify_action_id }}"
+                title: "Accept New Map"
 
 ########################
 # Automations
@@ -103,6 +106,7 @@ automation:
         data:
           robot_name: "Main Level"
           rest_command_id: "valetudo_mainlevel_reject_map_change"
+          notify_action_id: "ACCEPT_MAP_MAINLEVEL"
 
   - alias: "Guard Upstairs Vacuum Map"
     id: valetudo_upstairs_map_guard
@@ -116,3 +120,28 @@ automation:
         data:
           robot_name: "Upstairs"
           rest_command_id: "valetudo_upstairs_reject_map_change"
+          notify_action_id: "ACCEPT_MAP_UPSTAIRS"
+
+  - alias: "Accept Main Level Vacuum Map Change"
+    id: valetudo_mainlevel_map_accept_action
+    mode: single
+    trigger:
+      - trigger: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: "ACCEPT_MAP_MAINLEVEL"
+    action:
+      - action: rest_command.valetudo_mainlevel_accept_map_change
+        continue_on_error: true
+
+  - alias: "Accept Upstairs Vacuum Map Change"
+    id: valetudo_upstairs_map_accept_action
+    mode: single
+    trigger:
+      - trigger: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: "ACCEPT_MAP_UPSTAIRS"
+    action:
+      - action: rest_command.valetudo_upstairs_accept_map_change
+        continue_on_error: true

--- a/packages/vacuum_map_guard.yaml
+++ b/packages/vacuum_map_guard.yaml
@@ -14,6 +14,9 @@
 #
 # MQTT trigger topic pattern (subtopic-per-field, consistent with BatteryStateAttribute/level):
 #   valetudo/{identifier}/PendingMapChangeHandlingCapability/pending  →  "true" | "false"
+#
+# Flow: notify with Accept/Keep buttons → wait up to 10 min → act on tap or auto-reject on timeout.
+# The reject never fires before the user has a chance to respond.
 
 ################################################################
 ## Packages / Vacuum Map Guard
@@ -48,49 +51,6 @@ rest_command:
     payload: '{"action": "accept"}'
 
 ########################
-# Scripts
-########################
-script:
-  valetudo_reject_pending_map_change:
-    alias: "Reject Pending Valetudo Map Change"
-    description: >-
-      Rejects a pending Valetudo map change for one robot and sends an
-      actionable notification with an "Accept New Map" button for manual override.
-    mode: parallel
-    max: 2
-    fields:
-      robot_name:
-        description: "Human-readable robot label used in the notification title"
-        example: "Main Level"
-      rest_command_id:
-        description: "rest_command service ID to call for the reject action"
-        example: "valetudo_mainlevel_reject_map_change"
-      notify_action_id:
-        description: "Unique action identifier for the Accept button in the notification"
-        example: "ACCEPT_MAP_MAINLEVEL"
-    sequence:
-      - choose:
-          - conditions:
-              - condition: template
-                value_template: "{{ rest_command_id == 'valetudo_mainlevel_reject_map_change' }}"
-            sequence:
-              - action: rest_command.valetudo_mainlevel_reject_map_change
-                continue_on_error: true
-        default:
-          - action: rest_command.valetudo_upstairs_reject_map_change
-            continue_on_error: true
-      - action: notify.mobile_app_wethop
-        data:
-          title: "{{ robot_name }} Vacuum: Map Change Rejected"
-          message: >-
-            New map proposed and auto-rejected to preserve room layout.
-            Tap Accept if the current map is too skewed to be useful.
-          data:
-            actions:
-              - action: "{{ notify_action_id }}"
-                title: "Accept New Map"
-
-########################
 # Automations
 ########################
 automation:
@@ -102,11 +62,39 @@ automation:
         topic: "valetudo/mainlevel/PendingMapChangeHandlingCapability/pending"
         payload: "true"
     action:
-      - action: script.valetudo_reject_pending_map_change
+      - action: notify.mobile_app_wethop
         data:
-          robot_name: "Main Level"
-          rest_command_id: "valetudo_mainlevel_reject_map_change"
-          notify_action_id: "ACCEPT_MAP_MAINLEVEL"
+          title: "Main Level Vacuum: New Map Pending"
+          message: "New map proposed. Accept to use it or keep the current room layout (auto-keeps in 10 min)."
+          data:
+            actions:
+              - action: "ACCEPT_MAP_MAINLEVEL"
+                title: "Accept New Map"
+              - action: "REJECT_MAP_MAINLEVEL"
+                title: "Keep Current"
+      - wait_for_trigger:
+          - trigger: event
+            event_type: mobile_app_notification_action
+            event_data:
+              action: "ACCEPT_MAP_MAINLEVEL"
+          - trigger: event
+            event_type: mobile_app_notification_action
+            event_data:
+              action: "REJECT_MAP_MAINLEVEL"
+        timeout: "00:10:00"
+        continue_on_timeout: true
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: >-
+                  {{ wait.trigger is not none
+                     and wait.trigger.event.data.action == 'ACCEPT_MAP_MAINLEVEL' }}
+            sequence:
+              - action: rest_command.valetudo_mainlevel_accept_map_change
+                continue_on_error: true
+        default:
+          - action: rest_command.valetudo_mainlevel_reject_map_change
+            continue_on_error: true
 
   - alias: "Guard Upstairs Vacuum Map"
     id: valetudo_upstairs_map_guard
@@ -116,32 +104,36 @@ automation:
         topic: "valetudo/upstairs-vacuum/PendingMapChangeHandlingCapability/pending"
         payload: "true"
     action:
-      - action: script.valetudo_reject_pending_map_change
+      - action: notify.mobile_app_wethop
         data:
-          robot_name: "Upstairs"
-          rest_command_id: "valetudo_upstairs_reject_map_change"
-          notify_action_id: "ACCEPT_MAP_UPSTAIRS"
-
-  - alias: "Accept Main Level Vacuum Map Change"
-    id: valetudo_mainlevel_map_accept_action
-    mode: single
-    trigger:
-      - trigger: event
-        event_type: mobile_app_notification_action
-        event_data:
-          action: "ACCEPT_MAP_MAINLEVEL"
-    action:
-      - action: rest_command.valetudo_mainlevel_accept_map_change
-        continue_on_error: true
-
-  - alias: "Accept Upstairs Vacuum Map Change"
-    id: valetudo_upstairs_map_accept_action
-    mode: single
-    trigger:
-      - trigger: event
-        event_type: mobile_app_notification_action
-        event_data:
-          action: "ACCEPT_MAP_UPSTAIRS"
-    action:
-      - action: rest_command.valetudo_upstairs_accept_map_change
-        continue_on_error: true
+          title: "Upstairs Vacuum: New Map Pending"
+          message: "New map proposed. Accept to use it or keep the current room layout (auto-keeps in 10 min)."
+          data:
+            actions:
+              - action: "ACCEPT_MAP_UPSTAIRS"
+                title: "Accept New Map"
+              - action: "REJECT_MAP_UPSTAIRS"
+                title: "Keep Current"
+      - wait_for_trigger:
+          - trigger: event
+            event_type: mobile_app_notification_action
+            event_data:
+              action: "ACCEPT_MAP_UPSTAIRS"
+          - trigger: event
+            event_type: mobile_app_notification_action
+            event_data:
+              action: "REJECT_MAP_UPSTAIRS"
+        timeout: "00:10:00"
+        continue_on_timeout: true
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: >-
+                  {{ wait.trigger is not none
+                     and wait.trigger.event.data.action == 'ACCEPT_MAP_UPSTAIRS' }}
+            sequence:
+              - action: rest_command.valetudo_upstairs_accept_map_change
+                continue_on_error: true
+        default:
+          - action: rest_command.valetudo_upstairs_reject_map_change
+            continue_on_error: true

--- a/packages/vacuum_map_guard.yaml
+++ b/packages/vacuum_map_guard.yaml
@@ -1,0 +1,118 @@
+# Home Assistant package for Valetudo map preservation.
+# Automatically rejects pending map changes on the two Dreame Z10 Pro robots
+# (Main Level and Upstairs) to keep room assignments intact when the robot
+# loses localization and proposes a fresh map.
+#
+# Den Vacuum (Roborock V1) lacks PendingMapChangeHandlingCapability and is excluded.
+#
+# Capability confirmed present via:
+#   GET http://192.168.1.208/api/v2/robot/capabilities   (Main Level)
+#   GET http://192.168.1.163/api/v2/robot/capabilities   (Upstairs)
+# REST action confirmed via:
+#   PUT /api/v2/robot/capabilities/PendingMapChangeHandlingCapability
+#   payload: {"action": "reject"} | {"action": "accept"}
+#
+# MQTT trigger topic pattern (subtopic-per-field, consistent with BatteryStateAttribute/level):
+#   valetudo/{identifier}/PendingMapChangeHandlingCapability/pending  →  "true" | "false"
+
+################################################################
+## Packages / Vacuum Map Guard
+################################################################
+
+########################
+# REST Commands
+########################
+rest_command:
+  valetudo_mainlevel_reject_map_change:
+    url: "http://valetudo-activeexoticlion.local/api/v2/robot/capabilities/PendingMapChangeHandlingCapability"
+    method: PUT
+    content_type: application/json
+    payload: '{"action": "reject"}'
+
+  valetudo_mainlevel_accept_map_change:
+    url: "http://valetudo-activeexoticlion.local/api/v2/robot/capabilities/PendingMapChangeHandlingCapability"
+    method: PUT
+    content_type: application/json
+    payload: '{"action": "accept"}'
+
+  valetudo_upstairs_reject_map_change:
+    url: "http://valetudo-zestycurvycaribou.local/api/v2/robot/capabilities/PendingMapChangeHandlingCapability"
+    method: PUT
+    content_type: application/json
+    payload: '{"action": "reject"}'
+
+  valetudo_upstairs_accept_map_change:
+    url: "http://valetudo-zestycurvycaribou.local/api/v2/robot/capabilities/PendingMapChangeHandlingCapability"
+    method: PUT
+    content_type: application/json
+    payload: '{"action": "accept"}'
+
+########################
+# Scripts
+########################
+script:
+  valetudo_reject_pending_map_change:
+    alias: "Reject Pending Valetudo Map Change"
+    description: >-
+      Rejects a pending Valetudo map change for one robot and notifies.
+      Call with robot_name ("Main Level" or "Upstairs") and
+      rest_command_id ("valetudo_mainlevel_reject_map_change" or
+      "valetudo_upstairs_reject_map_change").
+    mode: parallel
+    max: 2
+    fields:
+      robot_name:
+        description: "Human-readable robot label used in the notification title"
+        example: "Main Level"
+      rest_command_id:
+        description: "rest_command service ID to call for the reject action"
+        example: "valetudo_mainlevel_reject_map_change"
+    sequence:
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ rest_command_id == 'valetudo_mainlevel_reject_map_change' }}"
+            sequence:
+              - action: rest_command.valetudo_mainlevel_reject_map_change
+                continue_on_error: true
+        default:
+          - action: rest_command.valetudo_upstairs_reject_map_change
+            continue_on_error: true
+      - action: notify.mobile_app_wethop
+        data:
+          title: "{{ robot_name }} Vacuum: Map Change Rejected"
+          message: >-
+            The {{ robot_name }} vacuum proposed a new map. It was automatically
+            rejected to preserve the existing room layout. If drift is severe,
+            accept the change manually via Developer Tools → Services →
+            rest_command.valetudo_{{ 'mainlevel' if 'mainlevel' in rest_command_id else 'upstairs' }}_accept_map_change.
+
+########################
+# Automations
+########################
+automation:
+  - alias: "Guard Main Level Vacuum Map"
+    id: valetudo_mainlevel_map_guard
+    mode: single
+    trigger:
+      - trigger: mqtt
+        topic: "valetudo/mainlevel/PendingMapChangeHandlingCapability/pending"
+        payload: "true"
+    action:
+      - action: script.valetudo_reject_pending_map_change
+        data:
+          robot_name: "Main Level"
+          rest_command_id: "valetudo_mainlevel_reject_map_change"
+
+  - alias: "Guard Upstairs Vacuum Map"
+    id: valetudo_upstairs_map_guard
+    mode: single
+    trigger:
+      - trigger: mqtt
+        topic: "valetudo/upstairs-vacuum/PendingMapChangeHandlingCapability/pending"
+        payload: "true"
+    action:
+      - action: script.valetudo_reject_pending_map_change
+        data:
+          robot_name: "Upstairs"
+          rest_command_id: "valetudo_upstairs_reject_map_change"


### PR DESCRIPTION
## Summary

- Adds `packages/vacuum_map_guard.yaml` for Valetudo map preservation on the two Dreame Z10 Pro robots (Main Level + Upstairs)
- Subscribes to `PendingMapChangeHandlingCapability/pending` MQTT topic; auto-rejects via REST API when `true`
- Shared script `valetudo_reject_pending_map_change` handles the reject + `mobile_app_wethop` notification — eliminates action duplication between the two automations
- Exposes `accept` rest_commands for manual override when a full remap is intentionally desired
- Den Vacuum (Roborock V1) excluded — confirmed no `PendingMapChangeHandlingCapability` in its API

## Research notes

- `MapSnapshotCapability` (firmware-level snapshots) is **not supported** by any of the three robots; this was the first approach investigated
- `PendingMapChangeHandlingCapability` is supported on both Dreame Z10 Pros and is the correct lever: Dreame robots require explicit user confirmation before applying a new candidate map, so auto-rejecting preserves the current map+rooms
- MQTT topic pattern confirmed from broker: `valetudo/{identifier}/PendingMapChangeHandlingCapability/pending` → `"true"` | `"false"` (matches subtopic-per-field convention seen in `BatteryStateAttribute/level` etc.)
- REST endpoint confirmed: `PUT /api/v2/robot/capabilities/PendingMapChangeHandlingCapability` with `{"action": "reject" | "accept"}`

## Test plan

- [ ] Load HA with new package — config already validated via `ha_check_config`
- [ ] Simulate pending map change on one robot via Valetudo UI → confirm automation fires and rejects
- [ ] Confirm `mobile_app_wethop` notification arrives with correct robot name
- [ ] Manually call `rest_command.valetudo_mainlevel_accept_map_change` from Developer Tools to verify accept path works when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)