### PR TITLE
fix: prevent MA group volume muting; label media players by integration; rename MA sync groups

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -431,7 +431,7 @@ automation:
                   playback_entity_id: media_player.ma_group_everywhere
               - action: media_player.volume_set
                 target:
-                  entity_id: media_player.bathroom_sonos
+                  entity_id: media_player.bathroom_sonos_2
                 data:
                   volume_level: 0.30
         default:
@@ -439,7 +439,7 @@ automation:
           - alias: "Set Volume 0.1"
             action: media_player.volume_set
             target:
-              entity_id: media_player.bathroom_sonos
+              entity_id: media_player.bathroom_sonos_2
             data:
               volume_level: 0.1
           - action: script.spotify_wake_up
@@ -451,7 +451,7 @@ automation:
                 - alias: "Increase Volume by 0.01"
                   action: media_player.volume_set
                   target:
-                    entity_id: media_player.bathroom_sonos
+                    entity_id: media_player.bathroom_sonos_2
                   data:
                     volume_level: "{{ 0.01 * repeat.index }}"
                 - delay:
@@ -1402,7 +1402,7 @@ script:
         data:
           entity_id:
             - media_player.bedroom_sonos
-            - media_player.bathroom_sonos
+            - media_player.bathroom_sonos_2
             - media_player.den_sonos
             - media_player.office_sonos
             - media_player.tiki_room_3

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -428,7 +428,7 @@ automation:
             sequence:
               - action: script.spotify_wake_up
                 data:
-                  playback_entity_id: media_player.everywhere_sonos
+                  playback_entity_id: media_player.ma_group_everywhere
               - action: media_player.volume_set
                 target:
                   entity_id: media_player.bathroom_sonos
@@ -444,7 +444,7 @@ automation:
               volume_level: 0.1
           - action: script.spotify_wake_up
             data:
-              playback_entity_id: media_player.everywhere_sonos
+              playback_entity_id: media_player.ma_group_everywhere
           - alias: "Repeat until desired volume reached"
             repeat:
               sequence:
@@ -1033,15 +1033,18 @@ script:
         description: "Kept for backwards compatibility; ignored — sync groups manage membership"
     variables:
       playback_player: >-
-        {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
-           else 'media_player.everywhere_sonos' }}
+        {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
+           else 'media_player.ma_group_everywhere' }}
       effective_ramp_steps: "{{ ramp_steps | default(30) | int(30) }}"
       effective_k_factor: "{{ ramp_k_factor | default(120) | int(120) }}"
+      group_members: >-
+        {{ state_attr(playback_player, 'group_members') | default([playback_player]) }}
     sequence:
-      - action: media_player.volume_set
+      - alias: "Set each member directly to 0.01 — individual sets are absolute, no MA proportional scaling"
         continue_on_error: true
+        action: media_player.volume_set
         target:
-          entity_id: "{{ playback_player }}"
+          entity_id: "{{ group_members }}"
         data:
           volume_level: 0.01
       - if:
@@ -1060,11 +1063,11 @@ script:
           enqueue: replace
       - repeat:
           sequence:
-            - alias: "Increase wake-up group volume by 0.01"
+            - alias: "Ramp each member directly — individual sets bypass MA proportional group scaling"
               continue_on_error: true
               action: media_player.volume_set
               target:
-                entity_id: "{{ playback_player }}"
+                entity_id: "{{ group_members }}"
               data:
                 volume_level: "{{ 0.01 * repeat.index }}"
             - delay:
@@ -1276,8 +1279,8 @@ script:
     alias: "Spotify Arrive Home"
     variables:
       playback_entity: >-
-        {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
-           else 'media_player.everywhere_sonos' }}
+        {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
+           else 'media_player.ma_group_everywhere' }}
     sequence:
       - variables:
           playlist: >-
@@ -1550,8 +1553,8 @@ script:
             {{ plists[pindex] }}
       - variables:
           bedtime_playback_entity: >-
-            {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
-               else 'media_player.everywhere_sonos' }}
+            {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
+               else 'media_player.ma_group_everywhere' }}
           bedtime_media_type: "{{ 'radio' if 'somafm.com' in playlist else '' }}"
       - action: media_player.shuffle_set
         continue_on_error: true
@@ -1618,31 +1621,31 @@ script:
             - delay_minutes: 0
               continue_on_error: true
               entity_id:
-                - media_player.bedroom_sonos
-                - media_player.office_sonos
-                - media_player.bathroom_sonos
-                - media_player.den_sonos
+                - media_player.bedroom_sonos_2
+                - media_player.office_sonos_2
+                - media_player.bathroom_sonos_2
+                - media_player.den_sonos_2
               volume_level: 0.1
             - delay_minutes: 2
               continue_on_error: true
               entity_id:
-                - media_player.bedroom_sonos
-                - media_player.bathroom_sonos
-                - media_player.office_sonos
+                - media_player.bedroom_sonos_2
+                - media_player.bathroom_sonos_2
+                - media_player.office_sonos_2
               volume_level: 0.07
             - delay_minutes: 2
               continue_on_error: false
               entity_id:
-                - media_player.bedroom_sonos
-                - media_player.bathroom_sonos
-                - media_player.office_sonos
+                - media_player.bedroom_sonos_2
+                - media_player.bathroom_sonos_2
+                - media_player.office_sonos_2
               volume_level: 0.05
             - delay_minutes: 2
               continue_on_error: true
               entity_id:
-                - media_player.bedroom_sonos
-                - media_player.bathroom_sonos
-                - media_player.office_sonos
+                - media_player.bedroom_sonos_2
+                - media_player.bathroom_sonos_2
+                - media_player.office_sonos_2
               volume_level: 0.01
       - repeat:
           for_each: "{{ bedtime_rampdown_steps }}"
