### PR TITLE
fix: guard owner-suite triggers against unavailable→on/off transitions

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1385,9 +1385,11 @@ automation:
       - trigger: state
         entity_id: binary_sensor.bedroom_occupancy
         to: "on"
+        from: "off"
       - trigger: state
         entity_id: binary_sensor.presense
         to: "on"
+        from: "off"
     condition:
       condition: and
       conditions:
@@ -1976,9 +1978,11 @@ automation:
       - trigger: state
         entity_id: binary_sensor.bedroom_motion
         to: "on"
+        from: "off"
       - trigger: state
         entity_id: binary_sensor.presense
         to: "on"
+        from: "off"
     condition:
       condition: and
       conditions:
@@ -2023,26 +2027,32 @@ automation:
         id: zone_1_on
         entity_id: binary_sensor.under_bed_presense_zone_1_occupancy
         to: "on"
+        from: "off"
       - trigger: state
         id: zone_2_on
         entity_id: binary_sensor.everything_presence_lite_2fbc58_zone_2_occupancy
         to: "on"
+        from: "off"
       - trigger: state
         id: zone_3_on
         entity_id: binary_sensor.everything_presence_lite_2fbc58_zone_3_occupancy
         to: "on"
+        from: "off"
       - trigger: state
         id: zone_4_on
         entity_id: binary_sensor.everything_presence_lite_2fbc58_zone_4_occupancy
         to: "on"
+        from: "off"
       - trigger: state
         id: motion_on
         entity_id: binary_sensor.presense
         to: "on"
+        from: "off"
       - trigger: state
         id: motion_off
         entity_id: binary_sensor.presense
         to: "off"
+        from: "on"
         for:
           minutes: 60
     condition:


### PR DESCRIPTION
Fixes #565

## Summary
- Added `from: "off"` to all `to: "on"` state triggers in `owner_suite_light_auto_on`, `turn_on_bedroom_light_when_leave_bathroom`, and `toggle_on_under_bed_on_motion`
- Added `from: "on"` to the `motion_off` (`to: "off"`) trigger in `toggle_on_under_bed_on_motion`
- Affected sensors: `binary_sensor.presense`, `binary_sensor.under_bed_presense_zone_1_occupancy`, zones 2–4, `binary_sensor.bedroom_occupancy`, `binary_sensor.bedroom_motion`

This stops `unavailable → on` recovery transitions from falsely firing owner-suite light-on logic, and `unavailable → off` transitions from starting the 60-minute bed-lightstrip turn-off timer. The underlying hardware/ESPHome/Bermuda flapping remains an open hardware issue, but these guards eliminate the downstream automation misfires in the meantime.

## Test plan
- [ ] Confirm `owner_suite_light_auto_on` does not fire when `binary_sensor.presense` recovers from `unavailable` to `on`
- [ ] Confirm `turn_on_bedroom_light_when_leave_bathroom` does not fire on the same recovery transition
- [ ] Confirm `toggle_on_under_bed_on_motion` zone triggers do not fire on `unavailable → on` for any zone sensor
- [ ] Confirm the 60-minute bed-lightstrip off timer does not start when `binary_sensor.presense` transitions from `unavailable` to `off`
- [ ] Confirm all three automations still fire correctly on genuine `off → on` (and `on → off`) transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)