### PR TITLE
[codex] Add HA 2026.5 update condition regression coverage

### DIFF
--- a/tests/test_ha_2026_5_upgrade.py
+++ b/tests/test_ha_2026_5_upgrade.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 Z2M_LIFECYCLE_PATH = ROOT / "packages" / "z2m_lifecycle.yaml"
 UTILITIES_PATH = ROOT / "packages" / "utilities.yaml"
+YAML_SEARCH_ROOTS = (
+    ROOT / "automations.yaml",
+    ROOT / "scripts.yaml",
+    ROOT / "packages",
+)
 
 
 def test_supervisor_restart_actions_preserve_failure_tolerant_behavior() -> None:
@@ -22,3 +28,81 @@ def test_supervisor_restart_actions_preserve_failure_tolerant_behavior() -> None
                 f"{package_path} must keep hassio.addon_restart failure-tolerant "
                 "for Home Assistant 2026.5 supervisor action semantics"
             )
+
+
+def _yaml_paths() -> list[Path]:
+    paths: list[Path] = []
+    for search_root in YAML_SEARCH_ROOTS:
+        if search_root.is_file():
+            paths.append(search_root)
+            continue
+        paths.extend(search_root.rglob("*.yaml"))
+    return sorted(paths)
+
+
+def _has_simple_update_state_availability_condition(text: str) -> bool:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if "condition: state" not in line:
+            continue
+
+        condition_indent = len(line) - len(line.lstrip())
+        block_lines = [line]
+        for following_line in lines[index + 1 :]:
+            stripped = following_line.strip()
+            following_indent = len(following_line) - len(following_line.lstrip())
+            if stripped and following_indent <= condition_indent:
+                break
+            block_lines.append(following_line)
+
+        block = "\n".join(block_lines)
+        if re.search(r"\bentity_id:\s*update\.", block) and re.search(
+            r"\bstate:\s*[\"']?(?:on|off)[\"']?\s*$",
+            block,
+            re.MULTILINE,
+        ):
+            return True
+
+    return False
+
+
+def test_update_state_availability_scanner_only_flags_on_off_checks() -> None:
+    assert _has_simple_update_state_availability_condition(
+        """
+automation:
+  - condition: state
+    entity_id: update.zigbee_firmware
+    state: "on"
+"""
+    )
+    assert not _has_simple_update_state_availability_condition(
+        """
+automation:
+  - condition: state
+    entity_id: update.zigbee_firmware
+    state: installing
+"""
+    )
+
+
+def test_simple_update_availability_checks_use_native_update_conditions() -> None:
+    simple_template_condition = re.compile(
+        r"condition:\s*template\s*\n(?:[^\n]*\n){0,8}?\s*value_template:\s*(?:>-\s*\n)?"
+        r"(?:[^\n]*\n){0,8}?.*(?:is_state\(['\"]update\.|states\(['\"]update\.).*['\"](?:on|off)['\"]",
+        re.MULTILINE,
+    )
+    offenders: list[str] = []
+
+    for path in _yaml_paths():
+        text = path.read_text(encoding="utf-8")
+        if (
+            _has_simple_update_state_availability_condition(text)
+            or simple_template_condition.search(text)
+        ):
+            offenders.append(str(path.relative_to(ROOT)))
+
+    assert offenders == [], (
+        "Simple update availability decisions should use Home Assistant 2026.5 "
+        "`condition: update.is_available` or `condition: update.is_not_available`, "
+        f"not state/template conditions: {offenders}"
+    )

--- a/tests/test_z2m_lifecycle_package.py
+++ b/tests/test_z2m_lifecycle_package.py
@@ -86,6 +86,19 @@ def test_z2m_lifecycle_watchdog_uses_plain_bridge_state_trigger() -> None:
     assert 'value_template: "{{ value_json.state }}"' not in block
 
 
+def test_z2m_ota_template_tracks_progress_attributes_not_simple_availability() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    template_block = text.split("z2m_ota_stats: >-", maxsplit=1)[1].split("  - trigger:", maxsplit=1)[0]
+
+    assert "entity_id.startswith('update.')" in template_block
+    assert "state_attr(entity_id, 'in_progress')" in template_block
+    assert "state_attr(entity_id, 'update_percentage')" in template_block
+    assert "'eta_minutes': eta_minutes" in template_block
+    assert "is_state(entity_id, 'on')" not in template_block
+    assert "states(entity_id) == 'on'" not in template_block
+    assert "states(entity_id) in ['on'" not in template_block
+
+
 def test_zigbee2mqtt_configuration_enables_health_feed_and_does_not_disable_removal() -> None:
     text = Z2M_CONFIG_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Add a Home Assistant 2026.5 regression guard that rejects simple `update.*` availability checks implemented as state/template conditions.
- Add Z2M lifecycle coverage documenting that the OTA progress template intentionally remains attribute-based for `in_progress`, `update_percentage`, and ETA data.

## Why
Home Assistant 2026.5 adds native update conditions: `update.is_available` and `update.is_not_available`. Simple availability decisions should use those native conditions, while templates should remain only where update attributes are required.

Fixes #619.

## Validation
- PASS: `uv run --with pytest pytest tests/test_ha_2026_5_upgrade.py tests/test_z2m_lifecycle_package.py`
- FAIL: `uv run --with pytest pytest`
  - 417 passed, 8 failed.
  - Failures are existing media/tiki wake-up group expectation failures in `tests/test_alarm_night_allium_alignment.py`, `tests/test_media_player_music_assistant.py`, and `tests/test_tiki_time.py`, unrelated to the issue 619 update-condition coverage.
