### PR TITLE
fix: tv_resumed false trigger + spotify_bedtime MA entity

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1545,7 +1545,7 @@ script:
       - variables:
           bedtime_playback_entity: >-
             {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
-               else 'media_player.everywhere_sonos' }}
+               else 'media_player.bedroom_sonos_2' }}
           bedtime_media_type: "{{ 'radio' if playlist.startswith('https://somafm.com/') else '' }}"
       - action: media_player.shuffle_set
         continue_on_error: true
@@ -1568,10 +1568,8 @@ script:
         continue_on_error: true
         data:
           entity_id:
-            - media_player.bedroom_sonos
-            - media_player.bathroom_sonos
-            - media_player.office_sonos
-            - media_player.den_sonos
+            - media_player.bedroom_sonos_2
+            - media_player.bathroom_sonos_2
           volume_level: 0.20
       - delay:
           seconds: 2

--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -356,6 +356,9 @@ automation:
         - condition: state
           entity_id: input_boolean.guest_mode
           state: "off"
+        - condition: state
+          entity_id: media_player.lg_webos_smart_tv
+          state: "on"
     action:
       - action: media_player.media_pause
         continue_on_error: true


### PR DESCRIPTION
Closes #601
Closes #602

## Summary
- **tv_resumed**: Add `media_player.lg_webos_smart_tv state: "on"` condition so Plex autoplay after Apple TV shutdown doesn't falsely dim the lights (#601)
- **spotify_bedtime**: Target `bedroom_sonos_2` (Music Assistant player) instead of `everywhere_sonos` (old Sonos group MA can't address); update volume targets to `_2` entities (#602)

## Test plan
- [ ] Turn off Apple TV while Plex is playing — verify basement lights stay on
- [ ] Trigger bed prep (TV off at night) — verify Music Assistant plays bedtime music in bedroom/bathroom

🤖 Generated with [Claude Code](https://claude.ai/claude-code)