### PR TITLE
Gate Inky updates on home occupancy

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -162,9 +162,16 @@ Primary entities:
   changes with a 15-second restart delay, then calls the publish script.
 
 The automation listens to wake alarm helpers, wake-up firing state, house mode,
-bed/owner-suite activity, trip/vacation state, garage/front-door exceptions,
-weather alerts, active weather, and a noon refresh. It does not listen to
-`sensor.time`, so it will not redraw on clock ticks.
+guest mode, Ryan's home state, bed/owner-suite activity, trip/vacation state,
+garage/front-door exceptions, weather alerts, active weather, and a noon
+refresh. It does not listen to `sensor.time`, so it will not redraw on clock
+ticks.
+
+The automation publishes only when guest mode is active, or when Ryan is home
+and trip mode is off. While Ryan is away or trip mode is on with guest mode off,
+the display keeps its last image and skips refreshes. Turning guest mode on or
+Ryan returning home is itself a meaningful source change and publishes again
+after the normal 15-second coalescing delay.
 
 Current owner-suite modes:
 

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -47,8 +47,10 @@ automation:
           - input_boolean.weekend_alarm_on
           - input_boolean.special_meeting
           - input_boolean.wakeup_alarm_firing
+          - input_boolean.guest_mode
           - input_boolean.trip
           - input_select.house_mode
+          - binary_sensor.bayesian_zeke_home
           - binary_sensor.bayesian_bed_occupancy
           - binary_sensor.bedroom_occupancy
           - binary_sensor.owner_suite_bathroom_room_occupancy
@@ -68,6 +70,14 @@ automation:
     action:
       - delay:
           seconds: 15
+      - condition: template
+        alias: Publish only when Ryan is home or guest mode is active
+        value_template: >-
+          {{ is_state('input_boolean.guest_mode', 'on')
+             or (
+               is_state('binary_sensor.bayesian_zeke_home', 'on')
+               and is_state('input_boolean.trip', 'off')
+             ) }}
       - action: script.publish_owner_suite_inky_display
         data:
           mode: >-

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -118,6 +118,17 @@ def test_owner_suite_automation_coalesces_meaningful_refresh_events() -> None:
     assert "sensor.time" not in block
 
 
+def test_owner_suite_automation_skips_publish_when_house_is_unoccupied() -> None:
+    block = _automation_block("publish_owner_suite_inky_display")
+
+    assert "input_boolean.guest_mode" in block
+    assert "binary_sensor.bayesian_zeke_home" in block
+    assert "alias: Publish only when Ryan is home or guest mode is active" in block
+    assert "is_state('input_boolean.guest_mode', 'on')" in block
+    assert "is_state('binary_sensor.bayesian_zeke_home', 'on')" in block
+    assert "is_state('input_boolean.trip', 'off')" in block
+
+
 def test_owner_suite_sources_are_documented() -> None:
     text = DOC_PATH.read_text(encoding="utf-8")
 
@@ -125,3 +136,5 @@ def test_owner_suite_sources_are_documented() -> None:
     assert "automation.publish_owner_suite_inky_display" in text
     assert "home/inky/owner_suite/state" in text
     assert "Updated 21:42" in text
+    assert "publishes only when guest mode is active" in text
+    assert "Ryan returning home" in text


### PR DESCRIPTION
Follow-up for issue 313.

Gates owner-suite Inky display publishes so the panel does not refresh while the house is effectively unoccupied.

Behavior:
- Publish when guest mode is active.
- Publish when Ryan is home and trip mode is off.
- Skip publish while Ryan is away or trip mode is on with guest mode off, leaving the last e-ink image visible.
- Trigger again when guest mode turns on or Ryan returns home, after the existing 15-second coalescing delay.

Tests:
- `python3 -m pytest tests/test_inky_displays_package.py tests/test_inky_display_renderer.py tests/test_inky_display_service.py`
- `python3 -m inky_display.service --check-config`
- `uv run --with pytest pytest`
