### PR TITLE
[codex] Migrate fan timer triggers

### DIFF
--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -266,33 +266,26 @@ automation:
     mode: parallel
     max: 7
     triggers:
-      - trigger: event
-        event_type: timer.finished
-        event_data:
+      - trigger: timer.finished
+        target:
           entity_id: timer.owner_suite_fan_timer
-      - trigger: event
-        event_type: timer.finished
-        event_data:
+      - trigger: timer.finished
+        target:
           entity_id: timer.owner_suite_bathroom_exhaust_timer
-      - trigger: event
-        event_type: timer.finished
-        event_data:
+      - trigger: timer.finished
+        target:
           entity_id: timer.office_ceiling_fan_timer
-      - trigger: event
-        event_type: timer.finished
-        event_data:
+      - trigger: timer.finished
+        target:
           entity_id: timer.basement_bathroom_exhaust_timer
-      - trigger: event
-        event_type: timer.finished
-        event_data:
+      - trigger: timer.finished
+        target:
           entity_id: timer.den_ceiling_fan_timer
-      - trigger: event
-        event_type: timer.finished
-        event_data:
+      - trigger: timer.finished
+        target:
           entity_id: timer.guest_room_fan_timer
-      - trigger: event
-        event_type: timer.finished
-        event_data:
+      - trigger: timer.finished
+        target:
           entity_id: timer.guest_bathroom_exhaust_timer
     actions:
       - variables:
@@ -306,7 +299,7 @@ automation:
             timer.guest_bathroom_exhaust_timer: fan.guest_bathroom_exhaust
       - action: fan.turn_off
         target:
-          entity_id: "{{ fan_map[trigger.event.data.entity_id] }}"
+          entity_id: "{{ fan_map[trigger.entity_id] }}"
 
   - alias: bedroom_fan_control
     id: bedroom_fan_control

--- a/tests/test_issue_617_timer_triggers.py
+++ b/tests/test_issue_617_timer_triggers.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+FANS_PATH = Path(__file__).resolve().parents[1] / "packages" / "fans.yaml"
+
+FAN_TIMER_MAP = {
+    "timer.owner_suite_fan_timer": "fan.owner_suite",
+    "timer.owner_suite_bathroom_exhaust_timer": "fan.owner_suite_bathroom_exhaust",
+    "timer.office_ceiling_fan_timer": "fan.office_ceiling_fan",
+    "timer.basement_bathroom_exhaust_timer": "fan.basement_bathroom_exhaust",
+    "timer.den_ceiling_fan_timer": "fan.den_ceiling",
+    "timer.guest_room_fan_timer": "fan.guest_room",
+    "timer.guest_bathroom_exhaust_timer": "fan.guest_bathroom_exhaust",
+}
+
+
+def _fan_timer_block() -> str:
+    lines = FANS_PATH.read_text(encoding="utf-8").splitlines()
+    start = lines.index("  - alias: fan_off_when_timer_ends")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - alias: "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_fan_timer_automation_uses_ha_2026_5_timer_finished_triggers() -> None:
+    block = _fan_timer_block()
+
+    assert "event_type: timer.finished" not in block
+    assert block.count("trigger: timer.finished") == len(FAN_TIMER_MAP)
+
+    for timer_entity in FAN_TIMER_MAP:
+        assert f"entity_id: {timer_entity}" in block
+
+
+def test_fan_timer_automation_maps_trigger_entity_to_target_fan() -> None:
+    block = _fan_timer_block()
+
+    assert '{{ fan_map[trigger.entity_id] }}' in block
+    assert "trigger.event.data.entity_id" not in block
+
+    for timer_entity, fan_entity in FAN_TIMER_MAP.items():
+        assert f"{timer_entity}: {fan_entity}" in block


### PR DESCRIPTION
## Summary
- Migrates the fan timer expiry automation from raw `timer.finished` event triggers to HA 2026.5 `timer.finished` purpose-specific triggers.
- Updates the fan lookup to use `trigger.entity_id`, matching the new trigger payload.
- Adds focused regression tests for the timer-to-fan mapping.

## Validation
- `uv run --with pytest pytest tests/test_issue_617_timer_triggers.py tests/test_den_ceiling_bond_reconcile.py` passed.
- Full `uv run --with pytest pytest` currently reports 417 passed and 8 failed. The same 8 media/tiki playback failures reproduce on a clean `origin/develop` worktree, so they are baseline failures unrelated to this branch.

Fixes #617