### PR TITLE
Add water softener depletion forecast

### DIFF
--- a/lovelace/tiles/tiles_other.yaml
+++ b/lovelace/tiles/tiles_other.yaml
@@ -46,6 +46,8 @@ cards:
         name: Forecast
       - entity: sensor.water_softener_days_until_low_salt
         name: Days until low
+      - entity: sensor.water_softener_forecast_low_salt_at
+        name: Forecast low date
       - entity: sensor.water_softener_salt_level
         name: Salt level
       - entity: input_number.bags_of_salt_at_home

--- a/lovelace/tiles/tiles_other.yaml
+++ b/lovelace/tiles/tiles_other.yaml
@@ -38,6 +38,19 @@ cards:
       - entity: number.tiki_room_lights_tiki_room_strip_animation_speed
         name: Animation Speed
 
+  - type: entities
+    title: Water Softener
+    show_header_toggle: false
+    entities:
+      - entity: sensor.water_softener_forecast_status
+        name: Forecast
+      - entity: sensor.water_softener_days_until_low_salt
+        name: Days until low
+      - entity: sensor.water_softener_salt_level
+        name: Salt level
+      - entity: input_number.bags_of_salt_at_home
+        name: Salt bags
+
   - type: custom:mini-media-player
     entity: media_player.bedroom_sonos_2
     name: Music

--- a/packages/water_softener.yaml
+++ b/packages/water_softener.yaml
@@ -124,7 +124,7 @@ automation:
       - alias: "Salt Level Low"
         condition: numeric_state
         entity_id: sensor.water_softener_salt_level
-        above: 500
+        above: input_number.water_softener_low_salt_threshold_mm
     action:
       - alias: "Notify"
         action: notify.all
@@ -134,6 +134,75 @@ automation:
             url: "/ryan-new-mushroom/cleaning"
           message: >-
             Water softener salt is low at {{states('sensor.water_softener_salt_level')}} mm.
+
+  - id: water_softener_forecast_refill_reminder
+    alias: Water Softener Forecast Refill Reminder
+    mode: single
+    trigger:
+      - trigger: numeric_state
+        id: forecast_window
+        entity_id: sensor.water_softener_days_until_low_salt
+        above: 0
+        below: input_number.water_softener_refill_reminder_days
+        for:
+          hours: 6
+      - trigger: time
+        id: daily_recheck
+        at: "16:15:00"
+      - trigger: homeassistant
+        id: startup_recheck
+        event: start
+    condition:
+      - alias: "Reminder not already sent this refill cycle"
+        condition: state
+        entity_id: input_boolean.water_softener_refill_reminder_sent
+        state: "off"
+      - alias: "Forecast is inside the reminder window"
+        condition: numeric_state
+        entity_id: sensor.water_softener_days_until_low_salt
+        above: 0
+        below: input_number.water_softener_refill_reminder_days
+      - alias: "Salt level is not already critical"
+        condition: numeric_state
+        entity_id: sensor.water_softener_salt_level
+        below: input_number.water_softener_low_salt_threshold_mm
+    action:
+      - alias: "Mark reminder sent"
+        action: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.water_softener_refill_reminder_sent
+      - alias: "Notify before salt is critical"
+        action: notify.all
+        data:
+          title: Softener salt forecast low
+          data:
+            url: "/ryan-new-mushroom/cleaning"
+            tag: water-softener-forecast-low
+          message: >-
+            Water softener salt is forecast to reach the low threshold in
+            {{ states('sensor.water_softener_days_until_low_salt') }} days.
+            Current level is {{ states('sensor.water_softener_salt_level') }} mm
+            and there are {{ states('input_number.bags_of_salt_at_home') | int(default=0) }} bags at home.
+
+  - id: water_softener_refill_reminder_reset
+    alias: Water Softener Refill Reminder Reset
+    mode: single
+    trigger:
+      - trigger: numeric_state
+        entity_id: sensor.water_softener_salt_level
+        below: input_number.water_softener_refill_reset_threshold_mm
+        for:
+          hours: 6
+    condition:
+      - alias: "Reminder has been sent"
+        condition: state
+        entity_id: input_boolean.water_softener_refill_reminder_sent
+        state: "on"
+    action:
+      - alias: "Allow next refill-cycle reminder"
+        action: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.water_softener_refill_reminder_sent
 
   - id: buy_more_salt
     alias: buy_more_salt
@@ -261,7 +330,10 @@ group: {}
 ########################
 # Input Booleans
 ########################
-input_boolean: {}
+input_boolean:
+  water_softener_refill_reminder_sent:
+    name: Water Softener Refill Reminder Sent
+    icon: mdi:bell-check
 
 ########################
 # Input Numbers
@@ -274,6 +346,33 @@ input_number:
     max: 20
     mode: box
     step: 1
