### PR TITLE
Enable extended HA trace retention

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -7,6 +7,8 @@ automation:
       while preserving each room's intended scene and task-lighting behavior.
       The runtime dining-room Adaptive Lighting switch now uses the current dining-room entity id.
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -95,6 +97,8 @@ automation:
       to switches that are already enabled; turn_on_lights=false keeps off
       lights undisturbed. Resolves #486.
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         id: bayesian-device-entered-home
@@ -200,6 +204,8 @@ automation:
       Control switches (sleep_mode, adapt_brightness, adapt_color) are excluded to
       preserve their settings.
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time_pattern
         id: nightly-cycle
@@ -256,6 +262,8 @@ automation:
       restored. The shared script accepts room or rooms so additional rooms
       can opt in without duplicating the LED-bar mapping logic.
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: adaptive_lighting_startup_reconciled
@@ -287,6 +295,8 @@ script:
       without breaking when a dedicated switch has not been created yet.
     icon: mdi:led-strip-variant
     mode: queued
+    trace:
+      stored_traces: 100
     fields:
       room:
         description: Single room to sync.

--- a/packages/airplanes.yaml
+++ b/packages/airplanes.yaml
@@ -140,6 +140,8 @@ automation:
   - alias: "ADSB: Refresh REST lookups when closest aircraft HEX changes"
     id: adsb_refresh_rest_on_hex_change
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.closest_aircraft_overhead

--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -91,6 +91,8 @@ alarm_control_panel:
 automation:
   - id: water_leak_detected
     alias: water_leak_detected
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.basement_unfinished_leak_water_leak
@@ -161,6 +163,8 @@ automation:
   - id: motion_detected_on_trip
     alias: motion_detected_on_trip
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.any_egress_open
@@ -207,6 +211,8 @@ automation:
 
   - alias: send_notification_when_alarm_triggered
     id: send_notification_when_alarm_triggered
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: alarm_control_panel.home_alarm
@@ -225,6 +231,8 @@ automation:
   - alias: mirror_shared_notifications_to_lg_tv_when_on
     id: mirror_shared_notifications_to_lg_tv_when_on
     mode: queued
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: call_service
@@ -260,6 +268,8 @@ automation:
     # Triggers on basement or living room motion sensors held for 5 seconds.
     # Fixed: entity_id must live inside data.data (not at the top level of data)
     # so the HA companion app can attach the camera snapshot correctly.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -287,6 +297,8 @@ automation:
 
   - alias: arm_alarm
     id: arm_alarm
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
@@ -320,6 +332,8 @@ automation:
 
   - alias: disarm_alarm
     id: disarm_alarm
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
@@ -417,6 +431,8 @@ scene: []
 ########################
 script:
   flash_lights:
+    trace:
+      stored_traces: 100
     sequence:
       - alias: Lights On
         action: light.turn_on

--- a/packages/batteries.yaml
+++ b/packages/batteries.yaml
@@ -232,6 +232,8 @@ automation:
     description: Keep the 20 percent battery notification current and send a push message when the situation gets worse.
     mode: queued
     max: 10
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         id: summary_change
@@ -299,6 +301,8 @@ automation:
     description: Keep the 10 percent battery notification current and send a push message when the situation gets worse.
     mode: queued
     max: 10
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         id: summary_change
@@ -366,6 +370,8 @@ automation:
     description: Keep the offline battery notification current and send a push message when a battery-powered device goes unavailable.
     mode: queued
     max: 10
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         id: summary_change

--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -111,6 +111,8 @@ alarm_control_panel: []
 automation:
   - id: hydrate_home_address_input_text
     alias: hydrate_home_address_input_text
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -124,6 +126,8 @@ automation:
   - id: tesla_departure_planner_apply
     alias: tesla_departure_planner_apply
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "21:35:00"
@@ -418,6 +422,8 @@ automation:
   - id: tesla_departure_schedule_cleanup
     alias: tesla_departure_schedule_cleanup
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: template
         id: departure_passed
@@ -466,6 +472,8 @@ automation:
     # ESP is briefly offline or has already been restarted) does not mark the
     # automation as errored. The restart is best-effort — if the device is
     # unreachable the automation should simply complete cleanly.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "04:00:00"
@@ -476,6 +484,8 @@ automation:
 
   - id: set_charging_rate
     alias: set_charging_rate
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: mobile_app_notification_action
@@ -579,6 +589,8 @@ automation:
 
   - id: garage_door_reminder
     alias: Close forgotten garage door
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: cover.garage_door
@@ -594,6 +606,8 @@ automation:
   - alias: Tesla set polling time short on startup if charger is connected
     id: tesla_short_polling_charger_connected
     description: When HA starts up. We adjust the Polling Interval down from the configured value if we are connected to a charger
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -610,6 +624,8 @@ automation:
   - alias: Tesla set polling time short on startup if car is driving
     id: tesla_short_polling_driving
     description: When HA starts up. We adjust the Polling Interval down from the configured value if we are driving
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -626,6 +642,8 @@ automation:
   - alias: Tesla set polling time long when charger is disconnected
     description: We adjust the Polling Interval up to the configured value if we are disconnecting from the charger
     id: tesla_long_polling_charger_disconnected
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.nigori_charging
@@ -644,6 +662,8 @@ automation:
   - alias: Tesla set polling time long when car is parked
     description: We adjust the Polling Interval up to the configured value when we are parked if the charger is not connected
     id: tesla_long_polling_charger_diconnected_parked
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.nigori_parking_brake
@@ -662,6 +682,8 @@ automation:
   - alias: Tire Rotations
     description: We adjust the Polling Interval up to the configured value when we are parked if the charger is not connected
     id: tire_rotation
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: numeric_state
         entity_id: sensor.nigori_odometer
@@ -795,6 +817,8 @@ script:
   tesla_set_precondition_schedule_time:
     alias: Tesla Set Precondition Schedule Time
     mode: restart
+    trace:
+      stored_traces: 100
     fields:
       enabled:
         description: Whether Tesla scheduled departure should be enabled or disabled.

--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -157,6 +157,8 @@ automation:
   - id: washer_started
     alias: washer_started
     description: Mark the washer as actively running.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.washing_machine_running
@@ -174,6 +176,8 @@ automation:
   - id: wash_finished
     alias: wash_finished
     description: Start the finished-washer reminder sequence when washer power returns to standby.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.washing_machine_running
@@ -200,6 +204,8 @@ automation:
   - id: dryer_finished
     alias: dryer_finished
     description: Notify when dryer power drops back to standby long enough to count as a completed cycle.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.dryer_running
@@ -213,6 +219,8 @@ automation:
   - id: washer_reminder
     alias: washer_reminder
     description: Escalate a finished washer load from lights at 30 minutes to audio at 60 minutes.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time_pattern
         minutes: "/5"
@@ -289,6 +297,8 @@ automation:
   - id: washer_cleared
     alias: washer_cleared
     description: Reset the washer back to IDLE once the finished load has been handled or manually acknowledged.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.laundry_room_washing_machine_door_contact

--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -192,6 +192,8 @@ homeassistant:
 automation:
   - id: buy_more_air_filters
     alias: buy_more_air_filters
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.zeke_place
@@ -227,6 +229,8 @@ automation:
 
   - id: air_filters_purchased
     alias: air_filters_purchased
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: mobile_app_notification_action
@@ -245,6 +249,8 @@ automation:
   - id: toggle_bathroom_fan_when_showering
     alias: toggle_bathroom_fan_when_showering
     mode: parallel
+    trace:
+      stored_traces: 100
     trigger:
       - id: bathroom-humidity-high
         trigger: state
@@ -332,6 +338,8 @@ automation:
   - id: window_climate_action_handler
     alias: window_climate_action_handler
     mode: queued
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: mobile_app_notification_action
@@ -408,6 +416,8 @@ automation:
   - id: window_climate_open_prompt
     alias: window_climate_open_prompt
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - id: initial
         trigger: state
@@ -497,6 +507,8 @@ automation:
   - id: window_climate_resume_prompt
     alias: window_climate_resume_prompt
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - id: initial
         trigger: state

--- a/packages/curling.yaml
+++ b/packages/curling.yaml
@@ -82,6 +82,8 @@ automation:
   - id: leave_home_for_curling
     alias: leave_home_for_curling
     description: Run one full-floor pass on the main and upstairs levels when leaving for curling.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -118,6 +120,8 @@ automation:
 
   - id: return_home_from_occ
     alias: return_home_from_occ
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -150,6 +154,8 @@ automation:
 
   - id: return_home_from_spcc
     alias: return_home_from_spcc
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -176,6 +182,8 @@ automation:
 
   - id: toggle_curling_automations_on_season_change
     alias: toggle_curling_automations_on_season_change
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.curling_season
@@ -237,6 +245,8 @@ group:
 ########################
 script:
   toggle_curling_automation_on_curling_season:
+    trace:
+      stored_traces: 100
     sequence:
       - if:
           - condition: state

--- a/packages/desk.yaml
+++ b/packages/desk.yaml
@@ -104,6 +104,8 @@ automation:
     description: >
       Raise the desk to its configured maximum height whenever guest mode
       turns on. Guest mode is the highest-priority desk state.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: input_boolean.guest_mode
