### PR TITLE
Fix PARASOLL persistent issues: unbind genPollCtrl + enforce zoneStatus reporting

### DIFF
--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -128,6 +128,8 @@ automation:
       - delay:
           seconds: 5
       - variables:
+          _ieee: "{{ trigger.payload_json.data.ieee_address }}"
+          _name: "{{ trigger.payload_json.data.friendly_name }}"
           parasoll_identify_btn: >
             {% set ieee = trigger.payload_json.data.ieee_address %}
             {% set ns = namespace(entity='') %}
@@ -151,11 +153,15 @@ automation:
               entity_id: "{{ parasoll_identify_btn }}"
           - delay:
               seconds: 2
+      - action: notify.mobile_app_wethop
+        data:
+          title: "PARASOLL"
+          message: "Reconfiguring {{ _name }}…"
       - action: mqtt.publish
         data:
           topic: zigbee2mqtt/bridge/request/device/unbind
           payload: >
-            {"from": "{{ trigger.payload_json.data.ieee_address }}",
+            {"from": "{{ _ieee }}",
              "from_endpoint": "1", "to": "Coordinator",
              "clusters": ["genPollCtrl"]}
       - delay:
@@ -163,4 +169,23 @@ automation:
       - action: mqtt.publish
         data:
           topic: zigbee2mqtt/bridge/request/device/configure
-          payload: '{"id": "{{ trigger.payload_json.data.ieee_address }}"}'
+          payload: '{"id": "{{ _ieee }}"}'
+      - wait_for_trigger:
+          - platform: mqtt
+            topic: zigbee2mqtt/bridge/response/device/configure
+            value_template: "{{ value_json.data.get('id') == _ieee }}"
+        timeout:
+          seconds: 60
+        continue_on_timeout: true
+      - action: notify.mobile_app_wethop
+        data:
+          title: "PARASOLL"
+          message: >
+            {% set resp = wait.trigger.payload_json if wait.trigger else none %}
+            {% if resp and resp.get('status') == 'ok' %}
+              ✓ {{ _name }} — all settings applied
+            {% elif resp %}
+              ✗ {{ _name }} — {{ resp.get('data', {}).get('error', 'configure failed') }}
+            {% else %}
+              ⏳ {{ _name }} — configure queued (sleepy; settings apply on next wakeup)
+            {% endif %}

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -62,6 +62,19 @@ script:
                     entity_id: "{{ repeat.item.identify }}"
             - delay:
                 milliseconds: 500
+            # Unbind genPollCtrl — devices paired with the stock converter
+            # retain this binding even after the patched converter is loaded.
+            # genPollCtrl is the cluster that writes an aggressive check-in
+            # interval and is the primary cause of rapid battery drain.
+            - action: mqtt.publish
+              data:
+                topic: zigbee2mqtt/bridge/request/device/unbind
+                payload: >
+                  {"from": "{{ repeat.item.ieee }}", "from_endpoint": "1",
+                   "to": "Coordinator",
+                   "clusters": ["genPollCtrl"]}
+            - delay:
+                milliseconds: 500
             - action: mqtt.publish
               data:
                 topic: zigbee2mqtt/bridge/request/device/configure
@@ -138,6 +151,15 @@ automation:
               entity_id: "{{ parasoll_identify_btn }}"
           - delay:
               seconds: 2
+      - action: mqtt.publish
+        data:
+          topic: zigbee2mqtt/bridge/request/device/unbind
+          payload: >
+            {"from": "{{ trigger.payload_json.data.ieee_address }}",
+             "from_endpoint": "1", "to": "Coordinator",
+             "clusters": ["genPollCtrl"]}
+      - delay:
+          milliseconds: 500
       - action: mqtt.publish
         data:
           topic: zigbee2mqtt/bridge/request/device/configure

--- a/zigbee2mqtt/external_converters/parasoll.js
+++ b/zigbee2mqtt/external_converters/parasoll.js
@@ -28,9 +28,23 @@ module.exports = {
     // Explicitly bind ssIasZone — the missing binding is the root cause of
     // sensors silently stopping state reports after a few hours.
     bindCluster({ cluster: "ssIasZone", clusterType: "input" }),
-    iasZoneAlarm({ zoneType: "contact", zoneAttributes: ["alarm_1"] }),
+    iasZoneAlarm({
+      zoneType: "contact",
+      zoneAttributes: ["alarm_1"],
+      // Required so configure sets up zoneStatus attribute reporting on ep2.
+      // Without this, sensors that have never had the interval bounded will
+      // silently oversleep at the factory default of 65000 s (~18 h) and drop
+      // off the network. The blueprint automation then tightens max to 14400 s.
+      zoneStatusReporting: true,
+    }),
     identify({ isSleepy: true }),
-    battery(),
+    battery({
+      // Enable voltage so both batteryVoltage and batteryPercentageRemaining
+      // are reported and visible in HA — matches what the stock IKEA converter
+      // configures and ensures the blueprint can enforce intervals on both.
+      voltage: true,
+      voltageReporting: true,
+    }),
     // genPollCtrl deliberately omitted — binding it writes an aggressive
     // check-in interval that drains AAA batteries in days/weeks.
   ],


### PR DESCRIPTION
## Summary

Follow-up to #429. Inspecting live Z2M device data (Mailbox and Kitchen/Bay North Window) revealed two issues that survive the original fix:

- **`genPollCtrl` is still bound on ep1** for all sensors paired before the patched converter was deployed. Z2M's `configure` command only adds bindings — it never removes them — so the aggressive check-in interval that drains batteries in days/weeks was still active.
- **`zoneStatus` reporting on ep2 is completely absent** on many sensors (e.g. Kitchen/Bay North showed \"Endpoint 2: None\"). `iasZoneAlarm` was called without `zoneStatusReporting: true`, so configure never set up interval reporting. Those sensors sleep at the factory-default max of 65000 s (~18 h) and drop off the mesh.

## Changes

### `zigbee2mqtt/external_converters/parasoll.js`
- `iasZoneAlarm`: added `zoneStatusReporting: true` — `configure` now sets up `ssIasZone/zoneStatus` attribute reporting on ep2
- `battery()`: added `voltage: true, voltageReporting: true` — matches the stock IKEA definition; ensures the blueprint can enforce intervals on both battery attributes

### `packages/parasoll_fix.yaml`
- Both the bulk `parasoll_reconfigure_all` script and the join/announce automation now publish `bridge/request/device/unbind` for `genPollCtrl` on ep1 **before** the `configure` command

## Companion (HA-side, no file change)

Blueprint `jhenkens/ikea_sensor_reporting_interval_enforcer_z2m.yaml` was imported and an automation created with `zone_max=14400 s` (4 h). This tightens the factory-default 65000 s max interval that `configure` leaves in place, so sensors send a heartbeat at least every 4 hours and cannot silently disappear.

## Run order after merge

1. Restart Z2M (picks up updated converter)
2. Run `script.parasoll_reconfigure_all` — unbinds `genPollCtrl` and reconfigures reporting on all 18 sensors (trigger each sensor once first to wake it)
3. Trigger **PARASOLL - Reporting Interval Enforcer** automation and walk each sensor to enforce `zone_max=14400`

## References

- Upstream issue: https://github.com/Koenkk/zigbee2mqtt/issues/22579 — community confirmed setting `zoneStatus` max to 7200–14400 s resolves drop-offs
- Blueprint author confirmed 3 weeks stable with `zone_max=14400` and 26 Parasoll sensors