### PR TITLE
fix: harden runtime log regressions

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -112,6 +112,9 @@ recorder:
       - vacuum
     entities:
       - sensor.time
+      # Live Z2M decommission helpers keep large selection maps as attributes.
+      # Recorder cannot persist those attributes and logs repeated size warnings.
+      - sensor.z2m_lifecycle_issues
 
 influxdb:
   exclude:

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -2715,12 +2715,12 @@ template:
         unique_id: circadian_brightness
         unit_of_measurement: "%"
         state: >-
-          {{ state_attr('switch.adaptive_lighting_hallway', 'brightness_pct') |int }}
+          {{ state_attr('switch.adaptive_lighting_hallway', 'brightness_pct') | int(1) }}
       - name: circadian_temperature
         unique_id: circadian_temperature
         unit_of_measurement: "°K"
         state: >-
-          {{ state_attr('switch.adaptive_lighting_hallway', 'color_temp_kelvin') }}
+          {{ state_attr('switch.adaptive_lighting_hallway', 'color_temp_kelvin') | int(1000) }}
 
 ########################
 # Zone

--- a/tests/test_issue_trip_led_suspend.py
+++ b/tests/test_issue_trip_led_suspend.py
@@ -77,8 +77,9 @@ def test_trip_suspend_script_zeros_led_intensities_and_clears_active_effects() -
     assert "all_switches_led_intensity_on" in block
     assert "all_switches_led_intensity_off" in block
     assert "value: 0" in block
-    assert "'clear_effect'" in block
-    assert "zigbee2mqtt/{{ repeat.item }}/set" in block
+    assert "script.inovelli_led_clear_all_effects" in block
+    assert "'clear_effect'" not in block
+    assert "zigbee2mqtt/{{ repeat.item }}/set" not in block
 
 
 def test_trip_restore_script_reuses_existing_day_and_night_profiles() -> None:

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -114,6 +114,15 @@ def test_garden_birds_sensor_is_excluded_from_influxdb() -> None:
     assert "sensor.garden_birds" in influx_block
 
 
+def test_large_z2m_lifecycle_helper_is_excluded_from_recorder() -> None:
+    text = _read(CONFIGURATION_PATH)
+
+    recorder_block = text.split("recorder:\n", 1)[1].split("\ninfluxdb:", 1)[0]
+
+    assert "sensor.z2m_lifecycle_issues" in recorder_block
+    assert "large selection maps as attributes" in recorder_block
+
+
 def test_garbage_notifications_use_computed_pickup_date_sensor() -> None:
     text = _read(UTILITIES_PATH)
 
@@ -221,3 +230,17 @@ def test_lights_off_except_skips_light_groups_that_contain_protected_members() -
     assert "light.entity_id in excluded or (members | select('in', excluded)" in block
     assert "members | select('in', excluded)" in block
     assert "rejectattr('entity_id', 'in', protected_lights)" in block
+
+
+def test_circadian_template_sensors_have_adaptive_lighting_fallbacks() -> None:
+    text = _read(ROOT / "packages" / "light.yaml")
+
+    block = text.split("name: circadian_brightness", 1)[1].split(
+        "\n########################\n# Zone",
+        1,
+    )[0]
+
+    assert "brightness_pct') | int(1)" in block
+    assert "color_temp_kelvin') | int(1000)" in block
+    assert "brightness_pct') |int" not in block
+    assert "color_temp_kelvin') }}\n" not in block

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -4,7 +4,9 @@ import re
 from pathlib import Path
 
 
-ZIGBEE_ZWAVE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zigbee_zwave.yaml"
+ROOT = Path(__file__).resolve().parents[1]
+ZIGBEE_ZWAVE_PATH = ROOT / "packages" / "zigbee_zwave.yaml"
+INOVELLI_LED_NOTIFICATIONS_PATH = ROOT / "packages" / "inovelli_led_notifications.yaml"
 
 
 def _script_block(script_id: str) -> str:
