### PR TITLE
[codex] Fix wake-up bedroom volume ramp

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1028,10 +1028,13 @@ script:
     sequence:
       - action: media_player.volume_set
         continue_on_error: true
-        data:
+        target:
           entity_id:
             - media_player.bedroom_sonos
+            - media_player.bedroom_sonos_2
             - media_player.bathroom_sonos
+            - media_player.bathroom_sonos_2
+        data:
           volume_level: 0.01
       - if:
           - condition: template
@@ -1052,10 +1055,13 @@ script:
             - alias: "Increase grouped wake-up volume by 0.01"
               continue_on_error: true
               action: media_player.volume_set
-              data:
+              target:
                 entity_id:
                   - media_player.bedroom_sonos
+                  - media_player.bedroom_sonos_2
                   - media_player.bathroom_sonos
+                  - media_player.bathroom_sonos_2
+              data:
                 volume_level: "{{ 0.01 * repeat.index }}"
             - delay:
                 seconds: "{{ (1/(tan(repeat.index/120))) | round(0, 'ceil', 5)}}"

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -301,8 +301,11 @@ automation:
               - delay:
                   seconds: 2
               - action: media_player.volume_set
+                target:
+                  entity_id:
+                    - media_player.bedroom_sonos
+                    - media_player.bedroom_sonos_2
                 data:
-                  entity_id: media_player.bedroom_sonos
                   volume_level: 0.2
               - delay:
                   seconds: 2

--- a/tests/test_alarm_night_allium_alignment.py
+++ b/tests/test_alarm_night_allium_alignment.py
@@ -116,6 +116,17 @@ def test_alarm_wake_up_has_distinct_weekday_weekend_and_meeting_branches() -> No
     ):
         assert token in block
 
+    assert re.search(
+        r"action: media_player\.volume_set\s+"
+        r"target:\s+"
+        r"entity_id:\s+"
+        r"- media_player\.bedroom_sonos\s+"
+        r"- media_player\.bedroom_sonos_2\s+"
+        r"data:\s+"
+        r"volume_level: 0\.2",
+        block,
+    )
+
 
 def test_snooze_cancel_and_rollover_cover_alarm_followup_semantics() -> None:
     snooze_automation = _automation_block(WORKDAY_PATH, "alarm_snooze")

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -224,6 +224,17 @@ def test_radio_wakeup_uses_guest_aware_sync_group_without_manual_regrouping() ->
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' not in block
 
 
+def test_radio_wakeup_ramps_legacy_and_music_assistant_bedroom_bathroom_players() -> None:
+    block = _script_block("music_assistant_radio_wake_up")
+
+    assert len(re.findall(r"^\s+- media_player\.bedroom_sonos$", block, re.MULTILINE)) == 2
+    assert len(re.findall(r"^\s+- media_player\.bedroom_sonos_2$", block, re.MULTILINE)) == 2
+    assert len(re.findall(r"^\s+- media_player\.bathroom_sonos$", block, re.MULTILINE)) == 2
+    assert len(re.findall(r"^\s+- media_player\.bathroom_sonos_2$", block, re.MULTILINE)) == 2
+    assert "volume_level: 0.01" in block
+    assert 'volume_level: "{{ 0.01 * repeat.index }}"' in block
+
+
 def test_spotify_wakeup_uses_guest_aware_sync_group_without_manual_regrouping() -> None:
     block = _script_block("spotify_wake_up")
 


### PR DESCRIPTION
## Summary
- Target both legacy Sonos and Music Assistant `_2` bedroom/bathroom entities during the radio wake-up volume ramp.
- Update the special meeting alarm volume set to include the Music Assistant bedroom player.
- Add regression tests covering the wake-up ramp and meeting alarm volume targets.

## Root Cause
Wake-up playback runs through the Music Assistant-backed `_2` players, but the radio alarm ramp only adjusted the legacy Sonos entities. That let the bedroom Music Assistant player stay near 1% while the bathroom path could still reach 30%.

## Validation
- `uv run --with pytest pytest tests/test_media_player_music_assistant.py tests/test_alarm_night_allium_alignment.py` - 35 passed
- `uv run --with pytest pytest` - 366 passed