### PR TITLE
feat: expose bedtime music routine to HomeKit/Siri

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -514,6 +514,25 @@ automation:
     action:
       - action: homeassistant.restart
 
+  - id: bedtime_music_homekit_trigger
+    alias: "Bedtime Music — HomeKit trigger"
+    description: >-
+      Exposes a momentary switch to HomeKit/Siri. Turning on input_boolean.bedtime_music
+      fires script.spotify_bedtime non-blocking, then immediately resets the boolean so
+      HomeKit always sees it as off (stateless trigger pattern).
+    mode: single
+    trigger:
+      - trigger: state
+        entity_id: input_boolean.bedtime_music
+        to: "on"
+    action:
+      - action: script.turn_on
+        target:
+          entity_id: script.spotify_bedtime
+      - action: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.bedtime_music
+
 
 ########################
 # Binary Sensors
@@ -543,7 +562,10 @@ group: {}
 ########################
 # Input Booleans
 ########################
-input_boolean: {}
+input_boolean:
+  bedtime_music:
+    name: "Bedtime Music"
+    icon: mdi:music-note-plus
 
 ########################
 # Input Numbers


### PR DESCRIPTION
## Summary
- Adds `input_boolean.bedtime_music` — appears as a **switch** in HomeKit named "Bedtime Music"
- Adds `automation: bedtime_music_homekit_trigger` (mode: `single`) — fires when the boolean turns on, runs `script.spotify_bedtime` non-blocking, then immediately resets the boolean to off (stateless/momentary trigger pattern)
- After merging, expose `input_boolean.bedtime_music` via **Settings → Devices & Services → HomeKit → HASS Bridge:21064 → Configure**, then say *"Hey Siri, turn on Bedtime Music"*

## Test plan
- [ ] Config validates (`ha_check_config` passes)
- [ ] After reload, `input_boolean.bedtime_music` appears in HA
- [ ] Toggling the boolean on triggers `script.spotify_bedtime` and resets to off
- [ ] Entity added to HomeKit bridge and visible in Apple Home
- [ ] Siri voice command starts bedtime music routine

🤖 Generated with [Claude Code](https://claude.com/claude-code)