### PR TITLE
[codex] Add Inky display docs and renderer scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 !docs/**/*.md
 !docs/**/*.yaml
 !docs/**/*.json
+!inky_display/
+!inky_display/**/*.py
+!inky_display/**/*.json
 !.githooks/
 !.githooks/**
 !scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@
 !docs/**/*.md
 !docs/**/*.yaml
 !docs/**/*.json
+!deploy/
+!deploy/**/*.service
 !inky_display/
 !inky_display/**/*.py
 !inky_display/**/*.json

--- a/deploy/systemd/inky-owner-suite.service
+++ b/deploy/systemd/inky-owner-suite.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Owner Suite Inky display renderer
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/hass-config
+Environment=INKY_DISPLAY_ID=owner_suite
+Environment=INKY_MQTT_HOST=homeassistant.local
+Environment=INKY_MQTT_PORT=1883
+Environment=INKY_MQTT_TOPIC=home/inky/owner_suite/state
+Environment=INKY_CACHE_DIR=/var/lib/inky-display/owner_suite
+ExecStart=/usr/bin/python3 -m inky_display.service
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -175,6 +175,54 @@ must be safe for a guest to read.
 Guest mode must suppress personal, work, meeting, calendar, and owner-location
 details on the office display.
 
+## Local Renderer Testing
+
+Always keep this section current when adding, renaming, or removing renderer
+samples.
+
+Run the focused renderer tests:
+
+```bash
+python3 -m pytest tests/test_inky_display_renderer.py
+```
+
+Render one sample locally:
+
+```bash
+python3 -m inky_display.cli \
+  inky_display/samples/owner_suite_night_preview.json \
+  /tmp/owner_suite_night_preview.png
+```
+
+Render all current owner-suite samples:
+
+```bash
+python3 -m inky_display.cli \
+  inky_display/samples/owner_suite_night_preview.json \
+  /tmp/owner_suite_night_preview.png
+
+python3 -m inky_display.cli \
+  inky_display/samples/owner_suite_morning.json \
+  /tmp/owner_suite_morning.png
+
+python3 -m inky_display.cli \
+  inky_display/samples/owner_suite_up_for_day.json \
+  /tmp/owner_suite_up_for_day.png
+
+python3 -m inky_display.cli \
+  inky_display/samples/owner_suite_midday.json \
+  /tmp/owner_suite_midday.png
+```
+
+Expected result for each rendered sample:
+
+- PNG output is `400x300`.
+- Weather rows show the configured fallback icon when the sample includes an
+  `mdi:weather-*` icon.
+- Unknown icons are skipped instead of failing the render.
+- Text stays high-contrast against emphasis or urgent row backgrounds.
+- Optional JSON `null` values render as blank text.
+
 ## Rollout Order
 
 1. Build local renderer and sample payloads for `owner_suite`.

--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -150,6 +150,30 @@ Known source-of-truth areas:
 - Wake-up behavior specification: `specs/alarm_wakeup.allium`
 - Room privacy policy: `docs/room_intent.yaml`
 
+## Home Assistant Payload Builder
+
+Owner-suite publishing lives in `packages/inky_displays.yaml`.
+
+Primary entities:
+
+- `script.publish_owner_suite_inky_display`: builds and publishes the compact
+  owner-suite payload to `home/inky/owner_suite/state`.
+- `automation.publish_owner_suite_inky_display`: coalesces meaningful source
+  changes with a 15-second restart delay, then calls the publish script.
+
+The automation listens to wake alarm helpers, wake-up firing state, house mode,
+bed/owner-suite activity, trip/vacation state, garage/front-door exceptions,
+weather alerts, active weather, and a noon refresh. It does not listen to
+`sensor.time`, so it will not redraw on clock ticks.
+
+Manual publish from Home Assistant Developer Tools:
+
+```yaml
+action: script.publish_owner_suite_inky_display
+data:
+  mode: night_preview
+```
+
 ## Office Modes
 
 The office is guest-capable. When guest mode is active, office display content

--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -11,11 +11,12 @@ services.
 
 | Display ID | Panel | Color semantics | Location | Driver |
 | --- | --- | --- | --- | --- |
-| `owner_suite` | Pimoroni Inky wHAT PIM408, red/black/white, 400x300 | Red means urgency or exception | Owner suite, exact placement TBD | Raspberry Pi TBD |
+| `owner_suite` | Pimoroni Inky wHAT PIM408, red/black/white, 400x300 | Red means urgency or exception | Owner suite, exact placement TBD | Raspberry Pi Zero W |
 | `office` | Yellow/black/white Inky display, 400x300, not yet confirmed | Yellow means emphasis or hospitality | Office, exact placement TBD | Raspberry Pi TBD |
 
 Available Raspberry Pi hardware from issue #313:
 
+- Raspberry Pi Zero W, assigned to `owner_suite`
 - Raspberry Pi Zero
 - Raspberry Pi 1
 - Raspberry Pi 3 Model B
@@ -169,4 +170,3 @@ details on the office display.
    rendering on the physical panel.
 5. Confirm and add the office panel hardware.
 6. Add `office` private modes and `guest_info`.
-

--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -265,6 +265,42 @@ Expected result for each rendered sample:
 - Text stays high-contrast against emphasis or urgent row backgrounds.
 - Optional JSON `null` values render as blank text.
 
+Run the Pi service cache/dedup tests:
+
+```bash
+python3 -m pytest tests/test_inky_display_service.py
+```
+
+Run the MQTT-backed Pi service locally after installing `paho-mqtt` on the Pi:
+
+```bash
+python3 -m pip install paho-mqtt
+python3 -m inky_display.service --check-config
+
+INKY_DISPLAY_ID=owner_suite \
+INKY_MQTT_HOST=homeassistant.local \
+INKY_MQTT_PORT=1883 \
+INKY_MQTT_TOPIC=home/inky/owner_suite/state \
+INKY_CACHE_DIR=/var/lib/inky-display/owner_suite \
+python3 -m inky_display.service
+```
+
+The service writes:
+
+- `last_payload.json`
+- `last_image.png`
+- `last_hash.txt`
+
+Duplicate payload hashes are ignored. Invalid payloads are logged and do not
+overwrite the last good cache.
+
+## Raspberry Pi Service
+
+The first Pi target is the owner-suite Pi Zero W. Use
+`deploy/systemd/inky-owner-suite.service` as the starting systemd unit and
+adjust `WorkingDirectory`, `INKY_MQTT_HOST`, and optional MQTT credentials for
+the deployed Pi.
+
 ## Rollout Order
 
 1. Build local renderer and sample payloads for `owner_suite`.

--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -166,6 +166,24 @@ bed/owner-suite activity, trip/vacation state, garage/front-door exceptions,
 weather alerts, active weather, and a noon refresh. It does not listen to
 `sensor.time`, so it will not redraw on clock ticks.
 
