### PR TITLE
Fix Inky weather and afternoon mode handling

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -181,7 +181,7 @@ Current owner-suite modes:
 | Mode | Selected when | Title | Subtitle |
 | --- | --- | --- | --- |
 | `night_preview` | Explicit mode or house mode is `night`, `in_bed`, or `asleep` | `Tonight` | `Next alarm and overnight status` |
-| `morning` | Explicit mode or `input_boolean.wakeup_alarm_firing` is on | `Good Morning` | `Wake sequence active` |
+| `morning` | Explicit mode or `input_boolean.wakeup_alarm_firing` is on before noon | `Good Morning` | `Wake sequence active` |
 | `up_for_day` | Explicit mode or automatic pre-noon non-sleep state | `Up For Day` | `Morning activity confirmed` |
 | `midday` | Explicit mode, noon trigger, or automatic afternoon state | `Midday` | `Low-frequency refresh` |
 
@@ -234,6 +234,11 @@ REST resources.
 The footer uses 24-hour local time, for example `Updated 21:42`. This timestamp
 is generated only when the payload is published. Do not add `sensor.time` or a
 minute-level clock trigger for this field.
+
+The Pi service preserves the last cached `Weather` and `Dest Wx` rows when a new
+payload marks those rows as `unknown` or `unavailable`. Other rows and the
+footer can still update, but stale weather source failures should not replace a
+previously useful weather value on the display.
 
 Manual publish from Home Assistant Developer Tools:
 

--- a/inky_display/service.py
+++ b/inky_display/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from copy import deepcopy
 from dataclasses import dataclass
 from io import BytesIO
 import json
@@ -15,6 +16,8 @@ from .renderer import render_payload
 
 LOG = logging.getLogger(__name__)
 DEFAULT_TOPIC = "home/inky/owner_suite/state"
+UNAVAILABLE_VALUES = {"", "unknown", "unavailable", "none", "null"}
+WEATHER_ROW_LABELS = {"weather", "dest wx"}
 
 
 @dataclass(frozen=True)
@@ -62,6 +65,17 @@ class PayloadCache:
             return None
         return self.image_path.read_bytes()
 
+    def last_payload_data(self) -> dict | None:
+        if not self.payload_path.exists():
+            return None
+        try:
+            data = json.loads(self.payload_path.read_text(encoding="utf-8"))
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+        if isinstance(data, dict):
+            return data
+        return None
+
     def save(self, raw_payload: str, image: bytes, content_hash: str) -> Path:
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.payload_path.write_text(raw_payload, encoding="utf-8")
@@ -94,7 +108,8 @@ def process_payload(
 ) -> ProcessResult:
     raw_text = _decode_payload(raw_payload)
     try:
-        data = json.loads(raw_text)
+        original_data = json.loads(raw_text)
+        data = preserve_cached_weather_rows(deepcopy(original_data), cache.last_payload_data())
         payload = validate_payload(data)
     except (TypeError, ValueError, json.JSONDecodeError) as error:
         LOG.warning("Ignoring invalid Inky payload: %s", error)
