### PR TITLE
fix(#568): guard Open-Meteo precipitation template

### DIFF
--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -735,7 +735,9 @@ sensor:
     timeout: 20
     unit_of_measurement: "%"
     value_template: >-
-      {% set probabilities = value_json.hourly.precipitation_probability if value_json.hourly is defined and value_json.hourly.precipitation_probability is defined else [] %}
+      {% set payload = value_json if value_json is mapping else {} %}
+      {% set hourly = payload.get('hourly', {}) %}
+      {% set probabilities = hourly.get('precipitation_probability', []) if hourly is mapping else [] %}
       {% set ns = namespace(max_probability = -1) %}
       {% for probability in probabilities %}
         {% set probability_value = probability | int(default=-1) %}

--- a/tests/test_weather_package.py
+++ b/tests/test_weather_package.py
@@ -21,6 +21,15 @@ def test_car_window_alert_closes_windows_even_when_notification_is_throttled() -
     assert "action: notify.mobile_app_wethop" in text
 
 
+def test_open_meteo_precipitation_template_handles_non_json_response() -> None:
+    text = WEATHER_PATH.read_text(encoding="utf-8")
+
+    assert "name: nigori_precip_next_2hr" in text
+    assert "{% set payload = value_json if value_json is mapping else {} %}" in text
+    assert "{% set hourly = payload.get('hourly', {}) %}" in text
+    assert "value_json.hourly" not in text
+
+
 def test_notify_weather_alert_uses_current_nws_alert_payload_shape() -> None:
     text = WEATHER_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Guard `sensor.nigori_precip_next_2hr` against non-JSON/HTML Open-Meteo failure responses before reading `hourly.precipitation_probability`.
- Preserve the existing `-1` no-data fallback and add a regression test for the template guard.

## Runtime evidence
- 2026-04-30 live HA log repeated Open-Meteo HTTP 502 warnings followed by `Template variable error: 'value_json' is undefined` for this sensor.
- Recorder history around 2026-04-30T03:00Z shows `sensor.nigori_precip_next_2hr` fell from `0` to `unknown`, then recovered to `0` after the upstream response recovered.
- Issue: Closes #568.

## Validation
- `uv run --with pytest pytest tests/test_weather_package.py` -> 3 passed
- `uv run --with pytest pytest` -> 399 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/weather.yaml` -> passed
- Live HA current-config endpoint: `{"result":"valid","errors":null,"warnings":null}`

## Validation limitation
- The CI-style pinned HA container check could not run locally because Podman was not connected (`unable to connect to Podman socket`).