@@ -116,6 +118,8 @@ automation:
     description: >
       Raise the desk to its configured maximum height whenever trip mode
       turns on, unless guest mode is already active.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: input_boolean.trip
@@ -132,6 +136,8 @@ automation:
     description: >
       Move the desk to preset 2 when the work laptop camera turns on,
       unless guest or trip mode has already taken control.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.f7m69c_5d3d6e76_camera_in_use
@@ -152,6 +158,8 @@ automation:
       Raise the desk when leaving home, using both person and zone tracking.
       Time-based moves are suppressed whenever guest mode, trip mode, or the
       work camera has higher priority.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: person.ryan
@@ -186,6 +194,8 @@ automation:
     description: >
       Return the desk to preset 1 when arriving home on workdays. Weekend and
       holiday arrivals leave the desk raised until the Monday-morning reset.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: person.ryan
@@ -223,6 +233,8 @@ automation:
       inactive long enough to be treated as asleep. These are considered timed
       moves and are suppressed by guest mode, trip mode, and the work camera
       rule.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         id: evening
@@ -251,6 +263,8 @@ automation:
     description: >
       Return the desk to preset 1 every Monday at 4 AM, but only when no
       higher-priority mode is active.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "04:00:00"
@@ -280,6 +294,8 @@ script:
       Automation-only wrapper that sends the desk to the configured maximum
       height when no other automated desk motion is already in progress.
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - condition: state
         entity_id: timer.uplift_desk_motion_window
@@ -297,6 +313,8 @@ script:
       Automation-only wrapper that sends the desk to preset 1 when no other
       automated desk motion is already in progress.
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - condition: state
         entity_id: timer.uplift_desk_motion_window
@@ -314,6 +332,8 @@ script:
       Automation-only wrapper that sends the desk to preset 2 when no other
       automated desk motion is already in progress.
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - condition: state
         entity_id: timer.uplift_desk_motion_window
@@ -333,6 +353,8 @@ script:
       maximum height immediately.
     mode: single
     icon: mdi:arrow-up-bold-box
+    trace:
+      stored_traces: 100
     sequence:
       - action: button.press
         target:
@@ -345,6 +367,8 @@ script:
       Home Assistant automation guard and sends the desk to preset 1.
     mode: single
     icon: mdi:numeric-1-box
+    trace:
+      stored_traces: 100
     sequence:
       - action: button.press
         target:
@@ -357,6 +381,8 @@ script:
       Home Assistant automation guard and sends the desk to preset 2.
     mode: single
     icon: mdi:numeric-2-box
+    trace:
+      stored_traces: 100
     sequence:
       - action: button.press
         target:

--- a/packages/domain_name.yaml
+++ b/packages/domain_name.yaml
@@ -103,6 +103,8 @@ alarm_control_panel: []
 automation:
   - id: alert_domain_expires_soon
     alias: alert_domain_expires_soon
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: numeric_state
         entity_id: !secret domain_days_to_expire_sensor

--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -93,6 +93,8 @@ alarm_control_panel: []
 automation:
   - alias: den_fan_control
     id: den_fan_control
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.den_occupancy_2
@@ -133,6 +135,8 @@ automation:
       After midnight, if the room has been vacant for an hour and still reads
       bright with those spill-light sources off, force the ceiling light off so
       it cannot stay on all night.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.den_motion_occupancy
@@ -265,6 +269,8 @@ automation:
       automation turns the fan off.
     mode: parallel
     max: 7
+    trace:
+      stored_traces: 100
     triggers:
       - trigger: timer.finished
         target:
@@ -303,6 +309,8 @@ automation:
 
   - alias: bedroom_fan_control
     id: bedroom_fan_control
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bedroom_occupancy
@@ -362,6 +370,8 @@ automation:
 
   - alias: toggle_office_fan
     id: toggle_office_fan
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.office_occupancy_2

--- a/packages/guest.yaml
+++ b/packages/guest.yaml
@@ -113,6 +113,8 @@ alarm_control_panel: []
 automation:
   - id: turn_off_guest_mode_when_guest_wifi_inactive
     alias: turn_off_guest_mode_when_guest_wifi_inactive
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.guest_on_wifi
@@ -144,6 +146,8 @@ automation:
   - id: turn_on_guest_mode_when_guest_wifi_active
     alias: turn_on_guest_mode_when_guest_wifi_active
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.guest_on_wifi
@@ -198,6 +202,8 @@ automation:
 
   - id: climate_guest_mode_day
     alias: climate_guest_mode_day
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: input_boolean.guest_mode
@@ -231,6 +237,8 @@ automation:
 
   - id: climate_guest_mode_night
     alias: climate_guest_mode_night
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: input_boolean.guest_mode

--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -120,6 +120,8 @@ automation:
   - id: christmas_tree_on
     alias: christmas_tree_on
     initial_state: false
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: sun
         event: sunset
@@ -138,6 +140,8 @@ automation:
   - id: christmas_tree_off_midnight
     alias: christmas_tree_off_midnight
     initial_state: false
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: 00:00:00
@@ -155,6 +159,8 @@ automation:
   - id: christmas_lights_off_bedroom_off
     alias: christmas_lights_off_bedroom_off
     initial_state: false
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: light.bedroom_lamp, light.bedroom_lamp_2
@@ -169,6 +175,8 @@ automation:
 
   - id: toggle_christmas_automations_on_season_change
     alias: toggle_christmas_automations_on_season_change
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.christmas_season
@@ -192,6 +200,8 @@ automation:
 
   - id: reset_after_holiday
     alias: reset_after_holiday
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: sun
         event: sunrise
@@ -208,6 +218,8 @@ automation:
 
   - id: outdoor_holiday_light_loop
     alias: outdoor_holiday_light_loop
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: sun
         event: sunset
@@ -236,6 +248,8 @@ automation:
 
   - id: notify_holiday_lighting_day
     alias: notify_holiday_lighting_day
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: sun
         event: sunset
@@ -257,6 +271,8 @@ automation:
 
   - alias: Garbage Holiday Update
     id: garbage_holiday_update
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: garbage_collection_loaded
@@ -542,6 +558,8 @@ scene:
 ########################
 script:
   toggle_christmas_automation_during_christmas_season:
+    trace:
+      stored_traces: 100
     sequence:
       - if:
           - condition: state
@@ -558,6 +576,8 @@ script:
 
   apply_outdoor_holiday_scene:
     mode: queued
+    trace:
+      stored_traces: 100
     fields:
       holiday_key:
         description: Holiday key from sensor.active_outdoor_holiday.

--- a/packages/house_mode.yaml
+++ b/packages/house_mode.yaml
@@ -77,6 +77,8 @@ script:
       callers can selectively reapply only media, climate, or travel policy.
     mode: restart
     max: 10
+    trace:
+      stored_traces: 100
     fields:
       mode:
         description: "House mode to apply: home, away, night, in_bed, or asleep."
@@ -354,6 +356,8 @@ script:
       covers, and climate for exceptions.
     mode: queued
     max: 5
+    trace:
+      stored_traces: 100
     fields:
       reason:
         description: Optional reason for the bedtime integrity run.

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -34,6 +34,8 @@ automation:
     alias: publish_owner_suite_inky_display
     description: Publish owner-suite e-ink desired state after meaningful source changes.
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -102,6 +104,8 @@ script:
     alias: Publish Owner Suite Inky Display
     description: Build and publish the compact owner-suite Inky display payload.
     mode: restart
+    trace:
+      stored_traces: 100
     fields:
       mode:
         description: "Display mode override: auto, night_preview, morning, up_for_day, or midday."

--- a/packages/inovelli_led_notifications.yaml
+++ b/packages/inovelli_led_notifications.yaml
@@ -23,6 +23,8 @@ script:
         duration: 10 Minutes
 
   # Clears any active LED effect on every Inovelli switch (e.g. trip mode).
+    trace:
+      stored_traces: 100
   inovelli_led_clear_all_effects:
     use_blueprint:
       path: kschlichter/inovelli_led_blueprint.yaml
@@ -30,3 +32,5 @@ script:
         label:
           - inovelli_switch
         effect: Clear Effect
+    trace:
+      stored_traces: 100

--- a/packages/ios_wakeup.yaml
+++ b/packages/ios_wakeup.yaml
@@ -37,6 +37,8 @@ automation:
   - id: sync_phone_wakeup_alarm_from_ios_shortcut
     alias: sync_phone_wakeup_alarm_from_ios_shortcut
     description: Receive the nightly iOS Shortcut wake-up alarm sync and forward it to the wake-up scheduler.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: webhook
         webhook_id: ios_phone_wakeup_alarm_sync

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -378,6 +378,8 @@ homeassistant:
 automation:
   - id: basement_lights_auto_on
     alias: basement_lights_auto_on
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.basement_landing_occupancy
@@ -438,6 +440,8 @@ automation:
 
   - id: cpap_on_lights_off
     alias: cpap_on_lights_off
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: numeric_state
         entity_id: sensor.owner_suite_cpap_plug_power
