### PR TITLE
Skip reconfigure when device config is provably current

### DIFF
--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -16,6 +16,19 @@
 #      the automation below handles them automatically as they re-join.
 
 ################################################################
+## Helpers
+################################################################
+
+input_text:
+  parasoll_config_state:
+    name: "PARASOLL Configuration State"
+    # JSON dict: { "<ieee>": { "configured_at": "<iso>", "notified_at": "<iso>" } }
+    # Written by the automation after each successful configure / notification.
+    # Used to skip redundant reconfigures and suppress repeat notifications.
+    max: 3000
+    initial: "{}"
+
+################################################################
 ## Scripts
 ################################################################
 
@@ -91,13 +104,12 @@ automation:
     id: parasoll_auto_reconfigure_on_join
     description: >
       Reconfigures PARASOLL sensors on three events:
-        • device_interview  — brand-new join, model E2013
-        • device_announce   — re-join after battery pull / reconnect
-        • contact_change    — any Z2M message containing a contact field from a
-                              known PARASOLL device (silent; device is already
-                              awake so commands land immediately)
-      Join/announce path: waits 5 s, presses identify, sends notifications.
-      Contact-change path: acts within 1 s, no notifications (idempotent).
+        • device_interview  — brand-new join, model E2013 (always reconfigures)
+        • device_announce   — re-join after battery pull / reconnect (always reconfigures)
+        • contact_change    — any Z2M message with a contact field from a known
+                              PARASOLL device (skipped if configured within 6 h)
+      Notifications are suppressed for 1 h per device after the last one sent,
+      regardless of trigger type. contact_change is always silent.
       No hardcoded entity list — new sensors are picked up automatically.
     mode: queued
     max: 10
@@ -155,6 +167,8 @@ automation:
       # before it goes back to sleep and Z2M loses the unbind command.
       - delay:
           milliseconds: "{{ 5000 if trigger.id == 'bridge_event' else 0 }}"
+
+      # ── Resolve device identity ──────────────────────────────────────────────
       - variables:
           _silent: "{{ trigger.id == 'contact_change' }}"
           _ieee: >
@@ -193,58 +207,119 @@ automation:
               {% endif %}
             {% endfor %}
             {{ ns.entity }}
-      # Press identify only on join/announce to nudge the device awake.
-      # On contact_change the device is already awake — no need.
+
+      # ── Check per-device cooldowns from persistent store ─────────────────────
+      - variables:
+          _store: >
+            {{ (states('input_text.parasoll_config_state') or '{}') | from_json }}
+          _dev_state: "{{ _store.get(_ieee, {}) }}"
+          _last_configured: "{{ _dev_state.get('configured_at', '') }}"
+          _last_notified: "{{ _dev_state.get('notified_at', '') }}"
+          # bridge_event always reconfigures (device just re-joined, settings are gone).
+          # contact_change skips if configured within the last 6 h — settings are
+          # likely still correct; this prevents redundant work on every open/close.
+          _needs_configure: >
+            {% if trigger.id == 'bridge_event' %}
+              true
+            {% elif _last_configured == '' %}
+              true
+            {% else %}
+              {{ (now() - _last_configured | as_datetime).total_seconds() > 21600 }}
+            {% endif %}
+          # Suppress repeat notifications within 1 h per device.
+          # contact_change is always silent regardless.
+          _can_notify: >
+            {% if _silent %}
+              false
+            {% elif _last_notified == '' %}
+              true
+            {% else %}
+              {{ (now() - _last_notified | as_datetime).total_seconds() > 3600 }}
+            {% endif %}
+
+      # ── Skip if settings are current ─────────────────────────────────────────
       - if:
           - condition: template
-            value_template: "{{ parasoll_identify_btn != '' and not _silent }}"
+            value_template: "{{ _needs_configure }}"
         then:
-          - action: button.press
-            target:
-              entity_id: "{{ parasoll_identify_btn }}"
+          # Press identify only on join/announce to nudge the device awake.
+          # On contact_change the device is already awake — no need.
+          - if:
+              - condition: template
+                value_template: "{{ parasoll_identify_btn != '' and not _silent }}"
+            then:
+              - action: button.press
+                target:
+                  entity_id: "{{ parasoll_identify_btn }}"
+              - delay:
+                  seconds: 2
+
+          - if:
+              - condition: template
+                value_template: "{{ _can_notify }}"
+            then:
+              - action: notify.mobile_app_wethop
+                data:
+                  title: "PARASOLL"
+                  message: "Reconfiguring {{ _name }}…"
+
+          - action: mqtt.publish
+            data:
+              topic: zigbee2mqtt/bridge/request/device/unbind
+              payload: >
+                {"from": "{{ _ieee }}",
+                 "from_endpoint": "1", "to": "Coordinator",
+                 "clusters": ["genPollCtrl"]}
           - delay:
-              seconds: 2
-      - if:
-          - condition: template
-            value_template: "{{ not _silent }}"
-        then:
-          - action: notify.mobile_app_wethop
+              milliseconds: 500
+          - action: mqtt.publish
             data:
-              title: "PARASOLL"
-              message: "Reconfiguring {{ _name }}…"
-      - action: mqtt.publish
-        data:
-          topic: zigbee2mqtt/bridge/request/device/unbind
-          payload: >
-            {"from": "{{ _ieee }}",
-             "from_endpoint": "1", "to": "Coordinator",
-             "clusters": ["genPollCtrl"]}
-      - delay:
-          milliseconds: 500
-      - action: mqtt.publish
-        data:
-          topic: zigbee2mqtt/bridge/request/device/configure
-          payload: '{"id": "{{ _ieee }}"}'
-      - wait_for_trigger:
-          - platform: mqtt
-            topic: zigbee2mqtt/bridge/response/device/configure
-            value_template: "{{ value_json.data.get('id') == _ieee }}"
-        timeout:
-          seconds: 60
-        continue_on_timeout: true
-      - if:
-          - condition: template
-            value_template: "{{ not _silent }}"
-        then:
-          - action: notify.mobile_app_wethop
-            data:
-              title: "PARASOLL"
-              message: >
+              topic: zigbee2mqtt/bridge/request/device/configure
+              payload: '{"id": "{{ _ieee }}"}'
+          - wait_for_trigger:
+              - platform: mqtt
+                topic: zigbee2mqtt/bridge/response/device/configure
+                value_template: "{{ value_json.data.get('id') == _ieee }}"
+            timeout:
+              seconds: 60
+            continue_on_timeout: true
+
+          # ── Update persistent store ───────────────────────────────────────────
+          # configured_at is stamped only on a successful response — a failed or
+          # queued configure leaves it unset so the next trigger retries.
+          # notified_at is stamped whenever a notification was sent this run.
+          - variables:
+              _configure_ok: >
                 {% set resp = wait.trigger.payload_json if wait.trigger else none %}
