### PR TITLE
Fix washer cleared state reconciliation (#268)

### DIFF
--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -239,15 +239,21 @@ automation:
 
   - id: washer_cleared
     alias: washer_cleared
-    description: Reset the washer back to IDLE once the door opens and the finished load is being handled.
+    description: Reset the washer back to IDLE once the finished load has been handled or is already open.
     trigger:
       - trigger: state
         entity_id: binary_sensor.laundry_room_washing_machine_door_contact
         to: "on"
+      - trigger: state
+        entity_id: input_select.washer_state
+        to: "CLEAN"
+      - trigger: state
+        entity_id: input_select.washer_state
+        to: "MUSTY"
     condition:
       - condition: state
-        entity_id: binary_sensor.washing_machine_running
-        state: "off"
+        entity_id: binary_sensor.laundry_room_washing_machine_door_contact
+        state: "on"
       - condition: or
         conditions:
           - condition: state

--- a/tests/test_laundry_plug_monitoring.py
+++ b/tests/test_laundry_plug_monitoring.py
@@ -118,7 +118,11 @@ def test_cleaning_package_notifies_from_power_based_running_sensors() -> None:
 
     assert "binary_sensor.laundry_room_washing_machine_door_contact" in washer_cleared
     assert 'to: "on"' in washer_cleared
+    assert "entity_id: input_select.washer_state" in washer_cleared
+    assert 'to: "CLEAN"' in washer_cleared
+    assert 'to: "MUSTY"' in washer_cleared
     assert "input_boolean.washer_wet_load_pending" not in washer_cleared
+    assert 'state: "on"' in washer_cleared
     assert 'state: "CLEAN"' in washer_cleared
     assert 'state: "MUSTY"' in washer_cleared
     assert "option: IDLE" in washer_cleared


### PR DESCRIPTION
## Summary
- verify recent live washer cycles against the power-based state machine
- clear `input_select.washer_state` when the washer becomes `CLEAN`/`MUSTY` while the door is already open
- cover the reconciliation path in `tests/test_laundry_plug_monitoring.py`

Fixes #268.

## Runtime evidence
- Live Home Assistant history for April 28, 2026 showed two coherent cycles: `IDLE -> CLEANING -> CLEAN`, then door-open reset to `IDLE`.
- The remaining edge case was immediate unload during the 8-minute washer-running `delay_off`: `wash_finished` can mark the load `CLEAN` after the door-open transition has already happened. The new state trigger reconciles that case without adding helpers or templates.

## Validation
- `uv run --with pytest pytest tests/test_laundry_plug_monitoring.py`
- `uv run --with pytest pytest`
- `uv run --with pyyaml python /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/cleaning.yaml --strict`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/cleaning.yaml`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt`
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `uv run --with homeassistant==2026.3.4 python -m homeassistant --config /Users/rtclauss/.codex/worktrees/review-ha-issues-268 --script check_config`

## Notes
- Docker is not installed locally, so Home Assistant config validation used the repo's pinned 2026.3.4 fallback through `uv` with local schema-valid placeholder secrets.
