### PR TITLE
[codex] Upgrade Home Assistant validation to 2026.5

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -14,10 +14,7 @@ permissions:
   contents: read
 
 env:
-  # Home Assistant 2026.4.0 regressed `check_config` for trigger-based automation,
-  # script, and template validation. Keep this pinned until upstream fixes
-  # home-assistant/core#167066 in a stable release.
-  HOME_ASSISTANT_CHECK_CONFIG_IMAGE: ghcr.io/home-assistant/home-assistant:2026.3.4
+  HOME_ASSISTANT_CHECK_CONFIG_IMAGE: ghcr.io/home-assistant/home-assistant:2026.5.0
 
 concurrency:
   group: validate-home-assistant-config-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 - This repo pins local tooling Python in `.python-version`.
 - CI validates that this pinned version is still compatible with the latest official `homeassistant` release from [PyPI](https://pypi.org/project/homeassistant/).
-- Config checks run against `ghcr.io/home-assistant/home-assistant:stable` so validation tracks current Home Assistant stable releases.
-- As of 2026-03-15, latest `homeassistant` requires Python `>=3.14.2`, so `.python-version` is set to `3.14.3`.
+- Config checks run against the pinned Home Assistant image in `.github/workflows/validate-config.yml` so PR validation is deterministic for the current upgrade target.
+- As of 2026-05-06, latest `homeassistant` requires Python `>=3.14.2`, so `.python-version` is set to `3.14.3`.
 
 ## Branch Flow
 
@@ -144,7 +144,7 @@ yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disab
   configuration.yaml automations.yaml blueprints packages zigbee2mqtt
 
 # If Docker is available
-docker run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:stable \
+docker run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:2026.5.0 \
   python -m homeassistant --config /config --script check_config
 ```
 

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -502,6 +502,7 @@ automation:
       #         Restarting AppDaemon. Check the Automation Log
     action:
       - action: hassio.addon_restart
+        continue_on_error: true
         data:
           addon: a0d7b954_appdaemon
 
@@ -517,6 +518,7 @@ automation:
         event: leave
     action:
       - action: hassio.addon_restart
+        continue_on_error: true
         data:
           addon: d5369777_music_assistant
 

--- a/packages/z2m_lifecycle.yaml
+++ b/packages/z2m_lifecycle.yaml
@@ -349,6 +349,7 @@ automation:
               message: >-
                 Z2M recovery attempt {{ states('counter.reboot_counter') }} of {{ max_restart_attempts }}. Reason: {{ issue_reason }}. Restarting Zigbee2MQTT.
           - action: hassio.addon_restart
+            continue_on_error: true
             data:
               addon: 45df7312_zigbee2mqtt
           - delay:
@@ -404,11 +405,13 @@ automation:
               message: >-
                 Z2M is still unhealthy after {{ states('counter.reboot_counter') }} restart attempts. Restarting EMQX, then Zigbee2MQTT, before host shutdown.
           - action: hassio.addon_restart
+            continue_on_error: true
             data:
               addon: a0d7b954_emqx
           - delay:
               minutes: 2
           - action: hassio.addon_restart
+            continue_on_error: true
             data:
               addon: 45df7312_zigbee2mqtt
           - delay:

--- a/tests/test_ha_2026_5_upgrade.py
+++ b/tests/test_ha_2026_5_upgrade.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+Z2M_LIFECYCLE_PATH = ROOT / "packages" / "z2m_lifecycle.yaml"
+UTILITIES_PATH = ROOT / "packages" / "utilities.yaml"
+
+
+def test_supervisor_restart_actions_preserve_failure_tolerant_behavior() -> None:
+    for package_path in (Z2M_LIFECYCLE_PATH, UTILITIES_PATH):
+        lines = package_path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if "action: hassio.addon_restart" not in line:
+                continue
+
+            action_indent = len(line) - len(line.lstrip())
+            following = lines[index + 1 : index + 4]
+            expected = f"{' ' * (action_indent + 2)}continue_on_error: true"
+            assert expected in following, (
+                f"{package_path} must keep hassio.addon_restart failure-tolerant "
+                "for Home Assistant 2026.5 supervisor action semantics"
+            )

--- a/tests/test_validate_config_workflow.py
+++ b/tests/test_validate_config_workflow.py
@@ -32,8 +32,7 @@ def test_home_assistant_config_check_does_not_depend_on_esphome_build() -> None:
 def test_home_assistant_config_check_pins_known_good_image() -> None:
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
 
-    assert "HOME_ASSISTANT_CHECK_CONFIG_IMAGE: ghcr.io/home-assistant/home-assistant:2026.3.4" in workflow_text
-    assert "home-assistant/core#167066" in workflow_text
+    assert "HOME_ASSISTANT_CHECK_CONFIG_IMAGE: ghcr.io/home-assistant/home-assistant:2026.5.0" in workflow_text
     assert '"$HOME_ASSISTANT_CHECK_CONFIG_IMAGE" \\' in workflow_text
 
 


### PR DESCRIPTION
## Summary

- Update GitHub Actions Home Assistant config validation from `2026.3.4` to `2026.5.0`.
- Preserve pre-2026.5 failure-tolerant behavior for Supervisor `hassio.addon_restart` recovery actions with `continue_on_error: true`.
- Align README validation docs with the pinned 2026.5 config-check image.
- Add regression coverage requiring all Supervisor restart actions in the touched packages to keep explicit failure-continuation semantics.

## Context

Home Assistant Core 2026.5 changes Supervisor action failures from log-only to raised automation errors. The Z2M recovery and app restart flows are recovery/maintenance paths where the prior behavior was to continue through the rest of the flow even if the restart action itself fails.

## Validation

- `uv run --with pytest pytest` -> `423 passed`

## Follow-up issues opened

- #614 Security dashboard activity coverage
- #615 Core shortcut cards
- #616 Native media tile controls
- #617 Purpose-specific timer triggers
- #618 Standardized doorbell trigger
- #619 Native update availability conditions
- #620 RF bridge for deck/seasonal lights
- #621 ESPHome serial proxy discovery
- #622 Sonos TV Autoplay/Ungroup switches
- #623 Custom integration deprecation watch
- #624 Kiosker discovery

Existing related issues updated instead of duplicated:

- #172 Battery/Maintenance dashboard follow-up
- #323 Valetudo/areas follow-up