### PR TITLE
fix: convert spotify: URIs to MA-native format; restore everywhere_sonos for bedtime

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -733,7 +733,13 @@ script:
       raw_media_type: "{{ media_type | default('') | trim }}"
       raw_enqueue: "{{ enqueue | default('replace') }}"
       normalized_item: >-
-        {{ ('spotify:' ~ raw_item.split(':')[3] ~ ':' ~ raw_item.split(':')[4]) if (raw_item.startswith('spotify:user:') and (raw_item.split(':') | length) == 5) else raw_item }}
+        {%- set s = ('spotify:' ~ raw_item.split(':')[3] ~ ':' ~ raw_item.split(':')[4]) if (raw_item.startswith('spotify:user:') and (raw_item.split(':') | length) == 5) else raw_item -%}
+        {%- if s.startswith('spotify:') and not s.startswith('spotify--') -%}
+          {%- set parts = s.split(':') -%}
+          {{ 'spotify--Tviw9k66://' ~ parts[1] ~ '/' ~ parts[2] if parts | length >= 3 else s }}
+        {%- else -%}
+          {{ s }}
+        {%- endif %}
     sequence:
       - choose:
           - conditions:
@@ -1545,7 +1551,7 @@ script:
       - variables:
           bedtime_playback_entity: >-
             {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
-               else 'media_player.bedroom_sonos_2' }}
+               else 'media_player.everywhere_sonos' }}
           bedtime_media_type: "{{ 'radio' if playlist.startswith('https://somafm.com/') else '' }}"
       - action: media_player.shuffle_set
         continue_on_error: true
@@ -1570,6 +1576,8 @@ script:
           entity_id:
             - media_player.bedroom_sonos_2
             - media_player.bathroom_sonos_2
+            - media_player.office_sonos_2
+            - media_player.den_sonos_2
           volume_level: 0.20
       - delay:
           seconds: 2


### PR DESCRIPTION
Closes #604

## Summary
- **music_assistant_play_item**: Adds a normalization step converting `spotify:type:id` → `spotify--Tviw9k66://type/id` so all standard Spotify URIs work with Music Assistant
- **spotify_bedtime**: Reverts playback target to `media_player.everywhere_sonos` (confirmed MA group entity) and restores volume targets to all `_2` entities

## Test plan
- [ ] Trigger bed prep — verify music plays house-wide through `everywhere_sonos`
- [ ] Confirm random playlist selection resolves and plays (not just the one already-native URI in the list)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)