### PR TITLE
Restart Music Assistant when leaving home

### DIFF
--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -505,25 +505,20 @@ automation:
         data:
           addon: a0d7b954_appdaemon
 
-  - alias: Restart Music Assistant every 12.17 hours
+  - alias: Restart Music Assistant when Ryan leaves home
     description: >
-      Restart the Music Assistant add-on on a self-rescheduling loop to work
-      around Sonos DNS issues.
+      Restart the Music Assistant app only when Ryan leaves home to refresh
+      Sonos discovery while the house is empty.
     id: restart_music_assistant_every_12_17_hours
     trigger:
-      - trigger: homeassistant
-        event: start
+      - trigger: zone
+        entity_id: person.ryan
+        zone: zone.home
+        event: leave
     action:
-      - repeat:
-          while:
-            - condition: template
-              value_template: "{{ true }}"
-          sequence:
-            # 12.17 hours interpreted as decimal hours: 12 hours, 10 minutes, 12 seconds.
-            - delay: "12:10:12"
-            - action: hassio.addon_restart
-              data:
-                addon: d5369777_music_assistant
+      - action: hassio.addon_restart
+        data:
+          addon: d5369777_music_assistant
 
   - alias: water_shutoff_on_trip
     id: water_shutoff_on_trip

--- a/tests/test_utilities_music_assistant_restart.py
+++ b/tests/test_utilities_music_assistant_restart.py
@@ -37,15 +37,23 @@ def _automation_block(automation_id: str) -> str:
     return block
 
 
-def test_music_assistant_restart_loop_uses_the_music_assistant_addon() -> None:
+def test_music_assistant_restart_only_runs_when_ryan_leaves_home() -> None:
     block = _automation_block("restart_music_assistant_every_12_17_hours")
+
+    for token in (
+        "trigger: zone",
+        "entity_id: person.ryan",
+        "zone: zone.home",
+        "event: leave",
+        "addon: d5369777_music_assistant",
+    ):
+        assert token in block
 
     for token in (
         "trigger: homeassistant",
         "event: start",
         "repeat:",
         'delay: "12:10:12"',
-        "addon: d5369777_music_assistant",
         "self-rescheduling loop",
     ):
-        assert token in block
+        assert token not in block


### PR DESCRIPTION
## Summary
- replace the self-rescheduling Music Assistant app restart loop with a zone leave trigger
- restart Music Assistant only when `person.ryan` leaves `zone.home`
- update regression coverage so the HA-start repeat loop cannot return

Closes #596

## Validation
- `uv run --with pytest pytest` (419 passed)