@@ -109,9 +124,64 @@ def process_payload(
         return ProcessResult(False, "duplicate", content_hash, cache.image_path)
 
     image = render_payload(payload)
-    image_path = cache.save(raw_text, image, content_hash)
+    payload_text = raw_text if data == original_data else json.dumps(data, separators=(",", ":"))
+    image_path = cache.save(payload_text, image, content_hash)
     update_image_sink(image_sink, image)
     return ProcessResult(True, "rendered", content_hash, image_path)
+
+
+def preserve_cached_weather_rows(data: object, cached_data: dict | None) -> object:
+    if not isinstance(data, dict) or cached_data is None:
+        return data
+
+    cached_rows = _rows_by_label(cached_data)
+    if not cached_rows:
+        return data
+
+    for section in data.get("sections", []):
+        if not isinstance(section, dict):
+            continue
+        rows = section.get("rows", [])
+        if not isinstance(rows, list):
+            continue
+        for index, row in enumerate(rows):
+            if not _is_unavailable_weather_row(row):
+                continue
+            cached_row = cached_rows.get(_row_label(row))
+            if cached_row is not None:
+                rows[index] = cached_row
+
+    return data
+
+
+def _rows_by_label(data: dict) -> dict[str, dict]:
+    rows_by_label: dict[str, dict] = {}
+    for section in data.get("sections", []):
+        if not isinstance(section, dict):
+            continue
+        rows = section.get("rows", [])
+        if not isinstance(rows, list):
+            continue
+        for row in rows:
+            label = _row_label(row)
+            if label in WEATHER_ROW_LABELS and isinstance(row, dict) and not _is_unavailable_weather_row(row):
+                rows_by_label[label] = dict(row)
+    return rows_by_label
+
+
+def _is_unavailable_weather_row(row: object) -> bool:
+    if not isinstance(row, dict):
+        return False
+    if _row_label(row) not in WEATHER_ROW_LABELS:
+        return False
+    value = str(row.get("value", "")).strip().lower()
+    return value in UNAVAILABLE_VALUES or "unknown" in value or "unavailable" in value
+
+
+def _row_label(row: object) -> str:
+    if not isinstance(row, dict):
+        return ""
+    return str(row.get("label", "")).strip().lower()
 
 
 def run_mqtt_service(config: ServiceConfig) -> None:

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -113,7 +113,7 @@ script:
             {% set house_mode = states('input_select.house_mode') %}
             {% if requested in ['night_preview', 'morning', 'up_for_day', 'midday'] %}
               {{ requested }}
-            {% elif is_state('input_boolean.wakeup_alarm_firing', 'on') %}
+            {% elif is_state('input_boolean.wakeup_alarm_firing', 'on') and now().hour < 12 %}
               morning
             {% elif house_mode in ['night', 'in_bed', 'asleep'] %}
               night_preview

--- a/tests/test_inky_display_service.py
+++ b/tests/test_inky_display_service.py
@@ -9,6 +9,7 @@ from inky_display.service import (
     PayloadCache,
     config_from_env,
     mqtt_connection_succeeded,
+    preserve_cached_weather_rows,
     process_payload,
     update_image_sink,
 )
@@ -82,6 +83,46 @@ def test_process_payload_ignores_invalid_payload_without_overwriting_cache(tmp_p
     assert invalid.reason == "invalid"
     assert cache.last_hash() == first.content_hash
     assert cache.restore_image() is not None
+
+
+def test_process_payload_preserves_cached_weather_when_new_weather_is_unavailable(tmp_path: Path) -> None:
+    cache = PayloadCache(tmp_path)
+    first_data = json.loads(_sample_text())
+    first_data["sections"][0]["rows"][0] = {
+        "icon": "mdi:weather-sunny",
+        "label": "Weather",
+        "value": "73F sunny",
+        "level": "normal",
+    }
+    first = process_payload(json.dumps(first_data), cache, "owner_suite")
+    next_data = json.loads(_sample_text())
+    next_data["footer"] = "Updated 13:05"
+    next_data["sections"][0]["rows"][0] = {
+        "icon": "mdi:weather-cloudy",
+        "label": "Weather",
+        "value": "unavailable",
+        "level": "normal",
+    }
+
+    result = process_payload(json.dumps(next_data), cache, "owner_suite")
+    cached = json.loads(cache.payload_path.read_text(encoding="utf-8"))
+
+    assert first.rendered is True
+    assert result.rendered is True
+    assert cached["sections"][0]["rows"][0]["value"] == "73F sunny"
+    assert cached["sections"][0]["rows"][0]["icon"] == "mdi:weather-sunny"
+    assert cached["footer"] == "Updated 13:05"
+
+
+def test_preserve_cached_weather_rows_preserves_destination_weather() -> None:
+    cached_data = {
+        "sections": [{"type": "rows", "rows": [{"label": "Dest Wx", "value": "65F cloudy", "level": "normal"}]}]
+    }
+    data = {"sections": [{"type": "rows", "rows": [{"label": "Dest Wx", "value": "unknown", "level": "normal"}]}]}
+
+    preserved = preserve_cached_weather_rows(data, cached_data)
+
+    assert preserved["sections"][0]["rows"][0]["value"] == "65F cloudy"
 
 
 def test_process_payload_rejects_payload_for_another_display(tmp_path: Path) -> None:

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -86,6 +86,13 @@ def test_owner_suite_footer_uses_publish_time_in_24_hour_format() -> None:
     assert "sensor.time" not in block
 
 
+def test_owner_suite_morning_mode_is_limited_to_pre_noon_wake_firing() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+
+    assert "is_state('input_boolean.wakeup_alarm_firing', 'on') and now().hour < 12" in block
+    assert "{% elif now().hour >= 12 %}" in block
+
+
 def test_owner_suite_payload_maps_weather_icons_and_exceptions() -> None:
     block = _script_block("publish_owner_suite_inky_display")
 


### PR DESCRIPTION
## Summary
- preserve cached Weather and Dest Wx rows when a new payload marks them unknown or unavailable
- keep other display rows/footer updating while stale weather is retained
- stop stale wakeup_alarm_firing from forcing Good Morning after noon
- document the weather-row cache behavior and morning mode time gate

Related: #313

## Tests
- PYTHONPATH="/private/tmp/hass-config-inky-refresh-fixes" uv run --with pytest pytest