+  water_softener_low_salt_threshold_mm:
+    name: Water Softener Low Salt Threshold
+    icon: mdi:arrow-collapse-down
+    min: 200
+    max: 800
+    mode: box
+    step: 10
+    unit_of_measurement: mm
+    initial: 500
+  water_softener_refill_reset_threshold_mm:
+    name: Water Softener Refill Reset Threshold
+    icon: mdi:arrow-expand-up
+    min: 100
+    max: 600
+    mode: box
+    step: 10
+    unit_of_measurement: mm
+    initial: 350
+  water_softener_refill_reminder_days:
+    name: Water Softener Refill Reminder Days
+    icon: mdi:calendar-alert
+    min: 1
+    max: 45
+    mode: box
+    step: 1
+    unit_of_measurement: d
+    initial: 14
 
 ########################
 # Input Select
@@ -352,6 +451,60 @@ sensor:
     #round: 2
     unit_time: d
     time_window: "168:00:00" # we look at the change over the 7 days
+
+########################
+# Template
+########################
+template:
+  - sensor:
+      - name: Water Softener Days Until Low Salt
+        unique_id: water_softener_days_until_low_salt
+        icon: mdi:calendar-clock
+        state_class: measurement
+        unit_of_measurement: d
+        availability: >-
+          {% set threshold = states('input_number.water_softener_low_salt_threshold_mm') | float(default=500) %}
+          {% set level = states('sensor.water_softener_salt_level') | float(default=none) %}
+          {% set rate_7d = states('sensor.water_softener_level_dt_7d') | float(default=none) %}
+          {% set rate_72h = states('sensor.water_softener_level_dt_72hrs') | float(default=none) %}
+          {% set rate = rate_7d if rate_7d is not none and rate_7d > 0 else rate_72h %}
+          {{ level is not none and (level >= threshold or (rate is not none and rate > 0)) }}
+        state: >-
+          {% set threshold = states('input_number.water_softener_low_salt_threshold_mm') | float(default=500) %}
+          {% set level = states('sensor.water_softener_salt_level') | float(default=none) %}
+          {% set rate_7d = states('sensor.water_softener_level_dt_7d') | float(default=none) %}
+          {% set rate_72h = states('sensor.water_softener_level_dt_72hrs') | float(default=none) %}
+          {% set rate = rate_7d if rate_7d is not none and rate_7d > 0 else rate_72h %}
+          {% if level is none %}
+            {{ none }}
+          {% elif level >= threshold %}
+            0
+          {% elif rate is none or rate <= 0 %}
+            {{ none }}
+          {% else %}
+            {{ ((threshold - level) / rate) | round(1) }}
+          {% endif %}
+      - name: Water Softener Forecast Status
+        unique_id: water_softener_forecast_status
+        icon: mdi:shaker-outline
+        availability: >-
+          {{ states('sensor.water_softener_salt_level') | float(default=none) is not none }}
+        state: >-
+          {% set threshold = states('input_number.water_softener_low_salt_threshold_mm') | float(default=500) %}
+          {% set reminder_days = states('input_number.water_softener_refill_reminder_days') | float(default=14) %}
+          {% set level = states('sensor.water_softener_salt_level') | float(default=none) %}
+          {% set days = states('sensor.water_softener_days_until_low_salt') | float(default=none) %}
+          {% if level is none %}
+            unknown
+          {% elif level >= threshold %}
+            low_now
+          {% elif days is not none and days > 0 and days <= reminder_days %}
+            refill_soon
+          {% elif days is not none %}
+            ok
+          {% else %}
+            trend_unknown
+          {% endif %}
 
 ########################
 # Switch

--- a/packages/water_softener.yaml
+++ b/packages/water_softener.yaml
@@ -247,20 +247,37 @@ automation:
                     data:
                       timestamp: "{{ as_timestamp(now()) }}"
               - if:
-                  - alias: "Reminder has been sent"
-                    condition: state
-                    entity_id: input_boolean.water_softener_refill_reminder_sent
-                    state: "on"
                   - alias: "Refill level has stayed stable for six hours"
                     condition: template
                     value_template: >-
                       {% set entered_at = states('input_datetime.water_softener_refill_window_entered_at') | as_timestamp(default=0) %}
                       {{ entered_at > 0 and as_timestamp(now()) - entered_at >= 6 * 60 * 60 }}
                 then:
-                  - alias: "Allow next refill-cycle reminder"
-                    action: input_boolean.turn_off
-                    target:
-                      entity_id: input_boolean.water_softener_refill_reminder_sent
+                  - if:
+                      - alias: "Reminder has been sent"
+                        condition: state
+                        entity_id: input_boolean.water_softener_refill_reminder_sent
+                        state: "on"
+                    then:
+                      - alias: "Allow next refill-cycle reminder"
+                        action: input_boolean.turn_off
+                        target:
+                          entity_id: input_boolean.water_softener_refill_reminder_sent
+                  - if:
+                      - alias: "Stable refill has not already been recorded"
+                        condition: template
+                        value_template: >-
+                          {% set entered_at = states('input_datetime.water_softener_refill_window_entered_at') | as_timestamp(default=0) %}
+                          {% set last_refill_at = states('input_datetime.water_softener_last_refill_at') | as_timestamp(default=0) %}
+                          {{ entered_at > last_refill_at }}
+                    then:
+                      - alias: "Record the stable refill"
+                        action: input_datetime.set_datetime
+                        target:
+                          entity_id: input_datetime.water_softener_last_refill_at
+                        data:
+                          timestamp: >-
+                            {{ states('input_datetime.water_softener_refill_window_entered_at') | as_timestamp(default=0) }}
           - alias: "Clear the refill timer only after a known reading leaves the window"
             conditions:
               - condition: template
