### PR TITLE
fix: ramp MPR wake-up volume on the MA sync group, not individual players

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1017,6 +1017,10 @@ script:
         description: "Music Assistant radio URI"
       initial_delay:
         description: "Optional delay before playback starts"
+      ramp_steps:
+        description: "Number of 0.01 volume steps to ramp through (default 30 → peak 0.30)"
+      ramp_k_factor:
+        description: "tan-curve k factor controlling total ramp duration (default 120 ≈ 7.5 min for 30 steps)"
       playback_entity_id:
         description: "Preferred Music Assistant player for wake-up playback (kept for backwards compatibility; ignored — sync group is used)"
       regroup_after_play:
@@ -1025,15 +1029,13 @@ script:
       playback_player: >-
         {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
            else 'media_player.everywhere_sonos' }}
+      effective_ramp_steps: "{{ ramp_steps | default(30) | int(30) }}"
+      effective_k_factor: "{{ ramp_k_factor | default(120) | int(120) }}"
     sequence:
       - action: media_player.volume_set
         continue_on_error: true
         target:
-          entity_id:
-            - media_player.bedroom_sonos
-            - media_player.bedroom_sonos_2
-            - media_player.bathroom_sonos
-            - media_player.bathroom_sonos_2
+          entity_id: "{{ playback_player }}"
         data:
           volume_level: 0.01
       - if:
@@ -1052,20 +1054,16 @@ script:
           enqueue: replace
       - repeat:
           sequence:
-            - alias: "Increase grouped wake-up volume by 0.01"
+            - alias: "Increase wake-up group volume by 0.01"
               continue_on_error: true
               action: media_player.volume_set
               target:
-                entity_id:
-                  - media_player.bedroom_sonos
-                  - media_player.bedroom_sonos_2
-                  - media_player.bathroom_sonos
-                  - media_player.bathroom_sonos_2
+                entity_id: "{{ playback_player }}"
               data:
                 volume_level: "{{ 0.01 * repeat.index }}"
             - delay:
-                seconds: "{{ (1/(tan(repeat.index/120))) | round(0, 'ceil', 5)}}"
-          until: "{{ repeat.index == 30 }}"
+                seconds: "{{ (1/(tan(repeat.index/effective_k_factor))) | round(0, 'ceil', 5)}}"
+          until: "{{ repeat.index == effective_ramp_steps }}"
 
   bedroom_playlist_0:
     alias: "Play LoFi"
@@ -1790,17 +1788,12 @@ script:
               ] -%}
               {% set pindex =  (range(0, (plists | length))|random) -%}
               {{ plists[pindex] }}
-      - alias: "Prime non-bathroom wake-up speakers to safe low volume"
-        # Bathroom volume is ramped separately by the calling automation.
-        # Set all other group members low so playback starts quietly.
+      - alias: "Prime wake-up group to safe low volume before playback"
         continue_on_error: true
         action: media_player.volume_set
+        target:
+          entity_id: "{{ playback_player }}"
         data:
-          entity_id:
-            - media_player.bedroom_sonos
-            - media_player.office_sonos
-            - media_player.den_sonos
-            - media_player.tiki_room_3
           volume_level: 0.05
       - alias: "Enable Shuffle"
         continue_on_error: true

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -687,6 +687,8 @@ script:
         data:
           radio_uri: "tunein--S3NwgspV://radio/s34350"
           initial_delay: 5
+          ramp_steps: 40
+          ramp_k_factor: 140
 
   sonos_the_current_wake_up:
     alias: Sonos The Current Wake Up

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -227,10 +227,17 @@ def test_radio_wakeup_uses_guest_aware_sync_group_without_manual_regrouping() ->
 def test_radio_wakeup_ramps_legacy_and_music_assistant_bedroom_bathroom_players() -> None:
     block = _script_block("music_assistant_radio_wake_up")
 
-    assert len(re.findall(r"^\s+- media_player\.bedroom_sonos$", block, re.MULTILINE)) == 2
-    assert len(re.findall(r"^\s+- media_player\.bedroom_sonos_2$", block, re.MULTILINE)) == 2
-    assert len(re.findall(r"^\s+- media_player\.bathroom_sonos$", block, re.MULTILINE)) == 2
-    assert len(re.findall(r"^\s+- media_player\.bathroom_sonos_2$", block, re.MULTILINE)) == 2
+    # Volume operations must target the MA sync group via playback_player,
+    # not individual native Sonos players. The group volume is what governs
+    # audible output when MA is playing.
+    assert len(re.findall(r"^\s+- media_player\.bedroom_sonos$", block, re.MULTILINE)) == 0
+    assert len(re.findall(r"^\s+- media_player\.bedroom_sonos_2$", block, re.MULTILINE)) == 0
+    assert len(re.findall(r"^\s+- media_player\.bathroom_sonos$", block, re.MULTILINE)) == 0
+    assert len(re.findall(r"^\s+- media_player\.bathroom_sonos_2$", block, re.MULTILINE)) == 0
+    assert 'playback_player' in block
+    assert 'media_player.guest_sonos' in block
+    assert 'media_player.everywhere_sonos' in block
+    assert block.count('entity_id: "{{ playback_player }}"') >= 2
     assert "volume_level: 0.01" in block
     assert 'volume_level: "{{ 0.01 * repeat.index }}"' in block
 


### PR DESCRIPTION
## Summary

- The morning radio volume ramp in `music_assistant_radio_wake_up` was targeting native Sonos entity IDs (`bedroom_sonos`, `bathroom_sonos`, etc.) while Music Assistant plays through the `everywhere_sonos` sync group. The group's own `volume_level` is what governs audible output — so the ramp had no effect and the alarm played at whatever volume the group was already set to.
- Investigated via HA history: this morning `everywhere_sonos` held steady at 0.3 the entire wake-up while the individual Sonos entities showed 0.01→0.05 changes that were never heard.

## Changes

**`packages/media_player.yaml`**
- `music_assistant_radio_wake_up`: target `{{ playback_player }}` (resolves to `everywhere_sonos` normally, `guest_sonos` in guest mode) for both the initial 0.01 prime and every step of the tan-curve ramp loop — fixes the ramp so it's actually audible
- Add `ramp_steps` and `ramp_k_factor` fields so callers can control peak volume and ramp duration without forking the shared script
- `spotify_wake_up`: apply the same `playback_player` fix to the pre-playback prime step (was hardcoded to a list of native Sonos players)

**`packages/workday.yaml`**
- `sonos_mpr_news_wake_up`: pass `ramp_steps: 40` (peak 0.40) and `ramp_k_factor: 140` (~10-minute ramp) to the shared script

## Reviewer notes

- All other callers of `music_assistant_radio_wake_up` that don't pass `ramp_steps`/`ramp_k_factor` continue using the existing defaults (30 steps → 0.30, k=120 ≈ 7.5 min)
- Guest mode is handled automatically via the existing `playback_player` variable in both scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)