### PR TITLE
[codex] Allow weekday alarm before meeting reminder

### DIFF
--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -240,9 +240,17 @@ automation:
               - condition: state
                 entity_id: input_boolean.weekday_alarm_on
                 state: "on"
-              - condition: state
-                entity_id: input_boolean.special_meeting
-                state: "off"
+              - condition: or
+                conditions:
+                  - condition: state
+                    entity_id: input_boolean.special_meeting
+                    state: "off"
+                  - condition: template
+                    alias: "weekday alarm is before meeting reminder"
+                    value_template: >-
+                      {% set weekday_alarm_timestamp = state_attr('input_datetime.weekday_alarm', 'timestamp') | int(0) %}
+                      {% set meeting_alarm_timestamp = state_attr('input_datetime.next_work_meeting', 'timestamp') | int(0) %}
+                      {{ weekday_alarm_timestamp > 0 and meeting_alarm_timestamp > 0 and weekday_alarm_timestamp < meeting_alarm_timestamp }}
             sequence:
               - parallel:
                   - action: script.turn_on

--- a/specs/alarm_wakeup.allium
+++ b/specs/alarm_wakeup.allium
@@ -147,7 +147,9 @@ rule TriggerWeekdayWakeup {
     when: wakeup.weekday_alarm_time <= now
     requires: calendar.today_is_workday
     requires: wakeup.weekday_alarm_enabled
-    requires: not wakeup.special_meeting_enabled
+    requires:
+        not wakeup.special_meeting_enabled
+        or wakeup.weekday_alarm_time < wakeup.next_work_meeting_alarm_time
     requires: wakeup_context.resident_home
     requires: not wakeup_context.planned_vacation_active
     requires: wakeup_context.resident_in_bed

--- a/tests/test_alarm_night_allium_alignment.py
+++ b/tests/test_alarm_night_allium_alignment.py
@@ -128,6 +128,22 @@ def test_alarm_wake_up_has_distinct_weekday_weekend_and_meeting_branches() -> No
     )
 
 
+def test_weekday_alarm_runs_when_it_is_before_meeting_reminder() -> None:
+    spec_text = (ROOT / "specs" / "alarm_wakeup.allium").read_text(encoding="utf-8")
+    block = _automation_block(WORKDAY_PATH, "alarm_wake_up")
+
+    assert "or wakeup.weekday_alarm_time < wakeup.next_work_meeting_alarm_time" in spec_text
+
+    for token in (
+        "condition: or",
+        "weekday alarm is before meeting reminder",
+        "state_attr('input_datetime.weekday_alarm', 'timestamp') | int(0)",
+        "state_attr('input_datetime.next_work_meeting', 'timestamp') | int(0)",
+        "weekday_alarm_timestamp < meeting_alarm_timestamp",
+    ):
+        assert token in block
+
+
 def test_snooze_cancel_and_rollover_cover_alarm_followup_semantics() -> None:
     snooze_automation = _automation_block(WORKDAY_PATH, "alarm_snooze")
     cancel_automation = _automation_block(WORKDAY_PATH, "cancel_alarms")


### PR DESCRIPTION
## Summary
- let the normal weekday alarm run even when `special_meeting` is enabled if the weekday alarm time is earlier than the meeting reminder time
- update the alarm wake-up Allium spec to match that behavior
- add regression coverage for the weekday-before-meeting condition

## Why
The current logic suppresses the normal workday alarm whenever `special_meeting` is on. That causes the weekday alarm at 8:20 AM to be skipped when a later meeting reminder exists at 8:50 AM, even though the normal wake-up should still happen first.

## Validation
- `uv run --with pytest pytest tests/test_alarm_night_allium_alignment.py` - passed
- `uv run --with pytest pytest` - failed on an unrelated existing issue: `tests/test_input_text_limits.py` reporting `packages/parasoll_fix.yaml:parasoll_config_state=3000`

## Scope
This PR only changes the weekday alarm gating logic and its spec/test coverage. It does not modify the unrelated `parasoll_fix.yaml` helper that is currently breaking the full local test run.