### PR TITLE
fix: set only_once=false for den and dining room adaptive lighting

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -19,7 +19,7 @@ automation:
           include_config_in_attributes: true
           take_over_control: true
           adapt_only_on_bare_turn_on: true
-          only_once: true
+          only_once: false
           initial_transition: 1
           transition: 5
           detect_non_ha_changes: false
@@ -41,7 +41,7 @@ automation:
           include_config_in_attributes: true
           take_over_control: true
           adapt_only_on_bare_turn_on: true
-          only_once: true
+          only_once: false
           initial_transition: 2
           transition: 2
           separate_turn_on_commands: true


### PR DESCRIPTION
## Summary

- Den and dining room adaptive lighting switches had `only_once: true`, causing lights to lock in the color from initial adaptation and never track the solar curve for the rest of the on-cycle
- At sunset, lights on since midday would still show cool/blue midday colors
- Changed both to `only_once: false` so color temperature updates continuously

Closes #554

## Test plan
- [ ] Trigger the cloudy arrival scene in the afternoon and verify den/dining room lights warm up naturally toward sunset
- [ ] Confirm kitchen adaptive lighting behavior is unchanged (still `only_once: true`)
- [ ] Verify HA restart reconcile still applies correct settings for all switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)