### PR TITLE
fix(#558): owner suite fan switch LED bar dark mode

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1977,6 +1977,7 @@ script:
 
   apply_owner_suite_inovelli_led_policy:
     icon: mdi:light-switch
+    mode: restart
     fields:
       policy:
         name: Policy
@@ -2756,6 +2757,11 @@ script:
                   - number.owner_suite_fan_switch_ledintensitywhenoff
                   - number.owner_suite_bathroom_vanity_ledintensitywhenoff
                   - number.office_fan_switch_ledintensitywhenoff
+            - action: number.set_value
+              data:
+                value: 0
+              target:
+                entity_id: number.owner_suite_fan_switch_ledintensitywhenon
           initial_grace_period: 30
           expected_state: 0
       - repeat:
@@ -2769,6 +2775,7 @@ script:
                 - number.owner_suite_fan_switch_ledintensitywhenoff
                 - number.owner_suite_bathroom_vanity_ledintensitywhenoff
                 - number.office_fan_switch_ledintensitywhenoff
+                - number.owner_suite_fan_switch_ledintensitywhenon
               data:
                 value: 0
 


### PR DESCRIPTION
## Summary

- `turn_off_owner_suite_inovelli_switch_leds`: zero `ledintensitywhenon` for the fan switch in both the `retry.actions` block and the follow-up `repeat` writes
- `apply_owner_suite_inovelli_led_policy`: change `mode: single` → `mode: restart`

Closes #558

## Why

The fan switch is in **SmartBulbMode** (relay always closed for constant fan power), so the hardware perpetually displays `ledintensitywhenon`. The old dark-mode script only zeroed `ledintensitywhenoff`, which has no visible effect on a SmartBulbMode device — the LED bar stayed lit at full brightness every night.

Because `ledintensitywhenoff` never settled at 0, the `retry.actions` loop ran every 30 s for up to 20 hours, holding `apply_owner_suite_inovelli_led_policy` (mode: single) permanently occupied and dropping all subsequent LED policy calls with `failed_single`.

## Test plan

- [ ] Trigger goodnight integrity (CPAP sleep or manual) and confirm the fan switch LED bar goes dark
- [ ] Confirm closet and vanity LED bars also go dark (unchanged behaviour)
- [ ] Let morning workday activity fire — confirm fan switch LED bar returns to blue (day mode) without `failed_single` in traces
- [ ] Confirm `night_red` mode still shows dim red on the fan switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)