+Current owner-suite modes:
+
+| Mode | Selected when | Title | Subtitle |
+| --- | --- | --- | --- |
+| `night_preview` | Explicit mode or house mode is `night`, `in_bed`, or `asleep` | `Tonight` | `Next alarm and overnight status` |
+| `morning` | Explicit mode or `input_boolean.wakeup_alarm_firing` is on | `Good Morning` | `Wake sequence active` |
+| `up_for_day` | Explicit mode or automatic pre-noon non-sleep state | `Up For Day` | `Morning activity confirmed` |
+| `midday` | Explicit mode, noon trigger, or automatic afternoon state | `Midday` | `Low-frequency refresh` |
+
+Current owner-suite rows:
+
+| Row | Value source | Level behavior |
+| --- | --- | --- |
+| Weather | `sensor.outside_temperature` plus `sensor.active_weather_entity_id` weather state | `urgent` when NWS alerts are active |
+| Alarm | `input_datetime.weekday_alarm` or `input_datetime.weekend_alarm` when the matching alarm helper is on | `emphasis` in `night_preview` when alarm is enabled |
+| Meeting | `input_datetime.next_work_meeting` when `input_boolean.special_meeting` is on | `emphasis` when special meeting is on |
+| Status | First active status from weather alert, garage door, front door, trip mode, vacation, otherwise `All clear` | `urgent` for alert/door/garage, `emphasis` for trip/vacation |
+
 Manual publish from Home Assistant Developer Tools:
 
 ```yaml

--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -81,8 +81,8 @@ Payloads are compact JSON. Required fields:
     {
       "type": "rows",
       "rows": [
-        {"label": "Weather", "value": "24F Snow", "level": "normal"},
-        {"label": "Doors", "value": "Closed", "level": "normal"}
+        {"icon": "mdi:weather-snowy", "label": "Weather", "value": "24F Snow", "level": "normal"},
+        {"icon": "mdi:door-closed", "label": "Doors", "value": "Closed", "level": "normal"}
       ]
     }
   ],
@@ -101,6 +101,20 @@ Supported row `level` values:
 - `normal`
 - `emphasis`
 - `urgent`
+
+Rows may include an optional `icon` field. Use Material Design Icons names with
+the `mdi:` prefix so payloads stay aligned with Home Assistant icon names. The
+Pi renderer should support a small weather-first fallback icon set and skip
+unknown icons instead of failing the render.
+
+Initial weather icon names:
+
+- `mdi:weather-sunny`
+- `mdi:weather-partly-cloudy`
+- `mdi:weather-cloudy`
+- `mdi:weather-rainy`
+- `mdi:weather-snowy`
+- `mdi:weather-lightning`
 
 The renderer must tolerate missing optional fields and unknown section types.
 Unknown content should be skipped, not rendered as an error screen.

--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -1,0 +1,172 @@
+# Inky E-Ink Displays
+
+Issue: [#313](https://github.com/rtclauss/hass-config/issues/313)
+
+This document is the source of truth for the first e-ink display rollout. Keep
+hardware assignments, MQTT topics, payload contracts, display modes, and privacy
+expectations here before wiring Home Assistant automations or Raspberry Pi
+services.
+
+## Hardware Assignments
+
+| Display ID | Panel | Color semantics | Location | Driver |
+| --- | --- | --- | --- | --- |
+| `owner_suite` | Pimoroni Inky wHAT PIM408, red/black/white, 400x300 | Red means urgency or exception | Owner suite, exact placement TBD | Raspberry Pi TBD |
+| `office` | Yellow/black/white Inky display, 400x300, not yet confirmed | Yellow means emphasis or hospitality | Office, exact placement TBD | Raspberry Pi TBD |
+
+Available Raspberry Pi hardware from issue #313:
+
+- Raspberry Pi Zero
+- Raspberry Pi 1
+- Raspberry Pi 3 Model B
+- Raspberry Pi 3 Model B+
+
+Start the rollout with `owner_suite` because the red/black/white panel already
+exists. Do not block renderer work on final mounting decisions, but document the
+final placement and assigned Pi here before deploying the physical service.
+
+## Architecture
+
+Home Assistant owns display state. The Raspberry Pi owns rendering, caching, and
+physical panel refresh.
+
+```text
+Home Assistant package/script
+  -> MQTT retained-ish compact payload
+  -> Raspberry Pi systemd service
+  -> payload validation
+  -> local render
+  -> duplicate content hash check
+  -> Inky refresh
+  -> last-good payload/image cache
+```
+
+The Pi service must keep the last valid image visible when Home Assistant or
+MQTT is unavailable. Failed renders must not blank the display.
+
+## MQTT Topics
+
+Use one command topic per display:
+
+| Display ID | Topic |
+| --- | --- |
+| `owner_suite` | `home/inky/owner_suite/state` |
+| `office` | `home/inky/office/state` |
+
+Future health/status topics should be separate from the desired-state topic:
+
+| Display ID | Topic |
+| --- | --- |
+| `owner_suite` | `home/inky/owner_suite/status` |
+| `office` | `home/inky/office/status` |
+
+The initial publisher should avoid clock-tick redraws. Publish only when a
+meaningful source value changes, then let the Pi suppress duplicate payloads by
+content hash.
+
+## Payload Contract
+
+Payloads are compact JSON. Required fields:
+
+```json
+{
+  "schema_version": 1,
+  "display_id": "owner_suite",
+  "mode": "night_preview",
+  "accent": "red",
+  "title": "Alarm 6:30",
+  "subtitle": "Workday tomorrow",
+  "sections": [
+    {
+      "type": "rows",
+      "rows": [
+        {"label": "Weather", "value": "24F Snow", "level": "normal"},
+        {"label": "Doors", "value": "Closed", "level": "normal"}
+      ]
+    }
+  ],
+  "footer": "Updated 9:42 PM"
+}
+```
+
+Supported `accent` values:
+
+- `red`
+- `yellow`
+- `black`
+
+Supported row `level` values:
+
+- `normal`
+- `emphasis`
+- `urgent`
+
+The renderer must tolerate missing optional fields and unknown section types.
+Unknown content should be skipped, not rendered as an error screen.
+
+## Layout Rules
+
+- Canvas is `400x300`.
+- Use high-contrast white, black, and one accent color.
+- Text must be readable from roughly 4 feet away.
+- Prefer one large title, one subtitle, and at most four status rows.
+- Reject dense paragraphs, tiny legends, and dashboard-like tables.
+- Red on `owner_suite` means urgent or exceptional.
+- Yellow on `office` means emphasis or hospitality, not urgency.
+- Do not render rapidly changing clocks.
+
+## Owner-Suite Modes
+
+`owner_suite` is private and owner-focused. It may show personal wake, trip,
+weather, and house-status context.
+
+| Mode | Purpose | Candidate fields |
+| --- | --- | --- |
+| `night_preview` | Bedtime preview before sleep | next alarm, tomorrow workday/meeting state, overnight weather, door/garage exceptions |
+| `morning` | Wake sequence is active | wake status, weather, first meeting/departure note, urgent house exceptions |
+| `up_for_day` | Morning activity confirms the day has started | weather, house mode, garage/door/weather exceptions |
+| `midday` | Low-frequency daytime refresh | current weather, trip mode, severe weather, garage/door status |
+
+Known source-of-truth areas:
+
+- Wake-up alarm sync and helper state: `packages/ios_wakeup.yaml`
+- Owner-suite wake transitions: `packages/workday.yaml`
+- Weather helper sensors: `packages/weather.yaml`
+- Wake-up behavior specification: `specs/alarm_wakeup.allium`
+- Room privacy policy: `docs/room_intent.yaml`
+
+## Office Modes
+
+The office is guest-capable. When guest mode is active, office display content
+must be safe for a guest to read.
+
+| Mode | Purpose |
+| --- | --- |
+| `focus` | Owner work focus status when no guest context is active |
+| `home_arrival` | Arrival-oriented owner information when no guest context is active |
+| `midday` | Low-frequency daytime owner refresh when no guest context is active |
+| `guest_info` | Guest-safe hospitality screen |
+
+`guest_info` should include only house-safe content:
+
+- guest Wi-Fi QR code
+- guest SSID text
+- 3-day weather strip
+- indoor temperature
+- Ecobee preset
+- house-safe status rows
+- footer prompt such as `Scan for Guest Wi-Fi`
+
+Guest mode must suppress personal, work, meeting, calendar, and owner-location
+details on the office display.
+
+## Rollout Order
+
+1. Build local renderer and sample payloads for `owner_suite`.
+2. Add HA-side MQTT payload builder for `owner_suite`.
+3. Deploy one Pi service with cache restore and duplicate suppression.
+4. Verify alarm sync, wake firing, morning activity, noon refresh, and exception
+   rendering on the physical panel.
+5. Confirm and add the office panel hardware.
+6. Add `office` private modes and `guest_info`.
+

--- a/inky_display/__init__.py
+++ b/inky_display/__init__.py
@@ -1,0 +1,14 @@
+"""Helpers for rendering Home Assistant e-ink display payloads."""
+
+from .payload import DisplayPayload, payload_hash, validate_payload
+from .renderer import HEIGHT, WIDTH, render_payload
+
+__all__ = [
+    "DisplayPayload",
+    "HEIGHT",
+    "WIDTH",
+    "payload_hash",
+    "render_payload",
+    "validate_payload",
+]
+

--- a/inky_display/cli.py
+++ b/inky_display/cli.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .payload import validate_payload
+from .renderer import render_payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render an Inky display payload to a PNG preview.")
+    parser.add_argument("payload", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+
+    payload = validate_payload(json.loads(args.payload.read_text(encoding="utf-8")))
+    args.output.write_bytes(render_payload(payload))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/inky_display/payload.py
+++ b/inky_display/payload.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any
+
+
+SUPPORTED_SCHEMA_VERSION = 1
+SUPPORTED_DISPLAY_IDS = {"owner_suite", "office"}
+SUPPORTED_MODES = {
+    "owner_suite": {"night_preview", "morning", "up_for_day", "midday"},
+    "office": {"focus", "home_arrival", "midday", "guest_info"},
+}
+SUPPORTED_ACCENTS = {"red", "yellow", "black"}
+SUPPORTED_LEVELS = {"normal", "emphasis", "urgent"}
+MAX_ROWS = 4
+MAX_TEXT_LENGTH = 48
+
+
+@dataclass(frozen=True)
+class DisplayPayload:
+    schema_version: int
+    display_id: str
+    mode: str
+    accent: str
+    title: str
+    subtitle: str
+    sections: tuple[dict[str, Any], ...]
+    footer: str
+
+
+def validate_payload(data: dict[str, Any]) -> DisplayPayload:
+    schema_version = int(data.get("schema_version", SUPPORTED_SCHEMA_VERSION))
+    if schema_version != SUPPORTED_SCHEMA_VERSION:
+        raise ValueError(f"Unsupported schema_version: {schema_version}")
+
+    display_id = _required_text(data, "display_id")
+    if display_id not in SUPPORTED_DISPLAY_IDS:
+        raise ValueError(f"Unsupported display_id: {display_id}")
+
+    mode = _required_text(data, "mode")
+    if mode not in SUPPORTED_MODES[display_id]:
+        raise ValueError(f"Unsupported mode for {display_id}: {mode}")
+
+    accent = _text(data.get("accent", "red"))
+    if accent not in SUPPORTED_ACCENTS:
+        raise ValueError(f"Unsupported accent: {accent}")
+
+    sections = tuple(_normalize_sections(data.get("sections", [])))
+    return DisplayPayload(
+        schema_version=schema_version,
+        display_id=display_id,
+        mode=mode,
+        accent=accent,
+        title=_clip(_text(data.get("title", ""))),
+        subtitle=_clip(_text(data.get("subtitle", ""))),
+        sections=sections,
+        footer=_clip(_text(data.get("footer", ""))),
+    )
+
+
+def payload_hash(payload: DisplayPayload) -> str:
+    canonical = json.dumps(
+        {
+            "schema_version": payload.schema_version,
+            "display_id": payload.display_id,
+            "mode": payload.mode,
+            "accent": payload.accent,
+            "title": payload.title,
+            "subtitle": payload.subtitle,
+            "sections": payload.sections,
+            "footer": payload.footer,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _normalize_sections(sections: Any) -> list[dict[str, Any]]:
+    if not isinstance(sections, list):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for section in sections:
+        if not isinstance(section, dict):
+            continue
+        if section.get("type") != "rows":
+            continue
+        rows = section.get("rows", [])
+        if not isinstance(rows, list):
+            continue
+        normalized.append(
+            {
+                "type": "rows",
+                "rows": tuple(_normalize_rows(rows[:MAX_ROWS])),
+            }
+        )
+    return normalized
+
+
+def _normalize_rows(rows: list[Any]) -> list[dict[str, str]]:
+    normalized: list[dict[str, str]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        level = _text(row.get("level", "normal"))
+        if level not in SUPPORTED_LEVELS:
+            level = "normal"
+        normalized.append(
+            {
+                "label": _clip(_text(row.get("label", "")), 18),
+                "value": _clip(_text(row.get("value", "")), 28),
+                "level": level,
+            }
+        )
+    return normalized
+
+
+def _required_text(data: dict[str, Any], key: str) -> str:
+    value = _text(data.get(key, ""))
+    if value == "":
+        raise ValueError(f"Missing required field: {key}")
+    return value
+
+
+def _text(value: Any) -> str:
+    return str(value).strip()
+
+
+def _clip(value: str, limit: int = MAX_TEXT_LENGTH) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - 3].rstrip() + "..."

--- a/inky_display/payload.py
+++ b/inky_display/payload.py
@@ -127,6 +127,8 @@ def _required_text(data: dict[str, Any], key: str) -> str:
 
 
 def _text(value: Any) -> str:
+    if value is None:
+        return ""
     return str(value).strip()
 
 

--- a/inky_display/payload.py
+++ b/inky_display/payload.py
@@ -113,6 +113,7 @@ def _normalize_rows(rows: list[Any]) -> list[dict[str, str]]:
                 "label": _clip(_text(row.get("label", "")), 18),
                 "value": _clip(_text(row.get("value", "")), 28),
                 "level": level,
+                "icon": _clip(_normalize_icon(row.get("icon", "")), 32),
             }
         )
     return normalized
@@ -127,6 +128,15 @@ def _required_text(data: dict[str, Any], key: str) -> str:
 
 def _text(value: Any) -> str:
     return str(value).strip()
+
+
+def _normalize_icon(value: Any) -> str:
+    icon = _text(value)
+    if icon == "":
+        return ""
+    if icon.startswith("mdi:"):
+        return icon
+    return f"mdi:{icon}"
 
 
 def _clip(value: str, limit: int = MAX_TEXT_LENGTH) -> str:

--- a/inky_display/renderer.py
+++ b/inky_display/renderer.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import binascii
+import struct
+import zlib
+
+from .payload import DisplayPayload
+
+
+WIDTH = 400
+HEIGHT = 300
+
+WHITE = (255, 255, 255)
+BLACK = (0, 0, 0)
+RED = (215, 0, 0)
+YELLOW = (235, 190, 0)
+
+ACCENT_COLORS = {
+    "black": BLACK,
+    "red": RED,
+    "yellow": YELLOW,
+}
+
+LEVEL_COLORS = {
+    "normal": BLACK,
+    "emphasis": BLACK,
+    "urgent": RED,
+}
+
+
+def render_payload(payload: DisplayPayload) -> bytes:
+    canvas = Canvas(WIDTH, HEIGHT)
+    accent = ACCENT_COLORS[payload.accent]
+
+    canvas.rectangle(0, 0, WIDTH, 14, accent)
+    canvas.text(
+        18,
+        30,
+        payload.title or payload.mode.replace("_", " "),
+        scale=4,
+        color=BLACK,
+    )
+    if payload.subtitle:
+        canvas.text(20, 75, payload.subtitle, scale=2, color=BLACK)
+
+    y = 112
+    for section in payload.sections:
+        if section.get("type") != "rows":
+            continue
+        for row in section.get("rows", ()):
+            level = row.get("level", "normal")
+            row_color = LEVEL_COLORS.get(level, BLACK)
+            if level in {"emphasis", "urgent"}:
+                canvas.rectangle(18, y - 8, 382, y + 28, ACCENT_COLORS[payload.accent])
+                row_color = WHITE if level == "urgent" else BLACK
+            canvas.text(26, y, row.get("label", ""), scale=2, color=row_color)
+            canvas.text(170, y, row.get("value", ""), scale=2, color=row_color)
+            y += 42
+
+    if payload.footer:
+        canvas.rectangle(0, HEIGHT - 30, WIDTH, HEIGHT, BLACK)
+        canvas.text(18, HEIGHT - 22, payload.footer, scale=1, color=WHITE)
+
+    return canvas.to_png()
+
+
+class Canvas:
+    def __init__(self, width: int, height: int) -> None:
+        self.width = width
+        self.height = height
+        self.pixels = bytearray(WHITE * width * height)
+
+    def rectangle(
+        self,
+        left: int,
+        top: int,
+        right: int,
+        bottom: int,
+        color: tuple[int, int, int],
+    ) -> None:
+        left = max(0, left)
+        top = max(0, top)
+        right = min(self.width, right)
+        bottom = min(self.height, bottom)
+        for y in range(top, bottom):
+            for x in range(left, right):
+                self._set_pixel(x, y, color)
+
+    def text(
+        self,
+        left: int,
+        top: int,
+        text: str,
+        scale: int,
+        color: tuple[int, int, int],
+    ) -> None:
+        x = left
+        max_x = self.width - 8
+        for char in text.upper():
+            glyph = FONT.get(char, FONT["?"])
+            if x + 5 * scale > max_x:
+                break
+            self._glyph(x, top, glyph, scale, color)
+            x += 6 * scale
+
+    def to_png(self) -> bytes:
+        raw = bytearray()
+        row_width = self.width * 3
+        for y in range(self.height):
+            row_start = y * row_width
+            raw.append(0)
+            raw.extend(self.pixels[row_start : row_start + row_width])
+
+        return (
+            PNG_SIGNATURE
+            + _chunk(
+                b"IHDR",
+                struct.pack(">IIBBBBB", self.width, self.height, 8, 2, 0, 0, 0),
+            )
+            + _chunk(b"IDAT", zlib.compress(bytes(raw), level=9))
+            + _chunk(b"IEND", b"")
+        )
+
+    def _glyph(
+        self,
+        left: int,
+        top: int,
+        glyph: tuple[str, ...],
+        scale: int,
+        color: tuple[int, int, int],
+    ) -> None:
+        for gy, row in enumerate(glyph):
+            for gx, value in enumerate(row):
+                if value != "1":
+                    continue
+                self.rectangle(
+                    left + gx * scale,
+                    top + gy * scale,
+                    left + (gx + 1) * scale,
+                    top + (gy + 1) * scale,
+                    color,
+                )
+
+    def _set_pixel(self, x: int, y: int, color: tuple[int, int, int]) -> None:
+        index = (y * self.width + x) * 3
+        self.pixels[index : index + 3] = bytes(color)
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def _chunk(kind: bytes, data: bytes) -> bytes:
+    body = kind + data
+    return (
+        struct.pack(">I", len(data))
+        + body
+        + struct.pack(">I", binascii.crc32(body) & 0xFFFFFFFF)
+    )
+
+
+FONT: dict[str, tuple[str, ...]] = {
+    " ": ("00000", "00000", "00000", "00000", "00000", "00000", "00000"),
+    "!": ("00100", "00100", "00100", "00100", "00100", "00000", "00100"),
+    "?": ("01110", "10001", "00001", "00010", "00100", "00000", "00100"),
+    ".": ("00000", "00000", "00000", "00000", "00000", "01100", "01100"),
+    ":": ("00000", "01100", "01100", "00000", "01100", "01100", "00000"),
+    "-": ("00000", "00000", "00000", "11111", "00000", "00000", "00000"),
+    "/": ("00001", "00010", "00100", "01000", "10000", "00000", "00000"),
+    "0": ("01110", "10001", "10011", "10101", "11001", "10001", "01110"),
+    "1": ("00100", "01100", "00100", "00100", "00100", "00100", "01110"),
+    "2": ("01110", "10001", "00001", "00010", "00100", "01000", "11111"),
+    "3": ("11110", "00001", "00001", "01110", "00001", "00001", "11110"),
+    "4": ("00010", "00110", "01010", "10010", "11111", "00010", "00010"),
+    "5": ("11111", "10000", "10000", "11110", "00001", "00001", "11110"),
+    "6": ("00110", "01000", "10000", "11110", "10001", "10001", "01110"),
+    "7": ("11111", "00001", "00010", "00100", "01000", "01000", "01000"),
+    "8": ("01110", "10001", "10001", "01110", "10001", "10001", "01110"),
+    "9": ("01110", "10001", "10001", "01111", "00001", "00010", "01100"),
+    "A": ("01110", "10001", "10001", "11111", "10001", "10001", "10001"),
+    "B": ("11110", "10001", "10001", "11110", "10001", "10001", "11110"),
+    "C": ("01110", "10001", "10000", "10000", "10000", "10001", "01110"),
+    "D": ("11110", "10001", "10001", "10001", "10001", "10001", "11110"),
+    "E": ("11111", "10000", "10000", "11110", "10000", "10000", "11111"),
+    "F": ("11111", "10000", "10000", "11110", "10000", "10000", "10000"),
+    "G": ("01110", "10001", "10000", "10111", "10001", "10001", "01110"),
+    "H": ("10001", "10001", "10001", "11111", "10001", "10001", "10001"),
+    "I": ("01110", "00100", "00100", "00100", "00100", "00100", "01110"),
+    "J": ("00001", "00001", "00001", "00001", "10001", "10001", "01110"),
+    "K": ("10001", "10010", "10100", "11000", "10100", "10010", "10001"),
+    "L": ("10000", "10000", "10000", "10000", "10000", "10000", "11111"),
+    "M": ("10001", "11011", "10101", "10101", "10001", "10001", "10001"),
+    "N": ("10001", "11001", "10101", "10011", "10001", "10001", "10001"),
+    "O": ("01110", "10001", "10001", "10001", "10001", "10001", "01110"),
+    "P": ("11110", "10001", "10001", "11110", "10000", "10000", "10000"),
+    "Q": ("01110", "10001", "10001", "10001", "10101", "10010", "01101"),
+    "R": ("11110", "10001", "10001", "11110", "10100", "10010", "10001"),
+    "S": ("01111", "10000", "10000", "01110", "00001", "00001", "11110"),
+    "T": ("11111", "00100", "00100", "00100", "00100", "00100", "00100"),
+    "U": ("10001", "10001", "10001", "10001", "10001", "10001", "01110"),
+    "V": ("10001", "10001", "10001", "10001", "10001", "01010", "00100"),
+    "W": ("10001", "10001", "10001", "10101", "10101", "10101", "01010"),
+    "X": ("10001", "10001", "01010", "00100", "01010", "10001", "10001"),
+    "Y": ("10001", "10001", "01010", "00100", "00100", "00100", "00100"),
+    "Z": ("11111", "00001", "00010", "00100", "01000", "10000", "11111"),
+}

--- a/inky_display/renderer.py
+++ b/inky_display/renderer.py
@@ -53,7 +53,8 @@ def render_payload(payload: DisplayPayload) -> bytes:
             if level in {"emphasis", "urgent"}:
                 canvas.rectangle(18, y - 8, 382, y + 28, ACCENT_COLORS[payload.accent])
                 row_color = WHITE if level == "urgent" else BLACK
-            canvas.text(26, y, row.get("label", ""), scale=2, color=row_color)
+            canvas.icon(26, y - 4, row.get("icon", ""), scale=2, color=row_color)
+            canvas.text(56, y, row.get("label", ""), scale=2, color=row_color)
             canvas.text(170, y, row.get("value", ""), scale=2, color=row_color)
             y += 42
 
@@ -102,6 +103,12 @@ class Canvas:
                 break
             self._glyph(x, top, glyph, scale, color)
             x += 6 * scale
+
+    def icon(self, left: int, top: int, name: str, scale: int, color: tuple[int, int, int]) -> None:
+        glyph = ICONS.get(name)
+        if glyph is None:
+            return
+        self._glyph(left, top, glyph, scale, color)
 
     def to_png(self) -> bytes:
         raw = bytearray()
@@ -202,4 +209,80 @@ FONT: dict[str, tuple[str, ...]] = {
     "X": ("10001", "10001", "01010", "00100", "01010", "10001", "10001"),
     "Y": ("10001", "10001", "01010", "00100", "00100", "00100", "00100"),
     "Z": ("11111", "00001", "00010", "00100", "01000", "10000", "11111"),
+}
+
+
+ICONS: dict[str, tuple[str, ...]] = {
+    "mdi:weather-sunny": (
+        "0010000100",
+        "0001001000",
+        "1000000001",
+        "0001111000",
+        "0011111100",
+        "0011111100",
+        "0001111000",
+        "1000000001",
+        "0001001000",
+        "0010000100",
+    ),
+    "mdi:weather-partly-cloudy": (
+        "0000100000",
+        "0010010000",
+        "0001110000",
+        "0011111000",
+        "0001110010",
+        "0011111111",
+        "0111111111",
+        "1111111110",
+        "0111111100",
+        "0000000000",
+    ),
+    "mdi:weather-cloudy": (
+        "0000000000",
+        "0001110000",
+        "0011111000",
+        "0111111100",
+        "1111111110",
+        "1111111111",
+        "0111111111",
+        "0011111110",
+        "0000000000",
+        "0000000000",
+    ),
+    "mdi:weather-rainy": (
+        "0001110000",
+        "0011111000",
+        "0111111100",
+        "1111111110",
+        "0111111111",
+        "0011111110",
+        "0000000000",
+        "0100100100",
+        "0010010010",
+        "0100100100",
+    ),
+    "mdi:weather-snowy": (
+        "0001110000",
+        "0011111000",
+        "0111111100",
+        "1111111110",
+        "0111111111",
+        "0011111110",
+        "0000000000",
+        "0101010100",
+        "0010101000",
+        "0101010100",
+    ),
+    "mdi:weather-lightning": (
+        "0001110000",
+        "0011111000",
+        "0111111100",
+        "1111111110",
+        "0111111111",
+        "0011111110",
+        "0000110000",
+        "0001100000",
+        "0000110000",
+        "0001100000",
+    ),
 }

--- a/inky_display/renderer.py
+++ b/inky_display/renderer.py
@@ -51,8 +51,9 @@ def render_payload(payload: DisplayPayload) -> bytes:
             level = row.get("level", "normal")
             row_color = LEVEL_COLORS.get(level, BLACK)
             if level in {"emphasis", "urgent"}:
-                canvas.rectangle(18, y - 8, 382, y + 28, ACCENT_COLORS[payload.accent])
-                row_color = WHITE if level == "urgent" else BLACK
+                background_color = ACCENT_COLORS[payload.accent]
+                canvas.rectangle(18, y - 8, 382, y + 28, background_color)
+                row_color = _text_color_for_background(background_color)
             canvas.icon(26, y - 4, row.get("icon", ""), scale=2, color=row_color)
             canvas.text(56, y, row.get("label", ""), scale=2, color=row_color)
             canvas.text(170, y, row.get("value", ""), scale=2, color=row_color)
@@ -163,6 +164,12 @@ def _chunk(kind: bytes, data: bytes) -> bytes:
         + body
         + struct.pack(">I", binascii.crc32(body) & 0xFFFFFFFF)
     )
+
+
+def _text_color_for_background(background: tuple[int, int, int]) -> tuple[int, int, int]:
+    if background in {BLACK, RED}:
+        return WHITE
+    return BLACK
 
 
 FONT: dict[str, tuple[str, ...]] = {

--- a/inky_display/samples/owner_suite_midday.json
+++ b/inky_display/samples/owner_suite_midday.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "display_id": "owner_suite",
+  "mode": "midday",
+  "accent": "red",
+  "title": "Midday",
+  "subtitle": "Low-frequency refresh",
+  "sections": [
+    {
+      "type": "rows",
+      "rows": [
+        {"label": "Weather", "value": "38F Cloudy", "level": "normal"},
+        {"label": "Alert", "value": "None", "level": "normal"},
+        {"label": "Garage", "value": "Closed", "level": "normal"}
+      ]
+    }
+  ],
+  "footer": "No clock refresh"
+}
+

--- a/inky_display/samples/owner_suite_midday.json
+++ b/inky_display/samples/owner_suite_midday.json
@@ -9,7 +9,7 @@
     {
       "type": "rows",
       "rows": [
-        {"label": "Weather", "value": "38F Cloudy", "level": "normal"},
+        {"icon": "mdi:weather-partly-cloudy", "label": "Weather", "value": "38F Cloudy", "level": "normal"},
         {"label": "Alert", "value": "None", "level": "normal"},
         {"label": "Garage", "value": "Closed", "level": "normal"}
       ]
@@ -17,4 +17,3 @@
   ],
   "footer": "No clock refresh"
 }
-

--- a/inky_display/samples/owner_suite_morning.json
+++ b/inky_display/samples/owner_suite_morning.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "display_id": "owner_suite",
+  "mode": "morning",
+  "accent": "red",
+  "title": "Good Morning",
+  "subtitle": "Wake sequence active",
+  "sections": [
+    {
+      "type": "rows",
+      "rows": [
+        {"label": "Weather", "value": "28F Clear", "level": "normal"},
+        {"label": "Blinds", "value": "Opening soon", "level": "emphasis"},
+        {"label": "Audio", "value": "News queued", "level": "normal"}
+      ]
+    }
+  ],
+  "footer": "Wake-up in progress"
+}
+

--- a/inky_display/samples/owner_suite_morning.json
+++ b/inky_display/samples/owner_suite_morning.json
@@ -9,7 +9,7 @@
     {
       "type": "rows",
       "rows": [
-        {"label": "Weather", "value": "28F Clear", "level": "normal"},
+        {"icon": "mdi:weather-sunny", "label": "Weather", "value": "28F Clear", "level": "normal"},
         {"label": "Blinds", "value": "Opening soon", "level": "emphasis"},
         {"label": "Audio", "value": "News queued", "level": "normal"}
       ]
@@ -17,4 +17,3 @@
   ],
   "footer": "Wake-up in progress"
 }
-

--- a/inky_display/samples/owner_suite_night_preview.json
+++ b/inky_display/samples/owner_suite_night_preview.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "display_id": "owner_suite",
+  "mode": "night_preview",
+  "accent": "red",
+  "title": "Alarm 6:30",
+  "subtitle": "Workday tomorrow",
+  "sections": [
+    {
+      "type": "rows",
+      "rows": [
+        {"label": "Weather", "value": "24F Snow", "level": "normal"},
+        {"label": "Meeting", "value": "8:55 AM", "level": "normal"},
+        {"label": "Doors", "value": "Closed", "level": "normal"},
+        {"label": "Garage", "value": "Closed", "level": "normal"}
+      ]
+    }
+  ],
+  "footer": "Updated after alarm sync"
+}
+

--- a/inky_display/samples/owner_suite_night_preview.json
+++ b/inky_display/samples/owner_suite_night_preview.json
@@ -9,7 +9,7 @@
     {
       "type": "rows",
       "rows": [
-        {"label": "Weather", "value": "24F Snow", "level": "normal"},
+        {"icon": "mdi:weather-snowy", "label": "Weather", "value": "24F Snow", "level": "normal"},
         {"label": "Meeting", "value": "8:55 AM", "level": "normal"},
         {"label": "Doors", "value": "Closed", "level": "normal"},
         {"label": "Garage", "value": "Closed", "level": "normal"}
@@ -18,4 +18,3 @@
   ],
   "footer": "Updated after alarm sync"
 }
-

--- a/inky_display/samples/owner_suite_up_for_day.json
+++ b/inky_display/samples/owner_suite_up_for_day.json
@@ -9,7 +9,7 @@
     {
       "type": "rows",
       "rows": [
-        {"label": "Weather", "value": "31F Wind", "level": "normal"},
+        {"icon": "mdi:weather-cloudy", "label": "Weather", "value": "31F Wind", "level": "normal"},
         {"label": "Garage", "value": "Closed", "level": "normal"},
         {"label": "Trip", "value": "Off", "level": "normal"}
       ]
@@ -17,4 +17,3 @@
   ],
   "footer": "Morning activity confirmed"
 }
-

--- a/inky_display/samples/owner_suite_up_for_day.json
+++ b/inky_display/samples/owner_suite_up_for_day.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "display_id": "owner_suite",
+  "mode": "up_for_day",
+  "accent": "red",
+  "title": "Up For Day",
+  "subtitle": "House mode home",
+  "sections": [
+    {
+      "type": "rows",
+      "rows": [
+        {"label": "Weather", "value": "31F Wind", "level": "normal"},
+        {"label": "Garage", "value": "Closed", "level": "normal"},
+        {"label": "Trip", "value": "Off", "level": "normal"}
+      ]
+    }
+  ],
+  "footer": "Morning activity confirmed"
+}
+

--- a/inky_display/service.py
+++ b/inky_display/service.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import logging
+import os
+from pathlib import Path
+
+from .payload import payload_hash, validate_payload
+from .renderer import render_payload
+
+
+LOG = logging.getLogger(__name__)
+DEFAULT_TOPIC = "home/inky/owner_suite/state"
+
+
+@dataclass(frozen=True)
+class ServiceConfig:
+    display_id: str
+    mqtt_host: str
+    mqtt_port: int
+    mqtt_topic: str
+    cache_dir: Path
+    mqtt_username: str
+    mqtt_password: str
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    rendered: bool
+    reason: str
+    content_hash: str
+    image_path: Path | None
+
+
+class PayloadCache:
+    def __init__(self, cache_dir: Path) -> None:
+        self.cache_dir = cache_dir
+        self.payload_path = cache_dir / "last_payload.json"
+        self.image_path = cache_dir / "last_image.png"
+        self.hash_path = cache_dir / "last_hash.txt"
+
+    def last_hash(self) -> str:
+        if not self.hash_path.exists():
+            return ""
+        return self.hash_path.read_text(encoding="utf-8").strip()
+
+    def restore_image(self) -> bytes | None:
+        if not self.image_path.exists():
+            return None
+        return self.image_path.read_bytes()
+
+    def save(self, raw_payload: str, image: bytes, content_hash: str) -> Path:
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.payload_path.write_text(raw_payload, encoding="utf-8")
+        self.image_path.write_bytes(image)
+        self.hash_path.write_text(content_hash, encoding="utf-8")
+        return self.image_path
+
+
+def config_from_env() -> ServiceConfig:
+    return ServiceConfig(
+        display_id=os.environ.get("INKY_DISPLAY_ID", "owner_suite"),
+        mqtt_host=os.environ.get("INKY_MQTT_HOST", "localhost"),
+        mqtt_port=int(os.environ.get("INKY_MQTT_PORT", "1883")),
+        mqtt_topic=os.environ.get("INKY_MQTT_TOPIC", DEFAULT_TOPIC),
+        cache_dir=Path(os.environ.get("INKY_CACHE_DIR", ".inky-cache")),
+        mqtt_username=os.environ.get("INKY_MQTT_USERNAME", ""),
+        mqtt_password=os.environ.get("INKY_MQTT_PASSWORD", ""),
+    )
+
+
+def process_payload(raw_payload: bytes | str, cache: PayloadCache, display_id: str) -> ProcessResult:
+    raw_text = _decode_payload(raw_payload)
+    try:
+        data = json.loads(raw_text)
+        payload = validate_payload(data)
+    except (TypeError, ValueError, json.JSONDecodeError) as error:
+        LOG.warning("Ignoring invalid Inky payload: %s", error)
+        return ProcessResult(False, "invalid", "", None)
+
+    if payload.display_id != display_id:
+        LOG.warning("Ignoring payload for display_id=%s", payload.display_id)
+        return ProcessResult(False, "wrong-display", payload_hash(payload), None)
+
+    content_hash = payload_hash(payload)
+    if content_hash == cache.last_hash():
+        return ProcessResult(False, "duplicate", content_hash, cache.image_path)
+
+    image = render_payload(payload)
+    image_path = cache.save(raw_text, image, content_hash)
+    return ProcessResult(True, "rendered", content_hash, image_path)
+
+
+def run_mqtt_service(config: ServiceConfig) -> None:
+    try:
+        from paho.mqtt import client as mqtt
+    except ImportError as error:
+        raise RuntimeError("Install paho-mqtt on the Raspberry Pi to run the MQTT service.") from error
+
+    cache = PayloadCache(config.cache_dir)
+    restored = cache.restore_image()
+    if restored is not None:
+        LOG.info("Restored cached image from %s", cache.image_path)
+
+    client = mqtt.Client()
+    if config.mqtt_username:
+        client.username_pw_set(config.mqtt_username, config.mqtt_password)
+
+    def on_connect(client, _userdata, _flags, reason_code, _properties=None) -> None:
+        if int(reason_code) == 0:
+            LOG.info("Connected to MQTT broker %s:%s", config.mqtt_host, config.mqtt_port)
+            client.subscribe(config.mqtt_topic)
+            return
+        LOG.error("MQTT connection failed with code %s", reason_code)
+
+    def on_message(_client, _userdata, message) -> None:
+        result = process_payload(message.payload, cache, config.display_id)
+        LOG.info("Processed MQTT payload from %s: %s", message.topic, result.reason)
+
+    client.on_connect = on_connect
+    client.on_message = on_message
+    client.connect(config.mqtt_host, config.mqtt_port)
+    client.loop_forever()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the MQTT-backed Inky display renderer service.")
+    parser.add_argument(
+        "--check-config",
+        action="store_true",
+        help="Load environment configuration and exit without connecting to MQTT.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=os.environ.get("INKY_LOG_LEVEL", "INFO"))
+    config = config_from_env()
+    if args.check_config:
+        LOG.info("Loaded Inky service config for display_id=%s topic=%s", config.display_id, config.mqtt_topic)
+        return
+    run_mqtt_service(config)
+
+
+def _decode_payload(raw_payload: bytes | str) -> str:
+    if isinstance(raw_payload, bytes):
+        return raw_payload.decode("utf-8")
+    return raw_payload
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -1,0 +1,200 @@
+# Home Assistant package for e-ink display payload publishing.
+# The Raspberry Pi renderer owns panel refresh, caching, and hardware recovery.
+
+################################################################
+## Packages / Inky Displays
+################################################################
+
+################################################
+## Customize
+################################################
+
+homeassistant:
+  customize:
+    package.node_anchors:
+      customize: &customize
+        package: "inky_displays"
+
+    automation.publish_owner_suite_inky_display:
+      <<: *customize
+      friendly_name: "Publish Owner Suite Inky Display"
+      icon: mdi:tablet-dashboard
+
+    script.publish_owner_suite_inky_display:
+      <<: *customize
+      friendly_name: "Publish Owner Suite Inky Display"
+      icon: mdi:tablet-dashboard
+
+################################################
+## Automation
+################################################
+
+automation:
+  - id: publish_owner_suite_inky_display
+    alias: publish_owner_suite_inky_display
+    description: Publish owner-suite e-ink desired state after meaningful source changes.
+    mode: restart
+    trigger:
+      - trigger: homeassistant
+        event: start
+        id: startup
+      - trigger: time
+        at: "12:00:00"
+        id: midday
+      - trigger: state
+        entity_id:
+          - input_boolean.weekday_alarm_on
+          - input_boolean.weekend_alarm_on
+          - input_boolean.special_meeting
+          - input_boolean.wakeup_alarm_firing
+          - input_boolean.trip
+          - input_select.house_mode
+          - binary_sensor.bayesian_bed_occupancy
+          - binary_sensor.bedroom_occupancy
+          - binary_sensor.owner_suite_bathroom_room_occupancy
+          - binary_sensor.planned_vacation_calendar
+          - binary_sensor.main_foyer_front_door_contact
+          - cover.garage_door
+          - sensor.nws_dakota_county_alerts_alerts_are_active
+          - sensor.outside_temperature
+          - sensor.active_weather_entity_id
+        id: state-change
+      - trigger: state
+        entity_id:
+          - input_datetime.weekday_alarm
+          - input_datetime.weekend_alarm
+          - input_datetime.next_work_meeting
+        id: schedule-change
+    action:
+      - delay:
+          seconds: 15
+      - action: script.publish_owner_suite_inky_display
+        data:
+          mode: >-
+            {% if trigger.id == 'midday' %}
+              midday
+            {% else %}
+              auto
+            {% endif %}
+
+################################################
+## Script
+################################################
+
+script:
+  publish_owner_suite_inky_display:
+    alias: Publish Owner Suite Inky Display
+    description: Build and publish the compact owner-suite Inky display payload.
+    mode: restart
+    fields:
+      mode:
+        description: "Display mode override: auto, night_preview, morning, up_for_day, or midday."
+        example: night_preview
+    sequence:
+      - variables:
+          requested_mode: "{{ mode | default('auto', true) | string | trim }}"
+          resolved_mode: >-
+            {% set requested = requested_mode %}
+            {% set house_mode = states('input_select.house_mode') %}
+            {% if requested in ['night_preview', 'morning', 'up_for_day', 'midday'] %}
+              {{ requested }}
+            {% elif is_state('input_boolean.wakeup_alarm_firing', 'on') %}
+              morning
+            {% elif house_mode in ['night', 'in_bed', 'asleep'] %}
+              night_preview
+            {% elif now().hour >= 12 %}
+              midday
+            {% else %}
+              up_for_day
+            {% endif %}
+      - action: mqtt.publish
+        data:
+          topic: home/inky/owner_suite/state
+          qos: 1
+          retain: true
+          payload: >-
+            {% set weather_entity = states('sensor.active_weather_entity_id') %}
+            {% set weather_state = states(weather_entity) %}
+            {% set weather_icon_map = {
+              'clear-night': 'mdi:weather-sunny',
+              'cloudy': 'mdi:weather-cloudy',
+              'fog': 'mdi:weather-cloudy',
+              'hail': 'mdi:weather-lightning',
+              'lightning': 'mdi:weather-lightning',
+              'lightning-rainy': 'mdi:weather-lightning',
+              'partlycloudy': 'mdi:weather-partly-cloudy',
+              'pouring': 'mdi:weather-rainy',
+              'rainy': 'mdi:weather-rainy',
+              'snowy': 'mdi:weather-snowy',
+              'snowy-rainy': 'mdi:weather-snowy',
+              'sunny': 'mdi:weather-sunny',
+              'windy': 'mdi:weather-cloudy',
+              'windy-variant': 'mdi:weather-cloudy'
+            } %}
+            {% set weather_icon = weather_icon_map.get(weather_state, 'mdi:weather-cloudy') %}
+            {% set temperature = states('sensor.outside_temperature') %}
+            {% set weather_value = (temperature ~ 'F ' ~ weather_state.replace('-', ' ')) if temperature not in ['unknown', 'unavailable'] else weather_state.replace('-', ' ') %}
+            {% set weekday_alarm = is_state('input_boolean.weekday_alarm_on', 'on') %}
+            {% set weekend_alarm = is_state('input_boolean.weekend_alarm_on', 'on') %}
+            {% set meeting_alarm = is_state('input_boolean.special_meeting', 'on') %}
+            {% if weekday_alarm %}
+              {% set alarm_value = states('input_datetime.weekday_alarm')[0:5] %}
+            {% elif weekend_alarm %}
+              {% set alarm_value = states('input_datetime.weekend_alarm')[0:5] %}
+            {% else %}
+              {% set alarm_value = 'Off' %}
+            {% endif %}
+            {% set meeting_value = states('input_datetime.next_work_meeting')[0:5] if meeting_alarm else 'Off' %}
+            {% set garage_open = states('cover.garage_door') not in ['closed', 'closing'] %}
+            {% set front_door_open = is_state('binary_sensor.main_foyer_front_door_contact', 'on') %}
+            {% set weather_alert_state = states('sensor.nws_dakota_county_alerts_alerts_are_active') | lower %}
+            {% set weather_alert = weather_alert_state not in ['no', 'off', '0', 'false', 'unknown', 'unavailable'] %}
+            {% set trip_mode = is_state('input_boolean.trip', 'on') %}
+            {% set vacation = is_state('binary_sensor.planned_vacation_calendar', 'on') %}
+            {% if weather_alert %}
+              {% set status_value = 'Weather alert' %}
+              {% set status_level = 'urgent' %}
+            {% elif garage_open %}
+              {% set status_value = 'Garage ' ~ states('cover.garage_door') %}
+              {% set status_level = 'urgent' %}
+            {% elif front_door_open %}
+              {% set status_value = 'Front door open' %}
+              {% set status_level = 'urgent' %}
+            {% elif trip_mode %}
+              {% set status_value = 'Trip mode' %}
+              {% set status_level = 'emphasis' %}
+            {% elif vacation %}
+              {% set status_value = 'Vacation' %}
+              {% set status_level = 'emphasis' %}
+            {% else %}
+              {% set status_value = 'All clear' %}
+              {% set status_level = 'normal' %}
+            {% endif %}
+            {% set title_map = {
+              'night_preview': 'Tonight',
+              'morning': 'Good Morning',
+              'up_for_day': 'Up For Day',
+              'midday': 'Midday'
+            } %}
+            {% set subtitle_map = {
+              'night_preview': 'Next alarm and overnight status',
+              'morning': 'Wake sequence active',
+              'up_for_day': 'Morning activity confirmed',
+              'midday': 'Low-frequency refresh'
+            } %}
+            {% set rows = [
+              {'icon': weather_icon, 'label': 'Weather', 'value': weather_value, 'level': 'urgent' if weather_alert else 'normal'},
+              {'label': 'Alarm', 'value': alarm_value, 'level': 'emphasis' if resolved_mode == 'night_preview' and alarm_value != 'Off' else 'normal'},
+              {'label': 'Meeting', 'value': meeting_value, 'level': 'emphasis' if meeting_alarm else 'normal'},
+              {'label': 'Status', 'value': status_value, 'level': status_level}
+            ] %}
+            {{ {
+              'schema_version': 1,
+              'display_id': 'owner_suite',
+              'mode': resolved_mode,
+              'accent': 'red',
+              'title': title_map.get(resolved_mode, 'Owner Suite'),
+              'subtitle': subtitle_map.get(resolved_mode, 'Owner-suite display'),
+              'sections': [{'type': 'rows', 'rows': rows}],
+              'footer': 'Updated from Home Assistant'
+            } | tojson }}

--- a/tests/test_inky_display_renderer.py
+++ b/tests/test_inky_display_renderer.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import struct
+
+import pytest
+
+from inky_display import HEIGHT, WIDTH, payload_hash, render_payload, validate_payload
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SAMPLES = ROOT / "inky_display" / "samples"
+
+
+def _sample(name: str) -> dict:
+    return json.loads((SAMPLES / name).read_text(encoding="utf-8"))
+
+
+def _png_size(data: bytes) -> tuple[int, int]:
+    assert data.startswith(b"\x89PNG\r\n\x1a\n")
+    assert data[12:16] == b"IHDR"
+    return struct.unpack(">II", data[16:24])
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "owner_suite_night_preview.json",
+        "owner_suite_morning.json",
+        "owner_suite_up_for_day.json",
+        "owner_suite_midday.json",
+    ],
+)
+def test_owner_suite_samples_render_as_400_by_300_pngs(name: str) -> None:
+    payload = validate_payload(_sample(name))
+    rendered = render_payload(payload)
+
+    assert _png_size(rendered) == (WIDTH, HEIGHT)
+    assert len(rendered) > 1000
+
+
+def test_payload_hash_is_stable_for_duplicate_suppression() -> None:
+    payload = validate_payload(_sample("owner_suite_night_preview.json"))
+
+    assert payload_hash(payload) == payload_hash(validate_payload(_sample("owner_suite_night_preview.json")))
+
+
+def test_payload_validation_limits_rows_for_legibility() -> None:
+    data = _sample("owner_suite_night_preview.json")
+    data["sections"][0]["rows"].append({"label": "Extra", "value": "Hidden", "level": "urgent"})
+
+    payload = validate_payload(data)
+
+    assert len(payload.sections[0]["rows"]) == 4
+
+
+def test_payload_validation_rejects_wrong_mode_for_display() -> None:
+    data = _sample("owner_suite_night_preview.json")
+    data["mode"] = "guest_info"
+
+    with pytest.raises(ValueError, match="Unsupported mode"):
+        validate_payload(data)
+
+
+def test_payload_validation_skips_unknown_sections() -> None:
+    data = _sample("owner_suite_night_preview.json")
+    data["sections"].append({"type": "qr", "value": "later"})
+
+    payload = validate_payload(data)
+
+    assert len(payload.sections) == 1
+

--- a/tests/test_inky_display_renderer.py
+++ b/tests/test_inky_display_renderer.py
@@ -71,3 +71,20 @@ def test_payload_validation_skips_unknown_sections() -> None:
 
     assert len(payload.sections) == 1
 
+
+def test_payload_validation_normalizes_mdi_icon_names() -> None:
+    data = _sample("owner_suite_night_preview.json")
+    data["sections"][0]["rows"][0]["icon"] = "weather-rainy"
+
+    payload = validate_payload(data)
+
+    assert payload.sections[0]["rows"][0]["icon"] == "mdi:weather-rainy"
+
+
+def test_renderer_tolerates_unknown_icons() -> None:
+    data = _sample("owner_suite_night_preview.json")
+    data["sections"][0]["rows"][0]["icon"] = "mdi:weather-hail"
+
+    rendered = render_payload(validate_payload(data))
+
+    assert _png_size(rendered) == (WIDTH, HEIGHT)

--- a/tests/test_inky_display_renderer.py
+++ b/tests/test_inky_display_renderer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import struct
+import zlib
 
 import pytest
 
@@ -21,6 +22,28 @@ def _png_size(data: bytes) -> tuple[int, int]:
     assert data.startswith(b"\x89PNG\r\n\x1a\n")
     assert data[12:16] == b"IHDR"
     return struct.unpack(">II", data[16:24])
+
+
+def _png_rgb(data: bytes) -> bytes:
+    width, height = _png_size(data)
+    offset = 8
+    compressed = bytearray()
+    while offset < len(data):
+        length = struct.unpack(">I", data[offset : offset + 4])[0]
+        chunk_type = data[offset + 4 : offset + 8]
+        chunk_data = data[offset + 8 : offset + 8 + length]
+        if chunk_type == b"IDAT":
+            compressed.extend(chunk_data)
+        offset += length + 12
+
+    raw = zlib.decompress(bytes(compressed))
+    row_size = width * 3
+    pixels = bytearray()
+    for y in range(height):
+        row_start = y * (row_size + 1)
+        assert raw[row_start] == 0
+        pixels.extend(raw[row_start + 1 : row_start + 1 + row_size])
+    return bytes(pixels)
 
 
 @pytest.mark.parametrize(
@@ -88,3 +111,30 @@ def test_renderer_tolerates_unknown_icons() -> None:
     rendered = render_payload(validate_payload(data))
 
     assert _png_size(rendered) == (WIDTH, HEIGHT)
+
+
+def test_null_optional_fields_render_as_blank_text() -> None:
+    data = _sample("owner_suite_night_preview.json")
+    data["title"] = None
+    data["subtitle"] = None
+    data["footer"] = None
+    data["sections"][0]["rows"][0]["label"] = None
+    data["sections"][0]["rows"][0]["value"] = None
+
+    payload = validate_payload(data)
+
+    assert payload.title == ""
+    assert payload.subtitle == ""
+    assert payload.footer == ""
+    assert payload.sections[0]["rows"][0]["label"] == ""
+    assert payload.sections[0]["rows"][0]["value"] == ""
+
+
+def test_black_accent_emphasis_rows_keep_visible_text() -> None:
+    data = _sample("owner_suite_night_preview.json")
+    data["accent"] = "black"
+    data["sections"][0]["rows"][0]["level"] = "emphasis"
+
+    pixels = _png_rgb(render_payload(validate_payload(data)))
+
+    assert b"\xff\xff\xff" in pixels

--- a/tests/test_inky_display_service.py
+++ b/tests/test_inky_display_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from inky_display.service import PayloadCache, config_from_env, process_payload
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SAMPLE_PATH = ROOT / "inky_display" / "samples" / "owner_suite_night_preview.json"
+
+
+def _sample_text() -> str:
+    return SAMPLE_PATH.read_text(encoding="utf-8")
+
+
+def test_process_payload_renders_and_caches_last_good_image(tmp_path: Path) -> None:
+    cache = PayloadCache(tmp_path)
+
+    result = process_payload(_sample_text(), cache, "owner_suite")
+
+    assert result.rendered is True
+    assert result.reason == "rendered"
+    assert result.image_path == cache.image_path
+    assert cache.image_path.exists()
+    assert cache.payload_path.read_text(encoding="utf-8") == _sample_text()
+    assert cache.last_hash() == result.content_hash
+    assert cache.restore_image() == cache.image_path.read_bytes()
+
+
+def test_process_payload_suppresses_duplicate_content_hash(tmp_path: Path) -> None:
+    cache = PayloadCache(tmp_path)
+    first = process_payload(_sample_text(), cache, "owner_suite")
+
+    duplicate = process_payload(_sample_text(), cache, "owner_suite")
+
+    assert first.rendered is True
+    assert duplicate.rendered is False
+    assert duplicate.reason == "duplicate"
+    assert duplicate.content_hash == first.content_hash
+
+
+def test_process_payload_ignores_invalid_payload_without_overwriting_cache(tmp_path: Path) -> None:
+    cache = PayloadCache(tmp_path)
+    first = process_payload(_sample_text(), cache, "owner_suite")
+
+    invalid = process_payload("{not-json", cache, "owner_suite")
+
+    assert invalid.rendered is False
+    assert invalid.reason == "invalid"
+    assert cache.last_hash() == first.content_hash
+    assert cache.restore_image() is not None
+
+
+def test_process_payload_rejects_payload_for_another_display(tmp_path: Path) -> None:
+    data = json.loads(_sample_text())
+    data["display_id"] = "office"
+    data["mode"] = "guest_info"
+
+    result = process_payload(json.dumps(data), PayloadCache(tmp_path), "owner_suite")
+
+    assert result.rendered is False
+    assert result.reason == "wrong-display"
+
+
+def test_config_from_env_uses_pi_service_environment(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("INKY_DISPLAY_ID", "owner_suite")
+    monkeypatch.setenv("INKY_MQTT_HOST", "mqtt.example.test")
+    monkeypatch.setenv("INKY_MQTT_PORT", "1884")
+    monkeypatch.setenv("INKY_MQTT_TOPIC", "home/inky/owner_suite/state")
+    monkeypatch.setenv("INKY_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("INKY_MQTT_USERNAME", "inky")
+    monkeypatch.setenv("INKY_MQTT_PASSWORD", "secret")
+
+    config = config_from_env()
+
+    assert config.display_id == "owner_suite"
+    assert config.mqtt_host == "mqtt.example.test"
+    assert config.mqtt_port == 1884
+    assert config.mqtt_topic == "home/inky/owner_suite/state"
+    assert config.cache_dir == tmp_path
+    assert config.mqtt_username == "inky"
+    assert config.mqtt_password == "secret"
+
+
+def test_service_help_does_not_require_mqtt_dependency() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "inky_display.service", "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "--check-config" in result.stdout

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_PATH = ROOT / "packages" / "inky_displays.yaml"
+DOC_PATH = ROOT / "docs" / "inky_displays.md"
+
+
+def _package_text() -> str:
+    return PACKAGE_PATH.read_text(encoding="utf-8")
+
+
+def _script_block(script_id: str) -> str:
+    lines = _package_text().splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  ") and not lines[index].startswith("    "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _automation_block(automation_id: str) -> str:
+    lines = _package_text().splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line == f"  - id: {automation_id}":
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation id {automation_id!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - id: "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_owner_suite_publish_script_uses_documented_mqtt_contract() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+
+    assert "action: mqtt.publish" in block
+    assert "topic: home/inky/owner_suite/state" in block
+    assert "retain: true" in block
+    assert "'schema_version': 1" in block
+    assert "'display_id': 'owner_suite'" in block
+    assert "'accent': 'red'" in block
+    assert "| tojson" in block
+
+
+def test_owner_suite_payload_includes_modes_and_four_rows() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+
+    for mode in ("night_preview", "morning", "up_for_day", "midday"):
+        assert mode in block
+
+    for label in ("Weather", "Alarm", "Meeting", "Status"):
+        assert f"'label': '{label}'" in block
+
+
+def test_owner_suite_payload_maps_weather_icons_and_exceptions() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+
+    for icon in (
+        "mdi:weather-sunny",
+        "mdi:weather-partly-cloudy",
+        "mdi:weather-cloudy",
+        "mdi:weather-rainy",
+        "mdi:weather-snowy",
+        "mdi:weather-lightning",
+    ):
+        assert icon in block
+
+    assert "sensor.nws_dakota_county_alerts_alerts_are_active" in block
+    assert "cover.garage_door" in block
+    assert "binary_sensor.main_foyer_front_door_contact" in block
+    assert "input_boolean.trip" in block
+    assert "binary_sensor.planned_vacation_calendar" in block
+
+
+def test_owner_suite_automation_coalesces_meaningful_refresh_events() -> None:
+    block = _automation_block("publish_owner_suite_inky_display")
+
+    assert "mode: restart" in block
+    assert "seconds: 15" in block
+    assert "trigger: time" in block
+    assert 'at: "12:00:00"' in block
+    assert "trigger: homeassistant" in block
+    assert "action: script.publish_owner_suite_inky_display" in block
+    assert "sensor.time" not in block
+
+
+def test_owner_suite_sources_are_documented() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+
+    assert "script.publish_owner_suite_inky_display" in text
+    assert "automation.publish_owner_suite_inky_display" in text
+    assert "home/inky/owner_suite/state" in text


### PR DESCRIPTION
## Summary

- Document the first Inky display rollout for issue 313, including hardware assignments, MQTT topics, payload contract, layout rules, owner-suite modes, office privacy expectations, and rollout order.
- Add a dependency-free Python renderer scaffold that validates compact display payloads and renders 400x300 PNG previews from owner-suite sample payloads.
- Add the owner-suite Home Assistant MQTT payload publisher, coalesced refresh automation, Pi-side MQTT service scaffold, cache/dedup behavior, and systemd unit template.
- Add focused pytest coverage for sample rendering, payload validation, row limits, unknown section handling, stable content hashes, HA publisher structure, and Pi service cache behavior.

## Notes

This PR intentionally keeps issue 313 open. It is an implementation slice, not the full physical rollout.

Home Assistant owns desired display state. The Pi service owns rendering, cache restore, duplicate suppression, and the physical Inky refresh.

## Validation

- `python3 -m pytest tests/test_inky_display_renderer.py`
- `python3 -m pytest tests/test_inky_display_service.py tests/test_inky_display_renderer.py tests/test_inky_displays_package.py`
- `python3 -m inky_display.cli inky_display/samples/owner_suite_night_preview.json /tmp/owner_suite_night_preview.png`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/inky_displays.yaml --strict`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/inky_displays.yaml`
- `uv run --with pytest pytest` (`394 passed`)