-                {% if resp and resp.get('status') == 'ok' %}
-                  ✓ {{ _name }} — all settings applied
-                {% elif resp %}
-                  ✗ {{ _name }} — {{ resp.get('data', {}).get('error', 'configure failed') }}
-                {% else %}
-                  ⏳ {{ _name }} — configure queued (sleepy; settings apply on next wakeup)
+                {{ resp is not none and resp.get('status') == 'ok' }}
+          - action: input_text.set_value
+            target:
+              entity_id: input_text.parasoll_config_state
+            data:
+              value: >
+                {% set store = (states('input_text.parasoll_config_state') or '{}') | from_json %}
+                {% set dev = store.get(_ieee, {}) %}
+                {% if _configure_ok %}
+                  {% set dev = dict(dev, **{'configured_at': now().isoformat()}) %}
                 {% endif %}
+                {% if _can_notify %}
+                  {% set dev = dict(dev, **{'notified_at': now().isoformat()}) %}
+                {% endif %}
+                {{ dict(store, **{_ieee: dev}) | tojson }}
+
+          - if:
+              - condition: template
+                value_template: "{{ _can_notify }}"
+            then:
+              - action: notify.mobile_app_wethop
+                data:
+                  title: "PARASOLL"
+                  message: >
+                    {% set resp = wait.trigger.payload_json if wait.trigger else none %}
+                    {% if resp and resp.get('status') == 'ok' %}
+                      ✓ {{ _name }} — all settings applied
+                    {% elif resp %}
+                      ✗ {{ _name }} — {{ resp.get('data', {}).get('error', 'configure failed') }}
+                    {% else %}
+                      ⏳ {{ _name }} — configure queued (sleepy; settings apply on next wakeup)
+                    {% endif %}

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -93,40 +93,43 @@ automation:
       Reconfigures PARASOLL sensors on three events:
         • device_interview  — brand-new join, model E2013
         • device_announce   — re-join after battery pull / reconnect
-        • contact_change    — any Z2M message containing a contact field from a
-                              known PARASOLL device (silent; device is already
-                              awake so commands land immediately)
+        • contact_change    — window/door opened or closed (silent; device is
+                              already awake so commands land immediately)
       Join/announce path: waits 5 s, presses identify, sends notifications.
       Contact-change path: acts within 1 s, no notifications (idempotent).
-      No hardcoded entity list — new sensors are picked up automatically.
+      Add new PARASOLL entity IDs to the contact_change trigger list when pairing.
     mode: queued
     max: 10
     trigger:
       - platform: mqtt
         topic: zigbee2mqtt/bridge/event
         id: bridge_event
-      # Single-level wildcard matches per-device topics (e.g. zigbee2mqtt/Office
-      # Window) but NOT zigbee2mqtt/bridge/event or deeper sub-topics.
-      - platform: mqtt
-        topic: "zigbee2mqtt/+"
+      - platform: state
+        entity_id:
+          - binary_sensor.mailbox_contact
+          - binary_sensor.powder_room_window_contact
+          - binary_sensor.dining_room_south_window_contact
+          - binary_sensor.dining_room_north_window_contact
+          - binary_sensor.kitchen_north_window_contact
+          - binary_sensor.kitchen_south_window_contact
+          - binary_sensor.kitchen_bay_north_window_contact
+          - binary_sensor.owner_suite_north_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_north_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
+          - binary_sensor.office_window_contact
+          - binary_sensor.unfinished_basement_window_contact
+          - binary_sensor.basement_window_contact
+          - binary_sensor.guest_bathroom_window_contact
+          - binary_sensor.kitchen_bay_middle_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
+          - binary_sensor.owner_suite_south_window_contact
+          - binary_sensor.kitchen_bay_south_window_contact
         id: contact_change
     condition:
       - condition: template
         value_template: >
           {% if trigger.id == 'contact_change' %}
-            {% if 'contact' not in trigger.payload_json %}
-              false
-            {% else %}
-              {% set fname = trigger.topic | replace('zigbee2mqtt/', '') %}
-              {% set ns = namespace(found=false) %}
-              {% for entity in states.binary_sensor %}
-                {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor (patched)'
-                   and device_attr(entity.entity_id, 'name') == fname %}
-                  {% set ns.found = true %}
-                {% endif %}
-              {% endfor %}
-              {{ ns.found }}
-            {% endif %}
+            true
           {% else %}
             {% set type = trigger.payload_json.type %}
             {% set ieee = trigger.payload_json.data.ieee_address %}
@@ -160,16 +163,10 @@ automation:
             {% if trigger.id == 'bridge_event' %}
               {{ trigger.payload_json.data.ieee_address }}
             {% else %}
-              {% set fname = trigger.topic | replace('zigbee2mqtt/', '') %}
               {% set ns = namespace(value='') %}
-              {% for entity in states.binary_sensor %}
-                {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor (patched)'
-                   and device_attr(entity.entity_id, 'name') == fname %}
-                  {% for id_tuple in device_attr(entity.entity_id, 'identifiers') | list %}
-                    {% if id_tuple[0] == 'mqtt' %}
-                      {% set ns.value = id_tuple[1] | replace('zigbee2mqtt_', '') %}
-                    {% endif %}
-                  {% endfor %}
+              {% for id_tuple in device_attr(trigger.entity_id, 'identifiers') | list %}
+                {% if id_tuple[0] == 'mqtt' %}
+                  {% set ns.value = id_tuple[1] | replace('zigbee2mqtt_', '') %}
                 {% endif %}
               {% endfor %}
               {{ ns.value }}
@@ -178,7 +175,7 @@ automation:
             {% if trigger.id == 'bridge_event' %}
               {{ trigger.payload_json.data.friendly_name }}
             {% else %}
-              {{ trigger.topic | replace('zigbee2mqtt/', '') }}
+              {{ device_attr(trigger.entity_id, 'name') }}
             {% endif %}
           parasoll_identify_btn: >
             {% set ns = namespace(entity='') %}

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -134,6 +134,8 @@ automation:
           - binary_sensor.dining_room_south_window_contact
           - binary_sensor.guest_bathroom_window_contact
           - binary_sensor.guest_room_window_contact
+          # TODO: rename to binary_sensor.kitchen_bay_middle_window_contact once
+          # the HA entity registry rename task is complete (malformed autodiscovery ID).
           - binary_sensor.kitchen_bay_middle_window_kitchen_bay_middle_window
           - binary_sensor.kitchen_bay_north_window_contact
           - binary_sensor.kitchen_bay_south_window_contact

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -151,9 +151,10 @@ automation:
           {% endif %}
     action:
       # Join/announce: wait for Z2M to finish interview setup.
