### PR TITLE
fix: resolve three CI test failures after #556 and #559

### DIFF
--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -363,16 +363,10 @@ automation:
           entity_id:
             - media_player.office_sonos_2
             - media_player.den_sonos_2
-      - action: script.lights_off_except
+      - action: scene.turn_on
         continue_on_error: true
-        data:
-          exclude_lights:
-            - light.outside_front_hue
-            - light.outside_north_west_garage
-            - light.outside_south_west_garage
-            - light.outside_front_door
-            - light.basement_tv_bias
-          transition: 15
+        target:
+          entity_id: scene.tv_resumed
       - action: script.turn_on
         continue_on_error: true
         target:
@@ -395,12 +389,6 @@ scene:
       light.basement_great_room:
         state: "on"
         brightness: 128
-      light.kitchen_sink_overhead:
-        state: "on"
-        brightness: 255
-      light.den_floods:
-        state: "on"
-        brightness: 255
 
   - name: tv_resumed
     entities:

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -195,7 +195,7 @@ def test_owner_suite_led_shutdown_waits_for_inovelli_state_settle() -> None:
 
     assert "initial_grace_period: 30" in block
     assert "expected_state: 0" in block
-    assert block.count("action: number.set_value") == 2
+    assert block.count("action: number.set_value") == 3
     assert "count: 2" in block
     assert block.count("seconds: 30") == 1
 


### PR DESCRIPTION
## Summary

- **tv_paused scene**: removed `light.kitchen_sink_overhead` and `light.den_floods` — the spec (added in 5130b3fb) constrains `tv_paused` to basement great room only; commit 55739a73 incorrectly widened scope
- **tv_resumed automation**: replaced `script.lights_off_except` whole-house sweep with `scene.turn_on` targeting `scene.tv_resumed` — the spec requires a scene-scoped transition, not a global lights-off
- **test assertion**: updated `number.set_value` count 2→3 in `test_owner_suite_led_shutdown_waits_for_inovelli_state_settle` after merged PR [#559](https://github.com/rtclauss/hass-config/pull/559) added a second `number.set_value` action in the retry block for `ledintensitywhenon`

## Test plan

- [x] `pytest` — 371/371 passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)