### PR TITLE
Show Inky precip warnings during flight mode

### DIFF
--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -263,7 +263,7 @@ script:
               'up_for_day': 'Morning activity confirmed',
               'midday': 'Low-frequency refresh'
             } %}
-            {% set exception_active = weather_alert or garage_open or front_door_open %}
+            {% set exception_active = weather_alert or garage_open or front_door_open or rain_next_hour or event_weather %}
             {% if flight_active and resolved_mode in ['morning', 'up_for_day', 'midday'] and not exception_active %}
               {% set rows = travel_rows %}
             {% elif flight_active and resolved_mode in ['morning', 'up_for_day', 'midday'] %}

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -148,7 +148,7 @@ def test_owner_suite_payload_consumes_flight_status_sources() -> None:
         assert entity_id in automation
 
     assert "travel_rows" in block
-    assert "exception_active = weather_alert or garage_open or front_door_open" in block
+    assert "exception_active = weather_alert or garage_open or front_door_open or rain_next_hour or event_weather" in block
     assert "resolved_mode in ['morning', 'up_for_day', 'midday']" in block
 
 


### PR DESCRIPTION
## Summary
- include near-term rain and next-event weather in the Inky flight-mode exception gate
- keep the mixed travel/status layout visible when precipitation warnings are active
- update the regression assertion for the flight-mode row selector

Fixes review comment: https://github.com/rtclauss/hass-config/pull/595#discussion_r3189374722
Related: #313, #595

## Tests
- uv run --with pytest pytest