@@ -418,6 +435,10 @@ input_datetime:
     name: Water Softener Refill Window Entered At
     has_date: true
     has_time: true
+  water_softener_last_refill_at:
+    name: Water Softener Last Refill At
+    has_date: true
+    has_time: true
 
 ########################
 # Input Numbers
@@ -457,6 +478,15 @@ input_number:
     step: 1
     unit_of_measurement: d
     initial: 14
+  water_softener_minimum_depletion_rate_mm_per_day:
+    name: Water Softener Minimum Depletion Rate
+    icon: mdi:speedometer-slow
+    min: 0.1
+    max: 25
+    mode: box
+    step: 0.1
+    unit_of_measurement: mm/d
+    initial: 0.5
 
 ########################
 # Input Select
@@ -536,11 +566,53 @@ sensor:
     unit_time: d
     time_window: "168:00:00" # we look at the change over the 7 days
 
+  - platform: statistics
+    entity_id: sensor.water_softener_forecast_rate
+    name: Water Softener Forecast Rate Median (24h)
+    unique_id: water_softener_forecast_rate_median_24h
+    state_characteristic: median
+    max_age:
+      hours: 24
+
 ########################
 # Template
 ########################
 template:
   - sensor:
+      - name: Water Softener Forecast Rate
+        unique_id: water_softener_forecast_rate
+        icon: mdi:chart-line
+        state_class: measurement
+        unit_of_measurement: mm/d
+        availability: >-
+          {% set minimum_rate = states('input_number.water_softener_minimum_depletion_rate_mm_per_day') | float(default=0.5) %}
+          {% set last_refill_at = states('input_datetime.water_softener_last_refill_at') | as_timestamp(default=0) %}
+          {% set include_7d = last_refill_at <= 0 or as_timestamp(now()) - last_refill_at >= 7 * 24 * 60 * 60 %}
+          {% set candidates = [
+            states('sensor.water_softener_level_dt_24hrs') | float(default=none),
+            states('sensor.water_softener_level_dt_48hrs') | float(default=none),
+            states('sensor.water_softener_level_dt_72hrs') | float(default=none),
+            states('sensor.water_softener_level_dt_7d') | float(default=none) if include_7d else none
+          ] %}
+          {% set valid_rates = candidates | select('number') | select('gt', minimum_rate) | list %}
+          {{ valid_rates | count >= 2 }}
+        state: >-
+          {% set minimum_rate = states('input_number.water_softener_minimum_depletion_rate_mm_per_day') | float(default=0.5) %}
+          {% set last_refill_at = states('input_datetime.water_softener_last_refill_at') | as_timestamp(default=0) %}
+          {% set include_7d = last_refill_at <= 0 or as_timestamp(now()) - last_refill_at >= 7 * 24 * 60 * 60 %}
+          {% set candidates = [
+            states('sensor.water_softener_level_dt_24hrs') | float(default=none),
+            states('sensor.water_softener_level_dt_48hrs') | float(default=none),
+            states('sensor.water_softener_level_dt_72hrs') | float(default=none),
+            states('sensor.water_softener_level_dt_7d') | float(default=none) if include_7d else none
+          ] %}
+          {% set rates = candidates | select('number') | select('gt', minimum_rate) | sort | list %}
+          {% set middle = rates | count // 2 %}
+          {% if rates | count % 2 %}
+            {{ rates[middle] | round(3) }}
+          {% else %}
+            {{ ((rates[middle - 1] + rates[middle]) / 2) | round(3) }}
+          {% endif %}
       - name: Water Softener Days Until Low Salt
         unique_id: water_softener_days_until_low_salt
         icon: mdi:calendar-clock
@@ -549,16 +621,12 @@ template:
         availability: >-
           {% set threshold = states('input_number.water_softener_low_salt_threshold_mm') | float(default=500) %}
           {% set level = states('sensor.water_softener_salt_level') | float(default=none) %}
-          {% set rate_7d = states('sensor.water_softener_level_dt_7d') | float(default=none) %}
-          {% set rate_72h = states('sensor.water_softener_level_dt_72hrs') | float(default=none) %}
-          {% set rate = rate_7d if rate_7d is not none and rate_7d > 0 else rate_72h %}
+          {% set rate = states('sensor.water_softener_forecast_rate_median_24h') | float(default=none) %}
           {{ level is not none and (level >= threshold or (rate is not none and rate > 0)) }}
         state: >-
           {% set threshold = states('input_number.water_softener_low_salt_threshold_mm') | float(default=500) %}
           {% set level = states('sensor.water_softener_salt_level') | float(default=none) %}
-          {% set rate_7d = states('sensor.water_softener_level_dt_7d') | float(default=none) %}
-          {% set rate_72h = states('sensor.water_softener_level_dt_72hrs') | float(default=none) %}
-          {% set rate = rate_7d if rate_7d is not none and rate_7d > 0 else rate_72h %}
+          {% set rate = states('sensor.water_softener_forecast_rate_median_24h') | float(default=none) %}
           {% if level is none %}
             {{ none }}
           {% elif level >= threshold %}
@@ -568,6 +636,15 @@ template:
           {% else %}
             {{ ((threshold - level) / rate) | round(1) }}
           {% endif %}
+      - name: Water Softener Forecast Low Salt At
+        unique_id: water_softener_forecast_low_salt_at
+        icon: mdi:calendar-alert
+        device_class: timestamp
+        availability: >-
+          {{ states('sensor.water_softener_days_until_low_salt') | float(default=none) is not none }}
+        state: >-
+          {% set days = states('sensor.water_softener_days_until_low_salt') | float(default=none) %}
+          {{ (now() + timedelta(days=days)).isoformat() }}
       - name: Water Softener Forecast Status
         unique_id: water_softener_forecast_status
         icon: mdi:shaker-outline

--- a/packages/water_softener.yaml
+++ b/packages/water_softener.yaml
@@ -137,72 +137,143 @@ automation:
 
   - id: water_softener_forecast_refill_reminder
     alias: Water Softener Forecast Refill Reminder
-    mode: single
+    mode: restart
+    trace:
+      stored_traces: 10
     trigger:
-      - trigger: numeric_state
-        id: forecast_window
+      - trigger: state
+        id: forecast_changed
         entity_id: sensor.water_softener_days_until_low_salt
-        above: 0
-        below: input_number.water_softener_refill_reminder_days
-        for:
-          hours: 6
-      - trigger: time
-        id: daily_recheck
-        at: "16:15:00"
+      - trigger: time_pattern
+        id: hourly_recheck
+        minutes: "15"
       - trigger: homeassistant
-        id: startup_recheck
+        id: forecast_startup_recheck
         event: start
-    condition:
-      - alias: "Reminder not already sent this refill cycle"
-        condition: state
-        entity_id: input_boolean.water_softener_refill_reminder_sent
-        state: "off"
-      - alias: "Forecast is inside the reminder window"
-        condition: numeric_state
-        entity_id: sensor.water_softener_days_until_low_salt
-        above: 0
-        below: input_number.water_softener_refill_reminder_days
-      - alias: "Salt level is not already critical"
-        condition: numeric_state
-        entity_id: sensor.water_softener_salt_level
-        below: input_number.water_softener_low_salt_threshold_mm
     action:
-      - alias: "Mark reminder sent"
-        action: input_boolean.turn_on
-        target:
-          entity_id: input_boolean.water_softener_refill_reminder_sent
-      - alias: "Notify before salt is critical"
-        action: notify.all
-        data:
-          title: Softener salt forecast low
-          data:
-            url: "/ryan-new-mushroom/cleaning"
-            tag: water-softener-forecast-low
-          message: >-
-            Water softener salt is forecast to reach the low threshold in
-            {{ states('sensor.water_softener_days_until_low_salt') }} days.
-            Current level is {{ states('sensor.water_softener_salt_level') }} mm
-            and there are {{ states('input_number.bags_of_salt_at_home') | int(default=0) }} bags at home.
+      - choose:
+          - alias: "Track stable forecasts and notify once per refill cycle"
+            conditions:
+              - condition: numeric_state
+                entity_id: sensor.water_softener_days_until_low_salt
+                above: 0
+                below: input_number.water_softener_refill_reminder_days
+              - condition: numeric_state
+                entity_id: sensor.water_softener_salt_level
+                below: input_number.water_softener_low_salt_threshold_mm
+            sequence:
+              - if:
+                  - condition: template
+                    value_template: >-
+                      {{ states('input_datetime.water_softener_forecast_window_entered_at') | as_timestamp(default=0) <= 0 }}
+                then:
+                  - action: input_datetime.set_datetime
+                    target:
+                      entity_id: input_datetime.water_softener_forecast_window_entered_at
+                    data:
+                      timestamp: "{{ as_timestamp(now()) }}"
+              - if:
+                  - alias: "Reminder not already sent this refill cycle"
+                    condition: state
+                    entity_id: input_boolean.water_softener_refill_reminder_sent
+                    state: "off"
+                  - alias: "Forecast has stayed inside the reminder window for six hours"
+                    condition: template
+                    value_template: >-
+                      {% set entered_at = states('input_datetime.water_softener_forecast_window_entered_at') | as_timestamp(default=0) %}
+                      {{ entered_at > 0 and as_timestamp(now()) - entered_at >= 6 * 60 * 60 }}
+                then:
+                  - alias: "Mark reminder sent"
+                    action: input_boolean.turn_on
+                    target:
+                      entity_id: input_boolean.water_softener_refill_reminder_sent
+                  - alias: "Notify before salt is critical"
+                    action: notify.all
+                    data:
+                      title: Softener salt forecast low
+                      data:
+                        url: "/ryan-new-mushroom/cleaning"
+                        tag: water-softener-forecast-low
+                      message: >-
+                        Water softener salt is forecast to reach the low threshold in
+                        {{ states('sensor.water_softener_days_until_low_salt') }} days.
+                        Current level is {{ states('sensor.water_softener_salt_level') }} mm
+                        and there are {{ states('input_number.bags_of_salt_at_home') | int(default=0) }} bags at home.
+          - alias: "Clear the forecast timer only after a known reading leaves the window"
+            conditions:
+              - condition: template
+                value_template: >-
+                  {% set days = states('sensor.water_softener_days_until_low_salt') | float(default=none) %}
+                  {% set reminder_days = states('input_number.water_softener_refill_reminder_days') | float(default=none) %}
+                  {{ days is not none and reminder_days is not none and not (0 < days < reminder_days) }}
+            sequence:
+              - action: input_datetime.set_datetime
+                target:
+                  entity_id: input_datetime.water_softener_forecast_window_entered_at
+                data:
+                  timestamp: 0
 
   - id: water_softener_refill_reminder_reset
     alias: Water Softener Refill Reminder Reset
-    mode: single
+    mode: restart
+    trace:
+      stored_traces: 10
     trigger:
-      - trigger: numeric_state
+      - trigger: state
+        id: salt_level_changed
         entity_id: sensor.water_softener_salt_level
-        below: input_number.water_softener_refill_reset_threshold_mm
-        for:
-          hours: 6
-    condition:
-      - alias: "Reminder has been sent"
-        condition: state
-        entity_id: input_boolean.water_softener_refill_reminder_sent
-        state: "on"
+      - trigger: time_pattern
+        id: hourly_recheck
+        minutes: "45"
+      - trigger: homeassistant
+        id: refill_startup_recheck
+        event: start
     action:
-      - alias: "Allow next refill-cycle reminder"
-        action: input_boolean.turn_off
-        target:
-          entity_id: input_boolean.water_softener_refill_reminder_sent
+      - choose:
+          - alias: "Track a stable refill and allow the next reminder cycle"
+            conditions:
+              - condition: numeric_state
+                entity_id: sensor.water_softener_salt_level
+                below: input_number.water_softener_refill_reset_threshold_mm
+            sequence:
+              - if:
+                  - condition: template
+                    value_template: >-
+                      {{ states('input_datetime.water_softener_refill_window_entered_at') | as_timestamp(default=0) <= 0 }}
+                then:
+                  - action: input_datetime.set_datetime
+                    target:
+                      entity_id: input_datetime.water_softener_refill_window_entered_at
+                    data:
+                      timestamp: "{{ as_timestamp(now()) }}"
+              - if:
+                  - alias: "Reminder has been sent"
+                    condition: state
+                    entity_id: input_boolean.water_softener_refill_reminder_sent
+                    state: "on"
+                  - alias: "Refill level has stayed stable for six hours"
+                    condition: template
+                    value_template: >-
+                      {% set entered_at = states('input_datetime.water_softener_refill_window_entered_at') | as_timestamp(default=0) %}
+                      {{ entered_at > 0 and as_timestamp(now()) - entered_at >= 6 * 60 * 60 }}
+                then:
+                  - alias: "Allow next refill-cycle reminder"
+                    action: input_boolean.turn_off
+                    target:
+                      entity_id: input_boolean.water_softener_refill_reminder_sent
+          - alias: "Clear the refill timer only after a known reading leaves the window"
+            conditions:
+              - condition: template
+                value_template: >-
+                  {% set level = states('sensor.water_softener_salt_level') | float(default=none) %}
+                  {% set reset_threshold = states('input_number.water_softener_refill_reset_threshold_mm') | float(default=none) %}
+                  {{ level is not none and reset_threshold is not none and level >= reset_threshold }}
+            sequence:
+              - action: input_datetime.set_datetime
+                target:
+                  entity_id: input_datetime.water_softener_refill_window_entered_at
+                data:
+                  timestamp: 0
 
   - id: buy_more_salt
     alias: buy_more_salt
@@ -334,6 +405,19 @@ input_boolean:
   water_softener_refill_reminder_sent:
     name: Water Softener Refill Reminder Sent
     icon: mdi:bell-check
+
+########################
+# Input Datetimes
+########################
+input_datetime:
+  water_softener_forecast_window_entered_at:
+    name: Water Softener Forecast Window Entered At
+    has_date: true
+    has_time: true
+  water_softener_refill_window_entered_at:
+    name: Water Softener Refill Window Entered At
+    has_date: true
+    has_time: true
 
 ########################
 # Input Numbers

--- a/tests/test_water_softener_package.py
+++ b/tests/test_water_softener_package.py
@@ -50,28 +50,73 @@ def test_water_softener_forecast_sensor_uses_guarded_derivative_trend() -> None:
 def test_water_softener_forecast_reminder_is_one_shot_before_critical() -> None:
     block = _automation_block("water_softener_forecast_refill_reminder")
 
-    assert "trigger: numeric_state" in block
+    assert "trigger: state" in block
     assert "entity_id: sensor.water_softener_days_until_low_salt" in block
     assert "below: input_number.water_softener_refill_reminder_days" in block
-    assert "for:\n          hours: 6" in block
+    assert "trigger: time_pattern" in block
+    assert "event: start" in block
     assert "condition: state" in block
     assert "entity_id: input_boolean.water_softener_refill_reminder_sent" in block
     assert "state: \"off\"" in block
     assert "below: input_number.water_softener_low_salt_threshold_mm" in block
+    assert "input_datetime.water_softener_forecast_window_entered_at" in block
+    assert "as_timestamp(now()) - entered_at >= 6 * 60 * 60" in block
     assert "action: input_boolean.turn_on" in block
     assert "tag: water-softener-forecast-low" in block
     assert "states('input_number.bags_of_salt_at_home') | int(default=0)" in block
 
 
+def test_water_softener_forecast_monitor_persists_entry_time() -> None:
+    block = _automation_block("water_softener_forecast_refill_reminder")
+
+    assert "entity_id: sensor.water_softener_days_until_low_salt" in block
+    assert "event: start" in block
+    assert "below: input_number.water_softener_refill_reminder_days" in block
+    assert "input_datetime.water_softener_forecast_window_entered_at" in block
+    assert "              - if:" in block
+    assert 'timestamp: "{{ as_timestamp(now()) }}"' in block
+    assert "days is not none and reminder_days is not none" in block
+    assert "timestamp: 0" in block
+
+
 def test_water_softener_refill_resets_next_reminder_cycle() -> None:
     block = _automation_block("water_softener_refill_reminder_reset")
 
-    assert "trigger: numeric_state" in block
+    assert "trigger: state" in block
     assert "entity_id: sensor.water_softener_salt_level" in block
+    assert "trigger: time_pattern" in block
+    assert "event: start" in block
     assert "below: input_number.water_softener_refill_reset_threshold_mm" in block
-    assert "for:\n          hours: 6" in block
+    assert "input_datetime.water_softener_refill_window_entered_at" in block
+    assert "as_timestamp(now()) - entered_at >= 6 * 60 * 60" in block
     assert "state: \"on\"" in block
     assert "action: input_boolean.turn_off" in block
+
+
+def test_water_softener_refill_monitor_persists_entry_time() -> None:
+    block = _automation_block("water_softener_refill_reminder_reset")
+
+    assert "entity_id: sensor.water_softener_salt_level" in block
+    assert "event: start" in block
+    assert "below: input_number.water_softener_refill_reset_threshold_mm" in block
+    assert "input_datetime.water_softener_refill_window_entered_at" in block
+    assert "              - if:" in block
+    assert 'timestamp: "{{ as_timestamp(now()) }}"' in block
+    assert "level is not none and reset_threshold is not none" in block
+    assert "timestamp: 0" in block
+
+
+def test_water_softener_window_timestamps_restore_across_restarts() -> None:
+    text = WATER_SOFTENER_PATH.read_text(encoding="utf-8")
+    input_datetimes = text.split("input_datetime:", maxsplit=1)[1].split(
+        "########################\n# Input Numbers", maxsplit=1
+    )[0]
+
+    assert "water_softener_forecast_window_entered_at:" in input_datetimes
+    assert "water_softener_refill_window_entered_at:" in input_datetimes
+    assert input_datetimes.count("has_date: true") == 2
+    assert input_datetimes.count("has_time: true") == 2
+    assert "initial:" not in input_datetimes
 
 
 def test_water_softener_forecast_status_is_visible_on_home_dashboard_tile() -> None:

--- a/tests/test_water_softener_package.py
+++ b/tests/test_water_softener_package.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 
@@ -33,18 +34,73 @@ def _template_sensor_block(sensor_name: str) -> str:
     return match.group(0)
 
 
-def test_water_softener_forecast_sensor_uses_guarded_derivative_trend() -> None:
+def _robust_forecast_rate(
+    rates: list[float | None],
+    *,
+    minimum_rate: float = 0.5,
+) -> float | None:
+    valid_rates = sorted(rate for rate in rates if rate is not None and rate > minimum_rate)
+    if len(valid_rates) < 2:
+        return None
+    middle = len(valid_rates) // 2
+    if len(valid_rates) % 2:
+        return valid_rates[middle]
+    return (valid_rates[middle - 1] + valid_rates[middle]) / 2
+
+
+def test_water_softener_forecast_rate_uses_guarded_multi_window_median() -> None:
+    block = _template_sensor_block("Water Softener Forecast Rate")
+
+    assert "unique_id: water_softener_forecast_rate" in block
+    assert "unit_of_measurement: mm/d" in block
+    assert "float(default=none)" in block
+    assert "sensor.water_softener_level_dt_24hrs" in block
+    assert "sensor.water_softener_level_dt_48hrs" in block
+    assert "sensor.water_softener_level_dt_72hrs" in block
+    assert "sensor.water_softener_level_dt_7d" in block
+    assert "select('gt', minimum_rate)" in block
+    assert "valid_rates | count >= 2" in block
+    assert "rates | count % 2" in block
+
+
+def test_water_softener_forecast_rate_rejects_noise_and_outlier_windows() -> None:
+    assert _robust_forecast_rate([0.1, 4.0, 4.5, 40.0]) == 4.5
+    assert _robust_forecast_rate([0.1, None, 0.5, -10.0]) is None
+    assert _robust_forecast_rate([None, 3.0, 5.0, None]) == 4.0
+
+
+def test_water_softener_forecast_uses_statistics_smoothed_rate() -> None:
+    text = WATER_SOFTENER_PATH.read_text(encoding="utf-8")
     block = _template_sensor_block("Water Softener Days Until Low Salt")
 
+    assert "platform: statistics" in text
+    assert "entity_id: sensor.water_softener_forecast_rate" in text
+    assert "state_characteristic: median" in text
+    assert "hours: 24" in text
     assert "unique_id: water_softener_days_until_low_salt" in block
     assert "unit_of_measurement: d" in block
-    assert "float(default=none)" in block
-    assert "sensor.water_softener_level_dt_7d" in block
-    assert "sensor.water_softener_level_dt_72hrs" in block
-    assert "rate_7d if rate_7d is not none and rate_7d > 0 else rate_72h" in block
+    assert "sensor.water_softener_forecast_rate_median_24h" in block
     assert "level >= threshold" in block
     assert "rate is none or rate <= 0" in block
     assert "((threshold - level) / rate) | round(1)" in block
+
+
+def test_water_softener_forecast_excludes_recent_refill_from_7d_rate() -> None:
+    block = _template_sensor_block("Water Softener Forecast Rate")
+
+    assert "input_datetime.water_softener_last_refill_at" in block
+    assert "as_timestamp(now()) - last_refill_at >= 7 * 24 * 60 * 60" in block
+    assert "if include_7d else none" in block
+
+
+def test_water_softener_forecast_low_date_projects_days_remaining() -> None:
+    block = _template_sensor_block("Water Softener Forecast Low Salt At")
+    now = datetime(2026, 6, 2, 12, tzinfo=UTC)
+
+    assert "device_class: timestamp" in block
+    assert "sensor.water_softener_days_until_low_salt" in block
+    assert "(now() + timedelta(days=days)).isoformat()" in block
+    assert now + timedelta(days=4.5) == datetime(2026, 6, 7, 0, tzinfo=UTC)
 
 
 def test_water_softener_forecast_reminder_is_one_shot_before_critical() -> None:
@@ -91,6 +147,7 @@ def test_water_softener_refill_resets_next_reminder_cycle() -> None:
     assert "as_timestamp(now()) - entered_at >= 6 * 60 * 60" in block
     assert "state: \"on\"" in block
     assert "action: input_boolean.turn_off" in block
+    assert "input_datetime.water_softener_last_refill_at" in block
 
 
 def test_water_softener_refill_monitor_persists_entry_time() -> None:
@@ -114,8 +171,9 @@ def test_water_softener_window_timestamps_restore_across_restarts() -> None:
 
     assert "water_softener_forecast_window_entered_at:" in input_datetimes
     assert "water_softener_refill_window_entered_at:" in input_datetimes
-    assert input_datetimes.count("has_date: true") == 2
-    assert input_datetimes.count("has_time: true") == 2
+    assert "water_softener_last_refill_at:" in input_datetimes
+    assert input_datetimes.count("has_date: true") == 3
+    assert input_datetimes.count("has_time: true") == 3
     assert "initial:" not in input_datetimes
 
 
@@ -125,5 +183,6 @@ def test_water_softener_forecast_status_is_visible_on_home_dashboard_tile() -> N
     assert "title: Water Softener" in text
     assert "entity: sensor.water_softener_forecast_status" in text
     assert "entity: sensor.water_softener_days_until_low_salt" in text
+    assert "entity: sensor.water_softener_forecast_low_salt_at" in text
     assert "entity: sensor.water_softener_salt_level" in text
     assert "entity: input_number.bags_of_salt_at_home" in text

--- a/tests/test_water_softener_package.py
+++ b/tests/test_water_softener_package.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WATER_SOFTENER_PATH = ROOT / "packages" / "water_softener.yaml"
+OTHER_TILE_PATH = ROOT / "lovelace" / "tiles" / "tiles_other.yaml"
+
+
+def _automation_block(automation_id: str) -> str:
+    text = WATER_SOFTENER_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^  - id: {re.escape(automation_id)}\n(.*?)(?=^  - id: |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+    return match.group(0)
+
+
+def _template_sensor_block(sensor_name: str) -> str:
+    text = WATER_SOFTENER_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^      - name: {re.escape(sensor_name)}\n(.*?)(?=^      - name: |^########################)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find template sensor block {sensor_name!r}")
+    return match.group(0)
+
+
+def test_water_softener_forecast_sensor_uses_guarded_derivative_trend() -> None:
+    block = _template_sensor_block("Water Softener Days Until Low Salt")
+
+    assert "unique_id: water_softener_days_until_low_salt" in block
+    assert "unit_of_measurement: d" in block
+    assert "float(default=none)" in block
+    assert "sensor.water_softener_level_dt_7d" in block
+    assert "sensor.water_softener_level_dt_72hrs" in block
+    assert "rate_7d if rate_7d is not none and rate_7d > 0 else rate_72h" in block
+    assert "level >= threshold" in block
+    assert "rate is none or rate <= 0" in block
+    assert "((threshold - level) / rate) | round(1)" in block
+
+
+def test_water_softener_forecast_reminder_is_one_shot_before_critical() -> None:
+    block = _automation_block("water_softener_forecast_refill_reminder")
+
+    assert "trigger: numeric_state" in block
+    assert "entity_id: sensor.water_softener_days_until_low_salt" in block
+    assert "below: input_number.water_softener_refill_reminder_days" in block
+    assert "for:\n          hours: 6" in block
+    assert "condition: state" in block
+    assert "entity_id: input_boolean.water_softener_refill_reminder_sent" in block
+    assert "state: \"off\"" in block
+    assert "below: input_number.water_softener_low_salt_threshold_mm" in block
+    assert "action: input_boolean.turn_on" in block
+    assert "tag: water-softener-forecast-low" in block
+    assert "states('input_number.bags_of_salt_at_home') | int(default=0)" in block
+
+
+def test_water_softener_refill_resets_next_reminder_cycle() -> None:
+    block = _automation_block("water_softener_refill_reminder_reset")
+
+    assert "trigger: numeric_state" in block
+    assert "entity_id: sensor.water_softener_salt_level" in block
+    assert "below: input_number.water_softener_refill_reset_threshold_mm" in block
+    assert "for:\n          hours: 6" in block
+    assert "state: \"on\"" in block
+    assert "action: input_boolean.turn_off" in block
+
+
+def test_water_softener_forecast_status_is_visible_on_home_dashboard_tile() -> None:
+    text = OTHER_TILE_PATH.read_text(encoding="utf-8")
+
+    assert "title: Water Softener" in text
+    assert "entity: sensor.water_softener_forecast_status" in text
+    assert "entity: sensor.water_softener_days_until_low_salt" in text
+    assert "entity: sensor.water_softener_salt_level" in text
+    assert "entity: input_number.bags_of_salt_at_home" in text


### PR DESCRIPTION
## Summary

Refs #115.

- Add a guarded water-softener days-until-low forecast from the existing filtered level and derivative sensors.
- Combine valid positive 24-hour, 48-hour, 72-hour, and 7-day depletion rates with a median instead of trusting a single window.
- Smooth the robust depletion rate with a native 24-hour Statistics helper and expose the projected low-salt date.
- Ignore the 7-day derivative for seven days after a stable refill so the refill jump cannot distort the long window.
- Add tunable low/refill thresholds, a minimum meaningful depletion rate, and a one-shot forecast reminder that resets after refill.
- Persist forecast-window, refill-window, and last-stable-refill timestamps with `input_datetime` helpers so debounce and refill guards survive Home Assistant restarts.
- Preserve persisted timestamps while dependent sensors are temporarily `unknown` during startup; clear them only after a known reading leaves the tracked window.
- Surface forecast status, days remaining, projected low date, salt level, and salt-bag inventory on the Home dashboard tile.
- Add focused regression tests for median selection, noise rejection, refill contamination, projected date, reminder restart recovery, dashboard, and reply-text behavior.

## Why this forecast is more robust

The forecast still uses the physically correct linear projection: `(low_threshold_mm - current_level_mm) / depletion_rate_mm_per_day`. The rate is now derived from multiple time windows rather than preferring the 7-day derivative whenever it is barely positive. Taking the median of at least two meaningful positive rates reduces sensitivity to sensor noise and one-window outliers. The native Statistics helper then applies a second median over the last 24 hours so a single recalculation does not move the projected date abruptly. Recording the last stable refill also prevents the refill step-change from contaminating the 7-day input while that jump is still inside its window.

## Validation

- `uv run --with pytest pytest` (`481 passed`)
- `uv run --with yamllint yamllint -d \"{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}\" packages/water_softener.yaml lovelace/tiles/tiles_other.yaml`
- `uv run --with pyyaml python /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/water_softener.yaml lovelace/tiles/tiles_other.yaml --strict`
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `uv run --with homeassistant==2026.5.4 python -m homeassistant --config . --script check_config` using the repo CI-style ignored secret setup
- `git diff --check`