### PR TITLE
Use auto-detected Inky panel driver

### DIFF
--- a/deploy/systemd/inky-owner-suite.service
+++ b/deploy/systemd/inky-owner-suite.service
@@ -12,7 +12,7 @@ Environment=INKY_MQTT_PORT=1883
 Environment=INKY_MQTT_TOPIC=home/inky/owner_suite/state
 Environment=INKY_CACHE_DIR=/var/lib/inky-display/owner_suite
 Environment=INKY_HARDWARE_ENABLED=true
-Environment=INKY_PANEL_TYPE=what
+Environment=INKY_PANEL_TYPE=auto
 Environment=INKY_PANEL_COLOR=red
 Environment=INKY_ROTATION=0
 ExecStart=/usr/bin/python3 -m inky_display.service

--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -306,7 +306,7 @@ INKY_MQTT_PORT=1883 \
 INKY_MQTT_TOPIC=home/inky/owner_suite/state \
 INKY_CACHE_DIR=/var/lib/inky-display/owner_suite \
 INKY_HARDWARE_ENABLED=true \
-INKY_PANEL_TYPE=what \
+INKY_PANEL_TYPE=auto \
 INKY_PANEL_COLOR=red \
 INKY_ROTATION=0 \
 python3 -m inky_display.service
@@ -318,9 +318,11 @@ one sample payload to it. Expected result: the panel refreshes once, the cache
 contains a `400x300` `last_image.png`, and the service log has no traceback,
 deprecation warning, or `Failed to update Inky panel` message.
 
-For older boards that cannot be detected automatically, keep
-`INKY_PANEL_TYPE=what` and `INKY_PANEL_COLOR=red`. If a board with a valid Inky
-EEPROM should be auto-detected instead, set `INKY_PANEL_TYPE=auto`.
+Keep `INKY_PANEL_TYPE=auto` for boards with a valid Inky EEPROM. The owner-suite
+red Inky wHAT currently reports as `Red wHAT (SSD1683)`, which needs the
+auto-detected driver rather than the legacy `what` driver. For older boards that
+cannot be detected automatically, set `INKY_PANEL_TYPE=what` and
+`INKY_PANEL_COLOR=red`.
 
 The service writes:
 

--- a/inky_display/service.py
+++ b/inky_display/service.py
@@ -80,7 +80,7 @@ def config_from_env() -> ServiceConfig:
         mqtt_username=os.environ.get("INKY_MQTT_USERNAME", ""),
         mqtt_password=os.environ.get("INKY_MQTT_PASSWORD", ""),
         hardware_enabled=_env_bool("INKY_HARDWARE_ENABLED", default=False),
-        panel_type=os.environ.get("INKY_PANEL_TYPE", "what"),
+        panel_type=os.environ.get("INKY_PANEL_TYPE", "auto"),
         panel_color=os.environ.get("INKY_PANEL_COLOR", "red"),
         rotation=int(os.environ.get("INKY_ROTATION", "0")),
     )

--- a/tests/test_inky_display_service.py
+++ b/tests/test_inky_display_service.py
@@ -123,6 +123,14 @@ def test_config_from_env_uses_pi_service_environment(monkeypatch, tmp_path: Path
     assert config.rotation == 180
 
 
+def test_config_from_env_defaults_to_auto_panel_detection(monkeypatch) -> None:
+    monkeypatch.delenv("INKY_PANEL_TYPE", raising=False)
+
+    config = config_from_env()
+
+    assert config.panel_type == "auto"
+
+
 def test_update_image_sink_logs_and_continues_on_panel_failure(caplog) -> None:
     class FailingSink:
         def update(self, _image: bytes) -> None:


### PR DESCRIPTION
Follow-up for issue 313 after the physical panel did not visibly update with the legacy Inky wHAT driver.\n\nThe owner-suite panel EEPROM reports as Red wHAT (SSD1683), so the service should use Pimoroni's EEPROM auto-detected driver by default rather than forcing the legacy what driver.\n\nReal Pi validation on red-inky:\n- direct Pimoroni auto() test detected Red wHAT (SSD1683) and visibly updated the panel\n- MQTT service smoke test with INKY_PANEL_TYPE=auto rendered, cached a 400x300 PNG, and visibly updated the panel\n\nTests:\n- python3 -m pytest tests/test_inky_display_service.py tests/test_inky_display_renderer.py\n- python3 -m inky_display.service --check-config\n- Pi Zero W: /home/rtclauss/inky-venv/bin/python -m pytest tests/test_inky_display_service.py tests/test_inky_display_renderer.py\n- Pi Zero W: physical direct auto-driver refresh\n- Pi Zero W: physical MQTT service smoke test