### PR TITLE
[codex] Fix HA label apply conflicts

### DIFF
--- a/docs/ha_label_taxonomy.yaml
+++ b/docs/ha_label_taxonomy.yaml
@@ -84,7 +84,7 @@ labels:
     reason: "Supports drift checks against the night routines behavioral spec."
     icon: "mdi:weather-night"
     color: "blue-grey"
-  - label_id: wakeup_scope
+  - label_id: wake_up_scope
     name: "Wake-Up Scope"
     description: "Items involved in alarms, snooze behavior, wake-up lighting, or morning audio."
     scopes:

--- a/scripts/ha_label_taxonomy.py
+++ b/scripts/ha_label_taxonomy.py
@@ -344,6 +344,36 @@ def plan_label_operations(specs: list[LabelSpec], live: dict[str, Any]) -> list[
     return operations
 
 
+def find_apply_conflicts(specs: list[LabelSpec], live: dict[str, Any]) -> list[dict[str, str]]:
+    live_labels = {
+        label["label_id"]: label
+        for label in live.get("labels", [])
+        if isinstance(label, dict) and label.get("label_id")
+    }
+    live_ids_by_name = {
+        str(label.get("name", "")).casefold(): str(label["label_id"])
+        for label in live_labels.values()
+        if label.get("name")
+    }
+    conflicts: list[dict[str, str]] = []
+
+    for spec in specs:
+        if spec.lifecycle == "deprecated":
+            continue
+        live_id_for_name = live_ids_by_name.get(spec.name.casefold())
+        if live_id_for_name is not None and live_id_for_name != spec.label_id:
+            conflicts.append(
+                {
+                    "label_id": spec.label_id,
+                    "name": spec.name,
+                    "live_label_id": live_id_for_name,
+                    "reason": "live label name already exists with a different label_id",
+                }
+            )
+
+    return conflicts
+
+
 class HomeAssistantWebSocket:
     def __init__(self, url: str, token: str, timeout: int = 30) -> None:
         parsed = urlparse(url)
@@ -565,6 +595,17 @@ def command_apply_labels(args: argparse.Namespace) -> int:
         return 1
     live = load_live_export(args.live_json) if args.live_json else fetch_live_from_ha()
     operations = plan_label_operations(specs, live)
+    conflicts = find_apply_conflicts(specs, live)
+    if conflicts:
+        print_json(
+            {
+                "status": "conflict",
+                "dry_run": not args.execute,
+                "conflicts": conflicts,
+                "operations": operations,
+            }
+        )
+        return 1
     if not args.execute:
         print_json({"dry_run": True, "operations": operations})
         return 0

--- a/tests/test_ha_label_taxonomy.py
+++ b/tests/test_ha_label_taxonomy.py
@@ -12,6 +12,7 @@ from scripts.ha_label_taxonomy import (  # noqa: E402
     ALLOWED_SCOPES,
     LABEL_ID_PATTERN,
     audit_live,
+    find_apply_conflicts,
     load_label_specs,
     plan_label_operations,
     validate_specs,
@@ -63,6 +64,12 @@ def test_hallway_label_remains_area_scoped_for_live_hallway_areas() -> None:
     assert "area" in hallway.scopes
     assert "hallway" in hallway.reason
     assert "upstairs_hallway" in hallway.reason
+
+
+def test_wake_up_scope_matches_home_assistant_generated_label_id() -> None:
+    specs = {spec.label_id: spec for spec in load_label_specs(TAXONOMY_PATH)}
+
+    assert specs["wake_up_scope"].name == "Wake-Up Scope"
 
 
 def test_ha_label_docs_explain_source_of_truth_and_no_inheritance() -> None:
@@ -137,3 +144,28 @@ def test_apply_label_plan_never_removes_unknown_live_labels() -> None:
     assert operations[0]["label_id"] == "hallway"
     assert all(operation["action"] in {"create", "update"} for operation in operations)
     assert all(operation["label_id"] != "ad_hoc" for operation in operations)
+
+
+def test_apply_label_plan_reports_live_name_id_conflicts_before_writes() -> None:
+    specs = load_label_specs(TAXONOMY_PATH)
+    live = {
+        "labels": [
+            {
+                "label_id": "wake-upscope",
+                "name": "Wake-Up Scope",
+                "description": "Legacy partial apply",
+                "icon": "mdi:alarm",
+                "color": "orange",
+            }
+        ],
+        "areas": [],
+    }
+
+    assert find_apply_conflicts(specs, live) == [
+        {
+            "label_id": "wake_up_scope",
+            "name": "Wake-Up Scope",
+            "live_label_id": "wake-upscope",
+            "reason": "live label name already exists with a different label_id",
+        }
+    ]


### PR DESCRIPTION
## Summary
- Align the canonical wake-up label ID with the live Home Assistant-generated `wake_up_scope` ID.
- Add an apply preflight that detects live label name/ID conflicts before any writes occur.
- Cover the partial-apply failure mode with pytest.

## Why
Running `python3 scripts/ha_label_taxonomy.py apply-labels --execute` after a partial label creation could attempt to recreate `Wake-Up Scope` because the taxonomy used `wakeup_scope` while HA generated `wake_up_scope`. This now matches live HA and future conflicts fail before writes.

## Validation
- `python3 scripts/ha_label_taxonomy.py validate`
- `uv run --with pytest pytest tests/test_ha_label_taxonomy.py` (11 passed)
- `uv run --with pytest pytest` (333 passed)