@@ -526,6 +530,8 @@ automation:
 
   - id: deck_light_auto_on
     alias: deck_light_auto_on
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -553,6 +559,8 @@ automation:
   - id: front_door_light_auto_toggle
     alias: front_door_light_auto_toggle
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.main_foyer_front_door_contact
@@ -648,6 +656,8 @@ automation:
 
   - id: front_lights_toggle
     alias: front_lights_toggle
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: sun
         event: sunrise
@@ -725,6 +735,8 @@ automation:
   - id: garage_entry_door_light_auto_toggle
     alias: garage_entry_light_auto_toggle
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.hall_garage_entry_contact
@@ -817,6 +829,8 @@ automation:
 
   - id: guest_room_ceiling_lights_on_off
     alias: guest_room_ceiling_lights_on_off
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: zha_event
@@ -833,7 +847,7 @@ automation:
     alias: hallway_light_toggle_at_night
     mode: restart
     trace:
-      stored_traces: 50
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -1061,6 +1075,8 @@ automation:
 
   - id: in_bed_turn_off_other_lights
     alias: in_bed_turn_off_other_lights
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -1111,6 +1127,8 @@ automation:
     alias: kitchen_lights_toggle
     description: Kitchen motion lighting; enabled when guest mode is off.
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -1218,6 +1236,8 @@ automation:
 
   - id: up_enable_owner_bedroom_light_auto_off
     alias: up_enable_owner_bedroom_light_auto_off
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -1241,6 +1261,8 @@ automation:
 
   - id: owner_suite_bath_light_auto_off_in_bed
     alias: owner_suite_bath_light_auto_off_in_bed
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_bed_occupancy
@@ -1261,6 +1283,8 @@ automation:
   - id: owner_suite_bath_light_auto_toggle
     alias: owner_suite_bath_light_auto_toggle
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.owner_suite_bathroom_room_occupancy
@@ -1313,6 +1337,8 @@ automation:
 
   - id: owner_suite_light_auto_off
     alias: owner_suite_light_auto_off
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bedroom_occupancy
@@ -1380,7 +1406,7 @@ automation:
       Turn on the owner suite lights to the current adaptive lighting target
       with a soft transition after bed occupancy clears.
     trace:
-      stored_traces: 20
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bedroom_occupancy
@@ -1494,6 +1520,8 @@ automation:
 
   - alias: toggle_dining_room
     id: toggle_dining_room
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -1507,6 +1535,8 @@ automation:
 
   - alias: toggle_kitchen
     id: toggle_kitchen
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -1520,6 +1550,8 @@ automation:
 
   - alias: toggle_office
     id: toggle_office
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: zha_event
@@ -1535,6 +1567,8 @@ automation:
 
   - alias: transition_on_lights_when_home_near_sunset
     id: transition_on_lights_when_home_near_sunset
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: sun
         event: sunset
@@ -1569,6 +1603,8 @@ automation:
 
   - alias: transition_on_lights_early_when_cloudy_when_home_near_sunset
     id: transition_on_lights_early_when_cloudy_when_home_near_sunset
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: sun
         event: sunset
@@ -1595,6 +1631,8 @@ automation:
 
   - alias: turn_off_alarm_firing
     id: turn_off_alarm_firing
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "14:34:56"
@@ -1609,7 +1647,7 @@ automation:
     id: toggle_hallway_day
     mode: restart
     trace:
-      stored_traces: 20
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -1762,6 +1800,8 @@ automation:
 
   - alias: turn_off_sleep_mode
     id: turn_off_sleep_mode
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "08:00:00"
@@ -1814,6 +1854,8 @@ automation:
   - alias: enable_office_guest_room_switch_day_mode_for_guest_mode
     id: enable_office_guest_room_switch_day_mode_for_guest_mode
     description: Keep the office and guest room switch LEDs in night mode until noon while guest mode is active.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "12:00:00"
@@ -1829,6 +1871,8 @@ automation:
   - alias: enable_owner_suite_bedroom_switch_day_mode_after_morning_activity
     id: enable_owner_suite_bedroom_switch_day_mode_after_morning_activity
     description: Apply owner suite bedroom switch day mode after 8 AM once bed occupancy clears and both the bedroom and bathroom have seen activity.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "08:00:00"
@@ -1866,6 +1910,8 @@ automation:
   - alias: owner_suite_switch_leds_red_when_lamps_on_at_night
     id: owner_suite_switch_leds_red_when_lamps_on_at_night
     description: Restore the owner suite Inovelli LED bars to the nighttime red state whenever the owner suite lamps come back on overnight.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: light.owner_suite_lamps
@@ -1881,6 +1927,8 @@ automation:
 
   - alias: button_reset_basement
     id: button_reset_basement
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -1894,6 +1942,8 @@ automation:
 
   - id: turn_off_all_lights_when_bed_off
     alias: turn_off_all_lights_when_bed_off
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -1954,6 +2004,8 @@ automation:
 
   - id: owner_suite_bed_strip_off_when_lamps_off
     alias: owner_suite_bed_strip_off_when_lamps_off
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: light.owner_suite_lamps
@@ -1974,6 +2026,8 @@ automation:
   - id: turn_on_bedroom_light_when_leave_bathroom
     alias: turn_on_bedroom_light_when_leave_bathroom
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bedroom_motion
@@ -2017,6 +2071,8 @@ automation:
   - id: toggle_on_under_bed_on_motion
     alias: toggle_on_under_bed_on_motion
     mode: restart
+    trace:
+      stored_traces: 100
     variables:
       under_bed_brightness_pct: >-
         {{ state_attr('switch.adaptive_lighting_owner_suite', 'brightness_pct') | int(25) }}
@@ -2176,6 +2232,8 @@ automation:
   - id: turn_off_basement_light_when_dark_in_room
     alias: turn_off_basement_light_when_dark_in_room
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.basement_motion
@@ -2203,6 +2261,8 @@ automation:
     alias: office_lights_morning_on_vacancy_off
     description: Turn office lights on with morning motion/occupancy (when not in guest/trip mode), then turn them off only after the confidence model and local office sensors all show vacancy.
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.office_motion_occupancy
@@ -2491,6 +2551,8 @@ scene:
 ########################
 script:
   reset_basement:
+    trace:
+      stored_traces: 100
     sequence:
       - action: scene.turn_on
         target:
@@ -2504,6 +2566,8 @@ script:
       Turn on the basement path in stages from the landing toward the TV, then
       bring up the TV bias light last.
     mode: restart
+    trace:
+      stored_traces: 100
     sequence:
       - repeat:
           for_each:
@@ -2531,6 +2595,8 @@ script:
     alias: "Tiki Room Solid"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2542,6 +2608,8 @@ script:
     alias: "Tiki Room BPM"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2553,6 +2621,8 @@ script:
     alias: "Tiki Room Candy Cane"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2564,6 +2634,8 @@ script:
     alias: "Tiki Room Christmas"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2575,6 +2647,8 @@ script:
     alias: "Tiki Room Confetti"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2586,6 +2660,8 @@ script:
     alias: "Tiki Room Cyclon Rainbow"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2597,6 +2673,8 @@ script:
     alias: "Tiki Room Dots"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2608,6 +2686,8 @@ script:
     alias: "Tiki Room Fire"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2619,6 +2699,8 @@ script:
     alias: "Tiki Room Glitter"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2630,6 +2712,8 @@ script:
     alias: "Tiki Room Juggle"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2641,6 +2725,8 @@ script:
     alias: "Tiki Room Lightning"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2652,6 +2738,8 @@ script:
     alias: "Tiki Room Noise"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2663,6 +2751,8 @@ script:
     alias: "Tiki Room Police All"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2674,6 +2764,8 @@ script:
     alias: "Tiki Room Police One"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2685,6 +2777,8 @@ script:
     alias: "Tiki Room Rainbow"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2696,6 +2790,8 @@ script:
     alias: "Tiki Room Rainbow With Glitter"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2707,6 +2803,8 @@ script:
     alias: "Tiki Room Ripple"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2718,6 +2816,8 @@ script:
     alias: "Tiki Room Sinelon"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2729,6 +2829,8 @@ script:
     alias: "Tiki Room Twinkle"
     icon: mdi:led-strip-variant
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_on
         target:
@@ -2739,6 +2841,8 @@ script:
   lights_off_except:
     icon: mdi:home-lightbulb
     mode: queued
+    trace:
+      stored_traces: 100
     fields:
       exclude_lights:
         description: "Excluded lights as list"

--- a/packages/logger.yaml
+++ b/packages/logger.yaml
@@ -60,6 +60,8 @@ automation:
   - id: log_level
     alias: log_level
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -111,6 +111,8 @@ alarm_control_panel: []
 automation:
   - id: bedroom_music_volume
     alias: bedroom_music_volume
+    trace:
+      stored_traces: 100
     trigger:
       # - platform: event
       #   event_type: zha_event
@@ -142,6 +144,8 @@ automation:
 
   - id: bedroom_music_play_pause
     alias: bedroom_music_play_pause
+    trace:
+      stored_traces: 100
     trigger:
       # - platform: event
       #   event_type: zha_event
