### PR TITLE
Fix #636 fan timer automation setup on HA 2026.5

### DIFF
--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -266,26 +266,33 @@ automation:
     mode: parallel
     max: 7
     triggers:
-      - trigger: timer.finished
-        target:
+      - trigger: event
+        event_type: timer.finished
+        event_data:
           entity_id: timer.owner_suite_fan_timer
-      - trigger: timer.finished
-        target:
+      - trigger: event
+        event_type: timer.finished
+        event_data:
           entity_id: timer.owner_suite_bathroom_exhaust_timer
-      - trigger: timer.finished
-        target:
+      - trigger: event
+        event_type: timer.finished
+        event_data:
           entity_id: timer.office_ceiling_fan_timer
-      - trigger: timer.finished
-        target:
+      - trigger: event
+        event_type: timer.finished
+        event_data:
           entity_id: timer.basement_bathroom_exhaust_timer
-      - trigger: timer.finished
-        target:
+      - trigger: event
+        event_type: timer.finished
+        event_data:
           entity_id: timer.den_ceiling_fan_timer
-      - trigger: timer.finished
-        target:
+      - trigger: event
+        event_type: timer.finished
+        event_data:
           entity_id: timer.guest_room_fan_timer
-      - trigger: timer.finished
-        target:
+      - trigger: event
+        event_type: timer.finished
+        event_data:
           entity_id: timer.guest_bathroom_exhaust_timer
     actions:
       - variables:
@@ -299,7 +306,7 @@ automation:
             timer.guest_bathroom_exhaust_timer: fan.guest_bathroom_exhaust
       - action: fan.turn_off
         target:
-          entity_id: "{{ fan_map[trigger.entity_id] }}"
+          entity_id: "{{ fan_map[trigger.event.data.entity_id] }}"
 
   - alias: bedroom_fan_control
     id: bedroom_fan_control

--- a/tests/test_issue_617_timer_triggers.py
+++ b/tests/test_issue_617_timer_triggers.py
@@ -29,11 +29,13 @@ def _fan_timer_block() -> str:
     return "\n".join(lines[start:end])
 
 
-def test_fan_timer_automation_uses_ha_2026_5_timer_finished_triggers() -> None:
+def test_fan_timer_automation_uses_stable_timer_finished_event_triggers() -> None:
     block = _fan_timer_block()
 
-    assert "event_type: timer.finished" not in block
-    assert block.count("trigger: timer.finished") == len(FAN_TIMER_MAP)
+    assert "trigger: timer.finished" not in block
+    assert block.count("trigger: event") == len(FAN_TIMER_MAP)
+    assert block.count("event_type: timer.finished") == len(FAN_TIMER_MAP)
+    assert block.count("event_data:") == len(FAN_TIMER_MAP)
 
     for timer_entity in FAN_TIMER_MAP:
         assert f"entity_id: {timer_entity}" in block
@@ -42,8 +44,8 @@ def test_fan_timer_automation_uses_ha_2026_5_timer_finished_triggers() -> None:
 def test_fan_timer_automation_maps_trigger_entity_to_target_fan() -> None:
     block = _fan_timer_block()
 
-    assert '{{ fan_map[trigger.entity_id] }}' in block
-    assert "trigger.event.data.entity_id" not in block
+    assert "{{ fan_map[trigger.event.data.entity_id] }}" in block
+    assert "fan_map[trigger.entity_id]" not in block
 
     for timer_entity, fan_entity in FAN_TIMER_MAP.items():
         assert f"{timer_entity}: {fan_entity}" in block


### PR DESCRIPTION
## Summary
- Replace HA Labs-only `timer.finished` purpose triggers in `fan_off_when_timer_ends` with stable raw `timer.finished` event triggers.
- Map fan targets from `trigger.event.data.entity_id`, matching the stable event payload.
- Update regression coverage so this automation cannot depend on the experimental `new_triggers_conditions` feature flag again.

Fixes #636.
Related: #617, #629.

## Runtime evidence
Live HA 2026.5.0 reports `automation.fan_off_when_timer_ends` as `unavailable`. The HA log says the automation failed setup because `timer.finished` requires the experimental Home Assistant Labs `new_triggers_conditions` feature flag.

## Validation
- PASS: `uv run --with pytest pytest tests/test_issue_617_timer_triggers.py tests/test_den_ceiling_bond_reconcile.py`
- PASS: `ruby -e 'require "yaml"; YAML.load_file("packages/fans.yaml"); puts "packages/fans.yaml yaml ok"'`
- PASS: `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/fans.yaml`
- PASS: `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/fans.yaml --strict`
- PASS: `uv run --with pytest pytest` (`430 passed`)
- PASS: `POST /api/config/core/check_config` on live HA returned valid before patch deploy
- PASS: `uv run --with homeassistant==2026.5.0 python -m homeassistant --config "$PWD" --script check_config` with CI-style placeholder secrets, then removed `secrets.yaml`
