### PR TITLE
fix(#556): restore whole-house lights-off on tv_resumed and kitchen/den on tv_paused

### DIFF
--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -363,11 +363,15 @@ automation:
           entity_id:
             - media_player.office_sonos_2
             - media_player.den_sonos_2
-      - action: scene.turn_on
+      - action: script.lights_off_except
         continue_on_error: true
-        target:
-          entity_id: scene.tv_resumed
         data:
+          exclude_lights:
+            - light.outside_front_hue
+            - light.outside_north_west_garage
+            - light.outside_south_west_garage
+            - light.outside_front_door
+            - light.basement_tv_bias
           transition: 15
       - action: script.turn_on
         continue_on_error: true
@@ -391,6 +395,12 @@ scene:
       light.basement_great_room:
         state: "on"
         brightness: 128
+      light.kitchen_sink_overhead:
+        state: "on"
+        brightness: 255
+      light.den_floods:
+        state: "on"
+        brightness: 255
 
   - name: tv_resumed
     entities:

--- a/specs/tv_watching.allium
+++ b/specs/tv_watching.allium
@@ -1,0 +1,105 @@
+-- allium: 3
+-- tv_watching.allium
+--
+-- Scope: Basement TV session lifecycle and whole-house lighting response.
+-- Includes:
+--   - ambient lighting response when TV starts playing or pauses
+--   - audio pause/handoff on TV resume
+--   - TV power on/off basement light reset
+--   - guest-mode gate: none of the evening automations run when guest mode is on
+-- Excludes:
+--   - specific watch scripts (watch_plex, watch_netflix, etc.)
+--   - bedtime handoff triggered by TV off (see night_routines.allium)
+--   - the exact light brightness/color values (those live in scene definitions)
+
+------------------------------------------------------------
+-- External Entities
+------------------------------------------------------------
+
+external entity TVContext {
+    guest_mode_enabled: Boolean
+    within_evening_window: Boolean    -- true between 19:30 and 23:59
+    bed_occupied: Boolean
+}
+
+external entity BasementTV {
+    status: playing | paused | idle | off | unavailable
+}
+
+external entity Light {
+    is_outside: Boolean
+    is_tv_bias: Boolean
+    on: Boolean
+    brightness: Integer               -- 0–255
+}
+
+------------------------------------------------------------
+-- Given
+------------------------------------------------------------
+
+given {
+    ctx: TVContext
+    basement_great_room: Light
+    kitchen_sink_overhead: Light
+    den_floods: Light
+    basement_tv_bias: Light
+}
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+rule TVResumesPlaying {
+    -- When any basement media source goes to playing, silence common-area
+    -- audio and kill all inside lights so the space reads as "movie mode".
+    -- Outside lights and TV bias are preserved.
+    when: _: BasementTV.status becomes playing
+    requires: ctx.within_evening_window
+    requires: not ctx.guest_mode_enabled
+    ensures: common_area_sonos_paused = true
+    ensures: house_audio_paused = true
+    ensures:
+        for light in Light where not light.is_outside and not light.is_tv_bias:
+            light.on = false
+    @guidance
+        -- Transition over 15 s. outside_front_hue, outside_north_west_garage,
+        -- outside_south_west_garage, outside_front_door, and basement_tv_bias
+        -- are excluded from the off sweep.
+}
+
+rule TVPauses {
+    -- When TV pauses, restore enough light for the owner to move around —
+    -- basement at half brightness, kitchen and den at full so upstairs spaces
+    -- are usable if the owner has stepped away from the basement.
+    when: _: BasementTV.status becomes paused
+    requires: ctx.within_evening_window
+    requires: not ctx.guest_mode_enabled
+    ensures: basement_great_room.on = true
+    ensures: basement_great_room.brightness = 128
+    ensures: kitchen_sink_overhead.on = true
+    ensures: kitchen_sink_overhead.brightness = 255
+    ensures: den_floods.on = true
+    ensures: den_floods.brightness = 255
+}
+
+rule TVPowerOn {
+    -- Physical TV power-on turns on the bias light for ambient viewing comfort
+    -- and pauses house audio.
+    when: _: BasementTV.status becomes playing
+    requires: not ctx.bed_occupied
+    ensures: basement_tv_bias.on = true
+    ensures: house_audio_paused = true
+    @guidance
+        -- 2 s delay before pausing audio, 10 s debounce on the LG TV trigger.
+}
+
+rule TVPowerOff {
+    -- TV off or unavailable resets the basement to normal occupancy lighting.
+    when: _: BasementTV.status becomes off | unavailable
+    ensures: basement_great_room.on = true
+    ensures: basement_great_room.brightness = 255
+    ensures: basement_tv_bias.on = false
+    @guidance
+        -- 15 s debounce to handle off-to-unavailable handoff without double-firing.
+        -- basement_tv_bias transitions off over 4 s.
+}


### PR DESCRIPTION
## Summary

Fixes #556 — reverting the lighting overcorrection introduced by PR #419.

- **`tv_resumed`**: restore `script.lights_off_except` (replacing `scene.turn_on scene.tv_resumed`) so all inside lights go off over 15 s when TV starts playing; outside lights and TV bias are excluded
- **`scene.tv_paused`**: restore `light.kitchen_sink_overhead` and `light.den_floods` at full brightness — these are intentional so the owner can move around upstairs when pausing

Also adds `specs/tv_watching.allium` — new Allium spec documenting the four TV session lighting rules (`TVResumesPlaying`, `TVPauses`, `TVPowerOn`, `TVPowerOff`).

## Root cause

PR #419 correctly removed non-basement lights from `scene.tv_paused` turning *on* during playback. It incorrectly also:
1. Replaced whole-house lights-off logic with a basement-only scene in `tv_resumed`
2. Removed kitchen/den from `tv_paused` (which were always intentional for upstairs usability on pause)

## Test plan

- [ ] Start playback in basement after 19:30 (guest mode off) — all inside lights should go off over 15 s; outside lights and TV bias stay on
- [ ] Pause playback — basement great room at ~50%, kitchen sink overhead and den floods at 100%
- [ ] Resume — inside lights go off again
- [ ] Verify guest mode on → no light changes on play/pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)