### PR TITLE
Fix stale entity connectivity noise (#560)

### DIFF
--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -197,6 +197,7 @@ automation:
         {%- for item in expand(states.binary_sensor, states.device_tracker, states.fan, states.light, states.lock, states.media_player, states.sensor, states.switch, states.vacuum) if (
           not is_state_attr(item.entity_id, 'hidden', true)
           and (now()-as_local(item.last_reported) > timedelta(hours=stale_threshold_hours))
+          and item.attributes.device_class != 'connectivity'
           and not (item.entity_id | lower).find('update') != -1
           and not (item.entity_id | lower).find('heading') != -1
           and not (item.entity_id | lower).find('alert') != -1

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -139,6 +139,7 @@ def test_stale_entity_notification_only_exists_when_entities_are_present() -> No
     assert "stale_threshold_hours: 12" in block
     assert "stale_entities:" in block
     assert "last_reported" in block
+    assert "item.attributes.device_class != 'connectivity'" in block
     assert "persistent_notification.create" in block
     assert "persistent_notification.dismiss" in block
     assert "notification_id: stale-entities" in block


### PR DESCRIPTION
## Summary
- exclude connectivity device-class entities from the catch-all stale entity notification
- keep Zigbee2MQTT availability failures covered by the dedicated z2m_devices_offline aggregate
- add a regression assertion for the stale entity filter

Fixes #560.

## Validation
- uv run --with pytest pytest
- yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/utilities.yaml
- uv run --with homeassistant==2026.3.4 python -m homeassistant --config "/Users/rtclauss/.codex/worktrees/review-ha-issues-560/New project" --script check_config
- python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/utilities.yaml --strict (reports pre-existing unrelated duplicates in water-meter/restart/water-restore automations; stale-entity block has no DRY finding)

## Notes
- Docker is not installed locally, so I ran Home Assistant check_config through uv with the same pinned HA version used by CI and a generated local test secrets file.