@@ -354,13 +356,15 @@ def test_inovelli_led_recovery_replays_trip_day_night_and_owner_suite_darkening(
 
 def test_reset_script_finishes_with_the_issue_aurora_led_effect() -> None:
     block = _script_block("reset_inovelli_switches")
+    notification_text = INOVELLI_LED_NOTIFICATIONS_PATH.read_text(encoding="utf-8")
 
-    assert "aurora_effect: aurora" in block
-    assert "aurora_color: 187" in block
-    assert "aurora_level: 51" in block
-    assert "aurora_duration: 70" in block
-    assert 'topic: "zigbee2mqtt/{{ repeat.item }}/set"' in block
-    assert "'led_effect': {" in block
+    assert "script.inovelli_led_aurora_notification" in block
+    assert "effect: Aurora" in notification_text
+    assert "brightness: 5.1" in notification_text
+    assert "color: Purple" in notification_text
+    assert "duration: 10 Minutes" in notification_text
+    assert 'topic: "zigbee2mqtt/{{ repeat.item }}/set"' not in block
+    assert "'led_effect': {" not in block
 
 
 def test_reset_script_skips_aurora_notification_while_bed_is_occupied() -> None:
@@ -369,5 +373,5 @@ def test_reset_script_skips_aurora_notification_while_bed_is_occupied() -> None:
     assert "binary_sensor.bayesian_bed_occupancy" in block
     assert 'state: "off"' in block
     assert block.index("binary_sensor.bayesian_bed_occupancy") < block.index(
-        'topic: "zigbee2mqtt/{{ repeat.item }}/set"'
+        "script.inovelli_led_aurora_notification"
     )


### PR DESCRIPTION
Refs #182

## Summary
- Add fallbacks to the `circadian_brightness` and `circadian_temperature` template sensors so the adaptive-lighting reset window does not log `int got invalid input None` when hallway Adaptive Lighting attributes are briefly absent.
- Exclude `sensor.z2m_lifecycle_issues` from Recorder because live runtime logs show its large decommission-selection attributes repeatedly exceed the 16 KB Recorder attribute limit.
- Update stale Inovelli LED regression tests to assert the merged blueprint-backed notification scripts instead of the removed raw MQTT LED-effect payloads.

## Runtime evidence
- 2026-04-21 04:00 CDT live HA log: `sensor.circadian_brightness` template failed while rendering `brightness_pct |int` because `switch.adaptive_lighting_hallway` returned `None` during the adaptive-lighting reset.
- 2026-04-21 03:29-03:53 CDT live HA log: Recorder repeatedly warned that `sensor.z2m_lifecycle_issues` attributes exceed 16384 bytes and were not stored.
- Saved automation/script traces since the prior run had no current execution errors; these fixes are from live log/state correlation.

## Validation
- `uv run --with pytest pytest tests/test_runtime_log_regressions.py tests/test_z2m_lifecycle_package.py -q`
- `uv run --with pytest pytest tests/test_issue_trip_led_suspend.py tests/test_zigbee_zwave_inovelli_reset_replay.py -q`
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml packages/light.yaml packages/z2m_lifecycle.yaml`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/light.yaml packages/z2m_lifecycle.yaml` (passes with pre-existing DRY findings only)
- `git diff --check`

## Follow-up runtime notes
- The `sensor.garden_birds` InfluxDB exclusion is present in live config from PR #487, but HA appears not to have restarted since that config became active; verify after the next HA restart.
- Bermuda is still logging repeated `process_advertisement on a metadevice` errors for the Under Bed Presence proxy while downstream room-confidence entities remain online; this needs integration-level review, not a safe YAML fix in this sweep.
- LG ThinQ refrigerator polling is still intermittently returning API error 9012 while refrigerator entities continue to update; this is a runtime integration/service issue to monitor under #182.
