### PR TITLE
fix: replace SomaFM .pls URLs with direct ice1 streams in spotify_bedtime

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1539,11 +1539,11 @@ script:
               "spotify:playlist:37i9dQZF1E8T1k2ZTHYNkV",
               "spotify:playlist:1Iowhep08Kl9MJ0XOwsBMp",
               "spotify:playlist:37i9dQZF1DX4nNmLlb3JR2",
-              "https://somafm.com/groovesalad.pls",
-              "https://somafm.com/deepspaceone.pls",
-              "https://somafm.com/missioncontrol.pls",
-              "https://somafm.com/spacestation.pls",
-              "https://somafm.com/vaporwaves.pls",
+              "https://ice1.somafm.com/groovesalad-128-mp3",
+              "https://ice1.somafm.com/deepspaceone-128-mp3",
+              "https://ice1.somafm.com/missioncontrol-128-mp3",
+              "https://ice1.somafm.com/spacestation-128-mp3",
+              "https://ice1.somafm.com/vaporwaves-128-mp3",
               "spotify--Tviw9k66://playlist/2I2cwYxeuLbIXaNRccMViZ"
               ] -%}
             {% set pindex = (range(0, (plists | length))|random) -%}
@@ -1552,7 +1552,7 @@ script:
           bedtime_playback_entity: >-
             {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
                else 'media_player.everywhere_sonos' }}
-          bedtime_media_type: "{{ 'radio' if playlist.startswith('https://somafm.com/') else '' }}"
+          bedtime_media_type: "{{ 'radio' if 'somafm.com' in playlist else '' }}"
       - action: media_player.shuffle_set
         continue_on_error: true
         target:


### PR DESCRIPTION
Closes #606

## Summary
- Replaces 5 SomaFM `.pls` playlist URLs with direct `ice1.somafm.com/station-128-mp3` stream URLs that Music Assistant can actually resolve
- Updates `bedtime_media_type` detection to match `somafm.com` anywhere in the URL (covers both old and new format)

## Verified
- All 54 Spotify URIs normalize correctly (template-tested)
- Album, artist, personal playlist, and SomaFM radio all play successfully via `everywhere_sonos`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)