### PR TITLE
feat: deploy Loki on infra server + configure Promtail for log aggregation (#520)

### DIFF
--- a/docs/infra/loki/README.md
+++ b/docs/infra/loki/README.md
@@ -1,0 +1,81 @@
+# Log Aggregation: Loki + Promtail
+
+## Architecture
+
+```
+HA core logs (/config/home-assistant.log)
+        │
+        ▼
+Promtail (HA app, 39bd2704_promtail)
+        │  pushes to http://10.24.1.99:3100
+        ▼
+Loki (Docker on 10.24.1.99, port 3100)
+        │
+        ▼
+Grafana (native on 10.24.1.99, port 3000) ← datasource: Loki
+```
+
+## Loki Setup (infra server: 10.24.1.99)
+
+Files in this directory are deployed to `~/loki/` on the infra server.
+
+```bash
+cd ~/loki
+docker compose up -d
+```
+
+Data is stored at `~/loki/data/` (Docker bind mount, runs as root for write access).
+
+## Promtail Configuration (HA App)
+
+Promtail (mdegat01/addon-promtail v2.6.1) is installed as a HA app.
+
+**Note on journal scraping**: The default journal scraping is disabled on HA OS 2026.x
+due to apparmor restrictions blocking systemd journal socket access. Instead, Promtail
+is configured to tail `/config/home-assistant.log` directly.
+
+Current live config (set via supervisor API):
+```yaml
+client:
+  url: http://10.24.1.99:3100/loki/api/v1/push
+log_level: info
+skip_default_scrape_config: true
+additional_scrape_configs: |
+  - job_name: homeassistant
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: homeassistant
+          host: brewery-ha
+          __path__: /config/home-assistant.log
+    pipeline_stages:
+      - regex:
+          expression: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+) (?P<level>\w+) \(\w+\) \[(?P<logger>[^\]]+)\] (?P<message>.+)$'
+      - labels:
+          level:
+          logger:
+```
+
+## Grafana Datasource
+
+`grafana-datasource.yaml` is provisioned to `/etc/grafana/provisioning/datasources/loki.yaml`
+on the infra server. Grafana is restarted to apply.
+
+Datasource URL: `http://localhost:3100` (local to infra server)
+
+## Querying Logs in Grafana
+
+Example LogQL queries:
+- All HA logs: `{job="homeassistant"}`
+- Errors only: `{job="homeassistant", level="ERROR"}`
+- Z2M events: `{job="homeassistant"} |= "zigbee2mqtt"`
+- Integration load failures: `{job="homeassistant"} |= "Error" |= "setup"`
+
+## Known Issues
+
+- **Alloy not available**: The Grafana Alloy HA app (Promtail replacement) is not yet in
+  the HA app store. Promtail (deprecated but functional) is used until Alloy becomes available.
+- **Journal access blocked**: HA OS 2026.x apparmor profile blocks Promtail from reading
+  the systemd journal. File-based scraping is used as a workaround.
+- **Loki HA app broken**: The mdegat01 Loki HA app (v1.11.2) fails with permission errors
+  on HA OS 2026.x. Loki runs on the infra server instead.

--- a/docs/infra/loki/docker-compose.yml
+++ b/docs/infra/loki/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  loki:
+    image: grafana/loki:2.9.10
+    container_name: loki
+    restart: unless-stopped
+    user: "0:0"
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./config/loki-config.yaml:/etc/loki/local-config.yaml
+      - ./data:/loki
+    command: -config.file=/etc/loki/local-config.yaml

--- a/docs/infra/loki/docker-compose.yml
+++ b/docs/infra/loki/docker-compose.yml
@@ -3,10 +3,11 @@ services:
     image: grafana/loki:2.9.10
     container_name: loki
     restart: unless-stopped
+    # data/ is owned by root (no sudo available to chown to uid 10001)
     user: "0:0"
     ports:
       - "3100:3100"
     volumes:
-      - ./config/loki-config.yaml:/etc/loki/local-config.yaml
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
       - ./data:/loki
     command: -config.file=/etc/loki/local-config.yaml

--- a/docs/infra/loki/grafana-datasource.yaml
+++ b/docs/infra/loki/grafana-datasource.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://localhost:3100
+    isDefault: false
+    editable: false
+    jsonData:
+      maxLines: 1000

--- a/docs/infra/loki/loki-config.yaml
+++ b/docs/infra/loki/loki-config.yaml
@@ -37,16 +37,14 @@ compactor:
   working_directory: /loki/compactor
   shared_store: filesystem
   compaction_interval: 10m
+  retention_enabled: true
 
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   ingestion_rate_mb: 8
   ingestion_burst_size_mb: 16
+  retention_period: 720h
 
 chunk_store_config:
   max_look_back_period: 720h
-
-table_manager:
-  retention_deletes_enabled: true
-  retention_period: 720h

--- a/docs/infra/loki/loki-config.yaml
+++ b/docs/infra/loki/loki-config.yaml
@@ -1,0 +1,52 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  log_level: info
+
+ingester:
+  lifecycler:
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+  chunk_idle_period: 5m
+  max_chunk_age: 1h
+  chunk_retain_period: 30s
+  max_transfer_retries: 0
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/boltdb-cache
+    shared_store: filesystem
+  filesystem:
+    directory: /loki/chunks
+
+compactor:
+  working_directory: /loki/compactor
+  shared_store: filesystem
+  compaction_interval: 10m
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  ingestion_rate_mb: 8
+  ingestion_burst_size_mb: 16
+
+chunk_store_config:
+  max_look_back_period: 720h
+
+table_manager:
+  retention_deletes_enabled: true
+  retention_period: 720h


### PR DESCRIPTION
Closes #520

## Summary

- Deploys Loki v2.9.10 as a Docker container on infra server (10.24.1.99:3100) — the HA Loki app fails with permission errors on HA OS 2026.x
- Provides Grafana datasource provisioning config for Loki
- Configures Promtail (mdegat01/addon-promtail) to tail `/config/home-assistant.log` with regex pipeline for `level` and `logger` labels — journal scraping is blocked by HA OS 2026.x apparmor

## Known limitations (documented in README)

- **Grafana Alloy** not yet available in the HA app store; Promtail is used as a stopgap
- **Journal access blocked**: HA OS 2026.x apparmor prevents Promtail from reading systemd journal — file-based scraping used
- **Loki HA app broken**: mdegat01/addon-loki v1.11.2 fails with permission errors on HA OS 2026.x

## Deployment

See `docs/infra/loki/README.md` for full setup instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)