### PR TITLE
[codex] Replace legacy light color_temp scene keys

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -2377,17 +2377,17 @@ scene:
       light.owner_suite_lamps:
         state: "on"
         brightness: 192
-        color_temp: 500
+        color_temp_kelvin: 2000
       light.bed_lightstrip:
         state: "on"
         brightness: 192
-        color_temp: 500
+        color_temp_kelvin: 2000
 
   - name: scene_reset_basement
     entities:
       light.basement_great_room:
         state: "on"
-        color_temp: 386
+        color_temp_kelvin: 2591
         brightness: 255
       light.basement_tv_bias:
         state: "on"

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -244,3 +244,11 @@ def test_circadian_template_sensors_have_adaptive_lighting_fallbacks() -> None:
     assert "color_temp_kelvin') | int(1000)" in block
     assert "brightness_pct') |int" not in block
     assert "color_temp_kelvin') }}\n" not in block
+
+
+def test_light_package_uses_kelvin_color_temperature_keys() -> None:
+    text = _read(ROOT / "packages" / "light.yaml")
+
+    assert "\n        color_temp:" not in text
+    assert "color_temp_kelvin: 2000" in text
+    assert "color_temp_kelvin: 2591" in text


### PR DESCRIPTION
## Summary
- replace remaining scene `color_temp` mired keys in `packages/light.yaml` with `color_temp_kelvin`
- preserve the same effective temperatures via direct mired-to-Kelvin conversion
- add regression coverage so legacy `color_temp:` keys do not return to the light package

## Why
Home Assistant 2026.3 no longer supports using mired-based `color_temp` to set light color temperature and directs configs to use `color_temp_kelvin` instead. The affected scenes used legacy keys that can fail or be ignored on current HA releases.

Direct conversions used:
- `500` mireds -> `2000` K
- `386` mireds -> `2591` K

Closes #528.
Refs #529 for the broader DRY refactor planning generated from the HA YAML scan.

## Coverage
- `rg "\\bcolor_temp\\s*:" packages/light.yaml` has no matches
- `uv run --with pytest pytest tests/test_runtime_log_regressions.py tests/test_issue_owner_suite_home_condition.py`
- `uv run --with pytest pytest`

## Sources
- HA 2026.3 release notes: https://www.home-assistant.io/blog/2026/03/04/release-20263/#backward-incompatible-changes
- HA community migration discussion: https://community.home-assistant.io/t/2026-3-0-convert-mireds-to-kelvin/992939
