### PR TITLE
Remove paid TSA wait time integration

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -147,7 +147,7 @@ Known source-of-truth areas:
 - Wake-up alarm sync and helper state: `packages/ios_wakeup.yaml`
 - Owner-suite wake transitions: `packages/workday.yaml`
 - Weather helper sensors: `packages/weather.yaml`
-- Flight status, TSA, airport delay, and destination weather sensors:
+- Flight status, airport delay, and destination weather sensors:
   `packages/flight_status.yaml`
 - Wake-up behavior specification: `specs/alarm_wakeup.allium`
 - Room privacy policy: `docs/room_intent.yaml`
@@ -205,7 +205,7 @@ Flight rows use these normalized entities from `packages/flight_status.yaml`:
 | --- | --- | --- |
 | Flight | `sensor.next_travel_flight` ident, destination code, and best departure time | `emphasis` |
 | Status | `sensor.next_travel_flight_live_status` plus FlightAware delay attributes | `urgent` for cancellation, diversion, or 30+ minute delay |
-| Airport | `sensor.next_travel_flight_tsa_wait` or `sensor.next_travel_flight_airport_delay` | `urgent` when airport delay alerts are present |
+| Airport | `sensor.next_travel_flight_airport_delay` | `urgent` when airport delay alerts are present; otherwise shows `Airport n/a` until a free delay source is configured |
 | Dest Wx | `sensor.next_travel_flight_destination_weather` | `normal` |
 
 Required travel integrations and secrets:
@@ -216,16 +216,12 @@ Required travel integrations and secrets:
   flight ident was parsed. It polls hourly inside the 3-day preflight window,
   then every 15 minutes from 24 hours before scheduled departure until
   FlightAware reports actual takeoff.
-- TSAWaitTimes puts the API key in the URL, so keep complete airport URLs in
-  `secrets.yaml` as `tsawaittimes_msp_airport_url` and
-  `tsawaittimes_rst_airport_url`, for example
-  `https://www.tsawaittimes.com/api/airport/APIKEY/MSP/json`.
 - Open-Meteo destination weather does not require a key. It uses the destination
   airport coordinate map in `packages/flight_status.yaml`.
 - Add the built-in FAA Delays integration for `MSP` and `RST` from Settings >
   Devices & services for richer airport-delay visibility elsewhere in Home
-  Assistant. The Inky flight row uses the TSAWaitTimes FAA alert payload when
-  available.
+  Assistant. The Inky flight row currently stays `Airport n/a` unless a free
+  airport-delay source is added later.
 
 REST sensors require a Home Assistant restart after the package and secrets are
 deployed. Template-only changes can be reloaded, but the travel package includes

--- a/packages/flight_status.yaml
+++ b/packages/flight_status.yaml
@@ -21,11 +21,6 @@ homeassistant:
       friendly_name: "Next Travel Flight Live Status"
       icon: mdi:airplane-check
 
-    sensor.next_travel_flight_tsa_wait:
-      <<: *customize
-      friendly_name: "Next Travel Flight TSA Wait"
-      icon: mdi:bag-checked
-
     sensor.next_travel_flight_airport_delay:
       <<: *customize
       friendly_name: "Next Travel Flight Airport Delay"
@@ -53,51 +48,6 @@ rest_command:
 ################################################
 
 rest:
-  # TSAWaitTimes requires the API key in the URL. Keep the complete URLs in secrets.yaml.
-  - resource: !secret tsawaittimes_msp_airport_url
-    scan_interval: 900
-    timeout: 20
-    sensor:
-      - name: MSP TSA Wait Times
-        unique_id: msp_tsa_wait_times
-        value_template: "{{ value_json.rightnow | int(default=-1) }}"
-        unit_of_measurement: "min"
-        json_attributes:
-          - code
-          - name
-          - city
-          - state
-          - latitude
-          - longitude
-          - rightnow
-          - rightnow_description
-          - user_reported
-          - precheck
-          - faa_alerts
-          - precheck_checkpoints
-
-  - resource: !secret tsawaittimes_rst_airport_url
-    scan_interval: 900
-    timeout: 20
-    sensor:
-      - name: RST TSA Wait Times
-        unique_id: rst_tsa_wait_times
-        value_template: "{{ value_json.rightnow | int(default=-1) }}"
-        unit_of_measurement: "min"
-        json_attributes:
-          - code
-          - name
-          - city
-          - state
-          - latitude
-          - longitude
-          - rightnow
-          - rightnow_description
-          - user_reported
-          - precheck
-          - faa_alerts
-          - precheck_checkpoints
-
   - resource_template: >-
       {% set lat = state_attr('sensor.next_travel_flight', 'destination_latitude') | float(default=none) %}
       {% set lon = state_attr('sensor.next_travel_flight', 'destination_longitude') | float(default=none) %}
@@ -494,66 +444,23 @@ template:
 
   - sensor:
 
