### PR TITLE
Add Inky hardware panel output

### DIFF
--- a/deploy/systemd/inky-owner-suite.service
+++ b/deploy/systemd/inky-owner-suite.service
@@ -11,6 +11,10 @@ Environment=INKY_MQTT_HOST=homeassistant.local
 Environment=INKY_MQTT_PORT=1883
 Environment=INKY_MQTT_TOPIC=home/inky/owner_suite/state
 Environment=INKY_CACHE_DIR=/var/lib/inky-display/owner_suite
+Environment=INKY_HARDWARE_ENABLED=true
+Environment=INKY_PANEL_TYPE=what
+Environment=INKY_PANEL_COLOR=red
+Environment=INKY_ROTATION=0
 ExecStart=/usr/bin/python3 -m inky_display.service
 Restart=always
 RestartSec=10

--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -285,14 +285,51 @@ INKY_CACHE_DIR=/var/lib/inky-display/owner_suite \
 python3 -m inky_display.service
 ```
 
+Run a real panel refresh on the Pi after the Inky wHAT is attached:
+
+```bash
+sudo raspi-config nonint do_i2c 0
+sudo raspi-config nonint do_spi 0
+sudo apt-get update
+sudo apt-get install -y libopenblas0-pthread
+python3 -m pip install paho-mqtt Pillow inky
+sudo reboot
+```
+
+After the reboot, render the next MQTT payload to the physical red/black/white
+Inky wHAT:
+
+```bash
+INKY_DISPLAY_ID=owner_suite \
+INKY_MQTT_HOST=homeassistant.local \
+INKY_MQTT_PORT=1883 \
+INKY_MQTT_TOPIC=home/inky/owner_suite/state \
+INKY_CACHE_DIR=/var/lib/inky-display/owner_suite \
+INKY_HARDWARE_ENABLED=true \
+INKY_PANEL_TYPE=what \
+INKY_PANEL_COLOR=red \
+INKY_ROTATION=0 \
+python3 -m inky_display.service
+```
+
+For a non-production physical smoke test, use a temporary topic such as
+`home/inky/owner_suite/real_test`, start the service with that topic, and publish
+one sample payload to it. Expected result: the panel refreshes once, the cache
+contains a `400x300` `last_image.png`, and the service log has no traceback,
+deprecation warning, or `Failed to update Inky panel` message.
+
+For older boards that cannot be detected automatically, keep
+`INKY_PANEL_TYPE=what` and `INKY_PANEL_COLOR=red`. If a board with a valid Inky
+EEPROM should be auto-detected instead, set `INKY_PANEL_TYPE=auto`.
+
 The service writes:
 
 - `last_payload.json`
 - `last_image.png`
 - `last_hash.txt`
 
-Duplicate payload hashes are ignored. Invalid payloads are logged and do not
-overwrite the last good cache.
+Duplicate payload hashes are ignored and do not refresh the physical panel.
+Invalid payloads are logged and do not overwrite the last good cache.
 
 ## Raspberry Pi Service
 

--- a/inky_display/service.py
+++ b/inky_display/service.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+from io import BytesIO
 import json
 import logging
 import os
 from pathlib import Path
+from typing import Protocol
 
 from .payload import payload_hash, validate_payload
 from .renderer import render_payload
@@ -24,6 +26,10 @@ class ServiceConfig:
     cache_dir: Path
     mqtt_username: str
     mqtt_password: str
+    hardware_enabled: bool
+    panel_type: str
+    panel_color: str
+    rotation: int
 
 
 @dataclass(frozen=True)
@@ -32,6 +38,11 @@ class ProcessResult:
     reason: str
     content_hash: str
     image_path: Path | None
+
+
+class ImageSink(Protocol):
+    def update(self, image: bytes) -> None:
+        ...
 
 
 class PayloadCache:
@@ -68,10 +79,19 @@ def config_from_env() -> ServiceConfig:
         cache_dir=Path(os.environ.get("INKY_CACHE_DIR", ".inky-cache")),
         mqtt_username=os.environ.get("INKY_MQTT_USERNAME", ""),
         mqtt_password=os.environ.get("INKY_MQTT_PASSWORD", ""),
+        hardware_enabled=_env_bool("INKY_HARDWARE_ENABLED", default=False),
+        panel_type=os.environ.get("INKY_PANEL_TYPE", "what"),
+        panel_color=os.environ.get("INKY_PANEL_COLOR", "red"),
+        rotation=int(os.environ.get("INKY_ROTATION", "0")),
     )
 
 
-def process_payload(raw_payload: bytes | str, cache: PayloadCache, display_id: str) -> ProcessResult:
+def process_payload(
+    raw_payload: bytes | str,
+    cache: PayloadCache,
+    display_id: str,
+    image_sink: ImageSink | None = None,
+) -> ProcessResult:
     raw_text = _decode_payload(raw_payload)
     try:
         data = json.loads(raw_text)
@@ -90,6 +110,7 @@ def process_payload(raw_payload: bytes | str, cache: PayloadCache, display_id: s
 
     image = render_payload(payload)
     image_path = cache.save(raw_text, image, content_hash)
+    update_image_sink(image_sink, image)
     return ProcessResult(True, "rendered", content_hash, image_path)
 
 
@@ -100,9 +121,11 @@ def run_mqtt_service(config: ServiceConfig) -> None:
         raise RuntimeError("Install paho-mqtt on the Raspberry Pi to run the MQTT service.") from error
 
     cache = PayloadCache(config.cache_dir)
+    image_sink = build_image_sink(config)
     restored = cache.restore_image()
     if restored is not None:
         LOG.info("Restored cached image from %s", cache.image_path)
+        update_image_sink(image_sink, restored)
 
     client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
     if config.mqtt_username:
@@ -116,7 +139,7 @@ def run_mqtt_service(config: ServiceConfig) -> None:
         LOG.error("MQTT connection failed with code %s", reason_code)
 
     def on_message(_client, _userdata, message) -> None:
-        result = process_payload(message.payload, cache, config.display_id)
+        result = process_payload(message.payload, cache, config.display_id, image_sink=image_sink)
         LOG.info("Processed MQTT payload from %s: %s", message.topic, result.reason)
 
     client.on_connect = on_connect
@@ -146,6 +169,71 @@ def _decode_payload(raw_payload: bytes | str) -> str:
     if isinstance(raw_payload, bytes):
         return raw_payload.decode("utf-8")
     return raw_payload
+
+
+def build_image_sink(config: ServiceConfig) -> ImageSink | None:
+    if not config.hardware_enabled:
+        return None
+    return InkyImageSink(config.panel_type, config.panel_color, config.rotation)
+
+
+def update_image_sink(image_sink: ImageSink | None, image: bytes) -> None:
+    if image_sink is None:
+        return
+    try:
+        image_sink.update(image)
+    except RuntimeError:
+        raise
+    except Exception:
+        LOG.exception("Failed to update Inky panel; keeping last cached image.")
+
+
+class InkyImageSink:
+    def __init__(self, panel_type: str, panel_color: str, rotation: int) -> None:
+        try:
+            from PIL import Image
+        except ImportError as error:
+            raise RuntimeError("Install Pillow on the Raspberry Pi to refresh the Inky panel.") from error
+
+        self.image_module = Image
+        self.display = _build_inky_display(panel_type, panel_color)
+        self.rotation = rotation
+        self.display.set_border(self.display.WHITE)
+
+    def update(self, image: bytes) -> None:
+        rendered = self.image_module.open(BytesIO(image)).convert("RGB")
+        if self.rotation:
+            rendered = rendered.rotate(self.rotation)
+        self.display.set_image(rendered)
+        self.display.show()
+
+
+def _build_inky_display(panel_type: str, panel_color: str):
+    if panel_type == "auto":
+        try:
+            from inky.auto import auto
+        except ImportError as error:
+            raise RuntimeError("Install the Pimoroni Inky library to refresh the Inky panel.") from error
+
+        return auto()
+
+    try:
+        from inky import InkyPHAT, InkyWHAT
+    except ImportError as error:
+        raise RuntimeError("Install the Pimoroni Inky library to refresh the Inky panel.") from error
+
+    if panel_type == "what":
+        return InkyWHAT(panel_color)
+    if panel_type == "phat":
+        return InkyPHAT(panel_color)
+    raise ValueError(f"Unsupported INKY_PANEL_TYPE: {panel_type}")
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
 
 
 def mqtt_connection_succeeded(reason_code: object) -> bool:

--- a/tests/test_inky_display_service.py
+++ b/tests/test_inky_display_service.py
@@ -5,7 +5,13 @@ from pathlib import Path
 import subprocess
 import sys
 
-from inky_display.service import PayloadCache, config_from_env, mqtt_connection_succeeded, process_payload
+from inky_display.service import (
+    PayloadCache,
+    config_from_env,
+    mqtt_connection_succeeded,
+    process_payload,
+    update_image_sink,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -14,6 +20,14 @@ SAMPLE_PATH = ROOT / "inky_display" / "samples" / "owner_suite_night_preview.jso
 
 def _sample_text() -> str:
     return SAMPLE_PATH.read_text(encoding="utf-8")
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.images: list[bytes] = []
+
+    def update(self, image: bytes) -> None:
+        self.images.append(image)
 
 
 def test_process_payload_renders_and_caches_last_good_image(tmp_path: Path) -> None:
@@ -30,6 +44,16 @@ def test_process_payload_renders_and_caches_last_good_image(tmp_path: Path) -> N
     assert cache.restore_image() == cache.image_path.read_bytes()
 
 
+def test_process_payload_updates_image_sink_when_rendered(tmp_path: Path) -> None:
+    cache = PayloadCache(tmp_path)
+    sink = RecordingSink()
+
+    result = process_payload(_sample_text(), cache, "owner_suite", image_sink=sink)
+
+    assert result.rendered is True
+    assert sink.images == [cache.image_path.read_bytes()]
+
+
 def test_process_payload_suppresses_duplicate_content_hash(tmp_path: Path) -> None:
     cache = PayloadCache(tmp_path)
     first = process_payload(_sample_text(), cache, "owner_suite")
@@ -40,6 +64,12 @@ def test_process_payload_suppresses_duplicate_content_hash(tmp_path: Path) -> No
     assert duplicate.rendered is False
     assert duplicate.reason == "duplicate"
     assert duplicate.content_hash == first.content_hash
+    sink = RecordingSink()
+
+    duplicate_with_sink = process_payload(_sample_text(), cache, "owner_suite", image_sink=sink)
+
+    assert duplicate_with_sink.reason == "duplicate"
+    assert sink.images == []
 
 
 def test_process_payload_ignores_invalid_payload_without_overwriting_cache(tmp_path: Path) -> None:
@@ -73,6 +103,10 @@ def test_config_from_env_uses_pi_service_environment(monkeypatch, tmp_path: Path
     monkeypatch.setenv("INKY_CACHE_DIR", str(tmp_path))
     monkeypatch.setenv("INKY_MQTT_USERNAME", "inky")
     monkeypatch.setenv("INKY_MQTT_PASSWORD", "secret")
+    monkeypatch.setenv("INKY_HARDWARE_ENABLED", "true")
+    monkeypatch.setenv("INKY_PANEL_TYPE", "what")
+    monkeypatch.setenv("INKY_PANEL_COLOR", "red")
+    monkeypatch.setenv("INKY_ROTATION", "180")
 
     config = config_from_env()
 
@@ -83,6 +117,20 @@ def test_config_from_env_uses_pi_service_environment(monkeypatch, tmp_path: Path
     assert config.cache_dir == tmp_path
     assert config.mqtt_username == "inky"
     assert config.mqtt_password == "secret"
+    assert config.hardware_enabled is True
+    assert config.panel_type == "what"
+    assert config.panel_color == "red"
+    assert config.rotation == 180
+
+
+def test_update_image_sink_logs_and_continues_on_panel_failure(caplog) -> None:
+    class FailingSink:
+        def update(self, _image: bytes) -> None:
+            raise OSError("panel offline")
+
+    update_image_sink(FailingSink(), b"not-a-real-image")
+
+    assert "Failed to update Inky panel" in caplog.text
 
 
 def test_mqtt_connection_succeeded_accepts_paho_v2_reason_code() -> None:


### PR DESCRIPTION
Follow-up for issue 313 real Pi Zero W / Inky wHAT testing.\n\nThis adds an opt-in hardware output path to the Pi MQTT service. The renderer remains dependency-free by default; setting INKY_HARDWARE_ENABLED=true loads Pillow and Pimoroni Inky only on the Pi, writes rendered PNGs to the physical panel, and keeps duplicate payloads from refreshing the panel.\n\nReal Pi test completed on red-inky / Pi Zero W with the attached red/black/white Inky wHAT:\n- enabled I2C and SPI\n- installed Pillow, inky 2.4.0, and libopenblas0-pthread\n- one-shot sample render refreshed the physical panel\n- MQTT smoke test on home/inky/owner_suite/real_test rendered, cached a 400x300 PNG, and refreshed the physical panel with no traceback, deprecation warning, or panel update failure\n\nTests:\n- python3 -m pytest tests/test_inky_display_service.py tests/test_inky_display_renderer.py\n- python3 -m inky_display.service --check-config\n- Pi Zero W: /home/rtclauss/inky-venv/bin/python -m pytest tests/test_inky_display_service.py tests/test_inky_display_renderer.py\n- Pi Zero W: physical Inky one-shot refresh\n- Pi Zero W: physical MQTT service smoke test on temporary topic