-      # Contact-change: device is already awake — act within 1 s.
+      # Contact-change: no delay — device is awake right now; every ms counts
+      # before it goes back to sleep and Z2M loses the unbind command.
       - delay:
-          milliseconds: "{{ 5000 if trigger.id == 'bridge_event' else 1000 }}"
+          milliseconds: "{{ 5000 if trigger.id == 'bridge_event' else 0 }}"
       - variables:
           _silent: "{{ trigger.id == 'contact_change' }}"
           _ieee: >

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -108,6 +108,8 @@ script:
 automation:
   - alias: "PARASOLL - Auto-Reconfigure on Join or Announce"
     id: parasoll_auto_reconfigure_on_join
+    trace:
+      stored_traces: 200
     description: >
       Reconfigures PARASOLL sensors only when actually needed:
         • device_interview  — brand-new join (always reconfigures; settings definitely lost)

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -128,6 +128,8 @@ automation:
       - delay:
           seconds: 5
       - variables:
+          _ieee: "{{ trigger.payload_json.data.ieee_address }}"
+          _name: "{{ trigger.payload_json.data.friendly_name }}"
           parasoll_identify_btn: >
             {% set ieee = trigger.payload_json.data.ieee_address %}
             {% set ns = namespace(entity='') %}
@@ -151,11 +153,15 @@ automation:
               entity_id: "{{ parasoll_identify_btn }}"
           - delay:
               seconds: 2
+      - action: notify.mobile_app_wethop
+        data:
+          title: "PARASOLL"
+          message: "Reconfiguring {{ _name }}…"
       - action: mqtt.publish
         data:
           topic: zigbee2mqtt/bridge/request/device/unbind
           payload: >
