### PR TITLE
[codex] Add HA label taxonomy governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ docker run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:stable \
 ## Feature Docs
 
 - [House Transition Framework](docs/house_transition_framework.md)
+- [Home Assistant Label Model](docs/ha_labels.md)
 - [Room Intent Policy](docs/room_intent.yaml)
 - [Room Naming Model](docs/room_names.md)
 - [ESPHome Layout And Bermuda BLE Proxy Notes](docs/esphome.md)

--- a/docs/ha_label_taxonomy.yaml
+++ b/docs/ha_label_taxonomy.yaml
@@ -1,0 +1,314 @@
+version: 1
+last_updated: "2026-04-19"
+owner: "rtclauss"
+summary: "Canonical Home Assistant labels for cross-cutting device, entity, and automation context."
+labels:
+  - label_id: hallway
+    name: "Hallway"
+    description: "Shared hallway context that spans the main hallway and upstairs hallway areas."
+    scopes:
+      - area
+    lifecycle: active
+    owner: "room_naming"
+    reason: "Keeps the live hallway label valid for both hallway and upstairs_hallway areas without replacing physical areas."
+    icon: "mdi:floor-plan"
+    color: "blue"
+  - label_id: guest_sensitive
+    name: "Guest Sensitive"
+    description: "Rooms, devices, or entities where guest presence should suppress intrusive convenience behavior."
+    scopes:
+      - area
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "room_intent"
+    reason: "Supports privacy-first searches and automation audits for guest-capable spaces."
+    icon: "mdi:account-group"
+    color: "purple"
+  - label_id: sleep_sensitive
+    name: "Sleep Sensitive"
+    description: "Items that should avoid disruptive changes while someone may be sleeping."
+    scopes:
+      - area
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "room_intent"
+    reason: "Identifies lighting, media, climate, and physical actions that need sleep-aware review."
+    icon: "mdi:sleep"
+    color: "indigo"
+  - label_id: privacy_sensitive
+    name: "Privacy Sensitive"
+    description: "Items that can affect private rooms, private sensors, or private notifications."
+    scopes:
+      - area
+      - device
+      - entity
+      - automation
+      - script
+      - scene
+    lifecycle: active
+    owner: "room_intent"
+    reason: "Makes privacy-impacting behavior easy to find even when entity names are room-specific."
+    icon: "mdi:shield-lock"
+    color: "deep-purple"
+  - label_id: arrival_scope
+    name: "Arrival Scope"
+    description: "Items involved in arriving-home behavior, welcome scenes, or post-arrival recovery."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+      - scene
+    lifecycle: active
+    owner: "arrival_lighting"
+    reason: "Groups cross-room arrival behavior that is otherwise spread across lighting, media, and house mode packages."
+    icon: "mdi:home-import-outline"
+    color: "green"
+  - label_id: goodnight_scope
+    name: "Goodnight Scope"
+    description: "Items involved in bedtime preparation, goodnight scenes, or overnight safety behavior."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+      - scene
+    lifecycle: active
+    owner: "night_routines"
+    reason: "Supports drift checks against the night routines behavioral spec."
+    icon: "mdi:weather-night"
+    color: "blue-grey"
+  - label_id: wakeup_scope
+    name: "Wake-Up Scope"
+    description: "Items involved in alarms, snooze behavior, wake-up lighting, or morning audio."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+      - scene
+    lifecycle: active
+    owner: "alarm_wakeup"
+    reason: "Keeps alarm and wake-up impact searchable across helpers, scripts, media players, and lights."
+    icon: "mdi:alarm"
+    color: "orange"
+  - label_id: vacuum_scope
+    name: "Vacuum Scope"
+    description: "Items involved in vacuum routing, room cleaning, guest-mode suppression, or robot recovery."
+    scopes:
+      - area
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "cleaning"
+    reason: "Finds physical-intrusion behavior that can affect guest privacy and room intent."
+    icon: "mdi:robot-vacuum"
+    color: "cyan"
+  - label_id: media_scope
+    name: "Media Scope"
+    description: "Items involved in music, TV, speaker grouping, playback handoff, or announcements."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+      - scene
+    lifecycle: active
+    owner: "media_player"
+    reason: "Groups media effects that can cross room names and impact privacy or sleep behavior."
+    icon: "mdi:speaker-multiple"
+    color: "pink"
+  - label_id: lighting_scope
+    name: "Lighting Scope"
+    description: "Items involved in automatic lighting, scenes, adaptive lighting, and LED policy."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+      - scene
+    lifecycle: active
+    owner: "lighting"
+    reason: "Makes room lighting effects searchable beyond individual light entity names."
+    icon: "mdi:lightbulb-group"
+    color: "yellow"
+  - label_id: climate_scope
+    name: "Climate Scope"
+    description: "Items involved in HVAC, fans, exhaust, temperature policy, or humidity response."
+    scopes:
+      - area
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "climate"
+    reason: "Groups comfort and air-quality behavior that crosses climate, fan, binary sensor, and helper domains."
+    icon: "mdi:thermostat"
+    color: "teal"
+  - label_id: critical
+    name: "Critical"
+    description: "Items that protect safety, water damage, security, access, or core availability."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "operations"
+    reason: "Highlights items that deserve conservative changes, monitoring, and explicit test coverage."
+    icon: "mdi:alert-circle"
+    color: "red"
+  - label_id: battery_powered
+    name: "Battery Powered"
+    description: "Devices and entities that rely on replaceable or rechargeable batteries."
+    scopes:
+      - device
+      - entity
+    lifecycle: active
+    owner: "operations"
+    reason: "Supports battery maintenance searches and low-battery notification audits."
+    icon: "mdi:battery"
+    color: "lime"
+  - label_id: maintenance
+    name: "Maintenance"
+    description: "Items that exist primarily for repair, diagnostics, reset, calibration, or periodic upkeep."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+      - helper
+    lifecycle: active
+    owner: "operations"
+    reason: "Separates operational support controls from normal household behavior."
+    icon: "mdi:wrench"
+    color: "grey"
+  - label_id: firmware_update
+    name: "Firmware Update"
+    description: "Update entities and devices where firmware or software lifecycle needs review."
+    scopes:
+      - device
+      - entity
+      - automation
+    lifecycle: active
+    owner: "operations"
+    reason: "Keeps update and recovery work findable without depending on integration-specific names."
+    icon: "mdi:update"
+    color: "light-blue"
+  - label_id: energy_monitoring
+    name: "Energy Monitoring"
+    description: "Meters, plugs, tariffs, and calculated sensors used for energy or utility accounting."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+      - helper
+    lifecycle: active
+    owner: "utilities"
+    reason: "Groups energy behavior across EV charging, house electrical, gas, and tariff helpers."
+    icon: "mdi:flash"
+    color: "deep-orange"
+  - label_id: security
+    name: "Security"
+    description: "Locks, doors, alarm behavior, cameras, and presence-sensitive security logic."
+    scopes:
+      - area
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "security"
+    reason: "Collects security-impacting items that may not share names or domains."
+    icon: "mdi:shield-home"
+    color: "black"
+  - label_id: water_safety
+    name: "Water Safety"
+    description: "Leak, water shutoff, softener, humidity, sump, and water-damage prevention items."
+    scopes:
+      - area
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "utilities"
+    reason: "Makes water-risk behavior searchable across sensors, switches, and notifications."
+    icon: "mdi:water-alert"
+    color: "blue"
+  - label_id: zigbee2mqtt
+    name: "Zigbee2MQTT"
+    description: "Items sourced from or managed through the Zigbee2MQTT integration."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "platform"
+    reason: "Supports Zigbee2MQTT lifecycle, recovery, and migration audits."
+    icon: "mdi:zigbee"
+    color: "orange"
+  - label_id: esphome
+    name: "ESPHome"
+    description: "Items sourced from or managed through ESPHome devices."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "platform"
+    reason: "Supports ESPHome build, proxy, and device maintenance audits."
+    icon: "mdi:chip"
+    color: "green"
+  - label_id: inovelli
+    name: "Inovelli"
+    description: "Inovelli switches, dimmers, LED bars, bindings, and related recovery automations."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "platform"
+    reason: "Groups Inovelli-specific LED, binding, and firmware behavior across rooms."
+    icon: "mdi:light-switch"
+    color: "purple"
+  - label_id: music_assistant
+    name: "Music Assistant"
+    description: "Music Assistant players, services, queue controls, provider selectors, and playback scripts."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+      - helper
+    lifecycle: active
+    owner: "platform"
+    reason: "Keeps Music Assistant migration and playback behavior searchable."
+    icon: "mdi:music"
+    color: "pink"
+  - label_id: matter_thread
+    name: "Matter / Thread"
+    description: "Matter, Thread, border-router, and related device lifecycle items."
+    scopes:
+      - device
+      - entity
+      - automation
+      - script
+    lifecycle: active
+    owner: "platform"
+    reason: "Separates Matter and Thread lifecycle concerns from Zigbee2MQTT and ESPHome."
+    icon: "mdi:graph"
+    color: "teal"

