### PR TITLE
fix(#590): size PARASOLL reconfigure queue for fleet bursts

### DIFF
--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -125,7 +125,10 @@ automation:
       Notifications gated by 1 h since last successful configure per device;
       contact_change is always silent.
     mode: queued
-    max: 10
+    # The fleet is roughly 20 PARASOLL sensors, and each run can wait up to 60 s
+    # for a sleepy-device configure response. Keep queued execution to avoid
+    # input_text write races, but allow a full fleet burst plus headroom.
+    max: 30
     trigger:
       - platform: mqtt
         topic: zigbee2mqtt/bridge/event

--- a/tests/test_parasoll_configure_state.py
+++ b/tests/test_parasoll_configure_state.py
@@ -28,3 +28,11 @@ def test_parasoll_csv_state_has_room_for_current_device_count() -> None:
     device_count = 20
     sample_pairs = [f"{index:04x}:9999" for index in range(device_count)]
     assert len(",".join(sample_pairs)) < 255
+
+
+def test_parasoll_auto_reconfigure_queue_covers_current_fleet_burst() -> None:
+    text = PARASOLL_PATH.read_text(encoding="utf-8")
+
+    assert "mode: queued" in text
+    assert "max: 30" in text
+    assert "full fleet burst plus headroom" in text


### PR DESCRIPTION
## Summary
- keep PARASOLL auto-reconfigure in queued mode to avoid input_text write races
- raise the queue limit from 10 to 30 so a full current fleet burst has headroom
- add regression coverage to keep the queue sized for the fleet

Fixes #590
Related: #562, #574

## Runtime evidence
- Live HA logged repeated warnings for `automation.parasoll_auto_reconfigure_on_join_or_announce`: `Maximum number of runs exceeded`.
- The current automation can wait up to 60 seconds for a sleepy-device configure response.
- With roughly 20 PARASOLL sensors, `max: 10` can discard join/announce/contact-change checks before the binding/reporting invariants are evaluated.

## Validation
- `uv run --with pytest pytest tests/test_parasoll_configure_state.py` -> 4 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/parasoll_fix.yaml` -> passed
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/parasoll_fix.yaml --strict` -> no findings
- `uv run --with pytest pytest` -> 415 passed
- `uv run --with homeassistant==2026.3.4 python -m homeassistant --config <worktree> --script check_config` with CI placeholder secrets -> passed
