### PR TITLE
fix(#608): ignore PARASOLL startup restore contact bursts

### DIFF
--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -157,6 +157,12 @@ automation:
           - binary_sensor.owner_suite_south_window_contact
           - binary_sensor.powder_room_window_contact
           - binary_sensor.unfinished_basement_window_contact
+        from:
+          - "on"
+          - "off"
+        to:
+          - "on"
+          - "off"
         id: contact_change
     condition:
       - condition: template

--- a/tests/test_parasoll_configure_state.py
+++ b/tests/test_parasoll_configure_state.py
@@ -38,6 +38,20 @@ def test_parasoll_auto_reconfigure_queue_covers_current_fleet_burst() -> None:
     assert "full fleet burst plus headroom" in text
 
 
+def test_parasoll_contact_change_ignores_startup_restores() -> None:
+    text = PARASOLL_PATH.read_text(encoding="utf-8")
+
+    assert 'id: contact_change' in text
+    assert 'from:\n          - "on"\n          - "off"' in text
+    assert 'to:\n          - "on"\n          - "off"' in text
+
+
+def test_parasoll_contact_change_keeps_restored_south_middle_contact() -> None:
+    text = PARASOLL_PATH.read_text(encoding="utf-8")
+
+    assert "binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact" in text
+
+
 def test_parasoll_ias_ok_checks_ep2_not_ep1() -> None:
     # PARASOLL's ssIasZone cluster lives on endpoint 2 (confirmed by Z2M Bind tab
     # "Source endpoint 2: ssIasZone").  Checking ep1 would always return False,


### PR DESCRIPTION
Closes #608

## Summary
- Restricts PARASOLL `contact_change` triggers to real `on`/`off` window state transitions so startup/restored `unknown` or `unavailable` changes do not consume the queued reconfigure worker pool.
- Keeps `binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact` in the trigger list and window customization map; follow-up live verification showed that entity is back online.
- Adds regression coverage for the startup-restore guard and for keeping the restored south-middle contact in the PARASOLL trigger list.

## Runtime evidence
- Live traces on 2026-05-06 showed repeated `failed_max_runs` for `automation.parasoll_auto_reconfigure_on_join_or_announce` during reload/startup bursts.
- Sampled finished contact-change traces waited on `zigbee2mqtt/bridge/devices` and resolved `_needs_configure: false`, so the queue was being consumed by restored state transitions rather than real contact changes.
- Follow-up verification after opening the PR confirmed `binary_sensor.owner_suite_bathroom_bay_south_middle_window_contact=off` and `binary_sensor.z2m_owner_suite_bathroom_bay_south_middle_window_availability=on`, so the stale-entity removal was reverted before merge.

## Validation
- `uv run --with pytest pytest tests/test_parasoll_configure_state.py tests/test_zigbee_zwave_window_reconciliation.py` -> 9 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/parasoll_fix.yaml packages/zigbee_zwave.yaml` -> passed
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/parasoll_fix.yaml --strict` -> no findings
- `uv run --with homeassistant==2026.4.4 python -m homeassistant --config . --script check_config` with CI placeholder secrets -> passed in the original PR validation; not rerun after restoring the entity reference because the final diff only adds the trigger `from`/`to` guard and tests.

## Known validation blocker
- `uv run --with pytest pytest` currently fails on current `origin/develop` with 3 unrelated Music Assistant/SomaFM test expectation failures. Tracked separately in #610. Result observed during this PR validation: 3 failed, 419 passed.
