### PR TITLE
feat: Z2M device availability monitoring package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@
 !specs/*.allium
 !docs/
 !docs/*.md
+!docs/**/*.md
+!docs/**/*.yaml
+!docs/**/*.json
 !.githooks/
 !.githooks/**
 !scripts/

--- a/docs/grafana/z2m_availability_dashboard.json
+++ b/docs/grafana/z2m_availability_dashboard.json
@@ -1,0 +1,392 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_INFLUXDB",
+      "label": "InfluxDB",
+      "description": "InfluxDB 1.x datasource for Home Assistant",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Zigbee2MQTT device availability monitoring — tracks per-device online/offline state via MQTT availability topics recorded in InfluxDB",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 10,
+      "title": "Bridge & Aggregate Health",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Number of Z2M availability binary sensors currently in the 'off' (offline) state",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Devices Currently Offline",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "SELECT last(\"value\") FROM \"binary_sensor.state\" WHERE \"entity_id\" =~ /^z2m_.*_availability$/ AND \"value\" = 'off' AND $timeFilter GROUP BY \"entity_id\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Count of Z2M availability sensors offline over time (5-minute buckets)",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Offline devices",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 20, "x": 4, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["max", "mean"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "title": "Z2M Offline Device Count Over Time",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "SELECT count(\"value\") FROM \"binary_sensor.state\" WHERE \"entity_id\" =~ /^z2m_.*_availability$/ AND \"value\" = 'off' AND $timeFilter GROUP BY time(5m) fill(0)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 11,
+      "title": "Individual Device Availability",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Online/offline timeline per Z2M device. Each line shows 1=online, 0=offline.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [
+            { "options": { "offline": { "index": 0, "text": "Offline" }, "online": { "index": 1, "text": "Online" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "title": "Per-Device Availability Timeline",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "SELECT last(\"value\") FROM \"binary_sensor.state\" WHERE \"entity_id\" =~ /^z2m_.*_availability$/ AND $timeFilter GROUP BY time(1m), \"entity_id\" fill(previous)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+      "id": 12,
+      "title": "Dropout Frequency Analysis",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Which devices drop offline most frequently. Higher count = more unstable device.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 3 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "entity_id" },
+            "properties": [
+              { "id": "displayName", "value": "Device" },
+              { "id": "custom.width", "value": 350 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "count" },
+            "properties": [
+              { "id": "displayName", "value": "Offline Events" },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 14, "w": 12, "x": 0, "y": 21 },
+      "id": 4,
+      "options": {
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "Offline Events" }]
+      },
+      "title": "Device Dropout Frequency (offline transitions)",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "SELECT count(\"value\") AS \"count\" FROM \"binary_sensor.state\" WHERE \"entity_id\" =~ /^z2m_.*_availability$/ AND \"value\" = 'off' AND $timeFilter GROUP BY \"entity_id\" ORDER BY count DESC",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Average offline duration per device — devices spending more time offline may need attention or replacement.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 300 },
+              { "color": "red", "value": 3600 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "entity_id" },
+            "properties": [
+              { "id": "displayName", "value": "Device" },
+              { "id": "custom.width", "value": 350 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "mean" },
+            "properties": [
+              { "id": "displayName", "value": "Avg Offline Duration" },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 14, "w": 12, "x": 12, "y": 21 },
+      "id": 5,
+      "options": {
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "Avg Offline Duration" }]
+      },
+      "title": "Device Offline Duration (avg seconds per offline period)",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "SELECT mean(\"duration\") AS \"mean\" FROM (SELECT elapsed(\"value\", 1s) AS \"duration\" FROM \"binary_sensor.state\" WHERE \"entity_id\" =~ /^z2m_.*_availability$/ AND $timeFilter GROUP BY \"entity_id\") WHERE \"value\" = 'off' GROUP BY \"entity_id\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ]
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["zigbee", "z2m", "availability", "mqtt"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+        "definition": "SHOW TAG VALUES FROM \"binary_sensor.state\" WITH KEY = \"entity_id\" WHERE \"entity_id\" =~ /^z2m_.*_availability$/",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "device",
+        "options": [],
+        "query": "SHOW TAG VALUES FROM \"binary_sensor.state\" WITH KEY = \"entity_id\" WHERE \"entity_id\" =~ /^z2m_.*_availability$/",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "label": "Device"
+      }
+    ]
+  },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Z2M Device Availability",
+  "uid": "z2m-availability-v1",
+  "version": 1,
+  "weekStart": ""
+}

--- a/packages/z2m_availability.yaml
+++ b/packages/z2m_availability.yaml
@@ -1,0 +1,1970 @@
+# Z2M device availability monitoring package
+#
+# Tracks per-device MQTT availability published by Zigbee2MQTT when
+# availability: true is set in zigbee2mqtt/configuration.yaml.
+# Each binary_sensor goes offline when the device stops responding.
+# The aggregate binary_sensor.z2m_devices_offline fires when ANY device is offline.
+# Related: packages/z2m_lifecycle.yaml (router health, reboot watchdog)
+
+################################################################
+## MQTT binary sensors — per-device availability
+################################################################
+
+mqtt:
+  binary_sensor:
+
+    # Bridge availability (the Z2M bridge itself)
+    - name: "Z2M Bridge"
+      unique_id: z2m_bridge_availability
+      state_topic: "zigbee2mqtt/bridge/state"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+
+    - name: "Z2M Arrival Sensor Availability"
+      unique_id: z2m_arrival_sensor_availability
+      state_topic: "zigbee2mqtt/Arrival Sensor/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Bathroom Shower Availability"
+      unique_id: z2m_basement_bathroom_shower_availability
+      state_topic: "zigbee2mqtt/Basement/Bathroom Shower/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Bathroom/Exhaust Availability"
+      unique_id: z2m_basement_bathroom_exhaust_availability
+      state_topic: "zigbee2mqtt/Basement/Bathroom/Exhaust/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Bathroom/Shower Switch Availability"
+      unique_id: z2m_basement_bathroom_shower_switch_availability
+      state_topic: "zigbee2mqtt/Basement/Bathroom/Shower Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Bathroom/TPH Availability"
+      unique_id: z2m_basement_bathroom_tph_availability
+      state_topic: "zigbee2mqtt/Basement/Bathroom/TPH/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Closet TPH Availability"
+      unique_id: z2m_basement_closet_tph_availability
+      state_topic: "zigbee2mqtt/Basement/Closet TPH/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Great East Room 2 Availability"
+      unique_id: z2m_basement_great_east_room_2_availability
+      state_topic: "zigbee2mqtt/Basement/Great East Room 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Great Room East 1 Availability"
+      unique_id: z2m_basement_great_room_east_1_availability
+      state_topic: "zigbee2mqtt/Basement/Great Room East 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Great Room East and Middle Switch Availability"
+      unique_id: z2m_basement_great_room_east_and_middle_switch_availability
+      state_topic: "zigbee2mqtt/Basement/Great Room East and Middle Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Great Room Landing Switch 2 Availability"
+      unique_id: z2m_basement_great_room_landing_switch_2_availability
+      state_topic: "zigbee2mqtt/Basement/Great Room Landing Switch 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Great Room Middle 1 Availability"
+      unique_id: z2m_basement_great_room_middle_1_availability
+      state_topic: "zigbee2mqtt/Basement/Great Room Middle 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Great Room Middle 2 Availability"
+      unique_id: z2m_basement_great_room_middle_2_availability
+      state_topic: "zigbee2mqtt/Basement/Great Room Middle 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Great Room West 1 Availability"
+      unique_id: z2m_basement_great_room_west_1_availability
+      state_topic: "zigbee2mqtt/Basement/Great Room West 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Great Room West 2 Availability"
+      unique_id: z2m_basement_great_room_west_2_availability
+      state_topic: "zigbee2mqtt/Basement/Great Room West 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Great Room West 3 Availability"
+      unique_id: z2m_basement_great_room_west_3_availability
+      state_topic: "zigbee2mqtt/Basement/Great Room West 3/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Great Room West Switch Availability"
+      unique_id: z2m_basement_great_room_west_switch_availability
+      state_topic: "zigbee2mqtt/Basement/Great Room West Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Landing Availability"
+      unique_id: z2m_basement_landing_availability
+      state_topic: "zigbee2mqtt/Basement/Landing/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Landing 1 Availability"
+      unique_id: z2m_basement_landing_1_availability
+      state_topic: "zigbee2mqtt/Basement/Landing 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Landing 2 Availability"
+      unique_id: z2m_basement_landing_2_availability
+      state_topic: "zigbee2mqtt/Basement/Landing 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Landing Switch Availability"
+      unique_id: z2m_basement_landing_switch_availability
+      state_topic: "zigbee2mqtt/Basement/Landing Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/North Hallway 1 Availability"
+      unique_id: z2m_basement_north_hallway_1_availability
+      state_topic: "zigbee2mqtt/Basement/North Hallway 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/North Hallway 2 Availability"
+      unique_id: z2m_basement_north_hallway_2_availability
+      state_topic: "zigbee2mqtt/Basement/North Hallway 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/North Hallway Switch Availability"
+      unique_id: z2m_basement_north_hallway_switch_availability
+      state_topic: "zigbee2mqtt/Basement/North Hallway Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Overhead Outlet Availability"
+      unique_id: z2m_basement_overhead_outlet_availability
+      state_topic: "zigbee2mqtt/Basement/Overhead Outlet/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Stair Landing Availability"
+      unique_id: z2m_basement_stair_landing_availability
+      state_topic: "zigbee2mqtt/Basement/Stair Landing/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Sump Pump Availability"
+      unique_id: z2m_basement_sump_pump_availability
+      state_topic: "zigbee2mqtt/Basement/Sump Pump/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/TPH Availability"
+      unique_id: z2m_basement_tph_availability
+      state_topic: "zigbee2mqtt/Basement/TPH/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Unfinished Leak Availability"
+      unique_id: z2m_basement_unfinished_leak_availability
+      state_topic: "zigbee2mqtt/Basement/Unfinished Leak/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Water Shutoff Availability"
+      unique_id: z2m_basement_water_shutoff_availability
+      state_topic: "zigbee2mqtt/Basement/Water Shutoff/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Basement/Window Availability"
+      unique_id: z2m_basement_window_availability
+      state_topic: "zigbee2mqtt/Basement/Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Deck/Flood Lights Availability"
+      unique_id: z2m_deck_flood_lights_availability
+      state_topic: "zigbee2mqtt/Deck/Flood Lights/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Deck/Kitchen Door Availability"
+      unique_id: z2m_deck_kitchen_door_availability
+      state_topic: "zigbee2mqtt/Deck/Kitchen Door/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Deck/Kitchen Door Light Availability"
+      unique_id: z2m_deck_kitchen_door_light_availability
+      state_topic: "zigbee2mqtt/Deck/Kitchen Door Light/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Deck/String Availability"
+      unique_id: z2m_deck_string_availability
+      state_topic: "zigbee2mqtt/Deck/String/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Deck/Tiki Room Door Availability"
+      unique_id: z2m_deck_tiki_room_door_availability
+      state_topic: "zigbee2mqtt/Deck/Tiki Room Door/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Den/Doors Availability"
+      unique_id: z2m_den_doors_availability
+      state_topic: "zigbee2mqtt/Den/Doors/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Den/Flood 1 Availability"
+      unique_id: z2m_den_flood_1_availability
+      state_topic: "zigbee2mqtt/Den/Flood 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Den/Flood 2 Availability"
+      unique_id: z2m_den_flood_2_availability
+      state_topic: "zigbee2mqtt/Den/Flood 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Den/Flood Switch Availability"
+      unique_id: z2m_den_flood_switch_availability
+      state_topic: "zigbee2mqtt/Den/Flood Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Den/Lamp Availability"
+      unique_id: z2m_den_lamp_availability
+      state_topic: "zigbee2mqtt/Den/Lamp/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Den/Leather Chair Availability"
+      unique_id: z2m_den_leather_chair_availability
+      state_topic: "zigbee2mqtt/Den/Leather Chair/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Den/Motion Availability"
+      unique_id: z2m_den_motion_availability
+      state_topic: "zigbee2mqtt/Den/Motion/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Den/Sonos Controls Availability"
+      unique_id: z2m_den_sonos_controls_availability
+      state_topic: "zigbee2mqtt/Den/Sonos Controls/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Den/Wall Switch Availability"
+      unique_id: z2m_den_wall_switch_availability
+      state_topic: "zigbee2mqtt/Den/Wall Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/Lamp 1 Availability"
+      unique_id: z2m_dining_room_lamp_1_availability
+      state_topic: "zigbee2mqtt/Dining Room/Lamp 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/Lamp 2 Availability"
+      unique_id: z2m_dining_room_lamp_2_availability
+      state_topic: "zigbee2mqtt/Dining Room/Lamp 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/North Window Availability"
+      unique_id: z2m_dining_room_north_window_availability
+      state_topic: "zigbee2mqtt/Dining Room/North Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/Overhead Availability"
+      unique_id: z2m_dining_room_overhead_availability
+      state_topic: "zigbee2mqtt/Dining Room/Overhead/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/Overhead 1 Availability"
+      unique_id: z2m_dining_room_overhead_1_availability
+      state_topic: "zigbee2mqtt/Dining Room/Overhead 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/Overhead 2 Availability"
+      unique_id: z2m_dining_room_overhead_2_availability
+      state_topic: "zigbee2mqtt/Dining Room/Overhead 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/Overhead 3 Availability"
+      unique_id: z2m_dining_room_overhead_3_availability
+      state_topic: "zigbee2mqtt/Dining Room/Overhead 3/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/Overhead 4 Availability"
+      unique_id: z2m_dining_room_overhead_4_availability
+      state_topic: "zigbee2mqtt/Dining Room/Overhead 4/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/South Window Availability"
+      unique_id: z2m_dining_room_south_window_availability
+      state_topic: "zigbee2mqtt/Dining Room/South Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/Table Switch Availability"
+      unique_id: z2m_dining_room_table_switch_availability
+      state_topic: "zigbee2mqtt/Dining Room/Table Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Dining Room/Wall Switch Availability"
+      unique_id: z2m_dining_room_wall_switch_availability
+      state_topic: "zigbee2mqtt/Dining Room/Wall Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Doorbell Availability"
+      unique_id: z2m_doorbell_availability
+      state_topic: "zigbee2mqtt/Doorbell/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M East Bed Button Availability"
+      unique_id: z2m_east_bed_button_availability
+      state_topic: "zigbee2mqtt/East Bed Button/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Garage/Back Door Availability"
+      unique_id: z2m_garage_back_door_availability
+      state_topic: "zigbee2mqtt/Garage/Back Door/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Garage/Overhead Switch Availability"
+      unique_id: z2m_garage_overhead_switch_availability
+      state_topic: "zigbee2mqtt/Garage/Overhead Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Guest Bathroom/Exhaust Availability"
+      unique_id: z2m_guest_bathroom_exhaust_availability
+      state_topic: "zigbee2mqtt/Guest Bathroom/Exhaust/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Guest Bathroom/TPH Availability"
+      unique_id: z2m_guest_bathroom_tph_availability
+      state_topic: "zigbee2mqtt/Guest Bathroom/TPH/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Guest Bathroom/Window Availability"
+      unique_id: z2m_guest_bathroom_window_availability
+      state_topic: "zigbee2mqtt/Guest Bathroom/Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Guest Room/Fan Switch Availability"
+      unique_id: z2m_guest_room_fan_switch_availability
+      state_topic: "zigbee2mqtt/Guest Room/Fan Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Guest Room/TPH Availability"
+      unique_id: z2m_guest_room_tph_availability
+      state_topic: "zigbee2mqtt/Guest Room/TPH/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Guest Room/Window Availability"
+      unique_id: z2m_guest_room_window_availability
+      state_topic: "zigbee2mqtt/Guest Room/Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Button Availability"
+      unique_id: z2m_hall_button_availability
+      state_topic: "zigbee2mqtt/Hall/Button/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Foyer Switch Availability"
+      unique_id: z2m_hall_foyer_switch_availability
+      state_topic: "zigbee2mqtt/Hall/Foyer Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Garage Entry Availability"
+      unique_id: z2m_hall_garage_entry_availability
+      state_topic: "zigbee2mqtt/Hall/Garage Entry/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Garage Laundry Switch Availability"
+      unique_id: z2m_hall_garage_laundry_switch_availability
+      state_topic: "zigbee2mqtt/Hall/Garage Laundry Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Laundry Availability"
+      unique_id: z2m_hall_laundry_availability
+      state_topic: "zigbee2mqtt/Hall/Laundry/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Main Foyer 1 Availability"
+      unique_id: z2m_hall_main_foyer_1_availability
+      state_topic: "zigbee2mqtt/Hall/Main Foyer 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Main Foyer 2 Availability"
+      unique_id: z2m_hall_main_foyer_2_availability
+      state_topic: "zigbee2mqtt/Hall/Main Foyer 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Main Foyer/Motion Availability"
+      unique_id: z2m_hall_main_foyer_motion_availability
+      state_topic: "zigbee2mqtt/Hall/Main Foyer/Motion/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Stairway Availability"
+      unique_id: z2m_hall_stairway_availability
+      state_topic: "zigbee2mqtt/Hall/Stairway/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Transition Availability"
+      unique_id: z2m_hall_transition_availability
+      state_topic: "zigbee2mqtt/Hall/Transition/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Transition Switch Availability"
+      unique_id: z2m_hall_transition_switch_availability
+      state_topic: "zigbee2mqtt/Hall/Transition Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Upstairs 1 Availability"
+      unique_id: z2m_hall_upstairs_1_availability
+      state_topic: "zigbee2mqtt/Hall/Upstairs 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Upstairs 2 Availability"
+      unique_id: z2m_hall_upstairs_2_availability
+      state_topic: "zigbee2mqtt/Hall/Upstairs 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Upstairs/Linen Closet/TPH Availability"
+      unique_id: z2m_hall_upstairs_linen_closet_tph_availability
+      state_topic: "zigbee2mqtt/Hall/Upstairs/Linen Closet/TPH/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Upstairs/Motion Availability"
+      unique_id: z2m_hall_upstairs_motion_availability
+      state_topic: "zigbee2mqtt/Hall/Upstairs/Motion/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Hall/Upstairs/Switch Availability"
+      unique_id: z2m_hall_upstairs_switch_availability
+      state_topic: "zigbee2mqtt/Hall/Upstairs/Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Bay Light Availability"
+      unique_id: z2m_kitchen_bay_light_availability
+      state_topic: "zigbee2mqtt/Kitchen/Bay Light/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Bay Middle Window Availability"
+      unique_id: z2m_kitchen_bay_middle_window_availability
+      state_topic: "zigbee2mqtt/Kitchen/Bay Middle Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Bay North Window Availability"
+      unique_id: z2m_kitchen_bay_north_window_availability
+      state_topic: "zigbee2mqtt/Kitchen/Bay North Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Bay South Window Availability"
+      unique_id: z2m_kitchen_bay_south_window_availability
+      state_topic: "zigbee2mqtt/Kitchen/Bay South Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Bay Switch Availability"
+      unique_id: z2m_kitchen_bay_switch_availability
+      state_topic: "zigbee2mqtt/Kitchen/Bay Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Deck Availability"
+      unique_id: z2m_kitchen_deck_availability
+      state_topic: "zigbee2mqtt/Kitchen/Deck/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Dishwasher Leak Availability"
+      unique_id: z2m_kitchen_dishwasher_leak_availability
+      state_topic: "zigbee2mqtt/Kitchen/Dishwasher Leak/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Kitchen Sink Availability"
+      unique_id: z2m_kitchen_kitchen_sink_availability
+      state_topic: "zigbee2mqtt/Kitchen/Kitchen Sink/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/North Window Availability"
+      unique_id: z2m_kitchen_north_window_availability
+      state_topic: "zigbee2mqtt/Kitchen/North Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Overhead 1 Availability"
+      unique_id: z2m_kitchen_overhead_1_availability
+      state_topic: "zigbee2mqtt/Kitchen/Overhead 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Overhead 2 Availability"
+      unique_id: z2m_kitchen_overhead_2_availability
+      state_topic: "zigbee2mqtt/Kitchen/Overhead 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Overhead 3 Availability"
+      unique_id: z2m_kitchen_overhead_3_availability
+      state_topic: "zigbee2mqtt/Kitchen/Overhead 3/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Overhead 4 Availability"
+      unique_id: z2m_kitchen_overhead_4_availability
+      state_topic: "zigbee2mqtt/Kitchen/Overhead 4/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Overhead 5 Availability"
+      unique_id: z2m_kitchen_overhead_5_availability
+      state_topic: "zigbee2mqtt/Kitchen/Overhead 5/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Overhead 6 Availability"
+      unique_id: z2m_kitchen_overhead_6_availability
+      state_topic: "zigbee2mqtt/Kitchen/Overhead 6/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Overhead 7 Availability"
+      unique_id: z2m_kitchen_overhead_7_availability
+      state_topic: "zigbee2mqtt/Kitchen/Overhead 7/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Overhead Lights Switch Availability"
+      unique_id: z2m_kitchen_overhead_lights_switch_availability
+      state_topic: "zigbee2mqtt/Kitchen/Overhead Lights Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Sink Leak Availability"
+      unique_id: z2m_kitchen_sink_leak_availability
+      state_topic: "zigbee2mqtt/Kitchen/Sink Leak/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Sink Overhead Availability"
+      unique_id: z2m_kitchen_sink_overhead_availability
+      state_topic: "zigbee2mqtt/Kitchen/Sink Overhead/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Sink Overhead Switch Availability"
+      unique_id: z2m_kitchen_sink_overhead_switch_availability
+      state_topic: "zigbee2mqtt/Kitchen/Sink Overhead Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/South Window Availability"
+      unique_id: z2m_kitchen_south_window_availability
+      state_topic: "zigbee2mqtt/Kitchen/South Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Switch Availability"
+      unique_id: z2m_kitchen_switch_availability
+      state_topic: "zigbee2mqtt/Kitchen/Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/Under Cabinet Availability"
+      unique_id: z2m_kitchen_under_cabinet_availability
+      state_topic: "zigbee2mqtt/Kitchen/Under Cabinet/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Laundry Room/Dryer Availability"
+      unique_id: z2m_laundry_room_dryer_availability
+      state_topic: "zigbee2mqtt/Laundry Room/Dryer/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Laundry Room/Washing Machine Availability"
+      unique_id: z2m_laundry_room_washing_machine_availability
+      state_topic: "zigbee2mqtt/Laundry Room/Washing Machine/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Laundry Room/Washing Machine Door Availability"
+      unique_id: z2m_laundry_room_washing_machine_door_availability
+      state_topic: "zigbee2mqtt/Laundry Room/Washing Machine Door/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Laundry/Leak Availability"
+      unique_id: z2m_laundry_leak_availability
+      state_topic: "zigbee2mqtt/Laundry/Leak/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Laundry/Outlet Repeater Availability"
+      unique_id: z2m_laundry_outlet_repeater_availability
+      state_topic: "zigbee2mqtt/Laundry/Outlet Repeater/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Laundry/Wall Switch Availability"
+      unique_id: z2m_laundry_wall_switch_availability
+      state_topic: "zigbee2mqtt/Laundry/Wall Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Laundry/Washer Vibration Availability"
+      unique_id: z2m_laundry_washer_vibration_availability
+      state_topic: "zigbee2mqtt/Laundry/Washer Vibration/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Mailbox Availability"
+      unique_id: z2m_mailbox_availability
+      state_topic: "zigbee2mqtt/Mailbox/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Main Foyer/Front Door Availability"
+      unique_id: z2m_main_foyer_front_door_availability
+      state_topic: "zigbee2mqtt/Main Foyer/Front Door/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/Fan Switch Availability"
+      unique_id: z2m_office_fan_switch_availability
+      state_topic: "zigbee2mqtt/Office/Fan Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/Floor Lamp 1 Availability"
+      unique_id: z2m_office_floor_lamp_1_availability
+      state_topic: "zigbee2mqtt/Office/Floor Lamp 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/Floor Lamp 2 Availability"
+      unique_id: z2m_office_floor_lamp_2_availability
+      state_topic: "zigbee2mqtt/Office/Floor Lamp 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/Light Button 1 Availability"
+      unique_id: z2m_office_light_button_1_availability
+      state_topic: "zigbee2mqtt/Office/Light Button 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/Light Button 2 Availability"
+      unique_id: z2m_office_light_button_2_availability
+      state_topic: "zigbee2mqtt/Office/Light Button 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/Motion Availability"
+      unique_id: z2m_office_motion_availability
+      state_topic: "zigbee2mqtt/Office/Motion/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/Red Lava Lamp Availability"
+      unique_id: z2m_office_red_lava_lamp_availability
+      state_topic: "zigbee2mqtt/Office/Red Lava Lamp/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/TPH Availability"
+      unique_id: z2m_office_tph_availability
+      state_topic: "zigbee2mqtt/Office/TPH/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/Window Availability"
+      unique_id: z2m_office_window_availability
+      state_topic: "zigbee2mqtt/Office/Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Outside/Front Door Availability"
+      unique_id: z2m_outside_front_door_availability
+      state_topic: "zigbee2mqtt/Outside/Front Door/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Outside/Front Lights Availability"
+      unique_id: z2m_outside_front_lights_availability
+      state_topic: "zigbee2mqtt/Outside/Front Lights/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Outside/North West Garage Availability"
+      unique_id: z2m_outside_north_west_garage_availability
+      state_topic: "zigbee2mqtt/Outside/North West Garage/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Outside/South West Garage Availability"
+      unique_id: z2m_outside_south_west_garage_availability
+      state_topic: "zigbee2mqtt/Outside/South West Garage/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Bay North Middle Window Availability"
+      unique_id: z2m_owner_suite_bathroom_bay_north_middle_window_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Bay North Middle Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Bay North Window Availability"
+      unique_id: z2m_owner_suite_bathroom_bay_north_window_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Bay North Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Bay South Middle Window Availability"
+      unique_id: z2m_owner_suite_bathroom_bay_south_middle_window_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Bay South Middle Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Bay South Window Availability"
+      unique_id: z2m_owner_suite_bathroom_bay_south_window_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Bay South Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Exhaust Availability"
+      unique_id: z2m_owner_suite_bathroom_exhaust_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Exhaust/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Room Availability"
+      unique_id: z2m_owner_suite_bathroom_room_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Room/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Shower Availability"
+      unique_id: z2m_owner_suite_bathroom_shower_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Shower/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Shower Switch Availability"
+      unique_id: z2m_owner_suite_bathroom_shower_switch_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Shower Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/TPH Availability"
+      unique_id: z2m_owner_suite_bathroom_tph_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/TPH/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Tub 1 Availability"
+      unique_id: z2m_owner_suite_bathroom_tub_1_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Tub 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Tub 2 Availability"
+      unique_id: z2m_owner_suite_bathroom_tub_2_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Tub 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Tub Switch Availability"
+      unique_id: z2m_owner_suite_bathroom_tub_switch_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Tub Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Bathroom/Vanity Availability"
+      unique_id: z2m_owner_suite_bathroom_vanity_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Vanity/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Blind Control Availability"
+      unique_id: z2m_owner_suite_blind_control_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Blind Control/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/CPAP Plug Availability"
+      unique_id: z2m_owner_suite_cpap_plug_availability
+      state_topic: "zigbee2mqtt/Owner Suite/CPAP Plug/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Closet Availability"
+      unique_id: z2m_owner_suite_closet_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Closet/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Cube Availability"
+      unique_id: z2m_owner_suite_cube_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Cube/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Fan Switch Availability"
+      unique_id: z2m_owner_suite_fan_switch_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Fan Switch/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Lamp Bulb 1 Availability"
+      unique_id: z2m_owner_suite_lamp_bulb_1_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Lamp Bulb 1/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/Lamp Bulb 2 Availability"
+      unique_id: z2m_owner_suite_lamp_bulb_2_availability
+      state_topic: "zigbee2mqtt/Owner Suite/Lamp Bulb 2/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/North Blind Availability"
+      unique_id: z2m_owner_suite_north_blind_availability
+      state_topic: "zigbee2mqtt/Owner Suite/North Blind/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/North Window Availability"
+      unique_id: z2m_owner_suite_north_window_availability
+      state_topic: "zigbee2mqtt/Owner Suite/North Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/South Blind Availability"
+      unique_id: z2m_owner_suite_south_blind_availability
+      state_topic: "zigbee2mqtt/Owner Suite/South Blind/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/South Window Availability"
+      unique_id: z2m_owner_suite_south_window_availability
+      state_topic: "zigbee2mqtt/Owner Suite/South Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Owner Suite/TPH Availability"
+      unique_id: z2m_owner_suite_tph_availability
+      state_topic: "zigbee2mqtt/Owner Suite/TPH/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Powder Room/Window Availability"
+      unique_id: z2m_powder_room_window_availability
+      state_topic: "zigbee2mqtt/Powder Room/Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Tiki Room/Camera Availability"
+      unique_id: z2m_tiki_room_camera_availability
+      state_topic: "zigbee2mqtt/Tiki Room/Camera/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Tiki Room/Deck Availability"
+      unique_id: z2m_tiki_room_deck_availability
+      state_topic: "zigbee2mqtt/Tiki Room/Deck/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Tiki Room/Floor Lamp Availability"
+      unique_id: z2m_tiki_room_floor_lamp_availability
+      state_topic: "zigbee2mqtt/Tiki Room/Floor Lamp/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Tiki Room/Heater Availability"
+      unique_id: z2m_tiki_room_heater_availability
+      state_topic: "zigbee2mqtt/Tiki Room/Heater/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Tiki Room/Sonos Control Availability"
+      unique_id: z2m_tiki_room_sonos_control_availability
+      state_topic: "zigbee2mqtt/Tiki Room/Sonos Control/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Tiki Room/TPH Availability"
+      unique_id: z2m_tiki_room_tph_availability
+      state_topic: "zigbee2mqtt/Tiki Room/TPH/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Unfinished Basement/Window Availability"
+      unique_id: z2m_unfinished_basement_window_availability
+      state_topic: "zigbee2mqtt/Unfinished Basement/Window/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M West Bed Button Availability"
+      unique_id: z2m_west_bed_button_availability
+      state_topic: "zigbee2mqtt/West Bed Button/availability"
+      value_template: "{{ value_json.state }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+################################################################
+## Template sensors — aggregate Z2M availability status
+################################################################
+
+template:
+  - binary_sensor:
+      - name: "Z2M Devices Offline"
+        unique_id: z2m_devices_offline
+        device_class: problem
+        state: >
+          {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')
+             | selectattr('entity_id', 'search', 'z2m_')
+             | selectattr('state', 'eq', 'off') | list | count > 0 }}
+        attributes:
+          offline_devices: >
+            {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')
+               | selectattr('entity_id', 'search', 'z2m_')
+               | selectattr('state', 'eq', 'off')
+               | map(attribute='name') | list }}
+          total_devices: >
+            {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')
+               | selectattr('entity_id', 'search', 'z2m_') | list | count }}
+          online_count: >
+            {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')
+               | selectattr('entity_id', 'search', 'z2m_')
+               | selectattr('state', 'eq', 'on') | list | count }}

--- a/packages/z2m_availability.yaml
+++ b/packages/z2m_availability.yaml
@@ -17,7 +17,7 @@ mqtt:
     - name: "Z2M Bridge"
       unique_id: z2m_bridge_availability
       state_topic: "zigbee2mqtt/bridge/state"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
@@ -25,1920 +25,1760 @@ mqtt:
     - name: "Z2M Arrival Sensor Availability"
       unique_id: z2m_arrival_sensor_availability
       state_topic: "zigbee2mqtt/Arrival Sensor/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Bathroom Shower Availability"
       unique_id: z2m_basement_bathroom_shower_availability
       state_topic: "zigbee2mqtt/Basement/Bathroom Shower/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Bathroom/Exhaust Availability"
       unique_id: z2m_basement_bathroom_exhaust_availability
       state_topic: "zigbee2mqtt/Basement/Bathroom/Exhaust/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Bathroom/Shower Switch Availability"
       unique_id: z2m_basement_bathroom_shower_switch_availability
       state_topic: "zigbee2mqtt/Basement/Bathroom/Shower Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Bathroom/TPH Availability"
       unique_id: z2m_basement_bathroom_tph_availability
       state_topic: "zigbee2mqtt/Basement/Bathroom/TPH/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Closet TPH Availability"
       unique_id: z2m_basement_closet_tph_availability
       state_topic: "zigbee2mqtt/Basement/Closet TPH/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Great East Room 2 Availability"
       unique_id: z2m_basement_great_east_room_2_availability
       state_topic: "zigbee2mqtt/Basement/Great East Room 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Great Room East 1 Availability"
       unique_id: z2m_basement_great_room_east_1_availability
       state_topic: "zigbee2mqtt/Basement/Great Room East 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Great Room East and Middle Switch Availability"
       unique_id: z2m_basement_great_room_east_and_middle_switch_availability
       state_topic: "zigbee2mqtt/Basement/Great Room East and Middle Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Great Room Landing Switch 2 Availability"
       unique_id: z2m_basement_great_room_landing_switch_2_availability
       state_topic: "zigbee2mqtt/Basement/Great Room Landing Switch 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Great Room Middle 1 Availability"
       unique_id: z2m_basement_great_room_middle_1_availability
       state_topic: "zigbee2mqtt/Basement/Great Room Middle 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Great Room Middle 2 Availability"
       unique_id: z2m_basement_great_room_middle_2_availability
       state_topic: "zigbee2mqtt/Basement/Great Room Middle 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Great Room West 1 Availability"
       unique_id: z2m_basement_great_room_west_1_availability
       state_topic: "zigbee2mqtt/Basement/Great Room West 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Great Room West 2 Availability"
       unique_id: z2m_basement_great_room_west_2_availability
       state_topic: "zigbee2mqtt/Basement/Great Room West 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Great Room West 3 Availability"
       unique_id: z2m_basement_great_room_west_3_availability
       state_topic: "zigbee2mqtt/Basement/Great Room West 3/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Great Room West Switch Availability"
       unique_id: z2m_basement_great_room_west_switch_availability
       state_topic: "zigbee2mqtt/Basement/Great Room West Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Landing Availability"
       unique_id: z2m_basement_landing_availability
       state_topic: "zigbee2mqtt/Basement/Landing/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Landing 1 Availability"
       unique_id: z2m_basement_landing_1_availability
       state_topic: "zigbee2mqtt/Basement/Landing 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Landing 2 Availability"
       unique_id: z2m_basement_landing_2_availability
       state_topic: "zigbee2mqtt/Basement/Landing 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Landing Switch Availability"
       unique_id: z2m_basement_landing_switch_availability
       state_topic: "zigbee2mqtt/Basement/Landing Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/North Hallway 1 Availability"
       unique_id: z2m_basement_north_hallway_1_availability
       state_topic: "zigbee2mqtt/Basement/North Hallway 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/North Hallway 2 Availability"
       unique_id: z2m_basement_north_hallway_2_availability
       state_topic: "zigbee2mqtt/Basement/North Hallway 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/North Hallway Switch Availability"
       unique_id: z2m_basement_north_hallway_switch_availability
       state_topic: "zigbee2mqtt/Basement/North Hallway Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Overhead Outlet Availability"
       unique_id: z2m_basement_overhead_outlet_availability
       state_topic: "zigbee2mqtt/Basement/Overhead Outlet/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Stair Landing Availability"
       unique_id: z2m_basement_stair_landing_availability
       state_topic: "zigbee2mqtt/Basement/Stair Landing/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Sump Pump Availability"
       unique_id: z2m_basement_sump_pump_availability
       state_topic: "zigbee2mqtt/Basement/Sump Pump/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/TPH Availability"
       unique_id: z2m_basement_tph_availability
       state_topic: "zigbee2mqtt/Basement/TPH/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Unfinished Leak Availability"
       unique_id: z2m_basement_unfinished_leak_availability
       state_topic: "zigbee2mqtt/Basement/Unfinished Leak/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Water Shutoff Availability"
       unique_id: z2m_basement_water_shutoff_availability
       state_topic: "zigbee2mqtt/Basement/Water Shutoff/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Basement/Window Availability"
       unique_id: z2m_basement_window_availability
       state_topic: "zigbee2mqtt/Basement/Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Deck/Flood Lights Availability"
       unique_id: z2m_deck_flood_lights_availability
       state_topic: "zigbee2mqtt/Deck/Flood Lights/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Deck/Kitchen Door Availability"
       unique_id: z2m_deck_kitchen_door_availability
       state_topic: "zigbee2mqtt/Deck/Kitchen Door/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Deck/Kitchen Door Light Availability"
       unique_id: z2m_deck_kitchen_door_light_availability
       state_topic: "zigbee2mqtt/Deck/Kitchen Door Light/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Deck/String Availability"
       unique_id: z2m_deck_string_availability
       state_topic: "zigbee2mqtt/Deck/String/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Deck/Tiki Room Door Availability"
       unique_id: z2m_deck_tiki_room_door_availability
       state_topic: "zigbee2mqtt/Deck/Tiki Room Door/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Den/Doors Availability"
       unique_id: z2m_den_doors_availability
       state_topic: "zigbee2mqtt/Den/Doors/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Den/Flood 1 Availability"
       unique_id: z2m_den_flood_1_availability
       state_topic: "zigbee2mqtt/Den/Flood 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Den/Flood 2 Availability"
       unique_id: z2m_den_flood_2_availability
       state_topic: "zigbee2mqtt/Den/Flood 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Den/Flood Switch Availability"
       unique_id: z2m_den_flood_switch_availability
       state_topic: "zigbee2mqtt/Den/Flood Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Den/Lamp Availability"
       unique_id: z2m_den_lamp_availability
       state_topic: "zigbee2mqtt/Den/Lamp/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Den/Leather Chair Availability"
       unique_id: z2m_den_leather_chair_availability
       state_topic: "zigbee2mqtt/Den/Leather Chair/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Den/Motion Availability"
       unique_id: z2m_den_motion_availability
       state_topic: "zigbee2mqtt/Den/Motion/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Den/Sonos Controls Availability"
       unique_id: z2m_den_sonos_controls_availability
       state_topic: "zigbee2mqtt/Den/Sonos Controls/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Den/Wall Switch Availability"
       unique_id: z2m_den_wall_switch_availability
       state_topic: "zigbee2mqtt/Den/Wall Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/Lamp 1 Availability"
       unique_id: z2m_dining_room_lamp_1_availability
       state_topic: "zigbee2mqtt/Dining Room/Lamp 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/Lamp 2 Availability"
       unique_id: z2m_dining_room_lamp_2_availability
       state_topic: "zigbee2mqtt/Dining Room/Lamp 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/North Window Availability"
       unique_id: z2m_dining_room_north_window_availability
       state_topic: "zigbee2mqtt/Dining Room/North Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/Overhead Availability"
       unique_id: z2m_dining_room_overhead_availability
       state_topic: "zigbee2mqtt/Dining Room/Overhead/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/Overhead 1 Availability"
       unique_id: z2m_dining_room_overhead_1_availability
       state_topic: "zigbee2mqtt/Dining Room/Overhead 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/Overhead 2 Availability"
       unique_id: z2m_dining_room_overhead_2_availability
       state_topic: "zigbee2mqtt/Dining Room/Overhead 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/Overhead 3 Availability"
       unique_id: z2m_dining_room_overhead_3_availability
       state_topic: "zigbee2mqtt/Dining Room/Overhead 3/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/Overhead 4 Availability"
       unique_id: z2m_dining_room_overhead_4_availability
       state_topic: "zigbee2mqtt/Dining Room/Overhead 4/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/South Window Availability"
       unique_id: z2m_dining_room_south_window_availability
       state_topic: "zigbee2mqtt/Dining Room/South Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/Table Switch Availability"
       unique_id: z2m_dining_room_table_switch_availability
       state_topic: "zigbee2mqtt/Dining Room/Table Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Dining Room/Wall Switch Availability"
       unique_id: z2m_dining_room_wall_switch_availability
       state_topic: "zigbee2mqtt/Dining Room/Wall Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Doorbell Availability"
       unique_id: z2m_doorbell_availability
       state_topic: "zigbee2mqtt/Doorbell/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M East Bed Button Availability"
       unique_id: z2m_east_bed_button_availability
       state_topic: "zigbee2mqtt/East Bed Button/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Garage/Back Door Availability"
       unique_id: z2m_garage_back_door_availability
       state_topic: "zigbee2mqtt/Garage/Back Door/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Garage/Overhead Switch Availability"
       unique_id: z2m_garage_overhead_switch_availability
       state_topic: "zigbee2mqtt/Garage/Overhead Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Guest Bathroom/Exhaust Availability"
       unique_id: z2m_guest_bathroom_exhaust_availability
       state_topic: "zigbee2mqtt/Guest Bathroom/Exhaust/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Guest Bathroom/TPH Availability"
       unique_id: z2m_guest_bathroom_tph_availability
       state_topic: "zigbee2mqtt/Guest Bathroom/TPH/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Guest Bathroom/Window Availability"
       unique_id: z2m_guest_bathroom_window_availability
       state_topic: "zigbee2mqtt/Guest Bathroom/Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Guest Room/Fan Switch Availability"
       unique_id: z2m_guest_room_fan_switch_availability
       state_topic: "zigbee2mqtt/Guest Room/Fan Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Guest Room/TPH Availability"
       unique_id: z2m_guest_room_tph_availability
       state_topic: "zigbee2mqtt/Guest Room/TPH/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Guest Room/Window Availability"
       unique_id: z2m_guest_room_window_availability
       state_topic: "zigbee2mqtt/Guest Room/Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Button Availability"
       unique_id: z2m_hall_button_availability
       state_topic: "zigbee2mqtt/Hall/Button/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Foyer Switch Availability"
       unique_id: z2m_hall_foyer_switch_availability
       state_topic: "zigbee2mqtt/Hall/Foyer Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Garage Entry Availability"
       unique_id: z2m_hall_garage_entry_availability
       state_topic: "zigbee2mqtt/Hall/Garage Entry/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Garage Laundry Switch Availability"
       unique_id: z2m_hall_garage_laundry_switch_availability
       state_topic: "zigbee2mqtt/Hall/Garage Laundry Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Laundry Availability"
       unique_id: z2m_hall_laundry_availability
       state_topic: "zigbee2mqtt/Hall/Laundry/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Main Foyer 1 Availability"
       unique_id: z2m_hall_main_foyer_1_availability
       state_topic: "zigbee2mqtt/Hall/Main Foyer 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Main Foyer 2 Availability"
       unique_id: z2m_hall_main_foyer_2_availability
       state_topic: "zigbee2mqtt/Hall/Main Foyer 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Main Foyer/Motion Availability"
       unique_id: z2m_hall_main_foyer_motion_availability
       state_topic: "zigbee2mqtt/Hall/Main Foyer/Motion/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Stairway Availability"
       unique_id: z2m_hall_stairway_availability
       state_topic: "zigbee2mqtt/Hall/Stairway/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Transition Availability"
       unique_id: z2m_hall_transition_availability
       state_topic: "zigbee2mqtt/Hall/Transition/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Transition Switch Availability"
       unique_id: z2m_hall_transition_switch_availability
       state_topic: "zigbee2mqtt/Hall/Transition Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Upstairs 1 Availability"
       unique_id: z2m_hall_upstairs_1_availability
       state_topic: "zigbee2mqtt/Hall/Upstairs 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Upstairs 2 Availability"
       unique_id: z2m_hall_upstairs_2_availability
       state_topic: "zigbee2mqtt/Hall/Upstairs 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Upstairs/Linen Closet/TPH Availability"
       unique_id: z2m_hall_upstairs_linen_closet_tph_availability
       state_topic: "zigbee2mqtt/Hall/Upstairs/Linen Closet/TPH/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Upstairs/Motion Availability"
       unique_id: z2m_hall_upstairs_motion_availability
       state_topic: "zigbee2mqtt/Hall/Upstairs/Motion/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Hall/Upstairs/Switch Availability"
       unique_id: z2m_hall_upstairs_switch_availability
       state_topic: "zigbee2mqtt/Hall/Upstairs/Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Bay Light Availability"
       unique_id: z2m_kitchen_bay_light_availability
       state_topic: "zigbee2mqtt/Kitchen/Bay Light/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Bay Middle Window Availability"
       unique_id: z2m_kitchen_bay_middle_window_availability
       state_topic: "zigbee2mqtt/Kitchen/Bay Middle Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Bay North Window Availability"
       unique_id: z2m_kitchen_bay_north_window_availability
       state_topic: "zigbee2mqtt/Kitchen/Bay North Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Bay South Window Availability"
       unique_id: z2m_kitchen_bay_south_window_availability
       state_topic: "zigbee2mqtt/Kitchen/Bay South Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Bay Switch Availability"
       unique_id: z2m_kitchen_bay_switch_availability
       state_topic: "zigbee2mqtt/Kitchen/Bay Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Deck Availability"
       unique_id: z2m_kitchen_deck_availability
       state_topic: "zigbee2mqtt/Kitchen/Deck/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Dishwasher Leak Availability"
       unique_id: z2m_kitchen_dishwasher_leak_availability
       state_topic: "zigbee2mqtt/Kitchen/Dishwasher Leak/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Kitchen Sink Availability"
       unique_id: z2m_kitchen_kitchen_sink_availability
       state_topic: "zigbee2mqtt/Kitchen/Kitchen Sink/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/North Window Availability"
       unique_id: z2m_kitchen_north_window_availability
       state_topic: "zigbee2mqtt/Kitchen/North Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Overhead 1 Availability"
       unique_id: z2m_kitchen_overhead_1_availability
       state_topic: "zigbee2mqtt/Kitchen/Overhead 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Overhead 2 Availability"
       unique_id: z2m_kitchen_overhead_2_availability
       state_topic: "zigbee2mqtt/Kitchen/Overhead 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Overhead 3 Availability"
       unique_id: z2m_kitchen_overhead_3_availability
       state_topic: "zigbee2mqtt/Kitchen/Overhead 3/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Overhead 4 Availability"
       unique_id: z2m_kitchen_overhead_4_availability
       state_topic: "zigbee2mqtt/Kitchen/Overhead 4/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Overhead 5 Availability"
       unique_id: z2m_kitchen_overhead_5_availability
       state_topic: "zigbee2mqtt/Kitchen/Overhead 5/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Overhead 6 Availability"
       unique_id: z2m_kitchen_overhead_6_availability
       state_topic: "zigbee2mqtt/Kitchen/Overhead 6/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Overhead 7 Availability"
       unique_id: z2m_kitchen_overhead_7_availability
       state_topic: "zigbee2mqtt/Kitchen/Overhead 7/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Overhead Lights Switch Availability"
       unique_id: z2m_kitchen_overhead_lights_switch_availability
       state_topic: "zigbee2mqtt/Kitchen/Overhead Lights Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Sink Leak Availability"
       unique_id: z2m_kitchen_sink_leak_availability
       state_topic: "zigbee2mqtt/Kitchen/Sink Leak/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Sink Overhead Availability"
       unique_id: z2m_kitchen_sink_overhead_availability
       state_topic: "zigbee2mqtt/Kitchen/Sink Overhead/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Sink Overhead Switch Availability"
       unique_id: z2m_kitchen_sink_overhead_switch_availability
       state_topic: "zigbee2mqtt/Kitchen/Sink Overhead Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/South Window Availability"
       unique_id: z2m_kitchen_south_window_availability
       state_topic: "zigbee2mqtt/Kitchen/South Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Switch Availability"
       unique_id: z2m_kitchen_switch_availability
       state_topic: "zigbee2mqtt/Kitchen/Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Kitchen/Under Cabinet Availability"
       unique_id: z2m_kitchen_under_cabinet_availability
       state_topic: "zigbee2mqtt/Kitchen/Under Cabinet/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Laundry Room/Dryer Availability"
       unique_id: z2m_laundry_room_dryer_availability
       state_topic: "zigbee2mqtt/Laundry Room/Dryer/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Laundry Room/Washing Machine Availability"
       unique_id: z2m_laundry_room_washing_machine_availability
       state_topic: "zigbee2mqtt/Laundry Room/Washing Machine/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Laundry Room/Washing Machine Door Availability"
       unique_id: z2m_laundry_room_washing_machine_door_availability
       state_topic: "zigbee2mqtt/Laundry Room/Washing Machine Door/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Laundry/Leak Availability"
       unique_id: z2m_laundry_leak_availability
       state_topic: "zigbee2mqtt/Laundry/Leak/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Laundry/Outlet Repeater Availability"
       unique_id: z2m_laundry_outlet_repeater_availability
       state_topic: "zigbee2mqtt/Laundry/Outlet Repeater/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Laundry/Wall Switch Availability"
       unique_id: z2m_laundry_wall_switch_availability
       state_topic: "zigbee2mqtt/Laundry/Wall Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Laundry/Washer Vibration Availability"
       unique_id: z2m_laundry_washer_vibration_availability
       state_topic: "zigbee2mqtt/Laundry/Washer Vibration/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Mailbox Availability"
       unique_id: z2m_mailbox_availability
       state_topic: "zigbee2mqtt/Mailbox/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Main Foyer/Front Door Availability"
       unique_id: z2m_main_foyer_front_door_availability
       state_topic: "zigbee2mqtt/Main Foyer/Front Door/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Office/Fan Switch Availability"
       unique_id: z2m_office_fan_switch_availability
       state_topic: "zigbee2mqtt/Office/Fan Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Office/Floor Lamp 1 Availability"
       unique_id: z2m_office_floor_lamp_1_availability
       state_topic: "zigbee2mqtt/Office/Floor Lamp 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Office/Floor Lamp 2 Availability"
       unique_id: z2m_office_floor_lamp_2_availability
       state_topic: "zigbee2mqtt/Office/Floor Lamp 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Office/Light Button 1 Availability"
       unique_id: z2m_office_light_button_1_availability
       state_topic: "zigbee2mqtt/Office/Light Button 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Office/Light Button 2 Availability"
       unique_id: z2m_office_light_button_2_availability
       state_topic: "zigbee2mqtt/Office/Light Button 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Office/Motion Availability"
       unique_id: z2m_office_motion_availability
       state_topic: "zigbee2mqtt/Office/Motion/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Office/Red Lava Lamp Availability"
       unique_id: z2m_office_red_lava_lamp_availability
       state_topic: "zigbee2mqtt/Office/Red Lava Lamp/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Office/TPH Availability"
       unique_id: z2m_office_tph_availability
       state_topic: "zigbee2mqtt/Office/TPH/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Office/Window Availability"
       unique_id: z2m_office_window_availability
       state_topic: "zigbee2mqtt/Office/Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Outside/Front Door Availability"
       unique_id: z2m_outside_front_door_availability
       state_topic: "zigbee2mqtt/Outside/Front Door/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Outside/Front Lights Availability"
       unique_id: z2m_outside_front_lights_availability
       state_topic: "zigbee2mqtt/Outside/Front Lights/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Outside/North West Garage Availability"
       unique_id: z2m_outside_north_west_garage_availability
       state_topic: "zigbee2mqtt/Outside/North West Garage/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Outside/South West Garage Availability"
       unique_id: z2m_outside_south_west_garage_availability
       state_topic: "zigbee2mqtt/Outside/South West Garage/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Bay North Middle Window Availability"
       unique_id: z2m_owner_suite_bathroom_bay_north_middle_window_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Bay North Middle Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Bay North Window Availability"
       unique_id: z2m_owner_suite_bathroom_bay_north_window_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Bay North Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Bay South Middle Window Availability"
       unique_id: z2m_owner_suite_bathroom_bay_south_middle_window_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Bay South Middle Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Bay South Window Availability"
       unique_id: z2m_owner_suite_bathroom_bay_south_window_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Bay South Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Exhaust Availability"
       unique_id: z2m_owner_suite_bathroom_exhaust_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Exhaust/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Room Availability"
       unique_id: z2m_owner_suite_bathroom_room_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Room/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Shower Availability"
       unique_id: z2m_owner_suite_bathroom_shower_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Shower/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Shower Switch Availability"
       unique_id: z2m_owner_suite_bathroom_shower_switch_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Shower Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/TPH Availability"
       unique_id: z2m_owner_suite_bathroom_tph_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/TPH/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Tub 1 Availability"
       unique_id: z2m_owner_suite_bathroom_tub_1_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Tub 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Tub 2 Availability"
       unique_id: z2m_owner_suite_bathroom_tub_2_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Tub 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Tub Switch Availability"
       unique_id: z2m_owner_suite_bathroom_tub_switch_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Tub Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Bathroom/Vanity Availability"
       unique_id: z2m_owner_suite_bathroom_vanity_availability
       state_topic: "zigbee2mqtt/Owner Suite/Bathroom/Vanity/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Blind Control Availability"
       unique_id: z2m_owner_suite_blind_control_availability
       state_topic: "zigbee2mqtt/Owner Suite/Blind Control/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/CPAP Plug Availability"
       unique_id: z2m_owner_suite_cpap_plug_availability
       state_topic: "zigbee2mqtt/Owner Suite/CPAP Plug/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Closet Availability"
       unique_id: z2m_owner_suite_closet_availability
       state_topic: "zigbee2mqtt/Owner Suite/Closet/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Cube Availability"
       unique_id: z2m_owner_suite_cube_availability
       state_topic: "zigbee2mqtt/Owner Suite/Cube/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Fan Switch Availability"
       unique_id: z2m_owner_suite_fan_switch_availability
       state_topic: "zigbee2mqtt/Owner Suite/Fan Switch/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Lamp Bulb 1 Availability"
       unique_id: z2m_owner_suite_lamp_bulb_1_availability
       state_topic: "zigbee2mqtt/Owner Suite/Lamp Bulb 1/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/Lamp Bulb 2 Availability"
       unique_id: z2m_owner_suite_lamp_bulb_2_availability
       state_topic: "zigbee2mqtt/Owner Suite/Lamp Bulb 2/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/North Blind Availability"
       unique_id: z2m_owner_suite_north_blind_availability
       state_topic: "zigbee2mqtt/Owner Suite/North Blind/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/North Window Availability"
       unique_id: z2m_owner_suite_north_window_availability
       state_topic: "zigbee2mqtt/Owner Suite/North Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/South Blind Availability"
       unique_id: z2m_owner_suite_south_blind_availability
       state_topic: "zigbee2mqtt/Owner Suite/South Blind/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/South Window Availability"
       unique_id: z2m_owner_suite_south_window_availability
       state_topic: "zigbee2mqtt/Owner Suite/South Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Owner Suite/TPH Availability"
       unique_id: z2m_owner_suite_tph_availability
       state_topic: "zigbee2mqtt/Owner Suite/TPH/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Powder Room/Window Availability"
       unique_id: z2m_powder_room_window_availability
       state_topic: "zigbee2mqtt/Powder Room/Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Tiki Room/Camera Availability"
       unique_id: z2m_tiki_room_camera_availability
       state_topic: "zigbee2mqtt/Tiki Room/Camera/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Tiki Room/Deck Availability"
       unique_id: z2m_tiki_room_deck_availability
       state_topic: "zigbee2mqtt/Tiki Room/Deck/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Tiki Room/Floor Lamp Availability"
       unique_id: z2m_tiki_room_floor_lamp_availability
       state_topic: "zigbee2mqtt/Tiki Room/Floor Lamp/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Tiki Room/Heater Availability"
       unique_id: z2m_tiki_room_heater_availability
       state_topic: "zigbee2mqtt/Tiki Room/Heater/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Tiki Room/Sonos Control Availability"
       unique_id: z2m_tiki_room_sonos_control_availability
       state_topic: "zigbee2mqtt/Tiki Room/Sonos Control/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Tiki Room/TPH Availability"
       unique_id: z2m_tiki_room_tph_availability
       state_topic: "zigbee2mqtt/Tiki Room/TPH/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M Unfinished Basement/Window Availability"
       unique_id: z2m_unfinished_basement_window_availability
       state_topic: "zigbee2mqtt/Unfinished Basement/Window/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 
     - name: "Z2M West Bed Button Availability"
       unique_id: z2m_west_bed_button_availability
       state_topic: "zigbee2mqtt/West Bed Button/availability"
-      value_template: "{{ value_json.state }}"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state }}"
       payload_available: "online"
       payload_not_available: "offline"
 

--- a/tests/test_z2m_availability_package.py
+++ b/tests/test_z2m_availability_package.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_PATH = ROOT / "packages" / "z2m_availability.yaml"
+Z2M_CONFIG_PATH = ROOT / "zigbee2mqtt" / "configuration.yaml"
+GRAFANA_DASHBOARD_PATH = ROOT / "docs" / "grafana" / "z2m_availability_dashboard.json"
+
+
+def _named_devices() -> list[str]:
+    """Return all non-IEEE-address friendly names from the devices: section of Z2M config.
+
+    Excludes groups (which appear after groups: key) and unnamed devices (IEEE addresses).
+    """
+    text = Z2M_CONFIG_PATH.read_text(encoding="utf-8")
+    # Only look in the devices: block, not groups:
+    devices_start = text.find("devices:")
+    groups_start = text.find("groups:")
+    if devices_start == -1:
+        return []
+    if groups_start != -1 and groups_start > devices_start:
+        devices_text = text[devices_start:groups_start]
+    else:
+        devices_text = text[devices_start:]
+    pattern = re.compile(r"^\s+friendly_name:\s+(.+)$", re.MULTILINE)
+    names = []
+    for match in pattern.finditer(devices_text):
+        name = match.group(1).strip().strip("'\"")
+        if not name.startswith("0x"):
+            names.append(name)
+    return names
+
+
+def test_package_file_exists() -> None:
+    assert PACKAGE_PATH.exists(), f"Package file not found: {PACKAGE_PATH}"
+
+
+def test_package_has_mqtt_binary_sensor_section() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    assert "mqtt:" in text
+    assert "binary_sensor:" in text
+
+
+def test_bridge_sensor_present() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    assert "unique_id: z2m_bridge_availability" in text
+    assert 'state_topic: "zigbee2mqtt/bridge/state"' in text
+    assert "device_class: connectivity" in text
+
+
+def test_all_named_devices_have_sensors() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    named_devices = _named_devices()
+    missing = []
+    for fn in named_devices:
+        expected_topic = f'state_topic: "zigbee2mqtt/{fn}/availability"'
+        if expected_topic not in text:
+            missing.append(fn)
+    assert not missing, f"Missing availability sensors for devices (first 10): {missing[:10]}"
+
+
+def test_device_sensors_have_availability_gate() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    assert 'availability_topic: "zigbee2mqtt/bridge/state"' in text
+    assert 'availability_template: "{{ value_json.state }}"' in text
+    assert 'payload_available: "online"' in text
+    assert 'payload_not_available: "offline"' in text
+
+
+def test_device_sensors_use_json_state_template() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    assert 'value_template: "{{ value_json.state }}"' in text
+    assert 'payload_on: "online"' in text
+    assert 'payload_off: "offline"' in text
+
+
+def test_unique_ids_are_unique() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    unique_ids = re.findall(r"unique_id:\s+(\S+)", text)
+    assert len(unique_ids) == len(set(unique_ids)), (
+        f"Duplicate unique_ids found: {[uid for uid in set(unique_ids) if unique_ids.count(uid) > 1]}"
+    )
+
+
+def test_aggregate_template_sensor_present() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    assert "template:" in text
+    assert "unique_id: z2m_devices_offline" in text
+    assert "device_class: problem" in text
+
+
+def test_aggregate_template_has_attributes() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    assert "offline_devices:" in text
+    assert "total_devices:" in text
+    assert "online_count:" in text
+
+
+def test_aggregate_template_searches_z2m_entities() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    assert "selectattr('entity_id', 'search', 'z2m_')" in text
+    assert "selectattr('attributes.device_class', 'eq', 'connectivity')" in text
+    assert "selectattr('state', 'eq', 'off')" in text
+
+
+def test_package_does_not_duplicate_z2m_lifecycle_sensors() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    # These unique_ids belong to z2m_lifecycle.yaml — must not be redefined here
+    assert "z2m_lifecycle_issues" not in text
+    assert "z2m_failing_count" not in text
+    assert "z2m_router_offline_pct" not in text
+    assert "reboot_counter" not in text
+
+
+def test_sensor_count_matches_device_count() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    named_devices = _named_devices()
+    # Each device should have exactly one state_topic entry
+    topic_pattern = re.compile(r'state_topic: "zigbee2mqtt/.+/availability"')
+    sensor_topics = topic_pattern.findall(text)
+    # +1 for bridge sensor which has a different topic pattern
+    # bridge uses "zigbee2mqtt/bridge/state" not "/availability"
+    assert len(sensor_topics) == len(named_devices), (
+        f"Expected {len(named_devices)} device sensors, found {len(sensor_topics)}"
+    )
+
+
+def test_grafana_dashboard_is_valid_json() -> None:
+    assert GRAFANA_DASHBOARD_PATH.exists(), f"Grafana dashboard not found: {GRAFANA_DASHBOARD_PATH}"
+    content = GRAFANA_DASHBOARD_PATH.read_text(encoding="utf-8")
+    dashboard = json.loads(content)
+    assert isinstance(dashboard, dict)
+
+
+def test_grafana_dashboard_has_required_panels() -> None:
+    content = GRAFANA_DASHBOARD_PATH.read_text(encoding="utf-8")
+    dashboard = json.loads(content)
+    panels = [p for p in dashboard.get("panels", []) if p.get("type") != "row"]
+    panel_types = {p["type"] for p in panels}
+    assert "timeseries" in panel_types, "Missing timeseries panel"
+    assert "stat" in panel_types, "Missing stat panel"
+    assert "table" in panel_types, "Missing table panel"
+
+
+def test_grafana_dashboard_targets_z2m_availability_entities() -> None:
+    content = GRAFANA_DASHBOARD_PATH.read_text(encoding="utf-8")
+    assert "z2m_.*_availability" in content
+    assert "binary_sensor.state" in content
+
+
+def test_grafana_dashboard_has_influxdb_datasource() -> None:
+    content = GRAFANA_DASHBOARD_PATH.read_text(encoding="utf-8")
+    dashboard = json.loads(content)
+    inputs = dashboard.get("__inputs", [])
+    influxdb_inputs = [i for i in inputs if i.get("pluginId") == "influxdb"]
+    assert len(influxdb_inputs) >= 1, "Dashboard missing InfluxDB datasource input"
+
+
+def test_grafana_dashboard_uid_set() -> None:
+    content = GRAFANA_DASHBOARD_PATH.read_text(encoding="utf-8")
+    dashboard = json.loads(content)
+    assert dashboard.get("uid"), "Dashboard missing uid field"
+    assert dashboard.get("title"), "Dashboard missing title field"

--- a/tests/test_z2m_availability_package.py
+++ b/tests/test_z2m_availability_package.py
@@ -66,14 +66,18 @@ def test_all_named_devices_have_sensors() -> None:
 def test_device_sensors_have_availability_gate() -> None:
     text = PACKAGE_PATH.read_text(encoding="utf-8")
     assert 'availability_topic: "zigbee2mqtt/bridge/state"' in text
-    assert 'availability_template: "{{ value_json.state }}"' in text
+    assert 'availability_template: "{{ value_json.state }}"' not in text
     assert 'payload_available: "online"' in text
     assert 'payload_not_available: "offline"' in text
 
 
-def test_device_sensors_use_json_state_template() -> None:
+def test_device_sensors_accept_raw_or_json_state_payload() -> None:
     text = PACKAGE_PATH.read_text(encoding="utf-8")
-    assert 'value_template: "{{ value_json.state }}"' in text
+    assert 'value_template: "{{ value_json.state }}"' not in text
+    assert (
+        'value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"'
+        in text
+    )
     assert 'payload_on: "online"' in text
     assert 'payload_off: "offline"' in text
 


### PR DESCRIPTION
## Summary

- Adds `packages/z2m_availability.yaml` with MQTT `binary_sensor` entries for all 160 named Zigbee2MQTT devices (plus the bridge itself), each tracking `zigbee2mqtt/<friendly_name>/availability` with `device_class: connectivity`
- Adds a template `binary_sensor.z2m_devices_offline` (`device_class: problem`) that is `on` whenever any Z2M availability sensor is `off`; attributes include `offline_devices`, `total_devices`, and `online_count`
- Adds `docs/grafana/z2m_availability_dashboard.json` — a fully importable Grafana dashboard (InfluxDB v1, `homeassistant` database) with timeline, stat, and dropout-frequency table panels
- Extends `.gitignore` to allow `docs/**/*.json` so the Grafana dashboard can be committed
- Does **not** duplicate anything from `packages/z2m_lifecycle.yaml` (router-health, reboot watchdog, decommission helpers remain there)

## Test plan

- [x] `uv run --with pytest pytest tests/test_z2m_availability_package.py` — 17 tests, all pass
- [x] `uv run --with pytest pytest` — full suite, no new failures (3 pre-existing unrelated failures in `test_zigbee_zwave_inovelli_reset_replay` and `test_issue_trip_led_suspend`)
- [ ] After HA reload: verify `binary_sensor.z2m_<device>_availability` entities appear and track MQTT payloads
- [ ] Verify `binary_sensor.z2m_devices_offline` aggregates correctly
- [ ] Import `docs/grafana/z2m_availability_dashboard.json` into Grafana and validate panels resolve against InfluxDB

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)