@@ -158,6 +162,8 @@ automation:
 
   - id: bed_without_prep
     alias: bed_without_prep
+    trace:
+      stored_traces: 100
     trigger:
       # - platform: event
       #   event_type: zha_event
@@ -197,6 +203,8 @@ automation:
 
   - id: bedroom_music_select_playlist
     alias: bedroom_music_select_playlist
+    trace:
+      stored_traces: 100
     trigger:
       # - platform: event
       #   event_type: zha_event
@@ -221,6 +229,8 @@ automation:
 
   - id: bedroom_music_skip_track
     alias: bedroom_music_skip_track
+    trace:
+      stored_traces: 100
     trigger:
       # - platform: event
       #   event_type: zha_event
@@ -237,6 +247,8 @@ automation:
 
   - id: bedroom_music_shuffle
     alias: bedroom_music_shuffle
+    trace:
+      stored_traces: 100
     trigger:
       # - platform: event
       #   event_type: zha_event
@@ -255,6 +267,8 @@ automation:
 
   - id: den_sonos_control_actions
     alias: den_sonos_control_actions
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -349,6 +363,8 @@ automation:
 
   - id: play_music_in_bathroom_via_nfc_tap
     alias: play_music_in_bathroom_via_nfc_tap
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: tag_scanned
@@ -366,7 +382,7 @@ automation:
   - id: play_music_in_bathroom_when_up
     alias: play_music_in_bathroom_when_up
     trace:
-      stored_traces: 20
+      stored_traces: 100
     mode: single
     trigger:
       - trigger: state
@@ -462,7 +478,7 @@ automation:
   - id: recover_stuck_morning_audio_scripts
     alias: recover_stuck_morning_audio_scripts
     trace:
-      stored_traces: 20
+      stored_traces: 100
     mode: single
     trigger:
       - trigger: state
@@ -499,7 +515,7 @@ automation:
   - id: restart_sonos_unavailable
     alias: restart_sonos_unavailable
     trace:
-      stored_traces: 20
+      stored_traces: 100
     mode: single
     trigger:
       - trigger: state
@@ -521,6 +537,8 @@ automation:
       fires script.spotify_bedtime non-blocking, then immediately resets the boolean so
       HomeKit always sees it as off (stateless trigger pattern).
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: input_boolean.bedtime_music
@@ -678,6 +696,8 @@ shell_command:
 script:
   music_assistant_pause_house_audio:
     alias: "Pause whole-home MA audio"
+    trace:
+      stored_traces: 100
     sequence:
       - action: media_player.media_pause
         continue_on_error: true
@@ -691,6 +711,8 @@ script:
 
   music_assistant_sync_group_migration_stub:
     alias: "Log disabled Music Assistant sync-group migration helper"
+    trace:
+      stored_traces: 100
     fields:
       caller_entity_id:
         description: "Deprecated helper script entity that was called"
@@ -706,6 +728,8 @@ script:
     mode: restart
     # TODO: Remove once Music Assistant sync group verified working in production
     # sequence: (commented out — replaced by targeting sync group entities directly)
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.music_assistant_sync_group_migration_stub
         data:
@@ -716,6 +740,8 @@ script:
     mode: restart
     # TODO: Remove once Music Assistant sync group verified working in production
     # sequence: (commented out — replaced by targeting sync group entities directly)
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.music_assistant_sync_group_migration_stub
         data:
@@ -725,6 +751,8 @@ script:
     alias: "Prepare arrival Music Assistant group"
     # TODO: Remove once Music Assistant sync group verified working in production
     # sequence: (commented out — replaced by targeting sync group entities directly)
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.music_assistant_sync_group_migration_stub
         data:
@@ -734,6 +762,8 @@ script:
     alias: "Prepare house party Music Assistant group"
     # TODO: Remove once Music Assistant sync group verified working in production
     # sequence: (commented out — replaced by targeting sync group entities directly)
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.music_assistant_sync_group_migration_stub
         data:
@@ -741,6 +771,8 @@ script:
 
   music_assistant_play_item:
     alias: "Play Music Assistant item"
+    trace:
+      stored_traces: 100
     fields:
       entity_id:
         description: "Music Assistant media_player entity"
@@ -787,6 +819,8 @@ script:
 
   music_assistant_play_spotify_uri:
     alias: "Play Spotify item via Music Assistant"
+    trace:
+      stored_traces: 100
     fields:
       entity_id:
         description: "Music Assistant media_player entity"
@@ -812,6 +846,8 @@ script:
 
   music_assistant_play_bedroom_playlist_choice:
     alias: "Play bedroom playlist choice via Music Assistant"
+    trace:
+      stored_traces: 100
     fields:
       playlist:
         description: "Spotify URI selected by a bedroom playlist script"
@@ -832,6 +868,8 @@ script:
 
   music_assistant_search_music:
     alias: "Search Music Assistant"
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           query: "{{ states('input_text.music_assistant_search_query') | trim }}"
@@ -972,6 +1010,8 @@ script:
 
   music_assistant_play_selected_search_result:
     alias: "Play selected Music Assistant search result"
+    trace:
+      stored_traces: 100
     fields:
       entity_id:
         description: "Music Assistant media_player entity"
@@ -1000,6 +1040,8 @@ script:
 
   music_assistant_add_selected_search_result_to_playlist:
     alias: "Add selected Music Assistant search result to playlist"
+    trace:
+      stored_traces: 100
     fields:
       playlist_target:
         description: "Playlist target script id or option label"
@@ -1040,6 +1082,8 @@ script:
 
   music_assistant_radio_wake_up:
     alias: "Radio wake-up via Music Assistant"
+    trace:
+      stored_traces: 100
     fields:
       radio_uri:
         description: "Music Assistant radio URI"
@@ -1098,6 +1142,8 @@ script:
 
   bedroom_playlist_0:
     alias: "Play LoFi"
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           playlist: >-
@@ -1129,6 +1175,8 @@ script:
 
   bedroom_playlist_1:
     alias: "Play Guster"
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           playlist: >-
@@ -1166,6 +1214,8 @@ script:
 
   bedroom_playlist_2:
     alias: "Play Joe Pera"
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           playlist: >-
@@ -1189,6 +1239,8 @@ script:
 
   bedroom_playlist_3:
     alias: "Play VaporWave and Retro"
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           playlist: >-
@@ -1212,6 +1264,8 @@ script:
 
   bedroom_playlist_4:
     alias: "Play Alt/Independent"
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           playlist: >-
@@ -1249,6 +1303,8 @@ script:
 
   bedroom_playlist_5:
     alias: "Play LoFi"
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           playlist: >-
@@ -1278,6 +1334,8 @@ script:
 
   play_video_games:
     alias: "Play Video Games"
+    trace:
+      stored_traces: 100
     sequence:
       - action: media_player.turn_on
         data:
@@ -1299,6 +1357,8 @@ script:
 
   spotify_arrival:
     alias: "Spotify Arrive Home"
