### PR TITLE
[codex] Disable EnCh battery notifications

### DIFF
--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -498,17 +498,19 @@ thermostat_stats:
 #   module: group_all
 #   class: GroupAll
 
-ench:
-  module: ench
-  class: EnCh
-  notify: notify.all
-  show_friendly_name: false
-  # exclude:
-  #   - sensor.out_of_order
-  #   - binary_sensor.always_unavailable
-  battery:
-    interval_min: 360
-    min_level: 10
+# Disabled because the EnCh battery scan duplicates the batteries package and
+# reports the package's aggregate monitor sensors as low batteries.
+# ench:
+#   module: ench
+#   class: EnCh
+#   notify: notify.all
+#   show_friendly_name: false
+#   exclude:
+#     - sensor.out_of_order
+#     - binary_sensor.always_unavailable
+#   battery:
+#     interval_min: 360
+#     min_level: 10
 
 follow_laundry_room:
   # Office does not using a bound zigbee group to control the floor lamp

--- a/tests/test_appdaemon_ench.py
+++ b/tests/test_appdaemon_ench.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+APPDAEMON_APPS_PATH = Path(__file__).resolve().parents[1] / "appdaemon" / "apps" / "apps.yaml"
+
+
+def _top_level_block(config: str, key: str) -> str:
+    match = re.search(
+        rf"^{re.escape(key)}:\n(.*?)(?=^[A-Za-z0-9_]+:|\Z)",
+        config,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group(0) if match else ""
+
+
+def test_ench_battery_notifications_remain_disabled() -> None:
+    config = APPDAEMON_APPS_PATH.read_text(encoding="utf-8")
+    ench_block = _top_level_block(config, "ench")
+
+    assert "\n  battery:" not in ench_block


### PR DESCRIPTION
## Summary
- disable the active EnCh AppDaemon app so it stops running the generic battery scanner
- document why EnCh is disabled: it reports aggregate battery monitor counts as fake battery percentages
- add regression coverage to keep an active `ench:` battery block from returning

Closes #534

## Validation
- `uv run --with pytest pytest` -> 366 passed
- `python3 /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py appdaemon/apps/apps.yaml --strict` -> no findings
- live HA/AppDaemon verified via SSH: EnCh config is commented out and AppDaemon logged `App config deleted: ench` / `Stopped app 'ench'`\n\n## Coverage\n- `tests/test_appdaemon_ench.py` asserts a top-level active EnCh app does not contain a `battery:` block.