### PR TITLE
Show daytime Inky context after wakeup

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -166,9 +166,10 @@ Primary entities:
 
 The automation listens to wake alarm helpers, wake-up firing state, house mode,
 guest mode, Ryan's home state, bed/owner-suite activity, trip/vacation state,
-flight status, garage/front-door exceptions, weather alerts, active weather, and
-near-term precipitation/calendar weather, and a noon refresh. It does not listen
-to `sensor.time`, so it will not redraw on clock ticks.
+flight status, garage/front-door exceptions, weather alerts, active weather,
+near-term precipitation/calendar weather, upcoming personal calendar events, and
+a noon refresh. It does not listen to `sensor.time`, so it will not redraw on
+clock ticks.
 
 The publish script only allows updates when guest mode is active, or when Ryan
 is home and trip mode is off. While Ryan is away or trip mode is on with guest
@@ -190,20 +191,30 @@ Current owner-suite rows:
 | Row | Value source | Level behavior |
 | --- | --- | --- |
 | Weather | `sensor.outside_temperature` plus `sensor.active_weather_entity_id` weather state | `urgent` when NWS alerts are active |
-| Alarm | `input_datetime.weekday_alarm` or `input_datetime.weekend_alarm` when the matching alarm helper is on | `emphasis` in `night_preview` when alarm is enabled |
-| Meeting | `input_datetime.next_work_meeting` when `input_boolean.special_meeting` is on | `emphasis` when special meeting is on |
+| Alarm | `input_datetime.weekday_alarm` or `input_datetime.weekend_alarm` when the matching alarm helper is on | Night-only; `emphasis` in `night_preview` when alarm is enabled |
+| Meeting | `input_datetime.next_work_meeting` when `input_boolean.special_meeting` is on | Night-only; shown when no urgent status is active |
+| Next | Next `calendar.ryan_claussen` event from `calendar.get_events` in the next 12 hours | Day-only; `emphasis` when an event is available |
+| Place | Location from the next `calendar.ryan_claussen` event | Day-only |
+| Quote | Original rotating sci-fi/fantasy fallback text | Day-only when no next event is available |
 | Status | First active status from weather alert, garage door, front door, rain in the next hour, precipitation/weather during the next `calendar.ryan_claussen` event, trip mode, vacation, otherwise `All clear` | `urgent` for alert/door/garage/rain/event weather, `emphasis` for trip/vacation |
 
 In `night_preview`, the owner-suite rows are current `Weather`, tomorrow's
-daily forecast from `weather.get_forecasts`, next `Alarm`, and `Status`.
-Meeting is omitted at night to keep the display focused on sleep planning and
-morning conditions. The publish script also requests hourly forecast data at
-publish time for event-weather checks, with the legacy `forecast_json` attribute
-kept only as a fallback.
+daily forecast from `weather.get_forecasts`, next `Alarm`, and either the
+meeting alarm or urgent `Status`. Meeting alarm details are night-only, and
+safety/exception status takes priority over the meeting row. The publish script
+also requests hourly forecast data at publish time for event-weather checks,
+with the legacy `forecast_json` attribute kept only as a fallback.
+
+In `morning`, `up_for_day`, and `midday`, alarm and meeting-alarm rows are not
+shown. Those modes use current `Weather`, next calendar event time/title,
+calendar event location, and `Status`. If no calendar event is available in the
+next 12 hours, the event rows fall back to an original rotating sci-fi/fantasy
+quote plus a source row. This keeps the post-wakeup screen focused on what is
+next instead of repeating wake-up setup state.
 
 When `sensor.next_travel_flight` is inside its active travel window, `morning`,
 `up_for_day`, and `midday` modes use flight-oriented rows instead of the normal
-alarm/meeting rows. Weather alerts, garage-door exceptions, and front-door
+calendar/quote rows. Weather alerts, garage-door exceptions, and front-door
 exceptions still take display priority and keep an urgent status row visible.
 
 Flight rows use these normalized entities from `packages/flight_status.yaml`:

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -145,6 +145,13 @@ script:
         data:
           type: hourly
         response_variable: owner_suite_hourly_forecast
