### PR TITLE
fix(#140): upgrade entry path lighting

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -578,6 +578,11 @@ automation:
           - conditions:
               - condition: trigger
                 id: front-door-opened
+              - condition: state
+                entity_id:
+                  - light.hall_foyer_switch
+                  - light.hall_transition_switch
+                state: "off"
             sequence:
               - choose:
                   - conditions:

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -83,6 +83,12 @@ homeassistant:
       icon: mdi:home
       hidden: true
 
+    input_boolean.garage_entry_auto_on:
+      <<: *customize
+      friendly_name: "Garage Entry Lights Automatically Turned on"
+      icon: mdi:garage-open-variant
+      hidden: true
+
     input_boolean.owner_suite_bathroom_auto_on:
       <<: *customize
       friendly_name: "Owner Suite Lights Automatically Turned on"
@@ -546,53 +552,93 @@ automation:
 
   - id: front_door_light_auto_toggle
     alias: front_door_light_auto_toggle
+    mode: restart
     trigger:
       - trigger: state
         entity_id: binary_sensor.main_foyer_front_door_contact
         to: "off"
         for:
-          minutes: 30
-        id: door-closed
+          minutes: 2
+        id: front-path-vacant
       - trigger: state
         entity_id: binary_sensor.main_foyer_front_door_contact
         to: "on"
-        id: door-opened
-    condition:
-      - or:
-          - alias: "after sunset"
-            condition: sun
-            after: sunset
-            after_offset: "-00:45:00"
-          - alias: "before sunrise"
-            condition: sun
-            before: sunrise
-            before_offset: "-00:45:00"
-      # condition: state
-      # entity_id: input_boolean.front_door_auto_on
-      # state: "on"
+        id: front-door-opened
+      - trigger: state
+        entity_id:
+          - binary_sensor.hall_transition_switch_occupancy
+          - binary_sensor.hall_transition_switch_area1occupancy
+          - binary_sensor.hall_transition_switch_area2occupancy
+        to: "off"
+        for:
+          minutes: 2
+        id: front-path-vacant
     action:
       - choose:
           - conditions:
               - condition: trigger
-                id: door-closed
+                id: front-door-opened
             sequence:
-              # TODO maybe don't turn off the lights.
-              # - action: light.turn_off
-              #   data:
-              #     entity_id: light.outside_front_hue
-              - action: input_boolean.turn_off
-                data:
+              - choose:
+                  - conditions:
+                      - or:
+                          - condition: time
+                            after: "23:00:00"
+                            before: "06:00:00"
+                          - condition: state
+                            entity_id: binary_sensor.bayesian_bed_occupancy
+                            state: "on"
+                    sequence:
+                      - action: light.turn_on
+                        target:
+                          entity_id:
+                            - light.hall_foyer_switch
+                            - light.hall_transition_switch
+                        data:
+                          brightness_pct: 20
+                          transition: 2
+                default:
+                  - action: adaptive_lighting.apply
+                    data:
+                      lights:
+                        - light.hall_foyer_switch
+                        - light.hall_transition_switch
+                      entity_id: switch.adaptive_lighting_hallway
+                      adapt_brightness: true
+                      adapt_color: true
+                      turn_on_lights: true
+              - action: input_boolean.turn_on
+                target:
                   entity_id: input_boolean.front_door_auto_on
           - conditions:
               - condition: trigger
-                id: door-opened
+                id: front-path-vacant
+              - condition: state
+                entity_id: input_boolean.front_door_auto_on
+                state: "on"
+              - condition: state
+                entity_id: binary_sensor.main_foyer_front_door_contact
+                state: "off"
+                for:
+                  minutes: 2
+              - condition: state
+                entity_id:
+                  - binary_sensor.hall_transition_switch_occupancy
+                  - binary_sensor.hall_transition_switch_area1occupancy
+                  - binary_sensor.hall_transition_switch_area2occupancy
+                state: "off"
+                for:
+                  minutes: 2
             sequence:
-              - action: light.turn_on
-                data:
+              - action: light.turn_off
+                target:
                   entity_id:
-                    - light.hall_all
-              - action: input_boolean.turn_on
+                    - light.hall_foyer_switch
+                    - light.hall_transition_switch
                 data:
+                  transition: 5
+              - action: input_boolean.turn_off
+                target:
                   entity_id: input_boolean.front_door_auto_on
 
   - id: front_lights_toggle
@@ -673,43 +719,96 @@ automation:
 
   - id: garage_entry_door_light_auto_toggle
     alias: garage_entry_light_auto_toggle
+    mode: restart
     trigger:
       - trigger: state
         entity_id: binary_sensor.hall_garage_entry_contact
         to: "off"
         for:
-          minutes: 5
-        id: door-closed
+          minutes: 2
+        id: garage-path-vacant
       - trigger: state
         entity_id: binary_sensor.hall_garage_entry_contact
         to: "on"
-        id: door-opened
-    condition: []
+        id: garage-door-opened
+      - trigger: state
+        entity_id:
+          - binary_sensor.hall_transition_switch_occupancy
+          - binary_sensor.hall_transition_switch_area1occupancy
+          - binary_sensor.hall_transition_switch_area2occupancy
+        to: "off"
+        for:
+          minutes: 2
+        id: garage-path-vacant
     action:
       - choose:
           - conditions:
               - condition: trigger
-                id: door-closed
+                id: garage-door-opened
             sequence:
-              - action: light.turn_off
-                data:
-                  entity_id:
-                    - light.hall_foyer_switch
-                    - light.hall_transition
-                    - light.hall_garage_laundry_switch
-                    - light.garage_overhead_switch
-      - choose:
+              - choose:
+                  - conditions:
+                      - or:
+                          - condition: time
+                            after: "23:00:00"
+                            before: "06:00:00"
+                          - condition: state
+                            entity_id: binary_sensor.bayesian_bed_occupancy
+                            state: "on"
+                    sequence:
+                      - action: light.turn_on
+                        target:
+                          entity_id:
+                            - light.hall_transition_switch
+                            - light.hall_garage_laundry_switch
+                            - light.garage_overhead_switch
+                        data:
+                          brightness_pct: 15
+                          transition: 2
+                default:
+                  - action: light.turn_on
+                    target:
+                      entity_id:
+                        - light.hall_transition_switch
+                        - light.hall_garage_laundry_switch
+                        - light.garage_overhead_switch
+                    data:
+                      brightness_pct: 75
+                      transition: 2
+              - action: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.garage_entry_auto_on
           - conditions:
               - condition: trigger
-                id: door-opened
+                id: garage-path-vacant
+              - condition: state
+                entity_id: input_boolean.garage_entry_auto_on
+                state: "on"
+              - condition: state
+                entity_id: binary_sensor.hall_garage_entry_contact
+                state: "off"
+                for:
+                  minutes: 2
+              - condition: state
+                entity_id:
+                  - binary_sensor.hall_transition_switch_occupancy
+                  - binary_sensor.hall_transition_switch_area1occupancy
+                  - binary_sensor.hall_transition_switch_area2occupancy
+                state: "off"
+                for:
+                  minutes: 2
             sequence:
-              - action: light.turn_on
-                data:
+              - action: light.turn_off
+                target:
                   entity_id:
-                    - light.hall_foyer_switch
-                    - light.hall_transition
+                    - light.hall_transition_switch
                     - light.hall_garage_laundry_switch
                     - light.garage_overhead_switch
+                data:
+                  transition: 5
+              - action: input_boolean.turn_off
+                target:
+                  entity_id: input_boolean.garage_entry_auto_on
 
   - id: guest_room_ceiling_lights_on_off
     alias: guest_room_ceiling_lights_on_off
@@ -734,11 +833,13 @@ automation:
       - trigger: state
         entity_id:
           - binary_sensor.hall_main_foyer_motion_occupancy
+          - binary_sensor.hall_transition_switch_occupancy
         to: "on"
         id: main-motion-sensed
       - trigger: state
         entity_id:
           - binary_sensor.hall_main_foyer_motion_occupancy
+          - binary_sensor.hall_transition_switch_occupancy
         to: "off"
         id: main-motion-not-detected
       - trigger: state
@@ -816,6 +917,7 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                  - binary_sensor.hall_transition_switch_occupancy
                 state: "off"
                 for:
                   minutes: 3
@@ -845,6 +947,7 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                  - binary_sensor.hall_transition_switch_occupancy
                 state: "off"
                 for:
                   minutes: 15
@@ -906,6 +1009,7 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                  - binary_sensor.hall_transition_switch_occupancy
                 state: "off"
                 for:
                   minutes: 15
@@ -934,6 +1038,7 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                  - binary_sensor.hall_transition_switch_occupancy
                 state: "off"
                 for:
                   minutes: 3
@@ -1502,11 +1607,13 @@ automation:
       - trigger: state
         entity_id:
           - binary_sensor.hall_main_foyer_motion_occupancy
+          - binary_sensor.hall_transition_switch_occupancy
         to: "on"
         id: main-motion-sensed
       - trigger: state
         entity_id:
           - binary_sensor.hall_main_foyer_motion_occupancy
+          - binary_sensor.hall_transition_switch_occupancy
         to: "off"
         for:
           minutes: 15
@@ -1563,6 +1670,7 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                  - binary_sensor.hall_transition_switch_occupancy
                 state: "off"
                 for:
                   minutes: 15
@@ -1608,6 +1716,7 @@ automation:
               - condition: state
                 entity_id:
                   - binary_sensor.hall_main_foyer_motion_occupancy
+                  - binary_sensor.hall_transition_switch_occupancy
                 state: "off"
                 for:
                   minutes: 15
@@ -2189,6 +2298,7 @@ group: {}
 input_boolean:
   deck_auto_on:
   front_door_auto_on:
+  garage_entry_auto_on:
   basement_auto_on:
   office_auto_on:
   owner_suite_bedroom_auto_on:

--- a/tests/test_issue_140_entry_path_lighting.py
+++ b/tests/test_issue_140_entry_path_lighting.py
@@ -48,6 +48,19 @@ def test_front_door_entry_path_is_targeted_and_preserves_manual_offs() -> None:
     assert "action: input_boolean.turn_off" in block
 
 
+def test_front_door_entry_path_only_marks_auto_on_after_off_state_guard() -> None:
+    block = _automation_block("front_door_light_auto_toggle")
+
+    auto_on_marker = block.index("action: input_boolean.turn_on")
+    off_state_guard = block.index(
+        "entity_id:\n"
+        "                  - light.hall_foyer_switch\n"
+        "                  - light.hall_transition_switch\n"
+        '                state: "off"'
+    )
+    assert off_state_guard < auto_on_marker
+
+
 def test_garage_entry_path_uses_contact_mmwave_and_auto_on_guard() -> None:
     block = _automation_block("garage_entry_door_light_auto_toggle")
 

--- a/tests/test_issue_140_entry_path_lighting.py
+++ b/tests/test_issue_140_entry_path_lighting.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIGHT_PATH = ROOT / "packages" / "light.yaml"
+
+
+def _automation_block(automation_id: str) -> str:
+    text = LIGHT_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^  - (?:id|alias): {re.escape(automation_id)}\n(.*?)(?=^  - (?:id|alias): |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+    return match.group(0)
+
+
+def test_front_door_entry_path_uses_contact_and_mmwave_vacancy() -> None:
+    block = _automation_block("front_door_light_auto_toggle")
+
+    assert "id: front-door-opened" in block
+    assert "id: front-path-vacant" in block
+    assert "binary_sensor.main_foyer_front_door_contact" in block
+    for entity_id in (
+        "binary_sensor.hall_transition_switch_occupancy",
+        "binary_sensor.hall_transition_switch_area1occupancy",
+        "binary_sensor.hall_transition_switch_area2occupancy",
+    ):
+        assert entity_id in block
+    assert "minutes: 2" in block
+
+
+def test_front_door_entry_path_is_targeted_and_preserves_manual_offs() -> None:
+    block = _automation_block("front_door_light_auto_toggle")
+
+    assert "light.hall_foyer_switch" in block
+    assert "light.hall_transition_switch" in block
+    assert "light.hall_all" not in block
+    assert "brightness_pct: 20" in block
+    assert 'after: "23:00:00"' in block
+    assert 'before: "06:00:00"' in block
+    assert "input_boolean.front_door_auto_on" in block
+    assert "action: input_boolean.turn_off" in block
+
+
+def test_garage_entry_path_uses_contact_mmwave_and_auto_on_guard() -> None:
+    block = _automation_block("garage_entry_door_light_auto_toggle")
+
+    assert "id: garage-door-opened" in block
+    assert "id: garage-path-vacant" in block
+    assert "binary_sensor.hall_garage_entry_contact" in block
+    for entity_id in (
+        "binary_sensor.hall_transition_switch_occupancy",
+        "binary_sensor.hall_transition_switch_area1occupancy",
+        "binary_sensor.hall_transition_switch_area2occupancy",
+    ):
+        assert entity_id in block
+    assert "input_boolean.garage_entry_auto_on" in block
+    assert "brightness_pct: 15" in block
+    assert "brightness_pct: 75" in block
+
+
+def test_garage_entry_path_targets_garage_side_lights_only() -> None:
+    block = _automation_block("garage_entry_door_light_auto_toggle")
+
+    assert "light.hall_transition_switch" in block
+    assert "light.hall_garage_laundry_switch" in block
+    assert "light.garage_overhead_switch" in block
+    assert "light.hall_foyer_switch" not in block
+    assert "light.hall_all" not in block
+
+
+def test_hallway_pass_through_uses_transition_mmwave_occupancy() -> None:
+    for automation_id in ("hallway_light_toggle_at_night", "toggle_hallway_day"):
+        block = _automation_block(automation_id)
+        assert block.count("binary_sensor.hall_transition_switch_occupancy") >= 4
+        assert "id: main-motion-sensed" in block
+        assert "id: main-motion-not-detected" in block

--- a/tests/test_issue_333_hallway_motion_restart.py
+++ b/tests/test_issue_333_hallway_motion_restart.py
@@ -23,10 +23,18 @@ def _automation_block(path: Path, automation_name: str) -> str:
 
 def _off_condition_durations(block: str) -> Counter[tuple[str, str]]:
     pattern = re.compile(
-        r"entity_id:\n\s+- (binary_sensor\.hall_(?:main_foyer|upstairs)_motion_occupancy)\n"
+        r"entity_id:\n"
+        r"((?:\s+- binary_sensor\.hall_(?:main_foyer_motion|upstairs_motion|transition_switch)_occupancy\n)+)"
         r"\s+state: \"off\"\n\s+for:\n\s+minutes: (\d+)"
     )
-    return Counter(pattern.findall(block))
+    durations: Counter[tuple[str, str]] = Counter()
+    for entity_list, minutes in pattern.findall(block):
+        for entity_id in re.findall(
+            r"binary_sensor\.hall_(?:main_foyer_motion|upstairs_motion|transition_switch)_occupancy",
+            entity_list,
+        ):
+            durations[(entity_id, minutes)] += 1
+    return durations
 
 
 def test_toggle_hallway_day_requires_both_sensors_to_stay_clear_for_15_minutes() -> None:

--- a/tests/test_issue_trip_led_suspend.py
+++ b/tests/test_issue_trip_led_suspend.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 ZIGBEE_ZWAVE_PATH = ROOT / "packages" / "zigbee_zwave.yaml"
+INOVELLI_LED_NOTIFICATIONS_PATH = ROOT / "packages" / "inovelli_led_notifications.yaml"
 
 
 def _script_block(script_id: str) -> str:
@@ -73,12 +74,14 @@ def test_trip_mode_sync_automation_suspends_and_restores_inovelli_leds() -> None
 
 def test_trip_suspend_script_zeros_led_intensities_and_clears_active_effects() -> None:
     block = _script_block("turn_off_all_inovelli_switch_leds")
+    led_notification_text = INOVELLI_LED_NOTIFICATIONS_PATH.read_text(encoding="utf-8")
 
     assert "all_switches_led_intensity_on" in block
     assert "all_switches_led_intensity_off" in block
     assert "value: 0" in block
-    assert "'clear_effect'" in block
-    assert "zigbee2mqtt/{{ repeat.item }}/set" in block
+    assert "action: script.inovelli_led_clear_all_effects" in block
+    assert "inovelli_led_clear_all_effects:" in led_notification_text
+    assert "effect: Clear Effect" in led_notification_text
 
 
 def test_trip_restore_script_reuses_existing_day_and_night_profiles() -> None:

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -4,7 +4,9 @@ import re
 from pathlib import Path
 
 
-ZIGBEE_ZWAVE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zigbee_zwave.yaml"
+ROOT = Path(__file__).resolve().parents[1]
+ZIGBEE_ZWAVE_PATH = ROOT / "packages" / "zigbee_zwave.yaml"
+INOVELLI_LED_NOTIFICATIONS_PATH = ROOT / "packages" / "inovelli_led_notifications.yaml"
 
 
 def _script_block(script_id: str) -> str:
@@ -354,13 +356,14 @@ def test_inovelli_led_recovery_replays_trip_day_night_and_owner_suite_darkening(
 
 def test_reset_script_finishes_with_the_issue_aurora_led_effect() -> None:
     block = _script_block("reset_inovelli_switches")
+    led_notification_text = INOVELLI_LED_NOTIFICATIONS_PATH.read_text(encoding="utf-8")
 
-    assert "aurora_effect: aurora" in block
-    assert "aurora_color: 187" in block
-    assert "aurora_level: 51" in block
-    assert "aurora_duration: 70" in block
-    assert 'topic: "zigbee2mqtt/{{ repeat.item }}/set"' in block
-    assert "'led_effect': {" in block
+    assert "action: script.inovelli_led_aurora_notification" in block
+    assert "inovelli_led_aurora_notification:" in led_notification_text
+    assert "effect: Aurora" in led_notification_text
+    assert "color: Purple" in led_notification_text
+    assert "brightness: 5.1" in led_notification_text
+    assert "duration: 10 Minutes" in led_notification_text
 
 
 def test_reset_script_skips_aurora_notification_while_bed_is_occupied() -> None:
@@ -369,5 +372,5 @@ def test_reset_script_skips_aurora_notification_while_bed_is_occupied() -> None:
     assert "binary_sensor.bayesian_bed_occupancy" in block
     assert 'state: "off"' in block
     assert block.index("binary_sensor.bayesian_bed_occupancy") < block.index(
-        'topic: "zigbee2mqtt/{{ repeat.item }}/set"'
+        "action: script.inovelli_led_aurora_notification"
     )


### PR DESCRIPTION
Closes #140

## Summary
- Split front-door and garage-entry lighting into path-specific routes using the contact sensors plus hall transition mmWave occupancy/area sensors.
- Add late-night/sleep-adjacent dim entry paths and auto-off guards that only clear lights when the matching auto-on helper was set.
- Extend hallway day/night pass-through logic to use the hall transition mmWave occupancy sensor.
- Update regression coverage, including stale Inovelli LED tests that now need to assert the existing blueprint-backed notification scripts.

## Validation
- `uv run --with pytest pytest` -> 338 passed
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt` -> passed
- `git diff --check` -> passed
- Home Assistant live config check via `/api/config/core/check_config` -> valid, no warnings
- `uv run --with pyyaml python /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/light.yaml` -> no parse errors, no full-block/intra/central-script findings; reported 10 existing package-wide ENTRY duplicate groups deferred as a wider lighting-package refactor
