### PR TITLE
Add Allium weed validation gate

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -39,6 +39,58 @@ jobs:
       - name: Run pytest
         run: uv run --with pytest pytest
 
+  allium-weed:
+    name: Allium Weed Check
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        (github.event_name == 'pull_request' && github.base_ref == 'develop') ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch'
+      }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install Allium CLI
+        run: |
+          set -euo pipefail
+
+          version="3.2.3"
+          archive="allium-x86_64-unknown-linux-gnu.tar.gz"
+          expected_sha="3e1afbed99b039a1fe659b1a3aaa69dbb274bfe18a0680571c9d0a4ab3ac205f"
+          curl -fsSL -o "$archive" "https://github.com/juxt/allium-tools/releases/download/v${version}/${archive}"
+          echo "${expected_sha}  ${archive}" | sha256sum -c -
+          tar -xzf "$archive"
+          sudo install -m 0755 allium /usr/local/bin/allium
+          allium --version
+
+      - name: Run Allium weed check
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          args=(--format markdown --output "$GITHUB_STEP_SUMMARY")
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git fetch --no-tags origin "$BASE_REF"
+            args+=(--changed-from "origin/$BASE_REF")
+          elif [[ "$EVENT_NAME" == "push" && -n "$BEFORE_SHA" && "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]]; then
+            args+=(--changed-from "$BEFORE_SHA")
+          fi
+
+          python scripts/allium_weed_check.py --require-allium "${args[@]}"
+
   yaml-lint:
     name: YAML Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -42,6 +42,9 @@ jobs:
   allium-weed:
     name: Allium Weed Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     if: >-
       ${{
         (github.event_name == 'pull_request' && github.base_ref == 'develop') ||
@@ -78,6 +81,7 @@ jobs:
           BEFORE_SHA: ${{ github.event.before }}
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -87,6 +91,9 @@ jobs:
             args+=(--changed-from "origin/$BASE_REF")
           elif [[ "$EVENT_NAME" == "push" && -n "$BEFORE_SHA" && "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]]; then
             args+=(--changed-from "$BEFORE_SHA")
+          fi
+          if [[ "$EVENT_NAME" == "push" || "$EVENT_NAME" == "schedule" ]]; then
+            args+=(--create-issues)
           fi
 
           python scripts/allium_weed_check.py --require-allium "${args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 !inventory.md
 !specs/
 !specs/*.allium
+!specs/*.json
 !docs/
 !docs/*.md
 !docs/**/*.md

--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@
 python -m pip install --upgrade pip yamllint
 python scripts/check_ha_python_support.py --python-version-file .python-version
 uv run --with pytest pytest
+python scripts/allium_weed_check.py --changed-from origin/develop
 ```
+
+`scripts/allium_weed_check.py` runs `allium check` when the CLI is installed,
+falls back to lightweight structural checks when it is not, and fails protected
+behavior changes that touch implementation scopes without updating the
+governing `.allium` spec or adding a classified gap in
+`specs/allium_weed_config.json`. CI installs Allium CLI 3.2.3 and runs with
+`--require-allium` so full language validation cannot be skipped silently.
 
 ## Music Assistant Media Flow
 

--- a/scripts/allium_weed_check.py
+++ b/scripts/allium_weed_check.py
@@ -9,6 +9,8 @@ import re
 import shutil
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -453,6 +455,98 @@ def render_markdown(
     return "\n".join(lines) + "\n"
 
 
+def _github_api(method: str, path: str, token: str, payload: dict[str, Any] | None = None) -> Any:
+    url = f"https://api.github.com{path}"
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _ensure_allium_weed_label(repo: str, token: str) -> None:
+    try:
+        _github_api("POST", f"/repos/{repo}/labels", token, {
+            "name": "allium-weed",
+            "color": "5319e7",
+            "description": "Allium spec validity failure or spec/code drift",
+        })
+    except urllib.error.HTTPError as exc:
+        if exc.code != 422:  # 422 = label already exists
+            raise
+
+
+def _find_open_weed_issue(repo: str, token: str, title: str) -> dict[str, Any] | None:
+    issues = _github_api("GET", f"/repos/{repo}/issues?state=open&labels=allium-weed&per_page=100", token)
+    return next((i for i in issues if i.get("title") == title), None)
+
+
+def sync_github_issues(
+    specs: list[Path],
+    diagnostics: list[Diagnostic],
+    repo: str,
+    token: str,
+) -> None:
+    """Create or update one GitHub issue per failing spec; close issues for specs that now pass.
+
+    Only diagnostic errors are tracked — drift findings are ephemeral (PR-specific) and
+    are surfaced via the step summary rather than persistent issues.
+    """
+    _ensure_allium_weed_label(repo, token)
+
+    errors_by_spec: dict[str, list[str]] = {}
+    for diag in diagnostics:
+        if diag.is_error:
+            location = f"[{diag.file}{':' + str(diag.line) if diag.line else ''}]({link_for(diag.file, diag.line)})"
+            errors_by_spec.setdefault(diag.file, []).append(
+                f"| `{diag.severity}` | {location} | `{diag.code}` | {diag.message} |"
+            )
+
+    all_spec_keys = {repo_path(spec) for spec in specs}
+
+    for spec_key, rows in errors_by_spec.items():
+        title = f"Allium weed: {spec_key}"
+        body = "\n".join([
+            f"## Allium weed failures: `{spec_key}`",
+            "",
+            "### Spec diagnostics",
+            "",
+            "| Severity | Location | Code | Message |",
+            "| --- | --- | --- | --- |",
+            *rows,
+            "",
+            "_Detected by the Allium weed check. Run `python scripts/allium_weed_check.py "
+            "--require-allium --format terminal` locally to reproduce._",
+        ])
+        existing = _find_open_weed_issue(repo, token, title)
+        if existing:
+            _github_api("PATCH", f"/repos/{repo}/issues/{existing['number']}", token, {"body": body})
+        else:
+            _github_api("POST", f"/repos/{repo}/issues", token, {
+                "title": title,
+                "body": body,
+                "labels": ["allium-weed"],
+            })
+
+    for spec_key in all_spec_keys - set(errors_by_spec):
+        title = f"Allium weed: {spec_key}"
+        existing = _find_open_weed_issue(repo, token, title)
+        if existing:
+            _github_api("PATCH", f"/repos/{repo}/issues/{existing['number']}", token, {
+                "state": "closed",
+                "state_reason": "completed",
+            })
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate Allium specs and gate protected spec/code drift.")
     parser.add_argument("paths", nargs="*", help="Allium files or directories to validate. Defaults to specs/.")
@@ -464,6 +558,15 @@ def main(argv: list[str] | None = None) -> int:
         "--require-allium",
         action="store_true",
         help="Fail instead of using fallback structural checks when the allium CLI is missing.",
+    )
+    parser.add_argument(
+        "--create-issues",
+        action="store_true",
+        help=(
+            "Create or update one GitHub issue per spec with diagnostic errors; "
+            "close issues for specs that now pass. "
+            "Requires GITHUB_TOKEN and GITHUB_REPOSITORY env vars."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -504,6 +607,20 @@ def main(argv: list[str] | None = None) -> int:
             output_path.write_text(report, encoding="utf-8")
     else:
         print(report, end="")
+
+    if args.create_issues:
+        gh_token = os.environ.get("GITHUB_TOKEN")
+        gh_repo = os.environ.get("GITHUB_REPOSITORY")
+        if gh_token and gh_repo:
+            try:
+                sync_github_issues(specs, diagnostics, gh_repo, gh_token)
+            except Exception as exc:  # noqa: BLE001
+                print(f"Warning: failed to sync GitHub issues: {exc}", file=sys.stderr)
+        else:
+            print(
+                "Warning: --create-issues requires GITHUB_TOKEN and GITHUB_REPOSITORY env vars.",
+                file=sys.stderr,
+            )
 
     if any(diag.is_error for diag in diagnostics) or any(finding.is_failure for finding in drift_findings):
         return 1

--- a/scripts/allium_weed_check.py
+++ b/scripts/allium_weed_check.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = ROOT / "specs" / "allium_weed_config.json"
+
+ERROR_SEVERITIES = {"error", "fatal"}
+COLOR = {
+    "red": "\033[31m",
+    "yellow": "\033[33m",
+    "green": "\033[32m",
+    "cyan": "\033[36m",
+    "reset": "\033[0m",
+}
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    severity: str
+    code: str
+    message: str
+    file: str
+    line: int | None = None
+    col: int | None = None
+
+    @property
+    def is_error(self) -> bool:
+        return self.severity.lower() in ERROR_SEVERITIES
+
+
+@dataclass(frozen=True)
+class ProtectedScope:
+    spec: str
+    description: str
+    implementation_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DriftFinding:
+    scope: ProtectedScope
+    changed_implementation: tuple[str, ...]
+    changed_spec: bool
+    classification: str | None = None
+    reason: str | None = None
+
+    @property
+    def is_failure(self) -> bool:
+        return self.classification is None and not self.changed_spec
+
+
+def repo_path(path: Path | str) -> str:
+    path = Path(path)
+    if path.is_absolute():
+        try:
+            return path.relative_to(ROOT).as_posix()
+        except ValueError:
+            return path.as_posix()
+    return path.as_posix()
+
+
+def discover_specs(paths: Iterable[str]) -> list[Path]:
+    candidates = [ROOT / path for path in paths] if paths else [ROOT / "specs"]
+    specs: set[Path] = set()
+
+    for candidate in candidates:
+        if candidate.is_file() and candidate.suffix == ".allium":
+            specs.add(candidate)
+        elif candidate.is_dir():
+            specs.update(candidate.rglob("*.allium"))
+
+    return sorted(specs)
+
+
+def parse_json_stream(text: str) -> list[dict[str, Any]]:
+    decoder = json.JSONDecoder()
+    index = 0
+    objects: list[dict[str, Any]] = []
+
+    while index < len(text):
+        while index < len(text) and text[index].isspace():
+            index += 1
+        if index >= len(text):
+            break
+        obj, index = decoder.raw_decode(text, index)
+        if not isinstance(obj, dict):
+            raise ValueError("Allium emitted a non-object JSON payload.")
+        objects.append(obj)
+
+    return objects
+
+
+def _diagnostic_from_payload(item: dict[str, Any], fallback_file: str) -> Diagnostic:
+    location = item.get("location") or {}
+    return Diagnostic(
+        severity=str(item.get("severity") or "error"),
+        code=str(item.get("code") or "allium.diagnostic"),
+        message=str(item.get("message") or "Allium diagnostic reported."),
+        file=str(location.get("file") or fallback_file),
+        line=location.get("line"),
+        col=location.get("col"),
+    )
+
+
+def run_allium_check(specs: list[Path], require_allium: bool = False) -> tuple[list[Diagnostic], list[str]]:
+    allium = shutil.which("allium")
+    if allium is None:
+        if require_allium:
+            return [
+                Diagnostic(
+                    severity="error",
+                    code="allium.execution.missingCli",
+                    message="Allium CLI is required for this run but was not found on PATH.",
+                    file="specs",
+                )
+            ], []
+        return fallback_structural_check(specs), [
+            "Allium CLI was not found; used the repository fallback structural checks. "
+            "Install allium for full language validation."
+        ]
+
+    command = [allium, "check", *[repo_path(path) for path in specs]]
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    output = result.stdout.strip()
+    diagnostics: list[Diagnostic] = []
+    notes: list[str] = []
+
+    if not output:
+        if result.returncode != 0:
+            diagnostics.append(
+                Diagnostic(
+                    severity="error",
+                    code="allium.execution.failed",
+                    message=(result.stderr.strip() or "allium check failed without JSON output."),
+                    file="specs",
+                )
+            )
+        return diagnostics, notes
+
+    try:
+        payloads = parse_json_stream(output)
+    except ValueError as exc:
+        diagnostics.append(
+            Diagnostic(
+                severity="error",
+                code="allium.output.invalidJson",
+                message=f"Could not parse allium check JSON output: {exc}",
+                file="specs",
+            )
+        )
+        return diagnostics, notes
+
+    for payload in payloads:
+        fallback_file = str(payload.get("spec_file") or "specs")
+        diagnostics.extend(
+            _diagnostic_from_payload(item, fallback_file)
+            for item in payload.get("diagnostics", [])
+        )
+        diagnostics.extend(
+            _diagnostic_from_payload(item, fallback_file)
+            for item in payload.get("findings", [])
+            if isinstance(item, dict)
+        )
+
+    if result.stderr.strip():
+        notes.append(result.stderr.strip())
+
+    return diagnostics, notes
+
+
+def fallback_structural_check(specs: list[Path]) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    for spec in specs:
+        relative = repo_path(spec)
+        text = spec.read_text(encoding="utf-8")
+        lines = text.splitlines()
+
+        if not lines or not lines[0].startswith("-- allium:"):
+            diagnostics.append(
+                Diagnostic(
+                    severity="error",
+                    code="allium.header.missingVersion",
+                    message="Spec must declare the Allium language version on the first line.",
+                    file=relative,
+                    line=1,
+                )
+            )
+
+        for index, line in enumerate(lines, start=1):
+            if "==" in line and not line.lstrip().startswith("--"):
+                diagnostics.append(
+                    Diagnostic(
+                        severity="error",
+                        code="allium.syntax.doubleEquals",
+                        message="Allium equality uses '='; '==' is not valid in expressions.",
+                        file=relative,
+                        line=index,
+                    )
+                )
+            if re.search(r"\bcontext\.", line):
+                diagnostics.append(
+                    Diagnostic(
+                        severity="error",
+                        code="allium.syntax.unboundContextReference",
+                        message="Use the declared given binding instead of an unbound 'context.' reference.",
+                        file=relative,
+                        line=index,
+                    )
+                )
+
+        for opener, closer, code in (("{", "}", "braces"), ("(", ")", "parentheses")):
+            delta = text.count(opener) - text.count(closer)
+            if delta != 0:
+                diagnostics.append(
+                    Diagnostic(
+                        severity="error",
+                        code=f"allium.syntax.unbalanced{code.title()}",
+                        message=f"Unbalanced {code}: {opener!r} and {closer!r} counts differ.",
+                        file=relative,
+                    )
+                )
+
+    return diagnostics
+
+
+def load_config(path: Path) -> tuple[list[ProtectedScope], list[dict[str, Any]]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    scopes = [
+        ProtectedScope(
+            spec=str(item["spec"]),
+            description=str(item.get("description") or ""),
+            implementation_paths=tuple(str(path) for path in item.get("implementation_paths", [])),
+        )
+        for item in data.get("protected_scopes", [])
+    ]
+    return scopes, list(data.get("classified_gaps", []))
+
+
+def git_changed_files(changed_from: str) -> list[str]:
+    candidates = [
+        ["git", "diff", "--name-only", f"{changed_from}...HEAD"],
+        ["git", "diff", "--name-only", changed_from, "HEAD"],
+    ]
+    last_error = ""
+
+    for command in candidates:
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode == 0:
+            return sorted(line for line in result.stdout.splitlines() if line)
+        last_error = result.stderr.strip()
+
+    raise RuntimeError(f"Could not compute changed files from {changed_from!r}: {last_error}")
+
+
+def _matches(path: str, patterns: Iterable[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def _classification_for(scope: ProtectedScope, changed_file: str, classified_gaps: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for gap in classified_gaps:
+        if gap.get("spec") != scope.spec:
+            continue
+        files = [str(file) for file in gap.get("implementation_paths", [])]
+        if _matches(changed_file, files):
+            return gap
+    return None
+
+
+def detect_drift_risks(
+    changed_files: Iterable[str],
+    scopes: list[ProtectedScope],
+    classified_gaps: list[dict[str, Any]],
+) -> list[DriftFinding]:
+    changed = set(changed_files)
+    findings: list[DriftFinding] = []
+
+    for scope in scopes:
+        changed_impl = sorted(path for path in changed if _matches(path, scope.implementation_paths))
+        if not changed_impl:
+            continue
+
+        changed_spec = scope.spec in changed
+        unclassified = [
+            path for path in changed_impl
+            if _classification_for(scope, path, classified_gaps) is None
+        ]
+        if changed_spec:
+            findings.append(DriftFinding(scope, tuple(changed_impl), changed_spec=True))
+        elif unclassified:
+            findings.append(DriftFinding(scope, tuple(unclassified), changed_spec=False))
+        else:
+            first_gap = _classification_for(scope, changed_impl[0], classified_gaps)
+            findings.append(
+                DriftFinding(
+                    scope,
+                    tuple(changed_impl),
+                    changed_spec=False,
+                    classification=str(first_gap.get("classification")),
+                    reason=str(first_gap.get("reason") or ""),
+                )
+            )
+
+    return findings
+
+
+def link_for(path: str, line: int | None = None) -> str:
+    sha = os.environ.get("GITHUB_SHA")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+
+    if sha and repo:
+        suffix = f"#L{line}" if line else ""
+        return f"{server}/{repo}/blob/{sha}/{path}{suffix}"
+
+    return f"{path}:{line}" if line else path
+
+
+def _paint(text: str, color: str, enabled: bool) -> str:
+    if not enabled:
+        return text
+    return f"{COLOR[color]}{text}{COLOR['reset']}"
+
+
+def render_terminal(
+    specs: list[Path],
+    diagnostics: list[Diagnostic],
+    drift_findings: list[DriftFinding],
+    notes: list[str],
+) -> str:
+    use_color = sys.stdout.isatty()
+    failures = [diag for diag in diagnostics if diag.is_error]
+    drift_failures = [finding for finding in drift_findings if finding.is_failure]
+    lines = [
+        _paint("Allium weed check", "cyan", use_color),
+        f"Specs checked: {len(specs)}",
+    ]
+
+    if failures or drift_failures:
+        lines.append(_paint("Status: failed", "red", use_color))
+    else:
+        lines.append(_paint("Status: passed", "green", use_color))
+
+    if notes:
+        lines.append("")
+        lines.append("Notes:")
+        lines.extend(f"- {note}" for note in notes)
+
+    if diagnostics:
+        lines.append("")
+        lines.append("Allium diagnostics:")
+        for diag in diagnostics:
+            location = link_for(diag.file, diag.line)
+            color = "red" if diag.is_error else "yellow"
+            lines.append(f"- {_paint(diag.severity.upper(), color, use_color)} {location} {diag.code}: {diag.message}")
+
+    if drift_findings:
+        lines.append("")
+        lines.append("Spec/code drift gate:")
+        for finding in drift_findings:
+            if finding.changed_spec:
+                status = _paint("covered", "green", use_color)
+                detail = "spec changed in the same diff"
+            elif finding.classification:
+                status = _paint(f"classified: {finding.classification}", "yellow", use_color)
+                detail = finding.reason or "classified gap"
+            else:
+                status = _paint("unclassified", "red", use_color)
+                detail = "update the spec or add a classified gap with a reason"
+            lines.append(f"- {status} {finding.scope.spec}: {', '.join(finding.changed_implementation)} ({detail})")
+
+    if not diagnostics and not drift_findings:
+        lines.append("")
+        lines.append("No Allium diagnostics or protected-scope drift risks found.")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_markdown(
+    specs: list[Path],
+    diagnostics: list[Diagnostic],
+    drift_findings: list[DriftFinding],
+    notes: list[str],
+) -> str:
+    failures = [diag for diag in diagnostics if diag.is_error]
+    drift_failures = [finding for finding in drift_findings if finding.is_failure]
+    status = "failed" if failures or drift_failures else "passed"
+    lines = [
+        "## Allium Weed Check",
+        "",
+        f"**Status:** {status}",
+        f"**Specs checked:** {len(specs)}",
+    ]
+
+    if notes:
+        lines.extend(["", "### Notes"])
+        lines.extend(f"- {note}" for note in notes)
+
+    lines.extend(["", "### Allium Diagnostics"])
+    if diagnostics:
+        lines.append("| Severity | Location | Code | Message |")
+        lines.append("| --- | --- | --- | --- |")
+        for diag in diagnostics:
+            location = f"[{diag.file}{':' + str(diag.line) if diag.line else ''}]({link_for(diag.file, diag.line)})"
+            lines.append(f"| {diag.severity} | {location} | `{diag.code}` | {diag.message} |")
+    else:
+        lines.append("No structural diagnostics.")
+
+    lines.extend(["", "### Spec/Code Drift Gate"])
+    if drift_findings:
+        lines.append("| Scope | Changed implementation | Classification | Required next step |")
+        lines.append("| --- | --- | --- | --- |")
+        for finding in drift_findings:
+            files = ", ".join(f"`{path}`" for path in finding.changed_implementation)
+            if finding.changed_spec:
+                classification = "covered"
+                next_step = "Spec changed in the same diff."
+            elif finding.classification:
+                classification = finding.classification
+                next_step = finding.reason or "Review classified gap."
+            else:
+                classification = "unclassified"
+                next_step = "Update the governing `.allium` spec or add a classified gap with a reason and exact links."
+            lines.append(f"| `{finding.scope.spec}` | {files} | {classification} | {next_step} |")
+    else:
+        lines.append("No protected implementation scopes changed.")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Allium specs and gate protected spec/code drift.")
+    parser.add_argument("paths", nargs="*", help="Allium files or directories to validate. Defaults to specs/.")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Protected scope config JSON.")
+    parser.add_argument("--changed-from", help="Git ref/SHA used to compute changed files for drift gating.")
+    parser.add_argument("--format", choices=("terminal", "markdown"), default="terminal")
+    parser.add_argument("--output", help="Write the report to this file instead of stdout.")
+    parser.add_argument(
+        "--require-allium",
+        action="store_true",
+        help="Fail instead of using fallback structural checks when the allium CLI is missing.",
+    )
+    args = parser.parse_args(argv)
+
+    specs = discover_specs(args.paths)
+    if not specs:
+        print("No .allium files found.", file=sys.stderr)
+        return 2
+
+    diagnostics, notes = run_allium_check(specs, require_allium=args.require_allium)
+    scopes, classified_gaps = load_config(Path(args.config))
+    drift_findings: list[DriftFinding] = []
+
+    if args.changed_from:
+        try:
+            changed_files = git_changed_files(args.changed_from)
+        except RuntimeError as exc:
+            diagnostics.append(
+                Diagnostic(
+                    severity="error",
+                    code="allium.drift.changedFilesUnavailable",
+                    message=str(exc),
+                    file=".",
+                )
+            )
+        else:
+            drift_findings = detect_drift_risks(changed_files, scopes, classified_gaps)
+
+    if args.format == "markdown":
+        report = render_markdown(specs, diagnostics, drift_findings, notes)
+    else:
+        report = render_terminal(specs, diagnostics, drift_findings, notes)
+
+    if args.output:
+        output_path = Path(args.output)
+        if output_path.exists():
+            output_path.write_text(output_path.read_text(encoding="utf-8") + "\n" + report, encoding="utf-8")
+        else:
+            output_path.write_text(report, encoding="utf-8")
+    else:
+        print(report, end="")
+
+    if any(diag.is_error for diag in diagnostics) or any(finding.is_failure for finding in drift_findings):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/alarm_wakeup.allium
+++ b/specs/alarm_wakeup.allium
@@ -88,7 +88,7 @@ config {
     snooze_duration: Duration = 8.minutes
     morning_blinds_delay: Duration = 175.seconds
     morning_light_ramp_duration: Duration = 3.minutes
-    office_wakeup_peak_volume: Percentage = 10%
+    office_wakeup_peak_volume_percent: Integer = 10
 }
 
 ------------------------------------------------------------
@@ -273,7 +273,7 @@ rule RampWakeupVolumeByRoom {
     @guidance
         -- All group members fade in from silence using a tan-curve ramp.
         -- When the group is bedroom_bathroom_office_den, the office is capped
-        -- at config.office_wakeup_peak_volume; all other rooms ramp to the
+        -- at config.office_wakeup_peak_volume_percent; all other rooms ramp to the
         -- full peak. This prevents the wake-up routine from disturbing
         -- work-in-progress in the office.
 }

--- a/specs/allium_weed_config.json
+++ b/specs/allium_weed_config.json
@@ -25,6 +25,20 @@
         "packages/z2m_lifecycle.yaml",
         "inventory.md"
       ]
+    },
+    {
+      "spec": "specs/arrival_lighting.allium",
+      "description": "Arrival-time adaptive lighting correction and selected Inovelli LED-bar synchronization behavior.",
+      "implementation_paths": [
+        "packages/adaptive_lighting.yaml"
+      ]
+    },
+    {
+      "spec": "specs/tv_watching.allium",
+      "description": "Basement TV session lifecycle and guest-aware whole-house lighting response.",
+      "implementation_paths": [
+        "packages/tv.yaml"
+      ]
     }
   ],
   "classified_gaps": []

--- a/specs/allium_weed_config.json
+++ b/specs/allium_weed_config.json
@@ -1,0 +1,31 @@
+{
+  "protected_scopes": [
+    {
+      "spec": "specs/alarm_wakeup.allium",
+      "description": "Owner-suite wake-up scheduling, alarm sync, wake-up execution, bathroom follow-up audio, snooze, cancel, and morning recovery.",
+      "implementation_paths": [
+        "packages/ios_wakeup.yaml",
+        "packages/media_player.yaml",
+        "packages/workday.yaml"
+      ]
+    },
+    {
+      "spec": "specs/night_routines.allium",
+      "description": "Bedtime preparation, overnight goodnight integrity, owner-suite privacy, guest-aware shutdown, and owner-suite LED sleep/wake policies.",
+      "implementation_paths": [
+        "packages/house_mode.yaml",
+        "packages/media_player.yaml",
+        "packages/tv.yaml"
+      ]
+    },
+    {
+      "spec": "specs/z2m_lifecycle.allium",
+      "description": "Zigbee2MQTT join, leave, offline, systemic recovery, decommission, notification, and inventory reconciliation behavior.",
+      "implementation_paths": [
+        "packages/z2m_lifecycle.yaml",
+        "inventory.md"
+      ]
+    }
+  ],
+  "classified_gaps": []
+}

--- a/specs/z2m_lifecycle.allium
+++ b/specs/z2m_lifecycle.allium
@@ -121,14 +121,14 @@ rule NotifyLifecycleIssue {
 rule DelayTransientCoordinatorMissingRouters {
     when: CoordinatorMissingRoutersObserved()
     requires: bridge.coordinator_status = missing_routers
-    requires: DurationSinceCoordinatorMissingRoutersObserved() < coordinator_issue_hold_window
+    requires: DurationSinceCoordinatorMissingRoutersObserved() < config.coordinator_issue_hold_window
     ensures: notifications.push_notification_active = false
 }
 
 rule NotifyPersistentCoordinatorMissingRouters {
     when: CoordinatorMissingRoutersObserved()
     requires: bridge.coordinator_status = missing_routers
-    requires: DurationSinceCoordinatorMissingRoutersObserved() >= coordinator_issue_hold_window
+    requires: DurationSinceCoordinatorMissingRoutersObserved() >= config.coordinator_issue_hold_window
     ensures: notifications.lifecycle_issue_count = notifications.lifecycle_issue_count + 1
     ensures: notifications.persistent_notification_active = true
     ensures: notifications.push_notification_active = true
@@ -175,3 +175,9 @@ rule ConfirmForceDeviceDecommission {
         -- Force removal only removes the Zigbee2MQTT database entry; the
         -- device still needs a factory reset before it can be safely re-used.
 }
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open question "stabilization_window (5 min) is declared in config but no rule references it. It was likely intended for debouncing availability_offline and network_address_flapping classification — the issue_reason values are declared on ZigbeeDeviceLifecycle but no rule raises them. Should a rule be added that sets issue_reason = availability_offline after a device remains offline beyond stabilization_window, or should the value be removed and this gap documented as intentional?"

--- a/tests/test_alarm_night_allium_alignment.py
+++ b/tests/test_alarm_night_allium_alignment.py
@@ -101,7 +101,7 @@ def test_alarm_spec_documents_today_workday_as_holiday_aware() -> None:
 
 def test_wakeup_office_volume_caps_match_allium_peak() -> None:
     spec_text = ALARM_SPEC_PATH.read_text(encoding="utf-8")
-    match = re.search(r"office_wakeup_peak_volume: Percentage = (\d+)%", spec_text)
+    match = re.search(r"office_wakeup_peak_volume_percent: Integer = (\d+)", spec_text)
 
     assert match is not None
     cap = f"0.{int(match.group(1)):02d}"

--- a/tests/test_allium_weed_check.py
+++ b/tests/test_allium_weed_check.py
@@ -118,7 +118,9 @@ def test_default_config_lists_existing_specs_and_scopes() -> None:
     assert classified_gaps == []
     assert {scope.spec for scope in scopes} == {
         "specs/alarm_wakeup.allium",
+        "specs/arrival_lighting.allium",
         "specs/night_routines.allium",
+        "specs/tv_watching.allium",
         "specs/z2m_lifecycle.allium",
     }
     assert all(scope.implementation_paths for scope in scopes)

--- a/tests/test_allium_weed_check.py
+++ b/tests/test_allium_weed_check.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "allium_weed_check.py"
+SPEC = importlib.util.spec_from_file_location("allium_weed_check", SCRIPT_PATH)
+assert SPEC is not None
+weed = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = weed
+SPEC.loader.exec_module(weed)
+
+
+def test_parse_json_stream_accepts_allium_multi_object_output() -> None:
+    payloads = weed.parse_json_stream('{"spec_file":"a.allium","diagnostics":[]}\n{"spec_file":"b.allium","diagnostics":[]}')
+
+    assert [payload["spec_file"] for payload in payloads] == ["a.allium", "b.allium"]
+
+
+def test_fallback_structural_check_fails_double_equals(tmp_path: Path) -> None:
+    spec = tmp_path / "bad.allium"
+    spec.write_text(
+        "\n".join(
+            [
+                "-- allium: 3",
+                "entity Example {",
+                "    enabled: Boolean",
+                "}",
+                "rule BadEquality {",
+                "    when: ExampleChanged()",
+                "    requires: example.enabled == true",
+                "}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    diagnostics = weed.fallback_structural_check([spec])
+
+    assert any(diagnostic.code == "allium.syntax.doubleEquals" for diagnostic in diagnostics)
+    assert any(diagnostic.is_error for diagnostic in diagnostics)
+
+
+def test_require_allium_fails_when_cli_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(weed.shutil, "which", lambda _: None)
+
+    diagnostics, notes = weed.run_allium_check([], require_allium=True)
+
+    assert notes == []
+    assert diagnostics[0].code == "allium.execution.missingCli"
+    assert diagnostics[0].is_error
+
+
+def test_protected_implementation_change_without_spec_change_fails() -> None:
+    scope = weed.ProtectedScope(
+        spec="specs/night_routines.allium",
+        description="night behavior",
+        implementation_paths=("packages/tv.yaml",),
+    )
+
+    findings = weed.detect_drift_risks(["packages/tv.yaml"], [scope], [])
+
+    assert len(findings) == 1
+    assert findings[0].is_failure
+    assert findings[0].changed_implementation == ("packages/tv.yaml",)
+
+
+def test_protected_implementation_change_with_spec_change_is_covered() -> None:
+    scope = weed.ProtectedScope(
+        spec="specs/night_routines.allium",
+        description="night behavior",
+        implementation_paths=("packages/tv.yaml",),
+    )
+
+    findings = weed.detect_drift_risks(
+        ["packages/tv.yaml", "specs/night_routines.allium"],
+        [scope],
+        [],
+    )
+
+    assert len(findings) == 1
+    assert not findings[0].is_failure
+    assert findings[0].changed_spec
+
+
+def test_classified_gap_allows_protected_implementation_change() -> None:
+    scope = weed.ProtectedScope(
+        spec="specs/z2m_lifecycle.allium",
+        description="z2m behavior",
+        implementation_paths=("packages/z2m_lifecycle.yaml",),
+    )
+    classified_gaps = [
+        {
+            "spec": "specs/z2m_lifecycle.allium",
+            "implementation_paths": ["packages/z2m_lifecycle.yaml"],
+            "classification": "intentional gap",
+            "reason": "Tracked separately with exact issue links.",
+        }
+    ]
+
+    findings = weed.detect_drift_risks(["packages/z2m_lifecycle.yaml"], [scope], classified_gaps)
+
+    assert len(findings) == 1
+    assert not findings[0].is_failure
+    assert findings[0].classification == "intentional gap"
+
+
+def test_default_config_lists_existing_specs_and_scopes() -> None:
+    scopes, classified_gaps = weed.load_config(weed.DEFAULT_CONFIG)
+
+    assert classified_gaps == []
+    assert {scope.spec for scope in scopes} == {
+        "specs/alarm_wakeup.allium",
+        "specs/night_routines.allium",
+        "specs/z2m_lifecycle.allium",
+    }
+    assert all(scope.implementation_paths for scope in scopes)
+
+
+def test_markdown_report_includes_line_links(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "rtclauss/hass-config")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+    diagnostic = weed.Diagnostic(
+        severity="error",
+        code="allium.syntax.doubleEquals",
+        message="bad equality",
+        file="specs/alarm_wakeup.allium",
+        line=12,
+    )
+
+    report = weed.render_markdown(
+        [Path("specs/alarm_wakeup.allium")],
+        [diagnostic],
+        [],
+        [],
+    )
+
+    assert "https://github.com/rtclauss/hass-config/blob/abc123/specs/alarm_wakeup.allium#L12" in report
+    assert "`allium.syntax.doubleEquals`" in report
+
+
+def test_config_json_is_valid() -> None:
+    data = json.loads(weed.DEFAULT_CONFIG.read_text(encoding="utf-8"))
+
+    assert isinstance(data["protected_scopes"], list)

--- a/tests/test_allium_weed_check.py
+++ b/tests/test_allium_weed_check.py
@@ -150,3 +150,84 @@ def test_config_json_is_valid() -> None:
     data = json.loads(weed.DEFAULT_CONFIG.read_text(encoding="utf-8"))
 
     assert isinstance(data["protected_scopes"], list)
+
+
+def test_sync_github_issues_creates_issue_for_failing_spec(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    spec = tmp_path / "specs" / "bad.allium"
+    spec.parent.mkdir()
+    spec.write_text("-- allium: 3\n", encoding="utf-8")
+    diagnostic = weed.Diagnostic(
+        severity="error",
+        code="allium.syntax.doubleEquals",
+        message="bad equality",
+        file="specs/bad.allium",
+        line=5,
+    )
+    calls: list[tuple[str, str]] = []
+
+    def fake_api(method: str, path: str, token: str, payload=None):
+        calls.append((method, path))
+        if method == "GET":
+            return []
+        return {"number": 1}
+
+    monkeypatch.setattr(weed, "_github_api", fake_api)
+
+    weed.sync_github_issues([spec], [diagnostic], "owner/repo", "tok")
+
+    methods = [c[0] for c in calls]
+    assert "POST" in methods
+    post_path = next(p for m, p in calls if m == "POST" and "issues" in p and "labels" not in p)
+    assert post_path == "/repos/owner/repo/issues"
+
+
+def test_sync_github_issues_updates_existing_issue(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    spec = tmp_path / "specs" / "bad.allium"
+    spec.parent.mkdir()
+    spec.write_text("-- allium: 3\n", encoding="utf-8")
+    diagnostic = weed.Diagnostic(
+        severity="error",
+        code="allium.syntax.doubleEquals",
+        message="bad equality",
+        file="specs/bad.allium",
+    )
+    calls: list[tuple[str, str]] = []
+
+    def fake_api(method: str, path: str, token: str, payload=None):
+        calls.append((method, path))
+        if method == "GET":
+            return [{"number": 42, "title": "Allium weed: specs/bad.allium"}]
+        return {}
+
+    monkeypatch.setattr(weed, "_github_api", fake_api)
+
+    weed.sync_github_issues([spec], [diagnostic], "owner/repo", "tok")
+
+    assert ("PATCH", "/repos/owner/repo/issues/42") in calls
+    assert not any(m == "POST" and "issues" in p and "labels" not in p for m, p in calls)
+
+
+def test_sync_github_issues_closes_resolved_spec(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    spec = tmp_path / "specs" / "good.allium"
+    spec.parent.mkdir()
+    spec.write_text("-- allium: 3\n", encoding="utf-8")
+    monkeypatch.setattr(weed, "ROOT", tmp_path)
+    calls: list[tuple[str, str]] = []
+
+    def fake_api(method: str, path: str, token: str, payload=None):
+        calls.append((method, path))
+        if method == "GET":
+            return [{"number": 7, "title": "Allium weed: specs/good.allium"}]
+        return {}
+
+    monkeypatch.setattr(weed, "_github_api", fake_api)
+
+    weed.sync_github_issues([spec], [], "owner/repo", "tok")
+
+    assert ("PATCH", "/repos/owner/repo/issues/7") in calls

--- a/tests/test_validate_config_workflow.py
+++ b/tests/test_validate_config_workflow.py
@@ -40,3 +40,18 @@ def test_yaml_lint_covers_esphome_directory() -> None:
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert "          esphome \\" in workflow_text
+
+
+def test_allium_weed_check_runs_for_develop_validation() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    allium_section = workflow_text.split("allium-weed:", maxsplit=1)[1].split("yaml-lint:", maxsplit=1)[0]
+
+    assert "github.base_ref == 'develop'" in allium_section
+    assert "github.ref == 'refs/heads/develop'" in allium_section
+    assert "fetch-depth: 0" in allium_section
+    assert "Install Allium CLI" in allium_section
+    assert "allium-tools/releases/download/v${version}/${archive}" in allium_section
+    assert "sha256sum -c -" in allium_section
+    assert 'args=(--format markdown --output "$GITHUB_STEP_SUMMARY")' in allium_section
+    assert 'args+=(--changed-from "origin/$BASE_REF")' in allium_section
+    assert 'python scripts/allium_weed_check.py --require-allium "${args[@]}"' in allium_section

--- a/tests/test_validate_config_workflow.py
+++ b/tests/test_validate_config_workflow.py
@@ -55,3 +55,7 @@ def test_allium_weed_check_runs_for_develop_validation() -> None:
     assert 'args=(--format markdown --output "$GITHUB_STEP_SUMMARY")' in allium_section
     assert 'args+=(--changed-from "origin/$BASE_REF")' in allium_section
     assert 'python scripts/allium_weed_check.py --require-allium "${args[@]}"' in allium_section
+    assert "issues: write" in allium_section
+    assert "GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in allium_section
+    assert 'args+=(--create-issues)' in allium_section
+    assert '"push" || "$EVENT_NAME" == "schedule"' in allium_section


### PR DESCRIPTION
## Summary

- Adds `scripts/allium_weed_check.py` to run Allium structural validation and gate protected spec/code drift.
- Installs Allium CLI 3.2.3 in CI and runs with `--require-allium` so fallback checks cannot silently replace full validation.
- Adds GitHub issue synchronization for spec failures on push and schedule events.
- Fixes the current `alarm_wakeup.allium` parse error by representing the office wake-up cap as an integer percent field.
- Expands protected drift scopes to include `arrival_lighting.allium` and `tv_watching.allium`.
- Keeps the earlier `z2m_lifecycle.allium` reference fixes and adds regression coverage.

Closes #489.

## Validation

- `uv run --with pytest pytest` (`483 passed`)
- `python3 scripts/allium_weed_check.py --require-allium --format terminal --changed-from origin/develop`
- `python3 -m py_compile scripts/allium_weed_check.py`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt .github/workflows/validate-config.yml`
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `git diff --check`