+      - action: calendar.get_events
+        target:
+          entity_id: calendar.ryan_claussen
+        data:
+          start_date_time: "{{ (now() - timedelta(minutes=5)).isoformat() }}"
+          end_date_time: "{{ (now() + timedelta(hours=12)).isoformat() }}"
+        response_variable: owner_suite_calendar_window
       - action: mqtt.publish
         data:
           topic: home/inky/owner_suite/state
@@ -209,6 +216,33 @@ script:
               {% set alarm_value = 'Off' %}
             {% endif %}
             {% set meeting_value = states('input_datetime.next_work_meeting')[0:5] if meeting_alarm else 'Off' %}
+            {% set calendar_entity = 'calendar.ryan_claussen' %}
+            {% set calendar_response = owner_suite_calendar_window if owner_suite_calendar_window is mapping else {} %}
+            {% set calendar_items = calendar_response.get('events', calendar_response.get(calendar_entity, {}).get('events', [])) %}
+            {% set next_calendar = namespace(has_event=false, time='No event', place='No location') %}
+            {% set now_ts = as_timestamp(now()) %}
+            {% for item in calendar_items | sort(attribute='start') %}
+              {% set item_start = item.start | default('', true) %}
+              {% set item_end = item.end | default('', true) %}
+              {% set item_start_ts = as_timestamp(item_start, default=none) %}
+              {% set item_end_ts = as_timestamp(item_end, default=none) %}
+              {% if not next_calendar.has_event and item_start_ts is number and item_end_ts is number and item_end_ts > now_ts and item_start_ts < now_ts + 43200 %}
+                {% set item_title = item.summary | default('Calendar', true) | string | trim %}
+                {% set item_location = item.location | default('', true) | string | trim %}
+                {% set item_time = (item_start | as_datetime | as_local).strftime('%H:%M') %}
+                {% set next_calendar.has_event = true %}
+                {% set next_calendar.time = (item_time ~ ' ' ~ item_title) | trim %}
+                {% set next_calendar.place = item_location if item_location != '' else 'No location' %}
+              {% endif %}
+            {% endfor %}
+            {% set quotes = [
+              'Airlocks favor optimism.',
+              'Dragons respect checklists.',
+              'The star map can wait.',
+              'Keep the spell simple.',
+              'Pack snacks for hyperspace.'
+            ] %}
+            {% set quote_value = quotes[(now().strftime('%j') | int) % (quotes | count)] %}
             {% set garage_open = states('cover.garage_door') not in ['closed', 'closing'] %}
             {% set front_door_open = is_state('binary_sensor.main_foyer_front_door_contact', 'on') %}
             {% set weather_alert_state = states('sensor.nws_dakota_county_alerts_alerts_are_active') | lower %}
@@ -305,11 +339,12 @@ script:
             } %}
             {% set exception_active = weather_alert or garage_open or front_door_open or rain_next_hour or event_weather %}
             {% if resolved_mode == 'night_preview' %}
+              {% set night_detail_row = {'label': 'Status', 'value': status_value, 'level': status_level} if status_level != 'normal' else {'label': 'Meeting', 'value': meeting_value, 'level': 'emphasis' if meeting_alarm else 'normal'} %}
               {% set rows = [
                 {'icon': weather_icon, 'label': 'Weather', 'value': weather_value, 'level': 'urgent' if weather_alert else 'normal'},
                 {'icon': weather_icon, 'label': 'Tomorrow', 'value': tomorrow.value, 'level': 'normal'},
                 {'label': 'Alarm', 'value': alarm_value, 'level': 'emphasis' if alarm_value != 'Off' else 'normal'},
-                {'label': 'Status', 'value': status_value, 'level': status_level}
+                night_detail_row
               ] %}
             {% elif flight_active and resolved_mode in ['morning', 'up_for_day', 'midday'] and not exception_active %}
               {% set rows = travel_rows %}
@@ -321,12 +356,21 @@ script:
                 {'label': 'Status', 'value': status_value, 'level': status_level}
               ] %}
             {% else %}