-      - name: Next Travel Flight TSA Wait
-        unique_id: next_travel_flight_tsa_wait
-        default_entity_id: sensor.next_travel_flight_tsa_wait
-        unit_of_measurement: "min"
-        state: >-
-          {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') %}
-          {% if origin == 'MSP' %}
-            {{ states('sensor.msp_tsa_wait_times') | int(default=-1) }}
-          {% elif origin == 'RST' %}
-            {{ states('sensor.rst_tsa_wait_times') | int(default=-1) }}
-          {% else %}
-            -1
-          {% endif %}
-        attributes:
-          description: >-
-            {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') %}
-            {% if origin == 'MSP' %}
-              {{ state_attr('sensor.msp_tsa_wait_times', 'rightnow_description') | default('', true) }}
-            {% elif origin == 'RST' %}
-              {{ state_attr('sensor.rst_tsa_wait_times', 'rightnow_description') | default('', true) }}
-            {% else %}
-              {{ '' }}
-            {% endif %}
-          precheck: >-
-            {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') %}
-            {% if origin == 'MSP' %}
-              {{ state_attr('sensor.msp_tsa_wait_times', 'precheck') | default('', true) }}
-            {% elif origin == 'RST' %}
-              {{ state_attr('sensor.rst_tsa_wait_times', 'precheck') | default('', true) }}
-            {% else %}
-              {{ '' }}
-            {% endif %}
-
       - name: Next Travel Flight Airport Delay
         unique_id: next_travel_flight_airport_delay
         default_entity_id: sensor.next_travel_flight_airport_delay
         state: >-
           {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') %}
-          {% set attrs = state_attr('sensor.msp_tsa_wait_times', 'faa_alerts') if origin == 'MSP' else state_attr('sensor.rst_tsa_wait_times', 'faa_alerts') if origin == 'RST' else {} %}
-          {% if attrs is mapping and attrs | count > 0 %}
-            alert
-          {% elif origin in ['MSP', 'RST'] %}
-            clear
-          {% else %}
+          {% if origin in ['', none, 'unknown', 'unavailable'] %}
             unknown
+          {% else %}
+            unavailable
           {% endif %}
         attributes:
           summary: >-
             {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') %}
-            {% set attrs = state_attr('sensor.msp_tsa_wait_times', 'faa_alerts') if origin == 'MSP' else state_attr('sensor.rst_tsa_wait_times', 'faa_alerts') if origin == 'RST' else {} %}
-            {% if attrs is mapping and attrs.ground_stops is defined %}
-              Ground stop: {{ attrs.ground_stops.reason | default('active', true) }}
-            {% elif attrs is mapping and attrs.ground_delays is defined %}
-              Ground delay: {{ attrs.ground_delays.average | default(attrs.ground_delays.reason | default('active', true), true) }}
-            {% elif attrs is mapping and attrs.general_delays is defined %}
-              {{ attrs.general_delays.trend | default(attrs.general_delays.reason | default('Airport delays', true), true) }}
-            {% elif origin in ['MSP', 'RST'] %}
-              No airport delay alerts
-            {% else %}
+            {% if origin in ['', none, 'unknown', 'unavailable'] %}
               Airport delay unavailable
+            {% else %}
+              Airport delay source not configured
             {% endif %}
 
       - name: Next Travel Flight Destination Weather

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -59,7 +59,6 @@ automation:
           - cover.garage_door
           - sensor.next_travel_flight
           - sensor.next_travel_flight_live_status
-          - sensor.next_travel_flight_tsa_wait
           - sensor.next_travel_flight_airport_delay
           - sensor.next_travel_flight_destination_weather
           - sensor.nws_dakota_county_alerts_alerts_are_active
@@ -187,14 +186,14 @@ script:
             {% set flight_time = (flight_start | as_datetime | as_local).strftime('%H:%M') if flight_start not in ['', none, 'unknown', 'unavailable'] else 'TBD' %}
             {% set delay_minutes = state_attr('sensor.next_travel_flight_live_status', 'departure_delay_minutes') %}
             {% set flight_delay_value = ('Delay ' ~ delay_minutes ~ 'm') if delay_minutes not in ['', none, 'unknown', 'unavailable'] and delay_minutes | int(0) > 0 else (flight_status | replace('_', ' ') | title) %}
-            {% set tsa_wait = states('sensor.next_travel_flight_tsa_wait') | int(default=-1) %}
-            {% set tsa_value = (tsa_wait ~ 'm TSA') if tsa_wait >= 0 else 'TSA n/a' %}
             {% set airport_delay = states('sensor.next_travel_flight_airport_delay') %}
+            {% set airport_summary = state_attr('sensor.next_travel_flight_airport_delay', 'summary') | default('Airport n/a', true) %}
+            {% set airport_value = airport_summary if airport_delay == 'alert' else 'Airport n/a' %}
             {% set destination_weather = states('sensor.next_travel_flight_destination_weather') %}
             {% set travel_rows = [
               {'label': 'Flight', 'value': (flight_label ~ ' ' ~ flight_destination ~ ' ' ~ flight_time) | trim, 'level': 'emphasis'},
               {'label': 'Status', 'value': flight_delay_value, 'level': 'urgent' if flight_status in ['cancelled', 'diverted'] or delay_minutes | int(0) >= 30 else 'normal'},
-              {'label': 'Airport', 'value': tsa_value if airport_delay != 'alert' else state_attr('sensor.next_travel_flight_airport_delay', 'summary') | default('Airport alert', true), 'level': 'urgent' if airport_delay == 'alert' else 'normal'},
+              {'label': 'Airport', 'value': airport_value, 'level': 'urgent' if airport_delay == 'alert' else 'normal'},
               {'icon': weather_icon, 'label': 'Dest Wx', 'value': destination_weather if destination_weather not in ['unknown', 'unavailable', ''] else weather_value, 'level': 'normal'}
             ] %}
             {% if weather_alert %}
@@ -235,7 +234,7 @@ script:
               {% set rows = [
                 {'icon': weather_icon, 'label': 'Weather', 'value': weather_value, 'level': 'urgent' if weather_alert else 'normal'},
                 {'label': 'Flight', 'value': (flight_label ~ ' ' ~ flight_destination ~ ' ' ~ flight_time) | trim, 'level': 'emphasis'},
-                {'label': 'Airport', 'value': tsa_value if airport_delay != 'alert' else state_attr('sensor.next_travel_flight_airport_delay', 'summary') | default('Airport alert', true), 'level': 'urgent' if airport_delay == 'alert' else 'normal'},
+                {'label': 'Airport', 'value': airport_value, 'level': 'urgent' if airport_delay == 'alert' else 'normal'},
                 {'label': 'Status', 'value': status_value, 'level': status_level}
               ] %}
             {% else %}

--- a/tests/test_flight_status_package.py
+++ b/tests/test_flight_status_package.py
@@ -21,8 +21,7 @@ def test_flight_status_package_uses_calendar_and_rest_sources() -> None:
     assert "flightaware_next_travel_flight:" in text
     assert "https://aeroapi.flightaware.com/aeroapi/flights/" in text
     assert "!secret flightaware_aeroapi_key" in text
-    assert "!secret tsawaittimes_msp_airport_url" in text
-    assert "!secret tsawaittimes_rst_airport_url" in text
+    assert "tsawaittimes" not in text.lower()
     assert "https://api.open-meteo.com/v1/forecast" in text
 
 
@@ -32,7 +31,6 @@ def test_flight_status_package_exposes_normalized_display_sensors() -> None:
     for entity_name in (
         "Next Travel Flight",
         "Next Travel Flight Live Status",
-        "Next Travel Flight TSA Wait",
         "Next Travel Flight Airport Delay",
         "Next Travel Flight Destination Weather",
     ):

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -113,7 +113,6 @@ def test_owner_suite_payload_consumes_flight_status_sources() -> None:
     for entity_id in (
         "sensor.next_travel_flight",
         "sensor.next_travel_flight_live_status",
-        "sensor.next_travel_flight_tsa_wait",
         "sensor.next_travel_flight_airport_delay",
         "sensor.next_travel_flight_destination_weather",
     ):

--- a/travis_secrets.yaml
+++ b/travis_secrets.yaml
@@ -57,7 +57,5 @@ rst_longitude: 00.000
 # spotify_client_secret: 0000000000000000000000000000000aaaaaaaaa
 tesla_vehicle_id: 00000
 thermostat_recorder_db_url: postgresql://postgres
-tsawaittimes_msp_airport_url: https://www.tsawaittimes.com/api/airport/000000/MSP/json
-tsawaittimes_rst_airport_url: https://www.tsawaittimes.com/api/airport/000000/RST/json
 work_latitude: 00.00000
 work_longitude: -00.000


### PR DESCRIPTION
## Summary
- Remove TSAWaitTimes REST resources and secret URL placeholders
- Remove the normalized TSA wait sensor and Inky display dependency on it
- Leave the airport row as `Airport n/a` unless a free delay source is added later
- Update docs and tests to reflect the no-paid-TSA behavior

## Validation
- `python3 /Users/rtclauss/.codex/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/inky_displays.yaml packages/flight_status.yaml --strict`
- `python3 -m pytest tests/test_flight_status_package.py tests/test_inky_displays_package.py tests/test_inky_display_renderer.py tests/test_inky_display_service.py`
- `uv run --with pytest pytest`
- `uv run --with homeassistant python -m homeassistant --config <tmp> --script check_config`

## Manual steps
- Remove `tsawaittimes_msp_airport_url` and `tsawaittimes_rst_airport_url` from live `secrets.yaml` if they were added.
- Restart Home Assistant after deploying the package change because `rest:` resources changed.