-            {"from": "{{ trigger.payload_json.data.ieee_address }}",
+            {"from": "{{ _ieee }}",
              "from_endpoint": "1", "to": "Coordinator",
              "clusters": ["genPollCtrl"]}
       - delay:
@@ -163,4 +169,23 @@ automation:
       - action: mqtt.publish
         data:
           topic: zigbee2mqtt/bridge/request/device/configure
-          payload: '{"id": "{{ trigger.payload_json.data.ieee_address }}"}'
+          payload: '{"id": "{{ _ieee }}"}'
+      - wait_for_trigger:
+          - platform: mqtt
+            topic: zigbee2mqtt/bridge/response/device/configure
+            value_template: "{{ value_json.data.get('id') == _ieee }}"
+        timeout:
+          seconds: 60
+        continue_on_timeout: true
+      - action: notify.mobile_app_wethop
+        data:
+          title: "PARASOLL"
+          message: >
+            {% set resp = wait.trigger.payload_json if wait.trigger else none %}
+            {% if resp and resp.get('status') == 'ok' %}
+              ✓ {{ _name }} — all settings applied
+            {% elif resp %}
+              ✗ {{ _name }} — {{ resp.get('data', {}).get('error', 'configure failed') }}
+            {% else %}
+              ⏳ {{ _name }} — configure queued (sleepy; settings apply on next wakeup)
+            {% endif %}

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -93,42 +93,40 @@ automation:
       Reconfigures PARASOLL sensors on three events:
         • device_interview  — brand-new join, model E2013
         • device_announce   — re-join after battery pull / reconnect
-        • contact_change    — window/door opened or closed (silent; device is
-                              already awake so commands land immediately)
+        • contact_change    — any Z2M message containing a contact field from a
+                              known PARASOLL device (silent; device is already
+                              awake so commands land immediately)
       Join/announce path: waits 5 s, presses identify, sends notifications.
       Contact-change path: acts within 1 s, no notifications (idempotent).
+      No hardcoded entity list — new sensors are picked up automatically.
     mode: queued
     max: 10
     trigger:
       - platform: mqtt
         topic: zigbee2mqtt/bridge/event
         id: bridge_event
-      - platform: state
-        entity_id:
-          - binary_sensor.mailbox_contact
-          - binary_sensor.powder_room_window_contact
-          - binary_sensor.dining_room_south_window_contact
-          - binary_sensor.dining_room_north_window_contact
-          - binary_sensor.kitchen_north_window_contact
-          - binary_sensor.kitchen_south_window_contact
-          - binary_sensor.kitchen_bay_north_window_contact
-          - binary_sensor.owner_suite_north_window_contact
-          - binary_sensor.owner_suite_bathroom_bay_north_window_contact
-          - binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
-          - binary_sensor.office_window_contact
-          - binary_sensor.unfinished_basement_window_contact
-          - binary_sensor.basement_window_contact
-          - binary_sensor.guest_bathroom_window_contact
-          - binary_sensor.kitchen_bay_middle_window_contact
-          - binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
-          - binary_sensor.owner_suite_south_window_contact
-          - binary_sensor.kitchen_bay_south_window_contact
+      # Single-level wildcard matches per-device topics (e.g. zigbee2mqtt/Office
+      # Window) but NOT zigbee2mqtt/bridge/event or deeper sub-topics.
+      - platform: mqtt
+        topic: "zigbee2mqtt/+"
         id: contact_change
     condition:
       - condition: template
         value_template: >
           {% if trigger.id == 'contact_change' %}
-            true
+            {% if 'contact' not in trigger.payload_json %}
+              false
+            {% else %}
+              {% set fname = trigger.topic | replace('zigbee2mqtt/', '') %}
+              {% set ns = namespace(found=false) %}
+              {% for entity in states.binary_sensor %}
+                {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor (patched)'
+                   and device_attr(entity.entity_id, 'name') == fname %}
+                  {% set ns.found = true %}
+                {% endif %}
+              {% endfor %}
+              {{ ns.found }}
+            {% endif %}
           {% else %}
             {% set type = trigger.payload_json.type %}
             {% set ieee = trigger.payload_json.data.ieee_address %}
@@ -162,10 +160,16 @@ automation:
             {% if trigger.id == 'bridge_event' %}
               {{ trigger.payload_json.data.ieee_address }}
             {% else %}
+              {% set fname = trigger.topic | replace('zigbee2mqtt/', '') %}
               {% set ns = namespace(value='') %}
-              {% for id_tuple in device_attr(trigger.entity_id, 'identifiers') | list %}
-                {% if id_tuple[0] == 'mqtt' %}
-                  {% set ns.value = id_tuple[1] | replace('zigbee2mqtt_', '') %}
+              {% for entity in states.binary_sensor %}
+                {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor (patched)'
+                   and device_attr(entity.entity_id, 'name') == fname %}
+                  {% for id_tuple in device_attr(entity.entity_id, 'identifiers') | list %}
+                    {% if id_tuple[0] == 'mqtt' %}
+                      {% set ns.value = id_tuple[1] | replace('zigbee2mqtt_', '') %}
+                    {% endif %}
+                  {% endfor %}
                 {% endif %}
               {% endfor %}
               {{ ns.value }}
@@ -174,7 +178,7 @@ automation:
             {% if trigger.id == 'bridge_event' %}
               {{ trigger.payload_json.data.friendly_name }}
             {% else %}
-              {{ device_attr(trigger.entity_id, 'name') }}
+              {{ trigger.topic | replace('zigbee2mqtt/', '') }}
             {% endif %}
           parasoll_identify_btn: >
             {% set ns = namespace(entity='') %}

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -90,73 +90,123 @@ automation:
   - alias: "PARASOLL - Auto-Reconfigure on Join or Announce"
     id: parasoll_auto_reconfigure_on_join
     description: >
-      Watches Z2M bridge events and sends a reconfigure request when:
-        • A brand-new PARASOLL joins (device_interview event, model E2013).
-        • A known PARASOLL re-announces after a battery pull or reconnect
-          (device_announce event, cross-checked against HA device registry).
-      Waits 5 s for Z2M to finish setup, presses identify to keep the device
-      awake, waits 2 s more, then sends configure.
+      Reconfigures PARASOLL sensors on three events:
+        • device_interview  — brand-new join, model E2013
+        • device_announce   — re-join after battery pull / reconnect
+        • contact_change    — window/door opened or closed (silent; device is
+                              already awake so commands land immediately)
+      Join/announce path: waits 5 s, presses identify, sends notifications.
+      Contact-change path: acts within 1 s, no notifications (idempotent).
     mode: queued
     max: 10
     trigger:
       - platform: mqtt
         topic: zigbee2mqtt/bridge/event
+        id: bridge_event
+      - platform: state
+        entity_id:
+          - binary_sensor.mailbox_contact
+          - binary_sensor.powder_room_window_contact
+          - binary_sensor.dining_room_south_window_contact
+          - binary_sensor.dining_room_north_window_contact
+          - binary_sensor.kitchen_north_window_contact
+          - binary_sensor.kitchen_south_window_contact
+          - binary_sensor.kitchen_bay_north_window_contact
+          - binary_sensor.owner_suite_north_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_north_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
+          - binary_sensor.office_window_contact
+          - binary_sensor.unfinished_basement_window_contact
+          - binary_sensor.basement_window_contact
+          - binary_sensor.guest_bathroom_window_contact
+          - binary_sensor.kitchen_bay_middle_window_kitchen_bay_middle_window
+          - binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
+          - binary_sensor.owner_suite_south_window_contact
+          - binary_sensor.kitchen_bay_south_window_contact
+        id: contact_change
     condition:
       - condition: template
         value_template: >
-          {% set type = trigger.payload_json.type %}
-          {% set ieee = trigger.payload_json.data.ieee_address %}
-          {% if type == 'device_interview' %}
-            {{ trigger.payload_json.data.get('definition', {}).get('model', '') == 'E2013' }}
-          {% elif type == 'device_announce' %}
-            {% set ns = namespace(found=false) %}
-            {% for entity in states.binary_sensor %}
-              {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor (patched)' %}
-                {% set ids = device_attr(entity.entity_id, 'identifiers') | list %}
-                {% for id_tuple in ids %}
-                  {% if id_tuple[0] == 'mqtt' and id_tuple[1] == 'zigbee2mqtt_' ~ ieee %}
-                    {% set ns.found = true %}
-                  {% endif %}
-                {% endfor %}
-              {% endif %}
-            {% endfor %}
-            {{ ns.found }}
+          {% if trigger.id == 'contact_change' %}
+            true
           {% else %}
-            {{ false }}
+            {% set type = trigger.payload_json.type %}
+            {% set ieee = trigger.payload_json.data.ieee_address %}
+            {% if type == 'device_interview' %}
+              {{ trigger.payload_json.data.get('definition', {}).get('model', '') == 'E2013' }}
+            {% elif type == 'device_announce' %}
+              {% set ns = namespace(found=false) %}
+              {% for entity in states.binary_sensor %}
+                {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor (patched)' %}
+                  {% set ids = device_attr(entity.entity_id, 'identifiers') | list %}
+                  {% for id_tuple in ids %}
+                    {% if id_tuple[0] == 'mqtt' and id_tuple[1] == 'zigbee2mqtt_' ~ ieee %}
+                      {% set ns.found = true %}
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
+              {% endfor %}
+              {{ ns.found }}
+            {% else %}
+              {{ false }}
+            {% endif %}
           {% endif %}
     action:
+      # Join/announce: wait for Z2M to finish interview setup.
+      # Contact-change: device is already awake — act within 1 s.
       - delay:
-          seconds: 5
+          milliseconds: "{{ 5000 if trigger.id == 'bridge_event' else 1000 }}"
       - variables:
-          _ieee: "{{ trigger.payload_json.data.ieee_address }}"
-          _name: "{{ trigger.payload_json.data.friendly_name }}"
+          _silent: "{{ trigger.id == 'contact_change' }}"
+          _ieee: >
+            {% if trigger.id == 'bridge_event' %}
+              {{ trigger.payload_json.data.ieee_address }}
+            {% else %}
+              {% set ns = namespace(value='') %}
+              {% for id_tuple in device_attr(trigger.entity_id, 'identifiers') | list %}
+                {% if id_tuple[0] == 'mqtt' %}
+                  {% set ns.value = id_tuple[1] | replace('zigbee2mqtt_', '') %}
+                {% endif %}
+              {% endfor %}
+              {{ ns.value }}
+            {% endif %}
+          _name: >
+            {% if trigger.id == 'bridge_event' %}
+              {{ trigger.payload_json.data.friendly_name }}
+            {% else %}
+              {{ device_attr(trigger.entity_id, 'name') }}
+            {% endif %}
           parasoll_identify_btn: >
-            {% set ieee = trigger.payload_json.data.ieee_address %}
             {% set ns = namespace(entity='') %}
             {% for entity in states.button %}
               {% if 'identify' in entity.entity_id %}
-                {% set ids = device_attr(entity.entity_id, 'identifiers') | list %}
-                {% for id_tuple in ids %}
-                  {% if id_tuple[0] == 'mqtt' and id_tuple[1] == 'zigbee2mqtt_' ~ ieee %}
+                {% for id_tuple in device_attr(entity.entity_id, 'identifiers') | list %}
+                  {% if id_tuple[0] == 'mqtt' and id_tuple[1] == 'zigbee2mqtt_' ~ _ieee %}
                     {% set ns.entity = entity.entity_id %}
                   {% endif %}
                 {% endfor %}
               {% endif %}
             {% endfor %}
             {{ ns.entity }}
+      # Press identify only on join/announce to nudge the device awake.
+      # On contact_change the device is already awake — no need.
       - if:
           - condition: template
-            value_template: "{{ parasoll_identify_btn != '' }}"
+            value_template: "{{ parasoll_identify_btn != '' and not _silent }}"
         then:
           - action: button.press
             target:
               entity_id: "{{ parasoll_identify_btn }}"
           - delay:
               seconds: 2
-      - action: notify.mobile_app_wethop
-        data:
-          title: "PARASOLL"
-          message: "Reconfiguring {{ _name }}…"
+      - if:
+          - condition: template
+            value_template: "{{ not _silent }}"
+        then:
+          - action: notify.mobile_app_wethop
+            data:
+              title: "PARASOLL"
+              message: "Reconfiguring {{ _name }}…"
       - action: mqtt.publish
         data:
           topic: zigbee2mqtt/bridge/request/device/unbind
@@ -177,15 +227,19 @@ automation:
         timeout:
           seconds: 60
         continue_on_timeout: true
-      - action: notify.mobile_app_wethop
-        data:
-          title: "PARASOLL"
-          message: >
-            {% set resp = wait.trigger.payload_json if wait.trigger else none %}
-            {% if resp and resp.get('status') == 'ok' %}
-              ✓ {{ _name }} — all settings applied
-            {% elif resp %}
-              ✗ {{ _name }} — {{ resp.get('data', {}).get('error', 'configure failed') }}
-            {% else %}
-              ⏳ {{ _name }} — configure queued (sleepy; settings apply on next wakeup)
-            {% endif %}
+      - if:
+          - condition: template
+            value_template: "{{ not _silent }}"
+        then:
+          - action: notify.mobile_app_wethop
+            data:
+              title: "PARASOLL"
+              message: >
+                {% set resp = wait.trigger.payload_json if wait.trigger else none %}
+                {% if resp and resp.get('status') == 'ok' %}
+                  ✓ {{ _name }} — all settings applied
+                {% elif resp %}
+                  ✗ {{ _name }} — {{ resp.get('data', {}).get('error', 'configure failed') }}
+                {% else %}
+                  ⏳ {{ _name }} — configure queued (sleepy; settings apply on next wakeup)
+                {% endif %}

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -20,12 +20,18 @@
 ################################################################
 
 input_text:
-  parasoll_config_state:
-    name: "PARASOLL Configuration State"
-    # JSON dict: { "<ieee>": { "configured_at": "<iso>", "notified_at": "<iso>" } }
-    # Written by the automation after each successful configure / notification.
-    # Used to skip redundant reconfigures and suppress repeat notifications.
-    max: 3000
+  parasoll_configure_state:
+    name: "PARASOLL Configure State"
+    # Compact JSON: {"<last4_ieee>": <mod_hour>, ...}
+    # mod_hour = floor(unix_time / 3600) % 10000  — 4-digit cyclical counter
+    #            that wraps every ~416 days; cooldown checks use modular diff.
+    # Key is the last 4 hex chars of the device IEEE address, giving 65 536
+    # possible values — collision is extremely unlikely across ~20 home devices.
+    # Capacity: 21 devices fit within the 255-char HA state limit.
+    # Written only on a confirmed Z2M configure success.
+    # Used to gate contact_change reconfigure (>6 h) and bridge_event
+    # notifications (>1 h since last successful configure).
+    max: 255
     initial: "{}"
 
 ################################################################
@@ -108,9 +114,8 @@ automation:
         • device_announce   — re-join after battery pull / reconnect (always reconfigures)
         • contact_change    — any Z2M message with a contact field from a known
                               PARASOLL device (skipped if configured within 6 h)
-      Notifications are suppressed for 1 h per device after the last one sent,
-      regardless of trigger type. contact_change is always silent.
-      No hardcoded entity list — new sensors are picked up automatically.
+      Notifications gated by 1 h since last successful configure per device;
+      contact_change is always silent. No hardcoded entity list.
     mode: queued
     max: 10
     trigger:
@@ -208,36 +213,35 @@ automation:
             {% endfor %}
             {{ ns.entity }}
 
-      # ── Check per-device cooldowns from persistent store ─────────────────────
+      # ── Check per-device cooldowns ───────────────────────────────────────────
+      # Store format: {"<last4_ieee>": <mod_hour>}
+      # mod_hour = floor(unix/3600) % 10000.  Diff uses modular arithmetic to
+      # handle the ~416-day wraparound: (cur - prev) % 10000.
+      # Only a successful configure response updates the store, so a queued or
+      # failed configure leaves the slot empty and the next trigger retries.
+      # Notifications are gated by the same timestamp (1 h window); if configure
+      # keeps failing the user still receives alerts — which is the desired
+      # signal for a stuck device.
       - variables:
           _store: >
-            {{ (states('input_text.parasoll_config_state') or '{}') | from_json }}
-          _dev_state: "{{ _store.get(_ieee, {}) }}"
-          _last_configured: "{{ _dev_state.get('configured_at', '') }}"
-          _last_notified: "{{ _dev_state.get('notified_at', '') }}"
-          # bridge_event always reconfigures (device just re-joined, settings are gone).
-          # contact_change skips if configured within the last 6 h — settings are
-          # likely still correct; this prevents redundant work on every open/close.
+            {{ (states('input_text.parasoll_configure_state') or '{}') | from_json }}
+          _key: "{{ _ieee[-4:] }}"
+          _cur_h: "{{ (now().timestamp() / 3600) | int % 10000 }}"
+          _prev_h: "{{ _store.get(_ieee[-4:], 0) | int }}"
+          _hours_since: "{{ (_cur_h | int - _prev_h | int) % 10000 }}"
+          # bridge_event always reconfigures — device just re-joined and lost settings.
+          # contact_change skips if configured within the last 6 h.
           _needs_configure: >
             {% if trigger.id == 'bridge_event' %}
               true
-            {% elif _last_configured == '' %}
-              true
             {% else %}
-              {{ (now() - _last_configured | as_datetime).total_seconds() > 21600 }}
+              {{ _hours_since | int >= 6 }}
             {% endif %}
-          # Suppress repeat notifications within 1 h per device.
+          # Suppress notifications within 1 h of the last successful configure.
           # contact_change is always silent regardless.
-          _can_notify: >
-            {% if _silent %}
-              false
-            {% elif _last_notified == '' %}
-              true
-            {% else %}
-              {{ (now() - _last_notified | as_datetime).total_seconds() > 3600 }}
-            {% endif %}
+          _can_notify: "{{ not _silent and _hours_since | int >= 1 }}"
 
-      # ── Skip if settings are current ─────────────────────────────────────────
+      # ── Skip if settings are likely still current ─────────────────────────────
       - if:
           - condition: template
             value_template: "{{ _needs_configure }}"
@@ -284,28 +288,22 @@ automation:
               seconds: 60
             continue_on_timeout: true
 
-          # ── Update persistent store ───────────────────────────────────────────
-          # configured_at is stamped only on a successful response — a failed or
-          # queued configure leaves it unset so the next trigger retries.
-          # notified_at is stamped whenever a notification was sent this run.
+          # ── Update persistent store on success ────────────────────────────────
           - variables:
               _configure_ok: >
                 {% set resp = wait.trigger.payload_json if wait.trigger else none %}
                 {{ resp is not none and resp.get('status') == 'ok' }}
-          - action: input_text.set_value
-            target:
-              entity_id: input_text.parasoll_config_state
-            data:
-              value: >
-                {% set store = (states('input_text.parasoll_config_state') or '{}') | from_json %}
-                {% set dev = store.get(_ieee, {}) %}
-                {% if _configure_ok %}
-                  {% set dev = dict(dev, **{'configured_at': now().isoformat()}) %}
-                {% endif %}
-                {% if _can_notify %}
-                  {% set dev = dict(dev, **{'notified_at': now().isoformat()}) %}
-                {% endif %}
-                {{ dict(store, **{_ieee: dev}) | tojson }}
+          - if:
+              - condition: template
+                value_template: "{{ _configure_ok }}"
+            then:
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.parasoll_configure_state
+                data:
+                  value: >
+                    {% set store = (states('input_text.parasoll_configure_state') or '{}') | from_json %}
+                    {{ dict(store, **{_ieee[-4:]: (now().timestamp() / 3600) | int % 10000}) | tojson }}
 
           - if:
               - condition: template

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -112,40 +112,46 @@ automation:
       Reconfigures PARASOLL sensors on three events:
         • device_interview  — brand-new join, model E2013 (always reconfigures)
         • device_announce   — re-join after battery pull / reconnect (always reconfigures)
-        • contact_change    — any Z2M message with a contact field from a known
-                              PARASOLL device (skipped if configured within 6 h)
+        • contact_change    — state change on any known PARASOLL sensor
+                              (skipped if configured within 6 h)
       Notifications gated by 1 h since last successful configure per device;
-      contact_change is always silent. No hardcoded entity list.
+      contact_change is always silent.
     mode: queued
     max: 10
     trigger:
       - platform: mqtt
         topic: zigbee2mqtt/bridge/event
         id: bridge_event
-      # Multi-level wildcard so friendly names containing "/" (e.g.
-      # "Office/Window" → zigbee2mqtt/Office/Window) are matched.
-      # Bridge sub-topics are excluded in the condition below.
-      - platform: mqtt
-        topic: "zigbee2mqtt/#"
+      # State triggers fire only for the 20 known PARASOLL sensors.
+      # Using state (not MQTT wildcard) avoids triggering on every Z2M message.
+      - platform: state
+        entity_id:
+          - binary_sensor.basement_window_contact
+          - binary_sensor.dining_room_north_window_contact
+          - binary_sensor.dining_room_south_window_contact
+          - binary_sensor.guest_bathroom_window_contact
+          - binary_sensor.guest_room_window_contact
+          - binary_sensor.kitchen_bay_middle_window_kitchen_bay_middle_window
+          - binary_sensor.kitchen_bay_north_window_contact
+          - binary_sensor.kitchen_bay_south_window_contact
+          - binary_sensor.kitchen_north_window_contact
+          - binary_sensor.kitchen_south_window_contact
+          - binary_sensor.mailbox_contact
+          - binary_sensor.office_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_north_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
+          - binary_sensor.owner_suite_bathroom_bay_south_window_contact
+          - binary_sensor.owner_suite_north_window_contact
+          - binary_sensor.owner_suite_south_window_contact
+          - binary_sensor.powder_room_window_contact
+          - binary_sensor.unfinished_basement_window_contact
         id: contact_change
     condition:
       - condition: template
         value_template: >
           {% if trigger.id == 'contact_change' %}
-            {% if 'contact' not in trigger.payload_json
-               or trigger.topic.startswith('zigbee2mqtt/bridge') %}
-              false
-            {% else %}
-              {% set fname = trigger.topic | replace('zigbee2mqtt/', '') %}
-              {% set ns = namespace(found=false) %}
-              {% for entity in states.binary_sensor %}
-                {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor (patched)'
-                   and device_attr(entity.entity_id, 'name') == fname %}
-                  {% set ns.found = true %}
-                {% endif %}
-              {% endfor %}
-              {{ ns.found }}
-            {% endif %}
+            true
           {% else %}
             {% set type = trigger.payload_json.type %}
             {% set ieee = trigger.payload_json.data.ieee_address %}
@@ -182,16 +188,10 @@ automation:
             {% if trigger.id == 'bridge_event' %}
               {{ trigger.payload_json.data.ieee_address }}
             {% else %}
-              {% set fname = trigger.topic | replace('zigbee2mqtt/', '') %}
               {% set ns = namespace(value='') %}
-              {% for entity in states.binary_sensor %}
-                {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor (patched)'
-                   and device_attr(entity.entity_id, 'name') == fname %}
-                  {% for id_tuple in device_attr(entity.entity_id, 'identifiers') | list %}
-                    {% if id_tuple[0] == 'mqtt' %}
-                      {% set ns.value = id_tuple[1] | replace('zigbee2mqtt_', '') %}
-                    {% endif %}
-                  {% endfor %}
+              {% for id_tuple in device_attr(trigger.entity_id, 'identifiers') | list %}
+                {% if id_tuple[0] == 'mqtt' %}
+                  {% set ns.value = id_tuple[1] | replace('zigbee2mqtt_', '') %}
                 {% endif %}
               {% endfor %}
               {{ ns.value }}
@@ -200,7 +200,7 @@ automation:
             {% if trigger.id == 'bridge_event' %}
               {{ trigger.payload_json.data.friendly_name }}
             {% else %}
-              {{ trigger.topic | replace('zigbee2mqtt/', '') }}
+              {{ device_attr(trigger.entity_id, 'name') }}
             {% endif %}
           parasoll_identify_btn: >
             {% set ns = namespace(entity='') %}

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -62,6 +62,19 @@ script:
                     entity_id: "{{ repeat.item.identify }}"
             - delay:
                 milliseconds: 500
+            # Unbind genPollCtrl — devices paired with the stock converter
+            # retain this binding even after the patched converter is loaded.
+            # genPollCtrl is the cluster that writes an aggressive check-in
+            # interval and is the primary cause of rapid battery drain.
+            - action: mqtt.publish
+              data:
+                topic: zigbee2mqtt/bridge/request/device/unbind
+                payload: >
+                  {"from": "{{ repeat.item.ieee }}", "from_endpoint": "1",
+                   "to": "Coordinator",
+                   "clusters": ["genPollCtrl"]}
+            - delay:
+                milliseconds: 500
             - action: mqtt.publish
               data:
                 topic: zigbee2mqtt/bridge/request/device/configure
@@ -138,6 +151,15 @@ automation:
               entity_id: "{{ parasoll_identify_btn }}"
           - delay:
               seconds: 2
+      - action: mqtt.publish
+        data:
+          topic: zigbee2mqtt/bridge/request/device/unbind
+          payload: >
+            {"from": "{{ trigger.payload_json.data.ieee_address }}",
+             "from_endpoint": "1", "to": "Coordinator",
+             "clusters": ["genPollCtrl"]}
+      - delay:
+          milliseconds: 500
       - action: mqtt.publish
         data:
           topic: zigbee2mqtt/bridge/request/device/configure

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -93,43 +93,40 @@ automation:
       Reconfigures PARASOLL sensors on three events:
         • device_interview  — brand-new join, model E2013
         • device_announce   — re-join after battery pull / reconnect
-        • contact_change    — window/door opened or closed (silent; device is
-                              already awake so commands land immediately)
+        • contact_change    — any Z2M message containing a contact field from a
+                              known PARASOLL device (silent; device is already
+                              awake so commands land immediately)
       Join/announce path: waits 5 s, presses identify, sends notifications.
       Contact-change path: acts within 1 s, no notifications (idempotent).
-      Add new PARASOLL entity IDs to the contact_change trigger list when pairing.
+      No hardcoded entity list — new sensors are picked up automatically.
     mode: queued
     max: 10
     trigger:
       - platform: mqtt
         topic: zigbee2mqtt/bridge/event
         id: bridge_event
-      - platform: state
-        entity_id:
-          - binary_sensor.mailbox_contact
-          - binary_sensor.powder_room_window_contact
-          - binary_sensor.dining_room_south_window_contact
-          - binary_sensor.dining_room_north_window_contact
-          - binary_sensor.kitchen_north_window_contact
-          - binary_sensor.kitchen_south_window_contact
-          - binary_sensor.kitchen_bay_north_window_contact
-          - binary_sensor.owner_suite_north_window_contact
-          - binary_sensor.owner_suite_bathroom_bay_north_window_contact
-          - binary_sensor.owner_suite_bathroom_bay_north_middle_window_contact
-          - binary_sensor.office_window_contact
-          - binary_sensor.unfinished_basement_window_contact
-          - binary_sensor.basement_window_contact
-          - binary_sensor.guest_bathroom_window_contact
-          - binary_sensor.kitchen_bay_middle_window_contact
-          - binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
-          - binary_sensor.owner_suite_south_window_contact
-          - binary_sensor.kitchen_bay_south_window_contact
+      # Single-level wildcard matches per-device topics (e.g. zigbee2mqtt/Office
+      # Window) but NOT zigbee2mqtt/bridge/event or deeper sub-topics.
+      - platform: mqtt
+        topic: "zigbee2mqtt/+"
         id: contact_change
     condition:
       - condition: template
         value_template: >
           {% if trigger.id == 'contact_change' %}
-            true
+            {% if 'contact' not in trigger.payload_json %}
+              false
+            {% else %}
+              {% set fname = trigger.topic | replace('zigbee2mqtt/', '') %}
+              {% set ns = namespace(found=false) %}
+              {% for entity in states.binary_sensor %}
+                {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor (patched)'
+                   and device_attr(entity.entity_id, 'name') == fname %}
+                  {% set ns.found = true %}
+                {% endif %}
+              {% endfor %}
+              {{ ns.found }}
+            {% endif %}
           {% else %}
             {% set type = trigger.payload_json.type %}
             {% set ieee = trigger.payload_json.data.ieee_address %}
@@ -163,10 +160,16 @@ automation:
             {% if trigger.id == 'bridge_event' %}
               {{ trigger.payload_json.data.ieee_address }}
             {% else %}
+              {% set fname = trigger.topic | replace('zigbee2mqtt/', '') %}
               {% set ns = namespace(value='') %}
-              {% for id_tuple in device_attr(trigger.entity_id, 'identifiers') | list %}
-                {% if id_tuple[0] == 'mqtt' %}
-                  {% set ns.value = id_tuple[1] | replace('zigbee2mqtt_', '') %}
+              {% for entity in states.binary_sensor %}
+                {% if device_attr(entity.entity_id, 'model') == 'PARASOLL door/window sensor (patched)'
+                   and device_attr(entity.entity_id, 'name') == fname %}
+                  {% for id_tuple in device_attr(entity.entity_id, 'identifiers') | list %}
+                    {% if id_tuple[0] == 'mqtt' %}
+                      {% set ns.value = id_tuple[1] | replace('zigbee2mqtt_', '') %}
+                    {% endif %}
+                  {% endfor %}
                 {% endif %}
               {% endfor %}
               {{ ns.value }}
@@ -175,7 +178,7 @@ automation:
             {% if trigger.id == 'bridge_event' %}
               {{ trigger.payload_json.data.friendly_name }}
             {% else %}
-              {{ device_attr(trigger.entity_id, 'name') }}
+              {{ trigger.topic | replace('zigbee2mqtt/', '') }}
             {% endif %}
           parasoll_identify_btn: >
             {% set ns = namespace(entity='') %}

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -122,16 +122,18 @@ automation:
       - platform: mqtt
         topic: zigbee2mqtt/bridge/event
         id: bridge_event
-      # Single-level wildcard matches per-device topics (e.g. zigbee2mqtt/Office
-      # Window) but NOT zigbee2mqtt/bridge/event or deeper sub-topics.
+      # Multi-level wildcard so friendly names containing "/" (e.g.
+      # "Office/Window" → zigbee2mqtt/Office/Window) are matched.
+      # Bridge sub-topics are excluded in the condition below.
       - platform: mqtt
-        topic: "zigbee2mqtt/+"
+        topic: "zigbee2mqtt/#"
         id: contact_change
     condition:
       - condition: template
         value_template: >
           {% if trigger.id == 'contact_change' %}
-            {% if 'contact' not in trigger.payload_json %}
+            {% if 'contact' not in trigger.payload_json
+               or trigger.topic.startswith('zigbee2mqtt/bridge') %}
               false
             {% else %}
               {% set fname = trigger.topic | replace('zigbee2mqtt/', '') %}

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -109,11 +109,14 @@ automation:
   - alias: "PARASOLL - Auto-Reconfigure on Join or Announce"
     id: parasoll_auto_reconfigure_on_join
     description: >
-      Reconfigures PARASOLL sensors on three events:
-        • device_interview  — brand-new join, model E2013 (always reconfigures)
-        • device_announce   — re-join after battery pull / reconnect (always reconfigures)
-        • contact_change    — state change on any known PARASOLL sensor
-                              (skipped if configured within 6 h)
+      Reconfigures PARASOLL sensors only when actually needed:
+        • device_interview  — brand-new join (always reconfigures; settings definitely lost)
+        • device_announce   — re-join / reboot (skipped if configured within 6 h;
+                              Zigbee binding tables survive power cycles, so a plain
+                              announce does not mean settings were lost)
+        • contact_change    — state change on a known PARASOLL sensor (skipped if the
+                              device has ever been successfully configured; an active
+                              contact report proves IAS zone enrollment is working)
       Notifications gated by 1 h since last successful configure per device;
       contact_change is always silent.
     mode: queued
@@ -240,13 +243,21 @@ automation:
             {% else %}
               {{ (_cur_h | int - _prev_h | int) % 10000 }}
             {% endif %}
-          # bridge_event always reconfigures — device just re-joined and lost settings.
-          # contact_change skips if configured within the last 6 h.
+          # device_interview: always reconfigure — settings are definitively lost on new join.
+          # device_announce: reconfigure only if never confirmed OR last configure > 6 h ago;
+          #   Zigbee binding tables survive reboots/power cycles, so a plain announce
+          #   does not mean settings were lost.
+          # contact_change: skip if device has ever been successfully configured;
+          #   an active contact report is proof the IAS zone is enrolled and working.
           _needs_configure: >
             {% if trigger.id == 'bridge_event' %}
-              true
+              {% if trigger.payload_json.type == 'device_interview' %}
+                true
+              {% else %}
+                {{ _prev_h is none or _hours_since | int >= 6 }}
+              {% endif %}
             {% else %}
-              {{ _hours_since | int >= 6 }}
+              {{ _prev_h is none }}
             {% endif %}
           # Suppress notifications within 1 h of the last successful configure.
           # contact_change is always silent regardless.

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -229,8 +229,17 @@ automation:
             {{ (states('input_text.parasoll_configure_state') or '{}') | from_json }}
           _key: "{{ _ieee[-4:] }}"
           _cur_h: "{{ (now().timestamp() / 3600) | int % 10000 }}"
-          _prev_h: "{{ _store.get(_ieee[-4:], 0) | int }}"
-          _hours_since: "{{ (_cur_h | int - _prev_h | int) % 10000 }}"
+          # None when the device has never been successfully configured.
+          # Using none (not 0) avoids a false "recently configured" result if
+          # the current mod_hour happens to be in the 0–5 window.
+          _prev_h: "{{ _store.get(_ieee[-4:]) }}"
+          # 9999 when no prior record → always treated as expired.
+          _hours_since: >
+            {% if _prev_h is none %}
+              9999
+            {% else %}
+              {{ (_cur_h | int - _prev_h | int) % 10000 }}
+            {% endif %}
           # bridge_event always reconfigures — device just re-joined and lost settings.
           # contact_change skips if configured within the last 6 h.
           _needs_configure: >

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -119,7 +119,7 @@ automation:
           - binary_sensor.unfinished_basement_window_contact
           - binary_sensor.basement_window_contact
           - binary_sensor.guest_bathroom_window_contact
-          - binary_sensor.kitchen_bay_middle_window_kitchen_bay_middle_window
+          - binary_sensor.kitchen_bay_middle_window_contact
           - binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact
           - binary_sensor.owner_suite_south_window_contact
           - binary_sensor.kitchen_bay_south_window_contact

--- a/zigbee2mqtt/external_converters/parasoll.js
+++ b/zigbee2mqtt/external_converters/parasoll.js
@@ -28,9 +28,23 @@ module.exports = {
     // Explicitly bind ssIasZone — the missing binding is the root cause of
     // sensors silently stopping state reports after a few hours.
     bindCluster({ cluster: "ssIasZone", clusterType: "input" }),
-    iasZoneAlarm({ zoneType: "contact", zoneAttributes: ["alarm_1"] }),
+    iasZoneAlarm({
+      zoneType: "contact",
+      zoneAttributes: ["alarm_1"],
+      // Required so configure sets up zoneStatus attribute reporting on ep2.
+      // Without this, sensors that have never had the interval bounded will
+      // silently oversleep at the factory default of 65000 s (~18 h) and drop
+      // off the network. The blueprint automation then tightens max to 14400 s.
+      zoneStatusReporting: true,
+    }),
     identify({ isSleepy: true }),
-    battery(),
+    battery({
+      // Enable voltage so both batteryVoltage and batteryPercentageRemaining
+      // are reported and visible in HA — matches what the stock IKEA converter
+      // configures and ensures the blueprint can enforce intervals on both.
+      voltage: true,
+      voltageReporting: true,
+    }),
     // genPollCtrl deliberately omitted — binding it writes an aggressive
     // check-in interval that drains AAA batteries in days/weeks.
   ],


### PR DESCRIPTION
## Summary
- **`device_interview`**: still always reconfigures — new join definitively loses all Zigbee bindings
- **`device_announce`**: now applies the 6h cooldown instead of unconditionally reconfiguring. Zigbee binding tables live in device flash and survive reboots/power cycles; a plain announce ≠ lost settings
- **`contact_change`**: now skips reconfigure entirely if the device has ever been successfully confirmed (`_prev_h is not none`). An active contact report *is* proof that the IAS zone is enrolled and working — reconfiguring a device that is demonstrably delivering reports is unnecessary churn

## Motivation
A `device_announce` was triggering a reconfigure (and notification) on a sensor that had been configured ~1 hour earlier. The device hadn't lost any settings — it had simply re-announced, which Zigbee devices do periodically. The old `true`-always policy caused spurious notifications and unnecessary Z2M queue churn.

## Test plan
- [ ] CI passes
- [ ] Open/close a sensor that is in `input_text.parasoll_configure_state` → no reconfigure fires
- [ ] Open/close a sensor that is NOT in the store → reconfigure runs and store is updated
- [ ] Simulate `device_announce` from a configured sensor → no reconfigure (within 6h)
- [ ] Simulate `device_interview` → always reconfigures regardless of store

🤖 Generated with [Claude Code](https://claude.com/claude-code)