### PR TITLE
Add Inky footer update time

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -86,7 +86,7 @@ Payloads are compact JSON. Required fields:
       ]
     }
   ],
-  "footer": "Updated 9:42 PM"
+  "footer": "Updated 21:42"
 }
 ```
 
@@ -183,6 +183,10 @@ Current owner-suite rows:
 | Alarm | `input_datetime.weekday_alarm` or `input_datetime.weekend_alarm` when the matching alarm helper is on | `emphasis` in `night_preview` when alarm is enabled |
 | Meeting | `input_datetime.next_work_meeting` when `input_boolean.special_meeting` is on | `emphasis` when special meeting is on |
 | Status | First active status from weather alert, garage door, front door, trip mode, vacation, otherwise `All clear` | `urgent` for alert/door/garage, `emphasis` for trip/vacation |
+
+The footer uses 24-hour local time, for example `Updated 21:42`. This timestamp
+is generated only when the payload is published. Do not add `sensor.time` or a
+minute-level clock trigger for this field.
 
 Manual publish from Home Assistant Developer Tools:
 

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -196,5 +196,5 @@ script:
               'title': title_map.get(resolved_mode, 'Owner Suite'),
               'subtitle': subtitle_map.get(resolved_mode, 'Owner-suite display'),
               'sections': [{'type': 'rows', 'rows': rows}],
-              'footer': 'Updated from Home Assistant'
+              'footer': 'Updated ' ~ now().strftime('%H:%M')
             } | tojson }}

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -77,6 +77,15 @@ def test_owner_suite_payload_includes_modes_and_four_rows() -> None:
         assert f"'label': '{label}'" in block
 
 
+def test_owner_suite_footer_uses_publish_time_in_24_hour_format() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+
+    assert "'footer': 'Updated ' ~ now().strftime('%H:%M')" in block
+    assert "%I:%M" not in block
+    assert "%p" not in block
+    assert "sensor.time" not in block
+
+
 def test_owner_suite_payload_maps_weather_icons_and_exceptions() -> None:
     block = _script_block("publish_owner_suite_inky_display")
 
@@ -115,3 +124,4 @@ def test_owner_suite_sources_are_documented() -> None:
     assert "script.publish_owner_suite_inky_display" in text
     assert "automation.publish_owner_suite_inky_display" in text
     assert "home/inky/owner_suite/state" in text
+    assert "Updated 21:42" in text


### PR DESCRIPTION
Follow-up for issue 313.

Adds a 24-hour publish timestamp to the owner-suite Inky footer, for example `Updated 21:42`. The timestamp is generated when Home Assistant publishes the payload; no `sensor.time` trigger/source is added, so this does not create minute-level e-ink redraws.

Tests:
- python3 -m pytest tests/test_inky_displays_package.py tests/test_inky_display_renderer.py tests/test_inky_display_service.py
- python3 -m inky_display.service --check-config
