### PR TITLE
fix: reduce tv_off trigger delay from 15s to 5s

### DIFF
--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -123,13 +123,13 @@ automation:
         from: "on"
         to: "off"
         for:
-          seconds: 15
+          seconds: 5
       - trigger: state
         entity_id: media_player.lg_webos_smart_tv
         from: "on"
         to: "unavailable"
         for:
-          seconds: 15
+          seconds: 5
     action:
       - action: scene.turn_on
         target:


### PR DESCRIPTION
Closes #599

## Summary
- Reduces the `for:` delay on both `tv_off` triggers (`off` and `unavailable`) from 15s to 5s in `packages/tv.yaml`
- 5s is still enough to debounce transient LG TV state blips, but short enough that the lights feel responsive when you actually turn the TV off

## Test plan
- [ ] Turn off basement TV and verify lights come on within ~5 seconds
- [ ] Verify no false triggers during normal TV use

🤖 Generated with [Claude Code](https://claude.ai/claude-code)