@@ -1680,8 +1683,10 @@ script:
         description: "Kept for backwards compatibility; ignored — sync groups manage membership"
     variables:
       playback_player: >-
-        {{ 'media_player.guest_sonos' if is_state('input_boolean.guest_mode', 'on')
-           else 'media_player.everywhere_sonos' }}
+        {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
+           else 'media_player.ma_group_everywhere' }}
+      group_members: >-
+        {{ state_attr(playback_player, 'group_members') | default([playback_player]) }}
     sequence:
       - variables:
           playlist: >-
@@ -1794,11 +1799,11 @@ script:
               ] -%}
               {% set pindex =  (range(0, (plists | length))|random) -%}
               {{ plists[pindex] }}
-      - alias: "Prime wake-up group to safe low volume before playback"
+      - alias: "Prime each member to safe low volume — individual sets bypass MA proportional group scaling"
         continue_on_error: true
         action: media_player.volume_set
         target:
-          entity_id: "{{ playback_player }}"
+          entity_id: "{{ group_members }}"
         data:
           volume_level: 0.05
       - alias: "Enable Shuffle"

--- a/packages/tiki_time.yaml
+++ b/packages/tiki_time.yaml
@@ -344,7 +344,7 @@ script:
               - action: script.music_assistant_play_item
                 continue_on_error: true
                 data:
-                  entity_id: media_player.everywhere_sonos
+                  entity_id: media_player.ma_group_everywhere
                   media_item: "somafm://radio/tikitime"
                   enqueue: replace
               - action: media_player.turn_on


### PR DESCRIPTION
## Summary

- **Root cause fix**: Music Assistant proportional group volume scaling was silently muting individual Sonos speakers when the wake-up alarm played MPR. `bedroom_sonos_2`, `office_sonos_2`, and `den_sonos_2` all ended up at volume 0 and stayed there through the entire ramp-up.
- **Media player labelling**: All `media_player` entities now carry an integration-source label so the origin of any future issue is immediately apparent in the HA UI.
- **MA sync group renames**: `everywhere_sonos` → `ma_group_everywhere`, `guest_sonos` → `ma_group_guest`.
- **Sonos direct-integration entities disabled**: 5 Sonos entities superseded by MA counterparts disabled. `den_turntable` kept.
- **Ghost HomePod entities disabled**: 6 HomePod Mini entities at sw 17.6 all stuck `unknown` — confirmed stale config entries left over from a HomePod OS update. Active HomePods are at sw 26.4.

## Volume fix detail (`packages/media_player.yaml`)

`music_assistant_radio_wake_up` and `spotify_wake_up`:
- Capture `group_members` from `state_attr` at script start
- Set and ramp volume on **individual member entities** — individual `volume_set` is absolute; MA's proportional group scaler is never involved

`spotify_bedtime_volume`:
- Swapped V1 Sonos entity names (`bedroom_sonos`, etc.) for MA counterparts (`bedroom_sonos_2`, etc.) — V1 entities were setting hardware volume to 0.01 overnight, creating a stale baseline that fed wrong numbers into MA's proportional scaler the next morning.

## Entity registry changes (applied via MCP, no YAML changes needed)

**Labels created:** `sonos`, `homepod`, `apple_tv`, `lg_webos`, `spotify`, `plex` (plus existing `music_assistant`)

| Label | Entities |
|---|---|
| `music_assistant` | All `_2` Sonos players, MA sync groups, HomePod/TV/Mac MA representations (15) |
| `homepod` | HomePod Mini entities via apple_tv integration (7, most now disabled) |
| `apple_tv` | `media_player.basement` (4K gen 3), `media_player.living_room` (4K gen 2) |
| `sonos` | Direct Sonos integration entities (6, most now disabled) |
| `lg_webos` | `lg_webos_smart_tv` |
| `spotify` | `spotify_ryan_claussen` |
| `plex` | 9 Plex client entities |

**Disabled (11 total):**

| Entity | Reason |
|---|---|
| `media_player.bedroom_sonos` | Superseded by MA player `bedroom_sonos_2` |
| `media_player.office_sonos` | Superseded by MA player `office_sonos_2` |
| `media_player.den_sonos` | Superseded by MA player `den_sonos_2` |
| `media_player.bathroom_sonos` | Superseded by MA player `bathroom_sonos_2` |
| `media_player.tiki_room_3` | Superseded by MA player `tiki_room_2` |
| `media_player.kitchen` | Ghost HomePod Mini sw 17.6 — replaced by `kitchen_3` (sw 26.4) |
| `media_player.bedroom_2` | Ghost HomePod Mini sw 17.6 — `unknown`, not reachable |
| `media_player.living_room_2` | Ghost HomePod Mini sw 17.6 — `unknown`, not reachable |
| `media_player.tiki` | Ghost HomePod Mini sw 17.6 — `unknown`, not reachable |
| `media_player.office_2` | Ghost HomePod Mini sw 17.6 — `unknown`, not reachable |
| `media_player.basement_home_pod` | Ghost HomePod Mini sw 17.6 — `unknown`, not reachable |

**Renamed entity IDs:** `everywhere_sonos` → `ma_group_everywhere`, `guest_sonos` → `ma_group_guest`

## Test plan

- [ ] Verify MPR alarm plays audibly in bedroom, office, den, and bathroom tomorrow morning
- [ ] Verify `spotify_bedtime` ramp-down reaches correct volumes on `_2` entities
- [ ] Confirm `ma_group_everywhere` and `ma_group_guest` resolve correctly in all scripts
- [ ] Confirm no automations reference any of the 11 disabled entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)