### PR TITLE
fix(#549): parse Z2M bridge availability payload

### DIFF
--- a/packages/z2m_availability.yaml
+++ b/packages/z2m_availability.yaml
@@ -30,6 +30,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -41,6 +42,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -52,6 +54,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -63,6 +66,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -74,6 +78,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -85,6 +90,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -96,6 +102,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -107,6 +114,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -118,6 +126,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -129,6 +138,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -140,6 +150,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -151,6 +162,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -162,6 +174,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -173,6 +186,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -184,6 +198,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -195,6 +210,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -206,6 +222,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -217,6 +234,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -228,6 +246,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -239,6 +258,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -250,6 +270,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -261,6 +282,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -272,6 +294,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -283,6 +306,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -294,6 +318,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -305,6 +330,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -316,6 +342,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -327,6 +354,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -338,6 +366,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -349,6 +378,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -360,6 +390,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -371,6 +402,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -382,6 +414,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -393,6 +426,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -404,6 +438,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -415,6 +450,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -426,6 +462,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -437,6 +474,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -448,6 +486,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -459,6 +498,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -470,6 +510,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -481,6 +522,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -492,6 +534,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -503,6 +546,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -514,6 +558,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -525,6 +570,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -536,6 +582,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -547,6 +594,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -558,6 +606,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -569,6 +618,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -580,6 +630,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -591,6 +642,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -602,6 +654,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -613,6 +666,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -624,6 +678,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -635,6 +690,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -646,6 +702,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -657,6 +714,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -668,6 +726,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -679,6 +738,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -690,6 +750,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -701,6 +762,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -712,6 +774,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -723,6 +786,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -734,6 +798,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -745,6 +810,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -756,6 +822,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -767,6 +834,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -778,6 +846,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -789,6 +858,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -800,6 +870,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -811,6 +882,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -822,6 +894,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -833,6 +906,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -844,6 +918,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -855,6 +930,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -866,6 +942,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -877,6 +954,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -888,6 +966,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -899,6 +978,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -910,6 +990,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -921,6 +1002,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -932,6 +1014,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -943,6 +1026,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -954,6 +1038,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -965,6 +1050,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -976,6 +1062,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -987,6 +1074,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -998,6 +1086,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1009,6 +1098,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1020,6 +1110,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1031,6 +1122,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1042,6 +1134,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1053,6 +1146,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1064,6 +1158,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1075,6 +1170,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1086,6 +1182,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1097,6 +1194,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1108,6 +1206,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1119,6 +1218,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1130,6 +1230,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1141,6 +1242,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1152,6 +1254,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1163,6 +1266,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1174,6 +1278,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1185,6 +1290,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1196,6 +1302,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1207,6 +1314,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1218,6 +1326,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1229,6 +1338,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1240,6 +1350,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1251,6 +1362,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1262,6 +1374,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1273,6 +1386,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1284,6 +1398,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1295,6 +1410,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1306,6 +1422,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1317,6 +1434,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1328,6 +1446,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1339,6 +1458,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1350,6 +1470,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1361,6 +1482,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1372,6 +1494,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1383,6 +1506,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1394,6 +1518,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1405,6 +1530,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1416,6 +1542,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1427,6 +1554,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1438,6 +1566,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1449,6 +1578,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1460,6 +1590,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1471,6 +1602,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1482,6 +1614,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1493,6 +1626,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1504,6 +1638,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1515,6 +1650,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1526,6 +1662,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1537,6 +1674,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1548,6 +1686,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1559,6 +1698,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1570,6 +1710,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1581,6 +1722,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1592,6 +1734,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1603,6 +1746,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1614,6 +1758,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1625,6 +1770,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1636,6 +1782,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1647,6 +1794,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1658,6 +1806,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1669,6 +1818,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1680,6 +1830,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1691,6 +1842,7 @@ mqtt:
       payload_off: "offline"
       device_class: connectivity
       availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_available: "online"
       payload_not_available: "offline"
 
@@ -1706,12 +1858,13 @@ template:
         state: >
           {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')
              | selectattr('entity_id', 'search', 'z2m_')
-             | selectattr('state', 'eq', 'off') | list | count > 0 }}
+             | selectattr('state', 'in', ['off', 'unavailable', 'unknown'])
+             | list | count > 0 }}
         attributes:
           offline_devices: >
             {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')
                | selectattr('entity_id', 'search', 'z2m_')
-               | selectattr('state', 'eq', 'off')
+               | selectattr('state', 'in', ['off', 'unavailable', 'unknown'])
                | map(attribute='name') | list }}
           total_devices: >
             {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')

--- a/tests/test_z2m_availability_package.py
+++ b/tests/test_z2m_availability_package.py
@@ -65,8 +65,13 @@ def test_all_named_devices_have_sensors() -> None:
 
 def test_device_sensors_have_availability_gate() -> None:
     text = PACKAGE_PATH.read_text(encoding="utf-8")
-    assert 'availability_topic: "zigbee2mqtt/bridge/state"' in text
-    assert 'availability_template: "{{ value_json.state }}"' not in text
+    availability_topics = text.count('availability_topic: "zigbee2mqtt/bridge/state"')
+    availability_templates = text.count(
+        'availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"'
+    )
+
+    assert availability_topics > 0
+    assert availability_templates == availability_topics
     assert 'payload_available: "online"' in text
     assert 'payload_not_available: "offline"' in text
 
@@ -108,7 +113,7 @@ def test_aggregate_template_searches_z2m_entities() -> None:
     text = PACKAGE_PATH.read_text(encoding="utf-8")
     assert "selectattr('entity_id', 'search', 'z2m_')" in text
     assert "selectattr('attributes.device_class', 'eq', 'connectivity')" in text
-    assert "selectattr('state', 'eq', 'off')" in text
+    assert "selectattr('state', 'in', ['off', 'unavailable', 'unknown'])" in text
 
 
 def test_package_does_not_duplicate_z2m_lifecycle_sensors() -> None:


### PR DESCRIPTION
## Summary

Fixes #549.

- Parses the JSON-or-raw `zigbee2mqtt/bridge/state` payload for every per-device Z2M availability sensor.
- Treats `off`, `unavailable`, and `unknown` per-device availability monitors as aggregate problems so the dashboard cannot report green while monitoring is blind.
- Updates Z2M availability tests to require one availability template per bridge availability gate.

## Runtime Evidence

Nightly live sweep on 2026-04-23 found:

- `binary_sensor.z2m_bridge`: `on`
- `binary_sensor.zigbee2mqtt_running`: `on`
- `sensor.z2m_lifecycle_issues`: `0`
- 160/160 per-device `binary_sensor.z2m_*_availability` monitors: `unavailable`
- `binary_sensor.z2m_devices_offline`: `off` with `online_count: 1` and `total_devices: 161`

Home Assistant MQTT binary sensor docs specify that availability payloads are compared after optional `availability_template`, so the bridge payload needs the same raw-or-JSON parsing already used for the bridge state sensor: https://www.home-assistant.io/integrations/binary_sensor.mqtt/

## Validation

- `ruby -e 'require "yaml"; YAML.load_file("packages/z2m_availability.yaml"); puts "yaml ok"'`
- `uv run --with pytest pytest tests/test_z2m_availability_package.py tests/test_runtime_log_regressions.py`
- `uv run --with pytest pytest`
- `POST /api/config/core/check_config` on live HA returned `result: valid`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/z2m_availability.yaml --strict`
- `git diff --check`

## Post-Deploy Check

After deploy/reload, verify `binary_sensor.z2m_*_availability` device monitors are no longer all `unavailable` while `binary_sensor.z2m_bridge` is `on`.
