### PR TITLE
Document e-ink display usage criteria

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,16 @@
 - Use `specs/night_routines.allium` as the source of truth for bedtime preparation and overnight goodnight behavior.
 - Before changing related Home Assistant automations, scripts, helpers, dashboards, or tests, read the relevant Allium spec first and keep implementation changes aligned with it.
 
+## E-Ink Displays
+- Use `docs/inky_displays.md` as the source of truth before changing e-ink payloads, renderer behavior, MQTT topics, Pi service deployment, display layouts, or display-triggering automations.
+- The owner-suite display is a Pimoroni Inky wHAT red/black/white `400x300` panel on a Raspberry Pi Zero W. It reports as `Red wHAT (SSD1683)` and must use `INKY_PANEL_TYPE=auto`; do not force the legacy `what` driver for this board.
+- Home Assistant owns desired state and publishes compact retained MQTT payloads. The Pi service owns rendering, duplicate suppression, local cache restore, and physical refresh.
+- Current owner-suite command topic is `home/inky/owner_suite/state`. Keep future health/status topics separate from desired-state topics.
+- E-ink updates are expensive whole-panel refreshes. Do not add `sensor.time`, minute-level clock ticks, animation, or cosmetic-only refresh triggers. The footer update time must reflect the payload publish time, not drive periodic redraws.
+- New display content should be distance-legible: high-contrast `400x300`, one large title, one subtitle, at most four rows, Material Design Icons names where possible, and no dense dashboard-style text.
+- Preserve color semantics: red means urgent/exception on the owner-suite board; yellow means emphasis/hospitality on the future office board.
+- Test renderer changes with `python3 -m pytest tests/test_inky_display_renderer.py tests/test_inky_display_service.py tests/test_inky_displays_package.py`. For physical changes, verify on the Pi Zero W and confirm the panel visibly changes, not just that `show()` returns.
+
 ## Local Runtime Targets
 - Keep machine-local runtime verification targets in `AGENTS.local.md`.
 - Do not commit `AGENTS.local.md` unless explicitly asked.

--- a/README.md
+++ b/README.md
@@ -154,9 +154,44 @@ docker run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:stable \
 - [Home Assistant Label Model](docs/ha_labels.md)
 - [Room Intent Policy](docs/room_intent.yaml)
 - [Room Naming Model](docs/room_names.md)
+- [Inky E-Ink Displays](docs/inky_displays.md)
 - [ESPHome Layout And Bermuda BLE Proxy Notes](docs/esphome.md)
 - [EV Charging Tariff](docs/ev_charging_tariff.md)
 - [Tesla Departure Planner](docs/tesla_departure_planner.md)
+
+## E-Ink Display Capability
+
+This repo includes MQTT-backed e-ink display support for low-frequency,
+room-aware Home Assistant status surfaces. Home Assistant publishes compact
+desired-state payloads; Raspberry Pi services render, cache, suppress duplicate
+payloads, and refresh the physical panels.
+
+Current deployment:
+
+- `owner_suite`: Pimoroni Inky wHAT red/black/white `400x300`, driven by a
+  Raspberry Pi Zero W on `home/inky/owner_suite/state`.
+- The owner-suite panel reports as `Red wHAT (SSD1683)`, so the Pi service uses
+  `INKY_PANEL_TYPE=auto`.
+
+Use e-ink for information that should persist calmly between meaningful Home
+Assistant events: wake status, weather, door/garage exceptions, trip/vacation
+state, guest-safe info, and similar low-frequency status. Do not use these
+panels for clocks, animation, minute-level dashboards, or cosmetic updates.
+Tri-color Inky wHAT refreshes are whole-panel, slow, and should be driven only
+by meaningful source changes.
+
+Design criteria:
+
+- Keep layouts readable from about 4 feet away on a `400x300` canvas.
+- Prefer one title, one subtitle, and at most four status rows.
+- Use Material Design Icons names in payloads when possible.
+- Preserve color meaning: red is urgency/exception for owner-suite; yellow is
+  emphasis/hospitality for future office displays.
+- The footer's `Updated HH:MM` value is publish-time metadata and must not add a
+  `sensor.time` trigger or clock-tick redraws.
+
+See [docs/inky_displays.md](docs/inky_displays.md) for the payload contract,
+MQTT topics, renderer tests, Pi setup, and physical verification workflow.
 
 I have Home Assistant running on an [Intel NUC]().  This has been a work in progress since Nov 2015 (HA v0.7 or earlier).
 


### PR DESCRIPTION
Follow-up for issue 313.

Stores the e-ink usage model and criteria in the main repository guidance so future agents/components can reuse the Pimoroni Inky wHAT capability correctly.

Changes:
- Adds an `E-Ink Displays` section to `AGENTS.md` with source-of-truth docs, owner-suite hardware details, MQTT ownership boundaries, refresh constraints, layout rules, color semantics, and validation expectations.
- Adds an `E-Ink Display Capability` section to `README.md` and links `docs/inky_displays.md` from feature docs.

Tests:
- `python3 -m pytest tests/test_inky_displays_package.py tests/test_inky_display_renderer.py tests/test_inky_display_service.py`
- `uv run --with pytest pytest`
