### PR TITLE
Enforce Inky publish occupancy guard

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -157,7 +157,8 @@ Owner-suite publishing lives in `packages/inky_displays.yaml`.
 Primary entities:
 
 - `script.publish_owner_suite_inky_display`: builds and publishes the compact
-  owner-suite payload to `home/inky/owner_suite/state`.
+  owner-suite payload to `home/inky/owner_suite/state`, after enforcing the
+  occupancy/trip publish guard.
 - `automation.publish_owner_suite_inky_display`: coalesces meaningful source
   changes with a 15-second restart delay, then calls the publish script.
 
@@ -167,11 +168,11 @@ garage/front-door exceptions, weather alerts, active weather, and a noon
 refresh. It does not listen to `sensor.time`, so it will not redraw on clock
 ticks.
 
-The automation publishes only when guest mode is active, or when Ryan is home
-and trip mode is off. While Ryan is away or trip mode is on with guest mode off,
-the display keeps its last image and skips refreshes. Turning guest mode on or
-Ryan returning home is itself a meaningful source change and publishes again
-after the normal 15-second coalescing delay.
+The publish script only allows updates when guest mode is active, or when Ryan
+is home and trip mode is off. While Ryan is away or trip mode is on with guest
+mode off, the display keeps its last image and skips refreshes. Turning guest
+mode on or Ryan returning home is itself a meaningful source change and
+publishes again after the normal 15-second coalescing delay.
 
 Current owner-suite modes:
 

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -117,6 +117,14 @@ script:
             {% else %}
               up_for_day
             {% endif %}
+      - condition: template
+        alias: Publish only when Ryan is home or guest mode is active
+        value_template: >-
+          {{ is_state('input_boolean.guest_mode', 'on')
+             or (
+               is_state('binary_sensor.bayesian_zeke_home', 'on')
+               and is_state('input_boolean.trip', 'off')
+             ) }}
       - action: mqtt.publish
         data:
           topic: home/inky/owner_suite/state

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -129,6 +129,16 @@ def test_owner_suite_automation_skips_publish_when_house_is_unoccupied() -> None
     assert "is_state('input_boolean.trip', 'off')" in block
 
 
+def test_owner_suite_publish_script_enforces_occupancy_guard() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+
+    assert "alias: Publish only when Ryan is home or guest mode is active" in block
+    assert "is_state('input_boolean.guest_mode', 'on')" in block
+    assert "is_state('binary_sensor.bayesian_zeke_home', 'on')" in block
+    assert "is_state('input_boolean.trip', 'off')" in block
+    assert block.index("alias: Publish only when Ryan is home") < block.index("action: mqtt.publish")
+
+
 def test_owner_suite_sources_are_documented() -> None:
     text = DOC_PATH.read_text(encoding="utf-8")
 
@@ -136,5 +146,5 @@ def test_owner_suite_sources_are_documented() -> None:
     assert "automation.publish_owner_suite_inky_display" in text
     assert "home/inky/owner_suite/state" in text
     assert "Updated 21:42" in text
-    assert "publishes only when guest mode is active" in text
+    assert "publish script only allows updates when guest mode is active" in text
     assert "Ryan returning home" in text


### PR DESCRIPTION
## Summary
- add the owner-suite occupancy/trip guard directly before mqtt.publish
- document the publish script as the enforcement point
- cover the script boundary guard in package tests

Fixes #582
Related: #313, #581

## Tests
- uv run --with pytest pytest