### PR TITLE
[codex] Fix owner-suite blinds sunset close

### DIFF
--- a/packages/windows.yaml
+++ b/packages/windows.yaml
@@ -143,7 +143,7 @@ automation:
     trigger:
       - trigger: sun
         event: sunset
-        offset: -00:30:00
+        offset: -00:45:00
         id: sunset
       - trigger: state
         entity_id: cover.owner_suite_blinds_ha
@@ -160,12 +160,9 @@ automation:
           - conditions:
               - condition: trigger
                 id: sunset
-              - condition: state
-                entity_id: cover.owner_suite_blinds_ha
-                state: "open"
             sequence:
               - variables:
-                  blind_close_delay_minutes: "{{ range(5, 45) | random | int }}"
+                  blind_close_delay_minutes: "{{ range(0, 48) | random | int }}"
               - delay:
                   minutes: "{{ blind_close_delay_minutes }}"
               - action: cover.close_cover
@@ -178,8 +175,9 @@ automation:
                 id: recovery
               - condition: sun
                 after: sunset
-              - condition: time
-                before: "23:00:00"
+                after_offset: -00:45:00
+                before: sunset
+                before_offset: "+00:02:00"
             sequence:
               - delay:
                   minutes: 1

--- a/packages/z2m_availability.yaml
+++ b/packages/z2m_availability.yaml
@@ -495,17 +495,6 @@ mqtt:
       payload_available: "online"
       payload_not_available: "offline"
 
-    - name: "Z2M Den/Wall Switch Availability"
-      unique_id: z2m_den_wall_switch_availability
-      state_topic: "zigbee2mqtt/Den/Wall Switch/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      payload_available: "online"
-      payload_not_available: "offline"
-
     - name: "Z2M Dining Room/Lamp 1 Availability"
       unique_id: z2m_dining_room_lamp_1_availability
       state_topic: "zigbee2mqtt/Dining Room/Lamp 1/availability"
@@ -531,17 +520,6 @@ mqtt:
     - name: "Z2M Dining Room/North Window Availability"
       unique_id: z2m_dining_room_north_window_availability
       state_topic: "zigbee2mqtt/Dining Room/North Window/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      payload_available: "online"
-      payload_not_available: "offline"
-
-    - name: "Z2M Dining Room/Overhead Availability"
-      unique_id: z2m_dining_room_overhead_availability
-      state_topic: "zigbee2mqtt/Dining Room/Overhead/availability"
       value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
@@ -979,28 +957,6 @@ mqtt:
       payload_available: "online"
       payload_not_available: "offline"
 
-    - name: "Z2M Kitchen/Dishwasher Leak Availability"
-      unique_id: z2m_kitchen_dishwasher_leak_availability
-      state_topic: "zigbee2mqtt/Kitchen/Dishwasher Leak/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      payload_available: "online"
-      payload_not_available: "offline"
-
-    - name: "Z2M Kitchen/Kitchen Sink Availability"
-      unique_id: z2m_kitchen_kitchen_sink_availability
-      state_topic: "zigbee2mqtt/Kitchen/Kitchen Sink/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      payload_available: "online"
-      payload_not_available: "offline"
-
     - name: "Z2M Kitchen/North Window Availability"
       unique_id: z2m_kitchen_north_window_availability
       state_topic: "zigbee2mqtt/Kitchen/North Window/availability"
@@ -1089,28 +1045,6 @@ mqtt:
       payload_available: "online"
       payload_not_available: "offline"
 
-    - name: "Z2M Kitchen/Overhead Lights Switch Availability"
-      unique_id: z2m_kitchen_overhead_lights_switch_availability
-      state_topic: "zigbee2mqtt/Kitchen/Overhead Lights Switch/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      payload_available: "online"
-      payload_not_available: "offline"
-
-    - name: "Z2M Kitchen/Sink Leak Availability"
-      unique_id: z2m_kitchen_sink_leak_availability
-      state_topic: "zigbee2mqtt/Kitchen/Sink Leak/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      payload_available: "online"
-      payload_not_available: "offline"
-
     - name: "Z2M Kitchen/Sink Overhead Availability"
       unique_id: z2m_kitchen_sink_overhead_availability
       state_topic: "zigbee2mqtt/Kitchen/Sink Overhead/availability"
@@ -1191,28 +1125,6 @@ mqtt:
     - name: "Z2M Laundry Room/Washing Machine Door Availability"
       unique_id: z2m_laundry_room_washing_machine_door_availability
       state_topic: "zigbee2mqtt/Laundry Room/Washing Machine Door/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      payload_available: "online"
