### PR TITLE
Fix Inky MQTT callback API warning

### DIFF
--- a/inky_display/service.py
+++ b/inky_display/service.py
@@ -104,12 +104,12 @@ def run_mqtt_service(config: ServiceConfig) -> None:
     if restored is not None:
         LOG.info("Restored cached image from %s", cache.image_path)
 
-    client = mqtt.Client()
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
     if config.mqtt_username:
         client.username_pw_set(config.mqtt_username, config.mqtt_password)
 
     def on_connect(client, _userdata, _flags, reason_code, _properties=None) -> None:
-        if int(reason_code) == 0:
+        if mqtt_connection_succeeded(reason_code):
             LOG.info("Connected to MQTT broker %s:%s", config.mqtt_host, config.mqtt_port)
             client.subscribe(config.mqtt_topic)
             return
@@ -146,6 +146,17 @@ def _decode_payload(raw_payload: bytes | str) -> str:
     if isinstance(raw_payload, bytes):
         return raw_payload.decode("utf-8")
     return raw_payload
+
+
+def mqtt_connection_succeeded(reason_code: object) -> bool:
+    is_failure = getattr(reason_code, "is_failure", None)
+    if isinstance(is_failure, bool):
+        return not is_failure
+
+    try:
+        return int(reason_code) == 0
+    except (TypeError, ValueError):
+        return str(reason_code).lower() in {"0", "success"}
 
 
 if __name__ == "__main__":

--- a/tests/test_inky_display_service.py
+++ b/tests/test_inky_display_service.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import subprocess
 import sys
 
-from inky_display.service import PayloadCache, config_from_env, process_payload
+from inky_display.service import PayloadCache, config_from_env, mqtt_connection_succeeded, process_payload
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -83,6 +83,19 @@ def test_config_from_env_uses_pi_service_environment(monkeypatch, tmp_path: Path
     assert config.cache_dir == tmp_path
     assert config.mqtt_username == "inky"
     assert config.mqtt_password == "secret"
+
+
+def test_mqtt_connection_succeeded_accepts_paho_v2_reason_code() -> None:
+    class SuccessReason:
+        is_failure = False
+
+    class FailureReason:
+        is_failure = True
+
+    assert mqtt_connection_succeeded(SuccessReason()) is True
+    assert mqtt_connection_succeeded(FailureReason()) is False
+    assert mqtt_connection_succeeded(0) is True
+    assert mqtt_connection_succeeded(5) is False
 
 
 def test_service_help_does_not_require_mqtt_dependency() -> None:


### PR DESCRIPTION
Follow-up for issue 313 Pi Zero W smoke testing.\n\nThis updates the Inky MQTT service to use Paho MQTT callback API v2 so the service starts without the runtime deprecation warning observed on the Pi.\n\nTests:\n- python3 -m pytest tests/test_inky_display_service.py tests/test_inky_display_renderer.py\n- python3 -m inky_display.service --check-config