### PR TITLE
[codex] Guard bed_side_predictor disablement

### DIFF
--- a/tests/test_appdaemon_bed_side_predictor.py
+++ b/tests/test_appdaemon_bed_side_predictor.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+APPDAEMON_APPS_PATH = Path(__file__).resolve().parents[1] / "appdaemon" / "apps" / "apps.yaml"
+
+
+def _top_level_block(config: str, key: str) -> str:
+    match = re.search(
+        rf"^{re.escape(key)}:\n(.*?)(?=^[A-Za-z0-9_]+:|\Z)",
+        config,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group(0) if match else ""
+
+
+def test_bed_side_predictor_remains_disabled() -> None:
+    config = APPDAEMON_APPS_PATH.read_text(encoding="utf-8")
+    block = _top_level_block(config, "bed_side_predictor")
+
+    assert "module: bed_side_predictor" not in block


### PR DESCRIPTION
## Summary
- add regression coverage that keeps the AppDaemon `bed_side_predictor` app disabled
- verify live AppDaemon now has the block commented out to avoid the missing-`sklearn` failed import

Closes #536

## Validation
- `uv run --with pytest pytest` -> 367 passed
- `python3 /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py appdaemon/apps/apps.yaml --strict` -> no findings
- live HA/AppDaemon verified via SSH after restart: startup list excludes `bed_side_predictor` and no new failed import is logged

## Coverage
- `tests/test_appdaemon_bed_side_predictor.py` asserts an active top-level `bed_side_predictor:` app does not contain `module: bed_side_predictor`.