-              {% set rows = [
-                {'icon': weather_icon, 'label': 'Weather', 'value': weather_value, 'level': 'urgent' if weather_alert else 'normal'},
-                {'label': 'Alarm', 'value': alarm_value, 'level': 'emphasis' if resolved_mode == 'night_preview' and alarm_value != 'Off' else 'normal'},
-                {'label': 'Meeting', 'value': meeting_value, 'level': 'emphasis' if meeting_alarm else 'normal'},
-                {'label': 'Status', 'value': status_value, 'level': status_level}
-              ] %}
+              {% if next_calendar.has_event %}
+                {% set rows = [
+                  {'icon': weather_icon, 'label': 'Weather', 'value': weather_value, 'level': 'urgent' if weather_alert else 'normal'},
+                  {'label': 'Next', 'value': next_calendar.time, 'level': 'emphasis'},
+                  {'label': 'Place', 'value': next_calendar.place, 'level': 'normal'},
+                  {'label': 'Status', 'value': status_value, 'level': status_level}
+                ] %}
+              {% else %}
+                {% set rows = [
+                  {'icon': weather_icon, 'label': 'Weather', 'value': weather_value, 'level': 'urgent' if weather_alert else 'normal'},
+                  {'label': 'Quote', 'value': quote_value, 'level': 'normal'},
+                  {'label': 'Source', 'value': 'Sci-fi/fantasy', 'level': 'normal'},
+                  {'label': 'Status', 'value': status_value, 'level': status_level}
+                ] %}
+              {% endif %}
             {% endif %}
             {{ {
               'schema_version': 1,

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -73,7 +73,19 @@ def test_owner_suite_payload_includes_modes_and_four_rows() -> None:
     for mode in ("night_preview", "morning", "up_for_day", "midday"):
         assert mode in block
 
-    for label in ("Weather", "Tomorrow", "Alarm", "Meeting", "Status", "Flight", "Airport", "Dest Wx"):
+    for label in (
+        "Weather",
+        "Tomorrow",
+        "Alarm",
+        "Meeting",
+        "Status",
+        "Flight",
+        "Airport",
+        "Dest Wx",
+        "Next",
+        "Place",
+        "Quote",
+    ):
         assert f"'label': '{label}'" in block
 
 
@@ -116,7 +128,28 @@ def test_owner_suite_night_preview_includes_current_and_tomorrow_weather() -> No
     assert "resolved_mode == 'night_preview'" in block
     assert "'label': 'Tomorrow'" in block
     assert "'value': tomorrow.value" in block
-    assert "'label': 'Meeting'" not in block[block.index("resolved_mode == 'night_preview'") : block.index("{% elif flight_active")]
+    night_block = block[block.index("resolved_mode == 'night_preview'") : block.index("{% elif flight_active")]
+    assert "night_detail_row" in night_block
+    assert "'label': 'Alarm'" in night_block
+    assert "'label': 'Meeting'" in night_block
+
+
+def test_owner_suite_daytime_rows_use_calendar_or_quote_context_not_alarms() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+    daytime_block = block[block.index("{% else %}\n              {% if next_calendar.has_event %}") : block.index("            {% endif %}\n            {{ {")]
+
+    assert "action: calendar.get_events" in block
+    assert "response_variable: owner_suite_calendar_window" in block
+    assert "calendar_response.get('events'" in block
+    assert "item.location" in block
+    assert "'label': 'Next'" in daytime_block
+    assert "'value': next_calendar.time" in daytime_block
+    assert "'label': 'Place'" in daytime_block
+    assert "'value': next_calendar.place" in daytime_block
+    assert "'label': 'Quote'" in daytime_block
+    assert "'value': quote_value" in daytime_block
+    assert "'label': 'Alarm'" not in daytime_block
+    assert "'label': 'Meeting'" not in daytime_block
 
 
 def test_owner_suite_payload_maps_weather_icons_and_exceptions() -> None:


### PR DESCRIPTION
## Summary
- keep alarm and meeting-alarm rows night-only on the owner-suite Inky display
- show next calendar event time/title and location during daytime modes
- use original sci-fi/fantasy quote fallback when there is no upcoming calendar event
- document the night/day situational-awareness rules

## Tests
- uv run --with pytest pytest

Refs #313