### PR TITLE
Use forecast service for Inky weather rows

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -195,9 +195,11 @@ Current owner-suite rows:
 | Status | First active status from weather alert, garage door, front door, rain in the next hour, precipitation/weather during the next `calendar.ryan_claussen` event, trip mode, vacation, otherwise `All clear` | `urgent` for alert/door/garage/rain/event weather, `emphasis` for trip/vacation |
 
 In `night_preview`, the owner-suite rows are current `Weather`, tomorrow's
-forecast from `sensor.active_weather_entity_id` `forecast_json`, next `Alarm`,
-and `Status`. Meeting is omitted at night to keep the display focused on sleep
-planning and morning conditions.
+daily forecast from `weather.get_forecasts`, next `Alarm`, and `Status`.
+Meeting is omitted at night to keep the display focused on sleep planning and
+morning conditions. The publish script also requests hourly forecast data at
+publish time for event-weather checks, with the legacy `forecast_json` attribute
+kept only as a fallback.
 
 When `sensor.next_travel_flight` is inside its active travel window, `morning`,
 `up_for_day`, and `midday` modes use flight-oriented rows instead of the normal

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -133,13 +133,27 @@ script:
                is_state('binary_sensor.bayesian_zeke_home', 'on')
                and is_state('input_boolean.trip', 'off')
              ) }}
+      - action: weather.get_forecasts
+        target:
+          entity_id: weather.tomorrow_io_the_brewery_daily
+        data:
+          type: daily
+        response_variable: owner_suite_daily_forecast
+      - action: weather.get_forecasts
+        target:
+          entity_id: weather.tomorrow_io_the_brewery_daily
+        data:
+          type: hourly
+        response_variable: owner_suite_hourly_forecast
       - action: mqtt.publish
         data:
           topic: home/inky/owner_suite/state
           qos: 1
           retain: true
           payload: >-
-            {% set weather_entity = states('sensor.active_weather_entity_id') %}
+            {% set preferred_weather_entity = 'weather.tomorrow_io_the_brewery_daily' %}
+            {% set active_weather_entity = states('sensor.active_weather_entity_id') %}
+            {% set weather_entity = active_weather_entity if active_weather_entity not in ['', 'unknown', 'unavailable'] else preferred_weather_entity %}
             {% set weather_state = states(weather_entity) %}
             {% set weather_icon_map = {
               'clear-night': 'mdi:weather-sunny',
@@ -160,11 +174,17 @@ script:
             {% set weather_icon = weather_icon_map.get(weather_state, 'mdi:weather-cloudy') %}
             {% set temperature = states('sensor.outside_temperature') %}
             {% set weather_value = (temperature ~ 'F ' ~ weather_state.replace('-', ' ')) if temperature not in ['unknown', 'unavailable'] else weather_state.replace('-', ' ') %}
-            {% set forecast_rows = (state_attr('sensor.active_weather_entity_id', 'forecast_json') | default('[]', true) | from_json) | sort(attribute='datetime') %}
+            {% set daily_response = owner_suite_daily_forecast if owner_suite_daily_forecast is mapping else {} %}
+            {% set hourly_response = owner_suite_hourly_forecast if owner_suite_hourly_forecast is mapping else {} %}
+            {% set daily_forecast_rows = daily_response.get(weather_entity, daily_response.get(preferred_weather_entity, {})).get('forecast', []) | sort(attribute='datetime') %}
+            {% set forecast_rows = hourly_response.get(weather_entity, hourly_response.get(preferred_weather_entity, {})).get('forecast', []) | sort(attribute='datetime') %}
+            {% if forecast_rows | count == 0 %}
+              {% set forecast_rows = (state_attr('sensor.active_weather_entity_id', 'forecast_json') | default('[]', true) | from_json) | sort(attribute='datetime') %}
+            {% endif %}
             {% set tomorrow_start_ts = as_timestamp(today_at('00:00') + timedelta(days=1)) %}
             {% set tomorrow_end_ts = as_timestamp(today_at('00:00') + timedelta(days=2)) %}
             {% set tomorrow = namespace(value='Unavailable') %}
-            {% for forecast in forecast_rows %}
+            {% for forecast in daily_forecast_rows %}
               {% set forecast_ts = as_timestamp(forecast.datetime, default=none) %}
               {% if forecast_ts is number and forecast_ts >= tomorrow_start_ts and forecast_ts < tomorrow_end_ts and tomorrow.value == 'Unavailable' %}
                 {% set forecast_temp = forecast.temperature | int(default=none) %}

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -103,6 +103,13 @@ def test_owner_suite_evening_auto_mode_uses_night_preview() -> None:
 def test_owner_suite_night_preview_includes_current_and_tomorrow_weather() -> None:
     block = _script_block("publish_owner_suite_inky_display")
 
+    assert "action: weather.get_forecasts" in block
+    assert "type: daily" in block
+    assert "response_variable: owner_suite_daily_forecast" in block
+    assert "type: hourly" in block
+    assert "response_variable: owner_suite_hourly_forecast" in block
+    assert "daily_forecast_rows = daily_response.get(weather_entity" in block
+    assert "forecast_rows = hourly_response.get(weather_entity" in block
     assert "forecast_rows = (state_attr('sensor.active_weather_entity_id', 'forecast_json')" in block
     assert "tomorrow_start_ts = as_timestamp(today_at('00:00') + timedelta(days=1))" in block
     assert "forecast.temperature | int(default=none)" in block


### PR DESCRIPTION
## Summary
- fetch daily and hourly Tomorrow.io forecasts with weather.get_forecasts during owner-suite Inky publishes
- use daily forecast response data for the night Tomorrow row and hourly response data for event-weather checks
- document the forecast-service source and keep forecast_json as a fallback

## Tests
- uv run --with pytest pytest

Refs #313