### PR TITLE
Add Inky precipitation warnings

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -167,8 +167,8 @@ Primary entities:
 The automation listens to wake alarm helpers, wake-up firing state, house mode,
 guest mode, Ryan's home state, bed/owner-suite activity, trip/vacation state,
 flight status, garage/front-door exceptions, weather alerts, active weather, and
-a noon refresh. It does not listen to `sensor.time`, so it will not redraw on
-clock ticks.
+near-term precipitation/calendar weather, and a noon refresh. It does not listen
+to `sensor.time`, so it will not redraw on clock ticks.
 
 The publish script only allows updates when guest mode is active, or when Ryan
 is home and trip mode is off. While Ryan is away or trip mode is on with guest
@@ -192,7 +192,7 @@ Current owner-suite rows:
 | Weather | `sensor.outside_temperature` plus `sensor.active_weather_entity_id` weather state | `urgent` when NWS alerts are active |
 | Alarm | `input_datetime.weekday_alarm` or `input_datetime.weekend_alarm` when the matching alarm helper is on | `emphasis` in `night_preview` when alarm is enabled |
 | Meeting | `input_datetime.next_work_meeting` when `input_boolean.special_meeting` is on | `emphasis` when special meeting is on |
-| Status | First active status from weather alert, garage door, front door, trip mode, vacation, otherwise `All clear` | `urgent` for alert/door/garage, `emphasis` for trip/vacation |
+| Status | First active status from weather alert, garage door, front door, rain in the next hour, precipitation/weather during the next `calendar.ryan_claussen` event, trip mode, vacation, otherwise `All clear` | `urgent` for alert/door/garage/rain/event weather, `emphasis` for trip/vacation |
 
 When `sensor.next_travel_flight` is inside its active travel window, `morning`,
 `up_for_day`, and `midday` modes use flight-oriented rows instead of the normal

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -62,8 +62,10 @@ automation:
           - sensor.next_travel_flight_airport_delay
           - sensor.next_travel_flight_destination_weather
           - sensor.nws_dakota_county_alerts_alerts_are_active
+          - sensor.precip_next_1hr
           - sensor.outside_temperature
           - sensor.active_weather_entity_id
+          - calendar.ryan_claussen
         id: state-change
       - trigger: state
         entity_id:
@@ -171,6 +173,33 @@ script:
             {% set front_door_open = is_state('binary_sensor.main_foyer_front_door_contact', 'on') %}
             {% set weather_alert_state = states('sensor.nws_dakota_county_alerts_alerts_are_active') | lower %}
             {% set weather_alert = weather_alert_state not in ['no', 'off', '0', 'false', 'unknown', 'unavailable'] %}
+            {% set precip_next_hour = states('sensor.precip_next_1hr') | int(default=-1) %}
+            {% set rain_next_hour = precip_next_hour >= 40 %}
+            {% set event_start = state_attr('calendar.ryan_claussen', 'start_time') | default('', true) %}
+            {% set event_end = state_attr('calendar.ryan_claussen', 'end_time') | default('', true) %}
+            {% set event_title = state_attr('calendar.ryan_claussen', 'message') | default('Event', true) %}
+            {% set event_forecasts = (state_attr('sensor.active_weather_entity_id', 'forecast_json') | default('[]', true) | from_json) | sort(attribute='datetime') %}
+            {% set precip_conditions = ['hail', 'lightning-rainy', 'pouring', 'rainy', 'snowy', 'snowy-rainy'] %}
+            {% set event = namespace(max_precip=-1, weather=false) %}
+            {% if event_start not in ['', none, 'unknown', 'unavailable'] and event_end not in ['', none, 'unknown', 'unavailable'] %}
+              {% set event_start_dt = as_datetime(event_start) %}
+              {% set event_end_dt = as_datetime(event_end) %}
+              {% if event_start_dt is not none and event_end_dt is not none and event_start_dt < now() + timedelta(hours=12) and event_end_dt > now() %}
+                {% for forecast in event_forecasts %}
+                  {% set forecast_dt = as_datetime(forecast.datetime) %}
+                  {% if forecast_dt is not none and forecast_dt >= event_start_dt and forecast_dt < event_end_dt %}
+                    {% set probability = forecast.precipitation_probability | int(default=-1) %}
+                    {% if probability > event.max_precip %}
+                      {% set event.max_precip = probability %}
+                    {% endif %}
+                    {% if forecast.condition | default('', true) in precip_conditions %}
+                      {% set event.weather = true %}
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endif %}
+            {% set event_weather = event.weather or event.max_precip >= 40 %}
             {% set trip_mode = is_state('input_boolean.trip', 'on') %}
             {% set vacation = is_state('binary_sensor.planned_vacation_calendar', 'on') %}
             {% set flight_state = states('sensor.next_travel_flight') %}
@@ -204,6 +233,12 @@ script:
               {% set status_level = 'urgent' %}
             {% elif front_door_open %}
               {% set status_value = 'Front door open' %}
+              {% set status_level = 'urgent' %}
+            {% elif rain_next_hour %}
+              {% set status_value = 'Rain soon ' ~ precip_next_hour ~ '%' %}
+              {% set status_level = 'urgent' %}
+            {% elif event_weather %}
+              {% set status_value = 'Wx for ' ~ event_title %}
               {% set status_level = 'urgent' %}
             {% elif trip_mode %}
               {% set status_value = 'Trip mode' %}

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -113,6 +113,23 @@ def test_owner_suite_payload_maps_weather_icons_and_exceptions() -> None:
     assert "binary_sensor.planned_vacation_calendar" in block
 
 
+def test_owner_suite_payload_warns_about_near_term_and_event_precipitation() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+    automation = _automation_block("publish_owner_suite_inky_display")
+
+    for entity_id in ("sensor.precip_next_1hr", "calendar.ryan_claussen"):
+        assert entity_id in block
+        assert entity_id in automation
+
+    assert "precip_next_hour >= 40" in block
+    assert "'Rain soon ' ~ precip_next_hour ~ '%'" in block
+    assert "state_attr('calendar.ryan_claussen', 'start_time')" in block
+    assert "state_attr('calendar.ryan_claussen', 'end_time')" in block
+    assert "event.max_precip >= 40" in block
+    assert "forecast.condition | default('', true) in precip_conditions" in block
+    assert "'Wx for ' ~ event_title" in block
+
+
 def test_owner_suite_payload_consumes_flight_status_sources() -> None:
     block = _script_block("publish_owner_suite_inky_display")
     automation = _automation_block("publish_owner_suite_inky_display")
@@ -173,3 +190,5 @@ def test_owner_suite_sources_are_documented() -> None:
     assert "Updated 21:42" in text
     assert "publish script only allows updates when guest mode is active" in text
     assert "Ryan returning home" in text
+    assert "rain in the next hour" in text
+    assert "precipitation/weather during the next `calendar.ryan_claussen` event" in text


### PR DESCRIPTION
## Summary
- add owner-suite Inky status warnings for rain probability in the next hour
- add calendar-event weather warnings using the active weather forecast during the next Ryan calendar event
- trigger display refreshes from precip probability and calendar changes
- document the new status-row priority

Related: #313

## Tests
- uv run --with pytest pytest