--- a/docs/ha_labels.md
+++ b/docs/ha_labels.md
@@ -1,0 +1,62 @@
+# Home Assistant Label Model
+
+Issue `#511` defines the repo-owned canonical label taxonomy for Home Assistant. The source of truth is `docs/ha_label_taxonomy.yaml`; live labels should be reconciled from that file instead of being invented ad hoc in the UI.
+
+## Model
+
+- Use floors and areas for physical location. They answer where something is.
+- Use labels for logical cross-cutting concerns. They answer why something matters or which behavior it can affect.
+- Use categories for UI organization of automations, scripts, helpers, and scenes. They are not the behavioral taxonomy.
+- Do not use labels as replacements for entity IDs, room names, Zigbee2MQTT namespaces, or the room naming registry.
+- Do not rely on label inheritance. A label assigned to an area or device is useful for organization, but it does not automatically become an entity label in every registry and template context.
+
+## Community Findings
+
+- Home Assistant 2024.4 introduced floors, labels, and categories as different tools, not as competing names for the same thing.
+- Community usage generally keeps areas physical and uses labels for logical sets such as "all lights", "debug/history", or "maintenance".
+- A common pain point is assigning a label to a device but still needing explicit labels on selected entities for reliable searches, templates, and automation targets.
+
+## Canonical Label Rules
+
+- New labels must be added to `docs/ha_label_taxonomy.yaml` before they are created in live Home Assistant.
+- Label IDs use lowercase snake_case and should not be renamed. Deprecate and replace instead.
+- Each label needs a description, at least one scope, a lifecycle, an owner, and a reason.
+- Unknown live labels are drift. Either add them to the taxonomy or remove them intentionally.
+- Deprecated labels can remain in the taxonomy only with a replacement or a removal rationale.
+- The current live `hallway` label is intentionally valid for the `hallway` and `upstairs_hallway` areas because both represent circulation space while remaining distinct HA areas.
+
+## Reconciliation Workflow
+
+Validate the repo taxonomy:
+
+```bash
+python3 scripts/ha_label_taxonomy.py validate
+```
+
+Create a read-only live export when `HA_URL` and `HA_TOKEN` are available:
+
+```bash
+HA_URL="https://home-assistant.example" HA_TOKEN="..." \
+  python3 scripts/ha_label_taxonomy.py export-live
+```
+
+Audit live drift without changing Home Assistant:
+
+```bash
+python3 scripts/ha_label_taxonomy.py audit-live --live-json live-labels.json
+```
+
+Preview label definition reconciliation:
+
+```bash
+python3 scripts/ha_label_taxonomy.py apply-labels --live-json live-labels.json
+```
+
+Only after reviewing the dry-run output, apply label definition changes:
+
+```bash
+HA_URL="https://home-assistant.example" HA_TOKEN="..." \
+  python3 scripts/ha_label_taxonomy.py apply-labels --execute
+```
+
+`apply-labels` creates and updates label definitions only. It never removes labels and never assigns labels to areas, devices, or entities. Assignment batches should be planned separately so room intent and privacy behavior remain reviewable.