-      payload_not_available: "offline"
-
-    - name: "Z2M Laundry/Leak Availability"
-      unique_id: z2m_laundry_leak_availability
-      state_topic: "zigbee2mqtt/Laundry/Leak/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      payload_available: "online"
-      payload_not_available: "offline"
-
-    - name: "Z2M Laundry/Outlet Repeater Availability"
-      unique_id: z2m_laundry_outlet_repeater_availability
-      state_topic: "zigbee2mqtt/Laundry/Outlet Repeater/availability"
       value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"

--- a/specs/night_routines.allium
+++ b/specs/night_routines.allium
@@ -4,6 +4,7 @@
 -- Scope: Owner bedtime preparation and privacy-aware overnight shutdown.
 -- Includes:
 --   - soft bedtime-prep flow triggered by nighttime TV/button actions
+--   - owner-suite blind privacy close around sunset
 --   - CPAP-triggered escalation into the stricter goodnight integrity flow
 --   - guest/privacy-aware shutdown choices derived from docs/room_intent.yaml
 --   - lock, cover, climate, media, and notification expectations
@@ -70,6 +71,12 @@ entity HouseSleepSafety {
     climate_mode: resumed_program | guest_sleep | unavailable | away_like
 }
 
+entity OwnerSuiteBlindsPrivacySchedule {
+    selected_close_offset_after_window_start: Duration
+    scheduled_close_at: Timestamp
+    closed_for_current_sunset: Boolean
+}
+
 entity HouseModeStateMachine {
     mode: home | away | night | in_bed | asleep
 
@@ -94,6 +101,9 @@ config {
     bedtime_audio_timeout: Duration = 10.minutes
     bedtime_audio_rampdown_delay: Duration = 3.minutes
     goodnight_verification_delay: Duration = 30.seconds
+    owner_suite_blinds_sunset_window_start_lead: Duration = 45.minutes
+    owner_suite_blinds_sunset_window_end_lag: Duration = 2.minutes
+    owner_suite_blinds_sunset_window_duration: Duration = owner_suite_blinds_sunset_window_start_lead + owner_suite_blinds_sunset_window_end_lag
 }
 
 ------------------------------------------------------------
@@ -137,6 +147,29 @@ rule ScheduleBedtimeAudioRampdown {
 rule ChooseBedtimeAudioFromConfiguredPool {
     when: BedtimeAudioRequested(zone)
     ensures: BedtimeAudioSelectionChosen(configured_bedtime_media_pool, shuffle_optional, repeat_all)
+}
+
+rule ScheduleOwnerSuiteBlindsSunsetPrivacyClose {
+    when: SunsetTimeKnown(sunset_at)
+    let close_offset = RandomDurationBetween(0.minutes, config.owner_suite_blinds_sunset_window_duration)
+    ensures: OwnerSuiteBlindsPrivacySchedule.created(
+        selected_close_offset_after_window_start: close_offset,
+        scheduled_close_at: sunset_at - config.owner_suite_blinds_sunset_window_start_lead + close_offset,
+        closed_for_current_sunset: false
+    )
+    @guidance
+        -- The selected close time varies day to day so the owner-suite blinds
+        -- close in the privacy window from 45 minutes before sunset through
+        -- 2 minutes after sunset, inclusive.
+}
+
+rule CloseOwnerSuiteBlindsAroundSunset {
+    when: schedule: OwnerSuiteBlindsPrivacySchedule.scheduled_close_at <= now
+    requires: not schedule.closed_for_current_sunset
+    requires: schedule.selected_close_offset_after_window_start >= 0.minutes
+    requires: schedule.selected_close_offset_after_window_start <= config.owner_suite_blinds_sunset_window_duration
+    ensures: house.owner_suite_blinds_closed = true
+    ensures: schedule.closed_for_current_sunset = true
 }
 
 rule TriggerGoodnightFromCPAPSleep {

--- a/tests/test_allium_specs.py
+++ b/tests/test_allium_specs.py
@@ -31,6 +31,8 @@ def test_behavioral_allium_specs_exist_and_are_versioned() -> None:
             "ensures: house.overnight_exterior_lighting_preserved = true",
             "rule ChooseBedtimeAudioFromConfiguredPool",
             "rule TriggerGoodnightFromCPAPSleep",
+            "rule ScheduleOwnerSuiteBlindsSunsetPrivacyClose",
+            "rule CloseOwnerSuiteBlindsAroundSunset",
             "rule EnterAsleepHouseModeFromBedsideShutdown",
             "rule ApplyGoodnightIntegrity",
             "owner_suite_switch_led_mode: OwnerSuiteSwitchLedMode",

--- a/tests/test_night_routines_allium_alignment.py
+++ b/tests/test_night_routines_allium_alignment.py
@@ -174,3 +174,22 @@ def test_night_routines_spec_owns_owner_suite_led_policy_enum() -> None:
         "rule KeepOwnerSuiteSwitchLedsDarkOnNonWorkdayMornings",
     ):
         assert token in text
+
+
+def test_night_routines_spec_closes_owner_suite_blinds_around_sunset() -> None:
+    text = (ROOT / "specs" / "night_routines.allium").read_text(encoding="utf-8")
+
+    for token in (
+        "owner_suite_blinds_sunset_window_start_lead: Duration = 45.minutes",
+        "owner_suite_blinds_sunset_window_end_lag: Duration = 2.minutes",
+        "owner_suite_blinds_sunset_window_duration: Duration = owner_suite_blinds_sunset_window_start_lead + owner_suite_blinds_sunset_window_end_lag",
+        "rule ScheduleOwnerSuiteBlindsSunsetPrivacyClose",
+        "RandomDurationBetween(0.minutes, config.owner_suite_blinds_sunset_window_duration)",
+        "selected_close_offset_after_window_start: close_offset",
+        "scheduled_close_at: sunset_at - config.owner_suite_blinds_sunset_window_start_lead + close_offset",
+        "rule CloseOwnerSuiteBlindsAroundSunset",
+        "requires: schedule.selected_close_offset_after_window_start >= 0.minutes",
+        "requires: schedule.selected_close_offset_after_window_start <= config.owner_suite_blinds_sunset_window_duration",
+        "ensures: house.owner_suite_blinds_closed = true",
+    ):
+        assert token in text

--- a/tests/test_owner_suite_blinds_automation.py
+++ b/tests/test_owner_suite_blinds_automation.py
@@ -123,7 +123,22 @@ def test_close_owner_suite_blinds_catches_evening_recovery_after_missed_sunset()
     assert 'to: "open"' in block
     assert 'id: recovery' in block
     assert 'after: sunset' in block
-    assert 'before: "23:00:00"' in block
+    assert 'after_offset: -00:45:00' in block
+    assert 'before: sunset' in block
+    assert 'before_offset: "+00:02:00"' in block
+    assert "blind_close_delay_minutes: \"{{ range(0, 48) | random | int }}\"" in block
     assert 'minutes: "{{ blind_close_delay_minutes }}"' in block
+    assert "offset: -00:45:00" in block
+    assert "range(0, 24)" not in block
+    assert "range(5, 45)" not in block
     assert "action: cover.close_cover" in block
     assert "cover.owner_suite_blinds_ha" in block
+
+
+def test_close_owner_suite_blinds_sunset_path_does_not_require_open_state() -> None:
+    block = _automation_block(WINDOWS_PATH, "close_owner_suite_blinds_at_night")
+    sunset_marker = "              - condition: trigger\n                id: sunset"
+    sunset_branch = block.split(sunset_marker, 1)[1].split("          - conditions:", 1)[0]
+
+    assert "condition: state" not in sunset_branch
+    assert 'state: "open"' not in sunset_branch


### PR DESCRIPTION
## Summary
- restore the owner-suite blinds sunset close path so it no longer skips when the cover is not exactly `open` at trigger time
- randomize the close time across the requested window from 45 minutes before sunset through 2 minutes after sunset
- document the same behavior in the Allium night-routines spec and add regression coverage
- reconcile stale Z2M availability sensors left after the latest Z2M device removals so the full suite stays green

## Root cause
Commit `b881974a` added a `choose` branch for sunset recovery but gated the sunset close branch on `cover.owner_suite_blinds_ha` being exactly `open`. Covers briefly reporting `unknown`, `unavailable`, or another transitional state at the scheduled trigger skipped the close entirely.

## Validation
- `uv run --with pytest pytest tests/test_owner_suite_blinds_automation.py tests/test_allium_specs.py tests/test_night_routines_allium_alignment.py` -> 16 passed
- `uv run --with pytest pytest tests/test_z2m_availability_package.py` -> 17 passed
- `uv run --with pytest pytest` -> 365 passed
- `git diff --check` -> clean
- `allium check specs/night_routines.allium` -> 0 errors; existing warning/info diagnostics remain

Fixes #531