+    trace:
+      stored_traces: 100
     variables:
       playback_entity: >-
         {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
@@ -1443,6 +1503,8 @@ script:
 
   spotify_bedtime:
     alias: "Spotify Bedtime"
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           playlist: >-
@@ -1637,6 +1699,8 @@ script:
 
   spotify_bedtime_volume:
     alias: "Spotify Bedtime Rampdown"
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           bedtime_rampdown_steps:
@@ -1698,6 +1762,8 @@ script:
     alias: "Spotify Wake Up"
     icon: mdi:weather-sunset-up
     description: "Play music in the morning when I visit the bathroom."
+    trace:
+      stored_traces: 100
     fields:
       playback_entity_id:
         description: "Preferred Music Assistant player for wake-up playback (kept for backwards compatibility; ignored — sync group is used)"

--- a/packages/octoprint.yaml
+++ b/packages/octoprint.yaml
@@ -135,6 +135,8 @@ alarm_control_panel: []
 automation:
   - id: notify_3d_print_finished
     alias: notify_3d_print_finished
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.octoprint_printing

--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -48,6 +48,8 @@ script:
       queued by Z2M for sleepy devices and processed together on the next check-in.
       Sensors that are completely dead still need a battery pull first.
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           parasoll_devices: >

--- a/packages/plants.yaml
+++ b/packages/plants.yaml
@@ -196,6 +196,8 @@ alarm_control_panel: []
 automation:
   - id: carnivorous_plants_off
     alias: carnivorous_plants_off
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "20:30:00"
@@ -206,6 +208,8 @@ automation:
 
   - id: carnivorous_plants_on
     alias: carnivorous_plants_on
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "06:30:00"
@@ -216,6 +220,8 @@ automation:
 
   - id: water_notification
     alias: water_notification
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "12:15:00"

--- a/packages/themes.yaml
+++ b/packages/themes.yaml
@@ -110,6 +110,8 @@ automation:
       to the house timezone. Clients that use User Profile theme mode "Auto"
       will follow their own local device settings instead, while dark mode
       keeps a random theme choice at Home Assistant startup.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start

--- a/packages/tiki_time.yaml
+++ b/packages/tiki_time.yaml
@@ -48,6 +48,8 @@ script:
       while the Tiki Time station is still playing.
     icon: mdi:palette
     mode: restart
+    trace:
+      stored_traces: 100
     sequence:
       - if:
           - condition: not
@@ -304,6 +306,8 @@ script:
       tropical light rotation.
     icon: mdi:palm-tree
     mode: restart
+    trace:
+      stored_traces: 100
     sequence:
       - action: logbook.log
         data:

--- a/packages/trips.yaml
+++ b/packages/trips.yaml
@@ -173,6 +173,8 @@ automation:
   - id: trip_mode_startup_reconcile
     alias: trip_mode_startup_reconcile
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -302,6 +304,8 @@ automation:
   - id: trip_mode_manager
     alias: trip_mode_manager
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         id: startup_reconcile_enable
@@ -593,6 +597,8 @@ automation:
   - id: sync_ecobee_calendar_vacation
     alias: sync_ecobee_calendar_vacation
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         id: schedule_changed
@@ -646,6 +652,8 @@ automation:
   - id: log_calendar_vacation_plan_diagnostics
     alias: log_calendar_vacation_plan_diagnostics
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.ecobee_calendar_vacation_schedule
@@ -672,6 +680,8 @@ automation:
 
   - id: trip_mode_watchdog_home_1h
     alias: trip_mode_watchdog_home_1h
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
@@ -694,6 +704,8 @@ automation:
   - id: garage_opened_on_a_trip
     alias: Garage Door Opened while on a Trip
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: cover.garage_door
@@ -771,6 +783,8 @@ automation:
 
   - id: random_off_time
     alias: random_off_time
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         id: random_off_time_startup
@@ -801,6 +815,8 @@ automation:
   # TODO is this still needed with Vacation Mode?
   - id: return_home_from_parents
     alias: return_home_from_parents
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -834,6 +850,8 @@ automation:
 
   - id: send_nest_airport_home_eta
     alias: send_nest_airport_home_eta
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -863,6 +881,8 @@ automation:
 
   - id: vacation_lights_on
     alias: vacation_lights_on
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: sun
         event: sunset
@@ -889,6 +909,8 @@ automation:
 
   - id: vacation_lights_off
     alias: vacation_lights_off
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: input_datetime.random_vacation_lights_off
@@ -931,6 +953,8 @@ automation:
     alias: vacuum_on_trip
     description: >-
       Run one full-floor pass on the main and upstairs levels during trips.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "13:00:00"
@@ -960,6 +984,8 @@ automation:
     description: >-
       Run one full-floor pass on the main and upstairs levels before Ryan flies
       home.
+    trace:
+      stored_traces: 100
     trigger:
       - entity_id: binary_sensor.flying_home_today
         from: "off"
@@ -1174,6 +1200,8 @@ script:
     description: >-
       Resume the Ecobee program when a return-home travel signal fires.
     mode: queued
+    trace:
+      stored_traces: 100
     fields:
       reason:
         description: Return-home travel source requesting Ecobee resume.
@@ -1198,6 +1226,8 @@ script:
     description: >-
       Run trip-safe whole-floor vacuuming and send the travel notification.
     mode: queued
+    trace:
+      stored_traces: 100
     fields:
       notify_message:
         description: >-

--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -117,6 +117,8 @@ homeassistant:
 automation:
   - id: tv_off
     alias: tv_off
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: media_player.lg_webos_smart_tv
@@ -144,6 +146,8 @@ automation:
 
   - id: tv_on
     alias: tv_on
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: media_player.lg_webos_smart_tv
@@ -166,6 +170,8 @@ automation:
 
   - id: tv_off_at_night_bed_prep
     alias: tv_off_at_night_bed_prep
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         id: lg-tv-off
@@ -256,6 +262,8 @@ automation:
   - id: tv_paused
     alias: tv_paused
     initial_state: true
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: media_player.basement
@@ -294,6 +302,8 @@ automation:
   - id: tv_watching_scotland
     alias: tv_watching_scotland
     initial_state: true
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: media_player.basement
@@ -331,6 +341,8 @@ automation:
   - id: tv_resumed
     alias: tv_resumed
     initial_state: true
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: media_player.lg_webos_smart_tv
@@ -406,6 +418,8 @@ script:
   wait_for_basement_media_player_ready:
     alias: "Wait for Basement Media Player"
     mode: parallel
+    trace:
+      stored_traces: 100
     sequence:
       - if:
           - condition: not
@@ -433,6 +447,8 @@ script:
   wait_for_basement_plex_client_ready:
     alias: "Wait for Basement Plex Client"
     mode: parallel
+    trace:
+      stored_traces: 100
     sequence:
       - if:
           - condition: not
@@ -470,6 +486,8 @@ script:
   watch_basement_tv_startup:
     alias: "Basement TV Startup"
     mode: parallel
+    trace:
+      stored_traces: 100
     sequence:
       - action: media_player.turn_on
         data:
@@ -487,6 +505,8 @@ script:
   watch_plex_show:
     alias: "Watch Plex Show"
     mode: parallel
+    trace:
+      stored_traces: 100
     fields:
       show_name:
         description: "Plex library show name (must match library exactly)"
@@ -518,6 +538,8 @@ script:
 
   watch_tv:
     alias: "Watch TV"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
@@ -527,6 +549,8 @@ script:
 
   watch_youtube:
     alias: "Watch YouTube"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
@@ -536,6 +560,8 @@ script:
 
   watch_netflix:
     alias: "Watch Netflix"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
@@ -549,6 +575,8 @@ script:
 
   watch_plex:
     alias: "Watch Plex"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
@@ -562,6 +590,8 @@ script:
 
   watch_f1:
     alias: "Watch F1"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
@@ -575,6 +605,8 @@ script:
 
   watch_letterkenny:
     alias: "Watch Letterkenny"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_plex_show
         data:
@@ -582,6 +614,8 @@ script:
 
   watch_the_simpsons:
     alias: "Watch The Simpsons"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_plex_show
         data:
@@ -589,6 +623,8 @@ script:
 
   watch_american_dad:
     alias: "Watch American Dad"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_plex_show
         data:
@@ -596,6 +632,8 @@ script:
 
   watch_aqua_teen:
     alias: "Watch Aqua Teen"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_plex_show
         data:
@@ -603,6 +641,8 @@ script:
 
   watch_bobs_burgers:
     alias: "Watch Bobs Burgers"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_plex_show
         data:
@@ -610,6 +650,8 @@ script:
 
   watch_ds9:
     alias: "Watch DS9"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_plex_show
         data:
@@ -617,6 +659,8 @@ script:
 
   watch_rick_and_morty:
     alias: "Watch Rick and Morty"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_plex_show
         data:
@@ -624,6 +668,8 @@ script:
 
   watch_tng:
     alias: "Watch TNG"
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.watch_plex_show
         data:

--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -143,6 +143,8 @@ alarm_control_panel: []
 automation:
   - alias: restart_water_meter
     id: restart_water_meter
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time_pattern
         hours: "/1"
@@ -161,6 +163,8 @@ automation:
         # to get past.
   - alias: trigger_winter_watermeter_flow
     id: trigger_winter_watermeter_flow
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time_pattern
         minutes: "/23"
@@ -188,6 +192,8 @@ automation:
 
   - alias: check_non_responding_entities
     id: check_non_responding_entities
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time_pattern
         hours: "/12"
@@ -230,6 +236,8 @@ automation:
 
   - id: switch_electrical_tariff
     alias: switch_electrical_tariff
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: template
         value_template: >-
@@ -291,6 +299,8 @@ automation:
     description: >
       Keep the EV charging utility meters on Dakota Electric's time-of-use
       schedule. Weekends and holidays stay off-peak all day.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -365,6 +375,8 @@ automation:
     description: >
       Alert when the current-hour whole-home energy meter crosses the expected
       baseload while the house is away or in a sleep-oriented mode.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: numeric_state
         entity_id: sensor.hourly_home_electricity_energy
@@ -411,6 +423,8 @@ automation:
     description: >
       Send a weekly energy summary that combines whole-home and EV tariff
       utility meters into readable cost context.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "08:15:00"
@@ -466,6 +480,8 @@ automation:
 
   - id: switch_water_tariff
     alias: switch_water_tariff
+    trace:
+      stored_traces: 100
     trigger:
       []
       # - platform: time
@@ -491,6 +507,8 @@ automation:
   - alias: Restart AppDaemon on HA Startup or load cells unavailable
     description: When HA starts up, or bed load cells are unavailable restart AppDaemon
     id: restart_appdaemon_on_ha_startup
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -511,6 +529,8 @@ automation:
       Restart the Music Assistant app only when Ryan leaves home to refresh
       Sonos discovery while the house is empty.
     id: restart_music_assistant_every_12_17_hours
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: person.ryan
@@ -527,6 +547,8 @@ automation:
     description: >
       Notify when trip mode activates and offer a cancel window.
       Shuts off the water main automatically after 4 hours if not cancelled.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: input_boolean.trip
@@ -580,6 +602,8 @@ automation:
     description: >
       Notify when trip mode ends and offer a cancel window.
       Restores the water main automatically after 5 minutes if not cancelled.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: input_boolean.trip
@@ -637,6 +661,8 @@ automation:
     description: >
       Notify when a guest arrives during a trip and offer a cancel window.
       Restores the water main automatically after 4 hours if not cancelled.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: input_boolean.guest_mode
@@ -694,6 +720,8 @@ automation:
 
   - alias: Turn Sump Back On
     id: turn_sump_back_on
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -713,6 +741,8 @@ automation:
 
   - alias: Turn Laundry Plugs Back On
     id: turn_laundry_plugs_back_on
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -735,6 +765,8 @@ automation:
 
   - alias: Notify Sump Pit Getting Full
     id: notify_sump_pit_getting_full
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: numeric_state
         entity_id: sensor.sump_fill
@@ -747,6 +779,8 @@ automation:
 
   - alias: Notify Sump Pit Full
     id: notify_sump_pit_full
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: numeric_state
         entity_id: sensor.sump_fill
@@ -760,6 +794,8 @@ automation:
   - alias: Notify Sump Runs
     id: notify_sump_runs
     description: Notify number of times the sump pump runs
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "12:30:00"
@@ -796,6 +832,8 @@ automation:
   - alias: Notify Garbage
     id: notify_garbage_day
     description: Notify garbage day
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "14:30:00"
@@ -833,6 +871,8 @@ automation:
   - alias: Restart CPAP
     id: restart_cpap
     description: Restart CPAP so Bluetooth keeps working
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "15:30:00"
@@ -854,6 +894,8 @@ automation:
 
   - alias: Turn CPAP Back On
     id: turn_CPAP_back_on
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:

--- a/packages/vacuum_map_guard.yaml
+++ b/packages/vacuum_map_guard.yaml
@@ -57,6 +57,8 @@ automation:
   - alias: "Guard Main Level Vacuum Map"
     id: valetudo_mainlevel_map_guard
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: mqtt
         topic: "valetudo/mainlevel/PendingMapChangeHandlingCapability/pending"
@@ -99,6 +101,8 @@ automation:
   - alias: "Guard Upstairs Vacuum Map"
     id: valetudo_upstairs_map_guard
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: mqtt
         topic: "valetudo/upstairs-vacuum/PendingMapChangeHandlingCapability/pending"

--- a/packages/water_softener.yaml
+++ b/packages/water_softener.yaml
@@ -115,6 +115,8 @@ alarm_control_panel: []
 automation:
   - id: notify_refill_salt
     alias: Notify Salt Low
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "16:00:00"
@@ -135,6 +137,8 @@ automation:
 
   - id: buy_more_salt
     alias: buy_more_salt
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -172,6 +176,8 @@ automation:
 
   - id: salt_purchased
     alias: salt_purchased
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: mobile_app_notification_action
@@ -199,6 +205,8 @@ automation:
 
   - id: temp_notify_place_name
     alias: temp_notify_place_name
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         enabled: false

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -157,6 +157,8 @@ automation:
   - id: alert_car_windows_open_pressure_dropping
     alias: alert_car_windows_open_pressure_dropping
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: numeric_state
         entity_id: sensor.nigori_precip_next_2hr
@@ -199,6 +201,8 @@ automation:
 
   - id: alert_house_windows_open_pressure_dropping
     alias: alert_house_windows_open_pressure_dropping
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -227,6 +231,8 @@ automation:
 
   - id: notify_tornado_warning_alert
     alias: notify_tornado_warning_alert
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: numeric_state
         entity_id: sensor.nws_alerts
@@ -287,6 +293,8 @@ automation:
 
   - id: notify_weather_alert
     alias: notify_weather_alert
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: numeric_state
         entity_id: sensor.nws_alerts
@@ -317,6 +325,8 @@ automation:
   - id: window_open_departure_rain_warning
     alias: window_open_departure_rain_warning
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - id: trip_on
         trigger: state
@@ -365,6 +375,8 @@ automation:
   - id: window_open_home_rain_warning
     alias: window_open_home_rain_warning
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - id: rain_soon
         trigger: numeric_state
@@ -407,6 +419,8 @@ automation:
   - id: window_open_cool_weather_reminder
     alias: window_open_cool_weather_reminder
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - id: outside_cool
         trigger: numeric_state
@@ -468,6 +482,8 @@ automation:
     ## Automation to trigger a UI notification when there is an active weather alert.
     ## nws_dakota_county_alerts_alert_1 should always contain most recent alert.
   - alias: Weather Alert UI Notification - 1
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.nws_dakota_county_alerts_alert_1_last_changed
@@ -535,6 +551,8 @@ automation:
     ## Automation to dismiss UI notification if there are no active alerts for 30 minutes
     ## Disable or remove this automation if you don't want notifications to auto-dismiss
   - alias: Weather Alert UI Notification Auto-dismiss - 1
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.nws_dakota_county_alerts_alerts_are_active
@@ -555,6 +573,8 @@ automation:
   ## Automation to push alerts via Pushbullet service
   ## Disable or remove this automation if you don't use Pushbullet
   - alias: Weather Alerts Pushbullet Notification - 1
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.nws_dakota_county_alerts_alert_1_last_changed
@@ -653,6 +673,8 @@ script:
   ## Script creates UI notification and is called via automation defined above
   nws_dakota_county_alerts_popup_on_wx_alert:
     alias: Weather Alert Pop Up - 1
+    trace:
+      stored_traces: 100
     sequence:
       ## Dismiss any current alert so the UI isn't filled
       ## up with these if there are more then one.

--- a/packages/windows.yaml
+++ b/packages/windows.yaml
@@ -140,6 +140,8 @@ automation:
   - id: close_owner_suite_blinds_at_night
     alias: close_owner_suite_blinds_at_night
     description: Close the owner suite blinds near sunset and catch up after brief evening cover reconnects.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: sun
         event: sunset

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -132,6 +132,8 @@ homeassistant:
 automation:
   - id: arrive_at_work
     alias: arrive_at_work
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -157,6 +159,8 @@ automation:
 
   - id: turn_off_morning_routine
     alias: turn_off_morning_routine
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "00:00:01"
@@ -167,6 +171,8 @@ automation:
 
   - id: alarm_snooze
     alias: alarm_snooze
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: zha_event
@@ -192,6 +198,8 @@ automation:
 
   - id: cancel_alarms
     alias: cancel_alarms
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: zha_event
@@ -207,6 +215,8 @@ automation:
 
   - id: alarm_wake_up
     alias: alarm_wake_up
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: input_datetime.weekday_alarm
@@ -328,6 +338,8 @@ automation:
       Start the owner suite workday wake transition when bed occupancy clears
       and both the bedroom and bathroom show fresh wake-up activity.
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_bed_occupancy
@@ -381,6 +393,8 @@ automation:
 
   - id: toggle_lava_lamp_workday
     alias: toggle_lava_lamp_workday
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: template
         id: lava-lamp-off
@@ -436,6 +450,8 @@ automation:
   - id: turn_off_office_lamp_when_work_tp_camera_active
     alias: turn_off_office_lamp_when_work_tp_camera_active
     description: Turn off office ceiling when work laptop camera turns on.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.f7m69c_5d3d6e76_camera_in_use
@@ -465,6 +481,8 @@ automation:
   - id: turn_on_office_lamp_when_work_tp_camera_inactive
     alias: turn_on_office_lamp_when_work_tp_camera_inactive
     description: Turn on office ceiling when work laptop camera turns off.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.f7m69c_5d3d6e76_camera_in_use
@@ -482,6 +500,8 @@ automation:
   - id: vacuum_while_working
     alias: vacuum_while_working
     description: Run one full-floor pass on the main and upstairs levels while Ryan is away.
+    trace:
+      stored_traces: 100
     trigger:
       # - platform: state
       #   entity_id: device_tracker.bayesian_zeke_home
@@ -514,6 +534,8 @@ script:
     alias: Set Wakeup From Phone Alarm
     description: Set the next wakeup time from the phone alarm synced by iOS.
     mode: single
+    trace:
+      stored_traces: 100
     fields:
       alarm_time:
         description: Alarm time from iOS, in HH:mm or HH:mm:ss format.
@@ -654,6 +676,8 @@ script:
 
   snooze_script:
     alias: Snooze Tasks
+    trace:
+      stored_traces: 100
     sequence:
       - action: light.turn_off
         data:
@@ -675,6 +699,8 @@ script:
 
   sonos_ksdj_wake_up:
     alias: Sonos KSDJ Wake Up
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.music_assistant_radio_wake_up
         data:
@@ -682,6 +708,8 @@ script:
 
   sonos_mpr_news_wake_up:
     alias: Sonos MPR News Wake Up
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.music_assistant_radio_wake_up
         data:
@@ -692,6 +720,8 @@ script:
 
   sonos_the_current_wake_up:
     alias: Sonos The Current Wake Up
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.music_assistant_radio_wake_up
         data:
@@ -700,6 +730,8 @@ script:
   owner_suite_morning_transition:
     alias: Owner Suite Morning Transition
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - alias: "Start from the owner suite adaptive sleep target"
         continue_on_error: true
@@ -812,6 +844,8 @@ script:
 
   wake_up_script:
     alias: Common Wake Up Tasks
+    trace:
+      stored_traces: 100
     sequence:
       - alias: Have we already done this?
         condition: state
@@ -827,6 +861,8 @@ script:
     alias: Set Next Work Meeting From Phone
     description: Set the next work meeting reminder time from an iPhone shortcut such as Outlook Next Meeting.
     mode: single
+    trace:
+      stored_traces: 100
     fields:
       meeting_time:
         description: Next work meeting start time from iOS, in HH:mm or HH:mm:ss format.

--- a/packages/xiaomi_robot_vacuum.yaml
+++ b/packages/xiaomi_robot_vacuum.yaml
@@ -114,6 +114,8 @@ automation:
   - alias: "Resume vacuum on error (den)"
     id: resume_vacuum_on_error_den
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: vacuum.valetudo_den
@@ -214,6 +216,8 @@ scene: []
 script:
   vacuum_main_level_full_floor:
     alias: "Vacuum Main Level Full Floor"
+    trace:
+      stored_traces: 100
     sequence:
       - action: vacuum.start
         target:
@@ -221,6 +225,8 @@ script:
 
   vacuum_upstairs_full_floor:
     alias: "Vacuum Upstairs Full Floor"
+    trace:
+      stored_traces: 100
     sequence:
       - action: vacuum.start
         target:
@@ -230,6 +236,8 @@ script:
     alias: "Vacuum Main And Upstairs Levels"
     description: Run one full-floor cleaning pass on both resident levels.
     mode: queued
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.vacuum_main_level_full_floor
         continue_on_error: true
@@ -238,6 +246,8 @@ script:
 
   vacuum_master_bedroom:
     alias: "Vacuum Master Bedroom"
+    trace:
+      stored_traces: 100
     sequence:
       - action: mqtt.publish
         data:
@@ -247,6 +257,8 @@ script:
 
   vacuum_guest_room:
     alias: "Vacuum Guest Room"
+    trace:
+      stored_traces: 100
     sequence:
       - action: mqtt.publish
         data:
@@ -255,6 +267,8 @@ script:
             {"action": "start_segment_action","segment_ids": ["5"],"iterations": 4,"customOrder": true}
   vacuum_bathroom:
     alias: "Vacuum Bathroom"
+    trace:
+      stored_traces: 100
     sequence:
       - action: mqtt.publish
         data:
@@ -264,6 +278,8 @@ script:
   # Entryway not working correctly
   vacuum_hallway:
     alias: "Vacuum Hallway"
+    trace:
+      stored_traces: 100
     sequence:
       - action: mqtt.publish
         data:
@@ -272,6 +288,8 @@ script:
             {"action": "start_segment_action","segment_ids": ["6","1"],"iterations": 4,"customOrder": true}
   vacuum_kitchen:
     alias: "Vacuum Kitchen"
+    trace:
+      stored_traces: 100
     sequence:
       - action: vacuum.send_command
         data:
@@ -280,6 +298,8 @@ script:
           params: [[12367, 23534, 17767, 28084, 1]]
   vacuum_living_room:
     alias: "Vacuum Living Room"
+    trace:
+      stored_traces: 100
     sequence:
       - action: vacuum.send_command
         data:
@@ -288,6 +308,8 @@ script:
           params: [[12383, 27798, 19333, 31498, 1]]
   vacuum_office:
     alias: "Vacuum Office"
+    trace:
+      stored_traces: 100
     sequence:
       - action: mqtt.publish
         data:

--- a/packages/z2m_lifecycle.yaml
+++ b/packages/z2m_lifecycle.yaml
@@ -13,6 +13,8 @@ automation:
   - id: refresh_z2m_lifecycle_inventory
     alias: refresh_z2m_lifecycle_inventory
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -37,6 +39,8 @@ automation:
   - id: sync_z2m_decommission_options
     alias: sync_z2m_decommission_options
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -67,6 +71,8 @@ automation:
   - id: notify_z2m_lifecycle_issues
     alias: notify_z2m_lifecycle_issues
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         id: summary_change
@@ -127,6 +133,8 @@ automation:
     alias: handle_z2m_device_remove_response
     mode: queued
     max: 10
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: mqtt
         topic: zigbee2mqtt/bridge/response/device/remove
@@ -202,6 +210,8 @@ automation:
 
   - id: reset_z2m_reboot_counter
     alias: reset_z2m_reboot_counter
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: mobile_app_notification_action
@@ -214,6 +224,8 @@ automation:
 
   - id: reset_z2m_reboot_counter_on_recovery
     alias: reset_z2m_reboot_counter_on_recovery
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.zigbee2mqtt_running
@@ -255,6 +267,8 @@ automation:
     alias: shutdown_proxmox_z2m_unavailable
     mode: single
     max_exceeded: silent
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.z2m_failing
@@ -531,6 +545,8 @@ script:
   z2m_decommission_selected_device:
     alias: Z2M - Decommission Selected Device
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           selected_option: "{{ states('input_select.z2m_decommission_device') }}"
@@ -569,6 +585,8 @@ script:
   z2m_force_decommission_selected_device:
     alias: Z2M - Force Decommission Selected Device
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - variables:
           selected_option: "{{ states('input_select.z2m_decommission_device') }}"

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -496,6 +496,8 @@ automation:
   - alias: replay_inovelli_led_policy_on_recovery
     id: replay_inovelli_led_policy_on_recovery
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: event
         event_type: state_changed
@@ -519,6 +521,8 @@ automation:
 
   - alias: basement_bathroom_switch_actions
     id: basement_bathroom_switch_actions
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.basement_bathroom_shower_switch_action
@@ -555,6 +559,8 @@ automation:
 
   - alias: dining_room_switch_actions
     id: dining_room_switch_actions
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.dining_room_wall_switch_action
@@ -611,6 +617,8 @@ automation:
 
   - alias: dining_room_table_switch_actions
     id: dining_room_table_switch_actions
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.dining_room_table_switch_action
@@ -640,6 +648,8 @@ automation:
   - alias: side_of_bed_toggles
     id: side_of_bed_toggles
     mode: queued
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         # entity_id: binary_sensor.bayesian_bed_occupancy
@@ -875,6 +885,8 @@ automation:
 
   - alias: in_bed_toggles
     id: in_bed_toggles
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -936,6 +948,8 @@ automation:
 
   - id: mail_delivered
     alias: mail_delivered
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.mailbox_contact
@@ -963,6 +977,8 @@ automation:
 
   - id: office_light_control_button
     alias: office_light_control_button
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id:
@@ -1053,6 +1069,8 @@ automation:
 
   - id: reset_owner_suite_blinds
     alias: reset_owner_suite_blinds
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "13:01:34"
@@ -1081,6 +1099,8 @@ automation:
 
   - id: reset_mail_delivery
     alias: reset_mail_delivery
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: time
         at: "01:00:00"
@@ -1091,6 +1111,8 @@ automation:
 
   - alias: guest_room_switch_actions
     id: guest_room_switch_actions
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.guest_room_fan_switch_action
@@ -1141,6 +1163,8 @@ automation:
 
   - alias: garage_overhead_switch_actions
     id: garage_overhead_switch_actions
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.garage_overhead_switch_action
@@ -1170,6 +1194,8 @@ automation:
   - alias: kitchen_overhead_switch_actions
     id: kitchen_overhead_switch_actions
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.kitchen_switch_action
@@ -1265,6 +1291,8 @@ automation:
   - alias: laundry_switch_actions
     id: laundry_switch_actions
     mode: restart
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.laundry_wall_switch_action
@@ -1359,6 +1387,8 @@ automation:
 
   - alias: office_switch_actions
     id: office_switch_actions
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.office_fan_switch_action
@@ -1409,6 +1439,8 @@ automation:
 
   - alias: owner_suite_switch_actions
     id: owner_suite_switch_actions
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.owner_suite_fan_switch_action
@@ -1462,6 +1494,8 @@ automation:
 
   - id: reset_inovelli_config
     alias: reset_inovelli_config
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: input_button.reset_inovelli_switch_configurations
@@ -1471,6 +1505,8 @@ automation:
   - id: sync_trip_mode_inovelli_leds
     alias: sync_trip_mode_inovelli_leds
     description: Keep all Inovelli LED bars dark during trips and restore the normal LED profile when trip mode clears.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -1511,6 +1547,8 @@ automation:
     # Fixed: added continue_on_error: true to each rest_command so that a single
     # unreachable vacuum (e.g. den vacuum offline at boot) does not abort the
     # sequence and leave the remaining vacuums un-reconfigured.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -1625,6 +1663,8 @@ script:
   reset_z2m_bindings_and_groups:
     alias: Reset Zigbee Bindings & Groups (Zigbee2MQTT)
     mode: single
+    trace:
+      stored_traces: 100
     sequence:
       - alias: Request a fresh device roster
         service: mqtt.publish
@@ -1712,6 +1752,8 @@ script:
 
   night_tv_mode_switches:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     variables:
       all_switches_led_color_off: >
         {%- for device in states.number | select('match', '.*ledcolorwhenoff.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
@@ -1755,6 +1797,8 @@ script:
 
   day_mode_switches:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     sequence:
       - *trip_led_updates_allowed
       - action: script.turn_on
@@ -1768,6 +1812,8 @@ script:
 
   day_mode_switches_general:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     variables:
       all_off_led_switches: >
         {%- for device in states.number
@@ -1879,6 +1925,8 @@ script:
 
   day_mode_switches_owner_suite_bedroom:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.day_mode_switches_owner_suite_scope
         data:
@@ -1886,6 +1934,8 @@ script:
 
   day_mode_switches_owner_suite_bathroom:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     sequence:
       - action: script.day_mode_switches_owner_suite_scope
         data:
@@ -1893,6 +1943,8 @@ script:
 
   day_mode_switches_owner_suite_scope:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     fields:
       scope:
         name: Scope
@@ -1978,6 +2030,8 @@ script:
   apply_owner_suite_inovelli_led_policy:
     icon: mdi:light-switch
     mode: restart
+    trace:
+      stored_traces: 100
     fields:
       policy:
         name: Policy
@@ -2029,6 +2083,8 @@ script:
 
   night_mode_switches_owner_suite:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     sequence:
       - *trip_led_updates_allowed
       - action: logbook.log
@@ -2072,6 +2128,8 @@ script:
 
   day_mode_switches_office_guest_room:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     variables:
       office_guest_room_off_led_switches: >
         {%- for device in states.number
@@ -2128,6 +2186,8 @@ script:
 
   reset_inovelli_switches:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     variables:
       ha_write_delay: "00:00:01"
       mqtt_bind_delay: "00:00:03"
@@ -2611,6 +2671,8 @@ script:
 
   turn_off_all_inovelli_switch_leds:
     icon: mdi:light-switch-off
+    trace:
+      stored_traces: 100
     variables:
       all_switches_led_intensity_on: >
         {%- for device in states.number
@@ -2643,6 +2705,8 @@ script:
 
   restore_inovelli_switch_leds_from_trip:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     variables:
       office_guest_room_day_mode_ready: >-
         {{ is_state('input_boolean.guest_mode', 'off') or now() >= today_at('12:00') }}
@@ -2712,6 +2776,8 @@ script:
       Reapply the current Inovelli LED policy after any LED number entity
       recovers from unavailable so missed Zigbee2MQTT writes are replayed.
     mode: queued
+    trace:
+      stored_traces: 100
     variables:
       owner_suite_leds_should_be_dark: >-
         {{
@@ -2744,6 +2810,8 @@ script:
 
   turn_off_owner_suite_inovelli_switch_leds:
     icon: mdi:light-switch
+    trace:
+      stored_traces: 100
     sequence:
       - action: retry.actions
         data:

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -162,6 +162,8 @@ homeassistant:
 automation:
   - id: cloudy_home_arrival
     alias: cloudy_home_arrival
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -193,6 +195,8 @@ automation:
 
   - id: default_arrive_home
     alias: default_arrive_home
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -225,6 +229,8 @@ automation:
 
   - id: doors_open_when_leaving_home
     alias: doors_open_when_leaving_home
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -249,6 +255,8 @@ automation:
 
   - id: garage_door_open_when_leaving_home
     alias: garage_door_open_when_leaving_home
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -272,6 +280,8 @@ automation:
 
   - alias: input_boolean_tracker_on
     id: input_boolean_tracker_on
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
@@ -283,6 +293,8 @@ automation:
 
   - alias: input_boolean_tracker_off
     id: input_boolean_tracker_off
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
@@ -294,6 +306,8 @@ automation:
 
   - id: play_spotify_when_i_get_home
     alias: play_spotify_when_i_get_home
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -328,6 +342,8 @@ automation:
 
   - id: turn_on_lights_at_night_when_i_get_home
     alias: turn_on_lights_at_night_when_i_get_home
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -367,6 +383,8 @@ automation:
 
   - id: turn_on_bedroom_lights_at_night_when_i_get_home
     alias: turn_on_bedroom_lights_at_night_when_i_get_home
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -429,6 +447,8 @@ automation:
   # TODO change implementation
   - id: return_home_from_specific_location
     alias: return_home_from_specific_location
+    trace:
+      stored_traces: 100
     trigger:
       # - platform: state
       #   entity_id: device_tracker.bayesian_zeke_home
@@ -470,6 +490,8 @@ automation:
 
   - id: turn_off_lights_when_i_leave
     alias: turn_off_lights_when_i_leave
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -515,6 +537,8 @@ automation:
   - alias: Update Bayesian Device tracker on start
     description: When HA starts up, update bayesian device tracker GPS items
     id: update_bayesian_device_tracker_on_start
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start
@@ -533,6 +557,8 @@ automation:
 
   - id: update_trip_origin
     alias: update_trip_origin
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: device_tracker.bayesian_zeke_home
@@ -580,6 +606,8 @@ automation:
 
   - id: vacuum_return_home
     alias: vacuum_return_home
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: zone
         entity_id: device_tracker.bayesian_zeke_home
@@ -606,6 +634,8 @@ automation:
   - id: vacuum_leave_home
     alias: vacuum_leave_home
     description: Run the main and upstairs levels on departure, plus the den when its door is closed.
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home

--- a/tests/test_trace_storage.py
+++ b/tests/test_trace_storage.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TRACE_MINIMUM = 100
+
+
+def _is_top_level(line: str) -> bool:
+    stripped = line.strip()
+    return bool(stripped) and not line.startswith((" ", "\t")) and not stripped.startswith("#")
+
+
+def _top_key(line: str) -> str | None:
+    if not _is_top_level(line) or ":" not in line:
+        return None
+    return line.split(":", 1)[0]
+
+
+def _section_end(lines: list[str], section_start: int) -> int:
+    for index in range(section_start + 1, len(lines)):
+        if _is_top_level(lines[index]):
+            return index
+    return len(lines)
+
+
+def _automation_blocks(lines: list[str], section_start: int, section_end: int) -> list[tuple[int, int]]:
+    starts = [
+        index for index in range(section_start + 1, section_end) if lines[index].startswith("  - ")
+    ]
+    return [
+        (start, starts[index + 1] if index + 1 < len(starts) else section_end)
+        for index, start in enumerate(starts)
+    ]
+
+
+def _script_blocks(lines: list[str], section_start: int, section_end: int) -> list[tuple[int, int]]:
+    starts = []
+    for index in range(section_start + 1, section_end):
+        line = lines[index]
+        stripped = line.strip()
+        if (
+            line.startswith("  ")
+            and not line.startswith("    ")
+            and stripped
+            and not stripped.startswith("#")
+            and stripped.endswith(":")
+        ):
+            starts.append(index)
+    return [
+        (start, starts[index + 1] if index + 1 < len(starts) else section_end)
+        for index, start in enumerate(starts)
+    ]
+
+
+def _block_name(lines: list[str], start: int, end: int, fallback: str) -> str:
+    for line in lines[start:end]:
+        stripped = line.strip()
+        if stripped.startswith(("- id:", "id:", "- alias:", "alias:")):
+            return stripped.split(":", 1)[1].strip().strip('"')
+    return fallback
+
+
+def _stored_traces(lines: list[str], start: int, end: int) -> int | None:
+    for index in range(start, end):
+        if not lines[index].startswith("    trace:"):
+            continue
+        for trace_index in range(index + 1, end):
+            if lines[trace_index].startswith("    ") and not lines[trace_index].startswith("      "):
+                return None
+            stripped = lines[trace_index].strip()
+            if stripped.startswith("stored_traces:"):
+                value = stripped.split(":", 1)[1].strip()
+                return int(value) if value.isdigit() else None
+    return None
+
+
+def test_automation_and_script_traces_keep_at_least_100_runs() -> None:
+    config_paths = [
+        ROOT / "automations.yaml",
+        ROOT / "scripts.yaml",
+        *sorted((ROOT / "packages").glob("*.yaml")),
+    ]
+    missing_or_low_trace: list[str] = []
+
+    for path in config_paths:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for section_start, line in enumerate(lines):
+            key = _top_key(line)
+            if key not in {"automation", "script"}:
+                continue
+            section_end = _section_end(lines, section_start)
+            if key == "automation":
+                blocks = _automation_blocks(lines, section_start, section_end)
+            elif line.strip().endswith("{}"):
+                blocks = []
+            else:
+                blocks = _script_blocks(lines, section_start, section_end)
+
+            for start, end in blocks:
+                stored_traces = _stored_traces(lines, start, end)
+                if stored_traces is None or stored_traces < TRACE_MINIMUM:
+                    block_name = _block_name(lines, start, end, "<unnamed>")
+                    missing_or_low_trace.append(f"{path.relative_to(ROOT)} {key} {block_name}")
+
+    assert missing_or_low_trace == []


### PR DESCRIPTION
## Summary
- Closes #639
- Set every YAML-managed Home Assistant automation and script that supports traces to retain at least 100 traces.
- Preserve existing higher retention values such as the PARASOLL automation's 200 traces.
- Add regression coverage that scans root/package automations and scripts for trace retention.

## Tests
- `uv run --with pytest pytest`