--- a/scripts/ha_label_taxonomy.py
+++ b/scripts/ha_label_taxonomy.py
@@ -1,0 +1,619 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import socket
+import ssl
+import struct
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TAXONOMY_PATH = ROOT / "docs" / "ha_label_taxonomy.yaml"
+
+ALLOWED_SCOPES = {
+    "area",
+    "automation",
+    "device",
+    "entity",
+    "helper",
+    "scene",
+    "script",
+}
+ALLOWED_LIFECYCLES = {"active", "deprecated", "reserved"}
+LABEL_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class LabelSpec:
+    label_id: str
+    name: str
+    description: str
+    scopes: tuple[str, ...]
+    lifecycle: str
+    owner: str
+    reason: str
+    icon: str | None = None
+    color: str | None = None
+    replacement: str | None = None
+    removal_reason: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "LabelSpec":
+        return cls(
+            label_id=str(raw.get("label_id", "")),
+            name=str(raw.get("name", "")),
+            description=str(raw.get("description", "")),
+            scopes=tuple(str(scope) for scope in raw.get("scopes", ())),
+            lifecycle=str(raw.get("lifecycle", "")),
+            owner=str(raw.get("owner", "")),
+            reason=str(raw.get("reason", "")),
+            icon=_optional_str(raw.get("icon")),
+            color=_optional_str(raw.get("color")),
+            replacement=_optional_str(raw.get("replacement")),
+            removal_reason=_optional_str(raw.get("removal_reason")),
+        )
+
+    def live_fields(self) -> dict[str, str | None]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "icon": self.icon,
+            "color": self.color,
+        }
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _parse_scalar(value: str) -> object:
+    value = value.strip()
+    if value == "":
+        return ""
+    if value in {"null", "Null", "NULL", "~"}:
+        return None
+    if value in {"true", "True"}:
+        return True
+    if value in {"false", "False"}:
+        return False
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def _split_key_value(text: str, line_number: int) -> tuple[str, object]:
+    if ":" not in text:
+        raise ValueError(f"Line {line_number}: expected key: value")
+    key, value = text.split(":", 1)
+    return key.strip(), _parse_scalar(value)
+
+
+def _parse_taxonomy_yaml(path: Path) -> dict[str, Any]:
+    raw_lines = path.read_text(encoding="utf-8").splitlines()
+    document: dict[str, Any] = {}
+    labels: list[dict[str, Any]] = []
+    current_label: dict[str, Any] | None = None
+    current_list_key: str | None = None
+    in_labels = False
+
+    for line_number, raw_line in enumerate(raw_lines, start=1):
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        text = raw_line.strip()
+
+        if indent == 0:
+            key, value = _split_key_value(text, line_number)
+            current_label = None
+            current_list_key = None
+            in_labels = key == "labels"
+            if in_labels:
+                document[key] = labels
+            else:
+                document[key] = value
+            continue
+
+        if not in_labels:
+            raise ValueError(f"Line {line_number}: nested content is only supported under labels")
+
+        if indent == 2 and text.startswith("- "):
+            current_label = {}
+            labels.append(current_label)
+            current_list_key = None
+            rest = text[2:].strip()
+            if rest:
+                key, value = _split_key_value(rest, line_number)
+                current_label[key] = value
+            continue
+
+        if current_label is None:
+            raise ValueError(f"Line {line_number}: label field outside a label item")
+
+        if indent == 4:
+            key, value = _split_key_value(text, line_number)
+            if value == "":
+                current_label[key] = []
+                current_list_key = key
+            else:
+                current_label[key] = value
+                current_list_key = None
+            continue
+
+        if indent == 6 and text.startswith("- "):
+            if current_list_key is None:
+                raise ValueError(f"Line {line_number}: list item without a list field")
+            current_label[current_list_key].append(_parse_scalar(text[2:].strip()))
+            continue
+
+        raise ValueError(f"Line {line_number}: unsupported indentation or structure")
+
+    return document
+
+
+def load_taxonomy(path: Path = DEFAULT_TAXONOMY_PATH) -> dict[str, Any]:
+    return _parse_taxonomy_yaml(path)
+
+
+def load_label_specs(path: Path = DEFAULT_TAXONOMY_PATH) -> list[LabelSpec]:
+    taxonomy = load_taxonomy(path)
+    return [LabelSpec.from_dict(label) for label in taxonomy.get("labels", [])]
+
+
+def validate_specs(specs: list[LabelSpec]) -> list[str]:
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+
+    for spec in specs:
+        prefix = f"{spec.label_id or '<missing label_id>'}:"
+        if not spec.label_id:
+            errors.append("label_id is required")
+        elif not LABEL_ID_PATTERN.match(spec.label_id):
+            errors.append(f"{prefix} label_id must use lowercase snake_case")
+        elif spec.label_id in seen_ids:
+            errors.append(f"{prefix} duplicate label_id")
+        seen_ids.add(spec.label_id)
+
+        if not spec.name:
+            errors.append(f"{prefix} name is required")
+        if not spec.description:
+            errors.append(f"{prefix} description is required")
+        if not spec.scopes:
+            errors.append(f"{prefix} at least one scope is required")
+        invalid_scopes = sorted(set(spec.scopes) - ALLOWED_SCOPES)
+        if invalid_scopes:
+            errors.append(f"{prefix} invalid scopes: {', '.join(invalid_scopes)}")
+        if len(spec.scopes) != len(set(spec.scopes)):
+            errors.append(f"{prefix} scopes must be unique")
+        if spec.lifecycle not in ALLOWED_LIFECYCLES:
+            errors.append(f"{prefix} invalid lifecycle: {spec.lifecycle}")
+        if not spec.owner:
+            errors.append(f"{prefix} owner is required")
+        if not spec.reason:
+            errors.append(f"{prefix} reason is required")
+        if spec.lifecycle == "deprecated" and not (spec.replacement or spec.removal_reason):
+            errors.append(f"{prefix} deprecated labels need replacement or removal_reason")
+        if spec.icon and ":" not in spec.icon:
+            errors.append(f"{prefix} icon should include an icon namespace, such as mdi:tag")
+
+    if "hallway" not in seen_ids:
+        errors.append("hallway label must remain in the taxonomy while it exists in live HA")
+
+    return errors
+
+
+def specs_by_id(specs: list[LabelSpec]) -> dict[str, LabelSpec]:
+    return {spec.label_id: spec for spec in specs}
+
+
+def load_live_export(path: Path) -> dict[str, Any]:
+    if str(path) == "-":
+        return normalize_live_export(json.load(sys.stdin))
+    with path.open(encoding="utf-8") as file:
+        return normalize_live_export(json.load(file))
+
+
+def normalize_live_export(raw: dict[str, Any]) -> dict[str, Any]:
+    labels = raw.get("labels", [])
+    areas = raw.get("areas", [])
+
+    if isinstance(labels, dict):
+        labels = labels.get("labels", labels.get("result", []))
+    if isinstance(areas, dict):
+        areas = areas.get("areas", areas.get("result", []))
+
+    return {
+        "labels": sorted((label for label in labels), key=lambda label: label.get("label_id", "")),
+        "areas": sorted((area for area in areas), key=lambda area: area.get("area_id", "")),
+    }
+
+
+def audit_live(specs: list[LabelSpec], live: dict[str, Any]) -> dict[str, Any]:
+    spec_map = specs_by_id(specs)
+    live_labels = {
+        label["label_id"]: label
+        for label in live.get("labels", [])
+        if isinstance(label, dict) and label.get("label_id")
+    }
+    active_spec_ids = {
+        spec.label_id for spec in specs if spec.lifecycle in {"active", "reserved"}
+    }
+    deprecated_spec_ids = {
+        spec.label_id for spec in specs if spec.lifecycle == "deprecated"
+    }
+
+    field_mismatches: list[dict[str, Any]] = []
+    for label_id, live_label in sorted(live_labels.items()):
+        spec = spec_map.get(label_id)
+        if spec is None:
+            continue
+        for field, expected in spec.live_fields().items():
+            actual = live_label.get(field)
+            if actual != expected:
+                field_mismatches.append(
+                    {
+                        "label_id": label_id,
+                        "field": field,
+                        "expected": expected,
+                        "actual": actual,
+                    }
+                )
+
+    area_scope_mismatches: list[dict[str, str]] = []
+    for area in live.get("areas", []):
+        if not isinstance(area, dict):
+            continue
+        for label_id in area.get("labels", []) or []:
+            spec = spec_map.get(label_id)
+            if spec is None:
+                area_scope_mismatches.append(
+                    {
+                        "area_id": str(area.get("area_id", "")),
+                        "label_id": str(label_id),
+                        "reason": "label is not in taxonomy",
+                    }
+                )
+            elif "area" not in spec.scopes:
+                area_scope_mismatches.append(
+                    {
+                        "area_id": str(area.get("area_id", "")),
+                        "label_id": str(label_id),
+                        "reason": "label taxonomy does not allow area scope",
+                    }
+                )
+
+    return {
+        "missing_labels": sorted(active_spec_ids - set(live_labels)),
+        "unknown_live_labels": sorted(set(live_labels) - set(spec_map)),
+        "deprecated_live_labels": sorted(set(live_labels) & deprecated_spec_ids),
+        "field_mismatches": field_mismatches,
+        "area_scope_mismatches": area_scope_mismatches,
+        "live_label_count": len(live_labels),
+        "taxonomy_label_count": len(specs),
+    }
+
+
+def plan_label_operations(specs: list[LabelSpec], live: dict[str, Any]) -> list[dict[str, Any]]:
+    live_labels = {
+        label["label_id"]: label
+        for label in live.get("labels", [])
+        if isinstance(label, dict) and label.get("label_id")
+    }
+    operations: list[dict[str, Any]] = []
+
+    for spec in specs:
+        if spec.lifecycle == "deprecated":
+            continue
+        live_label = live_labels.get(spec.label_id)
+        if live_label is None:
+            operations.append(
+                {
+                    "action": "create",
+                    "label_id": spec.label_id,
+                    "fields": spec.live_fields(),
+                }
+            )
+            continue
+
+        updates = {
+            field: expected
+            for field, expected in spec.live_fields().items()
+            if live_label.get(field) != expected
+        }
+        if updates:
+            operations.append(
+                {
+                    "action": "update",
+                    "label_id": spec.label_id,
+                    "fields": updates,
+                }
+            )
+
+    return operations
+
+
+class HomeAssistantWebSocket:
+    def __init__(self, url: str, token: str, timeout: int = 30) -> None:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https", "ws", "wss"}:
+            raise ValueError("HA_URL must start with http, https, ws, or wss")
+        secure = parsed.scheme in {"https", "wss"}
+        port = parsed.port or (443 if secure else 80)
+        base_path = parsed.path.rstrip("/")
+        self.host = parsed.hostname or ""
+        self.path = f"{base_path}/api/websocket" if base_path else "/api/websocket"
+        self.port = port
+        self.secure = secure
+        self.token = token
+        self.timeout = timeout
+        self.sock: socket.socket | ssl.SSLSocket | None = None
+        self.next_id = 1
+
+    def __enter__(self) -> "HomeAssistantWebSocket":
+        self.connect()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self.sock is not None:
+            self.sock.close()
+            self.sock = None
+
+    def connect(self) -> None:
+        raw_sock = socket.create_connection((self.host, self.port), timeout=self.timeout)
+        if self.secure:
+            context = ssl.create_default_context()
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            self.sock = context.wrap_socket(raw_sock, server_hostname=self.host)
+        else:
+            self.sock = raw_sock
+        self.sock.settimeout(self.timeout)
+        self._handshake()
+        auth_required = self.receive_json()
+        if auth_required.get("type") != "auth_required":
+            raise RuntimeError(f"Unexpected auth handshake: {auth_required}")
+        self.send_json({"type": "auth", "access_token": self.token})
+        auth_response = self.receive_json()
+        if auth_response.get("type") != "auth_ok":
+            raise RuntimeError(f"Home Assistant authentication failed: {auth_response}")
+
+    def command(self, command_type: str, **payload: object) -> object:
+        message_id = self.next_id
+        self.next_id += 1
+        self.send_json({"id": message_id, "type": command_type, **payload})
+        while True:
+            message = self.receive_json()
+            if message.get("type") == "pong":
+                continue
+            if message.get("id") != message_id:
+                continue
+            if not message.get("success", False):
+                raise RuntimeError(f"{command_type} failed: {message.get('error')}")
+            return message.get("result")
+
+    def _handshake(self) -> None:
+        key = base64.b64encode(os.urandom(16)).decode("ascii")
+        headers = [
+            f"GET {self.path} HTTP/1.1",
+            f"Host: {self.host}:{self.port}",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            f"Sec-WebSocket-Key: {key}",
+            "Sec-WebSocket-Version: 13",
+            "",
+            "",
+        ]
+        self._send_raw("\r\n".join(headers).encode("ascii"))
+        response = b""
+        while b"\r\n\r\n" not in response:
+            response += self._recv_raw(4096)
+        if b" 101 " not in response.split(b"\r\n", 1)[0]:
+            raise RuntimeError(f"WebSocket handshake failed: {response[:200]!r}")
+
+    def send_json(self, payload: dict[str, object]) -> None:
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self._send_frame(0x1, data)
+
+    def receive_json(self) -> dict[str, Any]:
+        while True:
+            opcode, payload = self._recv_frame()
+            if opcode == 0x1:
+                return json.loads(payload.decode("utf-8"))
+            if opcode == 0x8:
+                raise RuntimeError("Home Assistant closed the WebSocket connection")
+            if opcode == 0x9:
+                self._send_frame(0xA, payload)
+
+    def _send_frame(self, opcode: int, payload: bytes) -> None:
+        mask = os.urandom(4)
+        first_byte = 0x80 | opcode
+        length = len(payload)
+        if length < 126:
+            header = struct.pack("!BB", first_byte, 0x80 | length)
+        elif length < 65536:
+            header = struct.pack("!BBH", first_byte, 0x80 | 126, length)
+        else:
+            header = struct.pack("!BBQ", first_byte, 0x80 | 127, length)
+        masked = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+        self._send_raw(header + mask + masked)
+
+    def _recv_frame(self) -> tuple[int, bytes]:
+        header = self._recv_exact(2)
+        first_byte, second_byte = header
+        opcode = first_byte & 0x0F
+        length = second_byte & 0x7F
+        if length == 126:
+            length = struct.unpack("!H", self._recv_exact(2))[0]
+        elif length == 127:
+            length = struct.unpack("!Q", self._recv_exact(8))[0]
+        if second_byte & 0x80:
+            mask = self._recv_exact(4)
+            payload = self._recv_exact(length)
+            payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+        else:
+            payload = self._recv_exact(length)
+        return opcode, payload
+
+    def _recv_exact(self, length: int) -> bytes:
+        data = b""
+        while len(data) < length:
+            data += self._recv_raw(length - len(data))
+        return data
+
+    def _send_raw(self, payload: bytes) -> None:
+        if self.sock is None:
+            raise RuntimeError("WebSocket is not connected")
+        self.sock.sendall(payload)
+
+    def _recv_raw(self, length: int) -> bytes:
+        if self.sock is None:
+            raise RuntimeError("WebSocket is not connected")
+        chunk = self.sock.recv(length)
+        if not chunk:
+            raise RuntimeError("WebSocket connection closed")
+        return chunk
+
+
+def fetch_live_from_ha() -> dict[str, Any]:
+    url = os.environ.get("HA_URL")
+    token = os.environ.get("HA_TOKEN")
+    if not url or not token:
+        raise RuntimeError("Set HA_URL and HA_TOKEN, or pass --live-json")
+    with HomeAssistantWebSocket(url=url, token=token) as client:
+        labels = client.command("config/label_registry/list")
+        areas = client.command("config/area_registry/list")
+    return normalize_live_export({"labels": labels, "areas": areas})
+
+
+def apply_operations(operations: list[dict[str, Any]], specs: list[LabelSpec]) -> list[dict[str, Any]]:
+    spec_map = specs_by_id(specs)
+    url = os.environ.get("HA_URL")
+    token = os.environ.get("HA_TOKEN")
+    if not url or not token:
+        raise RuntimeError("Set HA_URL and HA_TOKEN before using --execute")
+
+    results: list[dict[str, Any]] = []
+    with HomeAssistantWebSocket(url=url, token=token) as client:
+        for operation in operations:
+            label_id = operation["label_id"]
+            spec = spec_map[label_id]
+            fields = {key: value for key, value in spec.live_fields().items() if value is not None}
+            if operation["action"] == "create":
+                result = client.command("config/label_registry/create", **fields)
+                if isinstance(result, dict) and result.get("label_id") != label_id:
+                    raise RuntimeError(
+                        f"Created label {result.get('label_id')!r}, expected {label_id!r}"
+                    )
+            elif operation["action"] == "update":
+                result = client.command("config/label_registry/update", label_id=label_id, **fields)
+            else:
+                raise RuntimeError(f"Unsupported operation: {operation}")
+            results.append({"operation": operation, "result": result})
+    return results
+
+
+def print_json(payload: object) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def command_validate(args: argparse.Namespace) -> int:
+    specs = load_label_specs(args.taxonomy)
+    errors = validate_specs(specs)
+    print_json(
+        {
+            "label_count": len(specs),
+            "status": "valid" if not errors else "invalid",
+            "errors": errors,
+        }
+    )
+    return 0 if not errors else 1
+
+
+def command_export_live(args: argparse.Namespace) -> int:
+    live = load_live_export(args.live_json) if args.live_json else fetch_live_from_ha()
+    print_json(live)
+    return 0
+
+
+def command_audit_live(args: argparse.Namespace) -> int:
+    specs = load_label_specs(args.taxonomy)
+    errors = validate_specs(specs)
+    if errors:
+        print_json({"status": "invalid_taxonomy", "errors": errors})
+        return 1
+    live = load_live_export(args.live_json) if args.live_json else fetch_live_from_ha()
+    print_json(audit_live(specs, live))
+    return 0
+
+
+def command_apply_labels(args: argparse.Namespace) -> int:
+    specs = load_label_specs(args.taxonomy)
+    errors = validate_specs(specs)
+    if errors:
+        print_json({"status": "invalid_taxonomy", "errors": errors})
+        return 1
+    live = load_live_export(args.live_json) if args.live_json else fetch_live_from_ha()
+    operations = plan_label_operations(specs, live)
+    if not args.execute:
+        print_json({"dry_run": True, "operations": operations})
+        return 0
+    results = apply_operations(operations, specs)
+    print_json({"dry_run": False, "results": results})
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate and reconcile HA label taxonomy.")
+    parser.add_argument(
+        "--taxonomy",
+        type=Path,
+        default=DEFAULT_TAXONOMY_PATH,
+        help="Path to docs/ha_label_taxonomy.yaml.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate", help="Validate the repo taxonomy.")
+    validate.set_defaults(func=command_validate)
+
+    export_live = subparsers.add_parser("export-live", help="Export live labels and area labels.")
+    export_live.add_argument("--live-json", type=Path, help="Normalize an existing live export JSON.")
+    export_live.set_defaults(func=command_export_live)
+
+    audit_live_parser = subparsers.add_parser("audit-live", help="Compare live HA labels to taxonomy.")
+    audit_live_parser.add_argument("--live-json", type=Path, help="Use an existing live export JSON.")
+    audit_live_parser.set_defaults(func=command_audit_live)
+
+    apply_labels = subparsers.add_parser(
+        "apply-labels",
+        help="Create/update label definitions. Dry-run unless --execute is set.",
+    )
+    apply_labels.add_argument("--live-json", type=Path, help="Use an existing live export JSON.")
+    apply_labels.add_argument("--execute", action="store_true", help="Apply changes to live HA.")
+    apply_labels.set_defaults(func=command_apply_labels)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except Exception as exc:  # pragma: no cover - CLI guardrail
+        print_json({"status": "error", "error": str(exc)})
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ha_label_taxonomy.py
+++ b/tests/test_ha_label_taxonomy.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.ha_label_taxonomy import (  # noqa: E402
+    ALLOWED_LIFECYCLES,
+    ALLOWED_SCOPES,
+    LABEL_ID_PATTERN,
+    audit_live,
+    load_label_specs,
+    plan_label_operations,
+    validate_specs,
+)
+
+TAXONOMY_PATH = ROOT / "docs" / "ha_label_taxonomy.yaml"
+DOC_PATH = ROOT / "docs" / "ha_labels.md"
+README_PATH = ROOT / "README.md"
+
+
+def test_ha_label_taxonomy_is_valid() -> None:
+    specs = load_label_specs(TAXONOMY_PATH)
+
+    assert validate_specs(specs) == []
+
+
+def test_ha_label_ids_are_unique_stable_snake_case() -> None:
+    specs = load_label_specs(TAXONOMY_PATH)
+    label_ids = [spec.label_id for spec in specs]
+
+    assert len(label_ids) == len(set(label_ids))
+    assert all(LABEL_ID_PATTERN.match(label_id) for label_id in label_ids)
+
+
+def test_ha_labels_have_required_description_scope_and_lifecycle() -> None:
+    specs = load_label_specs(TAXONOMY_PATH)
+
+    for spec in specs:
+        assert spec.description
+        assert spec.scopes
+        assert set(spec.scopes) <= ALLOWED_SCOPES
+        assert spec.lifecycle in ALLOWED_LIFECYCLES
+        assert spec.owner
+        assert spec.reason
+
+
+def test_deprecated_ha_labels_require_replacement_or_removal_reason() -> None:
+    specs = load_label_specs(TAXONOMY_PATH)
+
+    for spec in specs:
+        if spec.lifecycle == "deprecated":
+            assert spec.replacement or spec.removal_reason
+
+
+def test_hallway_label_remains_area_scoped_for_live_hallway_areas() -> None:
+    specs = {spec.label_id: spec for spec in load_label_specs(TAXONOMY_PATH)}
+
+    hallway = specs["hallway"]
+    assert "area" in hallway.scopes
+    assert "hallway" in hallway.reason
+    assert "upstairs_hallway" in hallway.reason
+
+
+def test_ha_label_docs_explain_source_of_truth_and_no_inheritance() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+
+    assert "docs/ha_label_taxonomy.yaml" in text
+    assert "Do not rely on label inheritance" in text
+    assert "does not automatically become an entity label" in text
+
+
+def test_readme_links_to_ha_label_model() -> None:
+    text = README_PATH.read_text(encoding="utf-8")
+
+    assert "- [Home Assistant Label Model](docs/ha_labels.md)" in text
+
+
+def test_live_audit_detects_missing_unknown_and_scope_mismatches() -> None:
+    specs = load_label_specs(TAXONOMY_PATH)
+    live = {
+        "labels": [
+            {
+                "label_id": "hallway",
+                "name": "Hallway",
+                "description": "Shared hallway context that spans the main hallway and upstairs hallway areas.",
+                "icon": "mdi:floor-plan",
+                "color": "blue",
+            },
+            {"label_id": "ad_hoc", "name": "Ad Hoc"},
+        ],
+        "areas": [
+            {"area_id": "hallway", "labels": ["hallway"]},
+            {"area_id": "kitchen", "labels": ["media_scope"]},
+            {"area_id": "garage", "labels": ["ad_hoc"]},
+        ],
+    }
+
+    audit = audit_live(specs, live)
+
+    assert "guest_sensitive" in audit["missing_labels"]
+    assert audit["unknown_live_labels"] == ["ad_hoc"]
+    assert {
+        "area_id": "kitchen",
+        "label_id": "media_scope",
+        "reason": "label taxonomy does not allow area scope",
+    } in audit["area_scope_mismatches"]
+    assert {
+        "area_id": "garage",
+        "label_id": "ad_hoc",
+        "reason": "label is not in taxonomy",
+    } in audit["area_scope_mismatches"]
+
+
+def test_apply_label_plan_never_removes_unknown_live_labels() -> None:
+    specs = load_label_specs(TAXONOMY_PATH)
+    live = {
+        "labels": [
+            {
+                "label_id": "hallway",
+                "name": "Old Hallway",
+                "description": None,
+                "icon": None,
+                "color": None,
+            },
+            {"label_id": "ad_hoc", "name": "Ad Hoc"},
+        ],
+        "areas": [],
+    }
+
+    operations = plan_label_operations(specs, live)
+
+    assert operations[0]["action"] == "update"
+    assert operations[0]["label_id"] == "hallway"
+    assert all(operation["action"] in {"create", "update"} for operation in operations)
+    assert all(operation["label_id"] != "ad_hoc" for operation in operations)


### PR DESCRIPTION
## Summary
- Add `docs/ha_label_taxonomy.yaml` as the canonical Home Assistant label source of truth for issue #511.
- Document the label model in `docs/ha_labels.md`, including areas/floors vs labels vs categories and the no-inheritance warning.
- Add `scripts/ha_label_taxonomy.py` for repo validation, live export normalization, live drift audits, and dry-run-first label definition reconciliation.
- Add pytest coverage for taxonomy schema, hallway continuity, docs linkage, drift detection, and non-removal behavior.

## Live HA read-only audit
- Current live labels: `hallway` only.
- Current area label assignments: `hallway` and `upstairs_hallway` carry `hallway`.
- Drift report: no unknown live labels and no area-scope violations; the remaining canonical labels are missing until a reviewed apply step.

## Validation
- `python3 scripts/ha_label_taxonomy.py validate`
- `uv run --with pytest pytest` (331 passed)

Closes #511