### PR TITLE
Tighten Inky quote layout

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -209,8 +209,9 @@ In `morning`, `up_for_day`, and `midday`, alarm and meeting-alarm rows are not
 shown. Those modes use current `Weather`, next calendar event time/title,
 calendar event location, and `Status`. If no calendar event is available in the
 next 12 hours, the event rows fall back to an original rotating sci-fi/fantasy
-quote plus a source row. This keeps the post-wakeup screen focused on what is
-next instead of repeating wake-up setup state.
+quote. The renderer gives quote payloads a dedicated full-width quote layout
+instead of spending a row on source/metadata text. This keeps the post-wakeup
+screen focused on what is next instead of repeating wake-up setup state.
 
 When `sensor.next_travel_flight` is inside its active travel window, `morning`,
 `up_for_day`, and `midday` modes use flight-oriented rows instead of the normal

--- a/inky_display/renderer.py
+++ b/inky_display/renderer.py
@@ -31,8 +31,40 @@ LEVEL_COLORS = {
 def render_payload(payload: DisplayPayload) -> bytes:
     canvas = Canvas(WIDTH, HEIGHT)
     accent = ACCENT_COLORS[payload.accent]
+    rows = _payload_rows(payload)
 
     canvas.rectangle(0, 0, WIDTH, 14, accent)
+    if _has_quote_layout(rows):
+        _render_quote_layout(canvas, payload, rows, accent)
+    else:
+        _render_default_layout(canvas, payload, rows, accent)
+
+    if payload.footer:
+        canvas.rectangle(0, HEIGHT - 30, WIDTH, HEIGHT, BLACK)
+        canvas.text(18, HEIGHT - 22, payload.footer, scale=1, color=WHITE)
+
+    return canvas.to_png()
+
+
+def _payload_rows(payload: DisplayPayload) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for section in payload.sections:
+        if section.get("type") != "rows":
+            continue
+        rows.extend(section.get("rows", ()))
+    return rows
+
+
+def _has_quote_layout(rows: list[dict[str, str]]) -> bool:
+    return any(row.get("label") == "Quote" for row in rows)
+
+
+def _render_default_layout(
+    canvas: Canvas,
+    payload: DisplayPayload,
+    rows: list[dict[str, str]],
+    accent: tuple[int, int, int],
+) -> None:
     canvas.text(
         18,
         30,
@@ -44,26 +76,74 @@ def render_payload(payload: DisplayPayload) -> bytes:
         canvas.text(20, 75, payload.subtitle, scale=2, color=BLACK)
 
     y = 112
-    for section in payload.sections:
-        if section.get("type") != "rows":
+    for row in rows:
+        _render_row(canvas, row, payload.accent, y)
+        y += 42
+
+
+def _render_quote_layout(
+    canvas: Canvas,
+    payload: DisplayPayload,
+    rows: list[dict[str, str]],
+    accent: tuple[int, int, int],
+) -> None:
+    title = payload.title or payload.mode.replace("_", " ")
+    subtitle = payload.subtitle
+    quote = next((row.get("value", "") for row in rows if row.get("label") == "Quote"), "")
+    weather = next((row for row in rows if row.get("label") == "Weather"), None)
+    status = next((row for row in rows if row.get("label") == "Status"), None)
+
+    canvas.text(18, 28, title, scale=3, color=BLACK)
+    if subtitle:
+        canvas.text(20, 60, subtitle, scale=1, color=BLACK)
+
+    quote_lines = _wrap_text(quote, scale=3, max_width=352, max_lines=2)
+    quote_top = 100 if len(quote_lines) == 1 else 86
+    for index, line in enumerate(quote_lines):
+        canvas.text_centered(200, quote_top + index * 34, line, scale=3, color=BLACK)
+    canvas.rectangle(34, quote_top + len(quote_lines) * 34 + 8, 366, quote_top + len(quote_lines) * 34 + 12, accent)
+
+    y = 196
+    for row in (weather, status):
+        if row is None:
             continue
-        for row in section.get("rows", ()):
-            level = row.get("level", "normal")
-            row_color = LEVEL_COLORS.get(level, BLACK)
-            if level in {"emphasis", "urgent"}:
-                background_color = ACCENT_COLORS[payload.accent]
-                canvas.rectangle(18, y - 8, 382, y + 28, background_color)
-                row_color = _text_color_for_background(background_color)
-            canvas.icon(26, y - 4, row.get("icon", ""), scale=2, color=row_color)
-            canvas.text(56, y, row.get("label", ""), scale=2, color=row_color)
-            canvas.text(170, y, row.get("value", ""), scale=2, color=row_color)
-            y += 42
+        _render_row(canvas, row, payload.accent, y)
+        y += 38
 
-    if payload.footer:
-        canvas.rectangle(0, HEIGHT - 30, WIDTH, HEIGHT, BLACK)
-        canvas.text(18, HEIGHT - 22, payload.footer, scale=1, color=WHITE)
 
-    return canvas.to_png()
+def _render_row(canvas: Canvas, row: dict[str, str], accent: str, y: int) -> None:
+    level = row.get("level", "normal")
+    row_color = LEVEL_COLORS.get(level, BLACK)
+    if level in {"emphasis", "urgent"}:
+        background_color = ACCENT_COLORS[accent]
+        canvas.rectangle(18, y - 8, 382, y + 28, background_color)
+        row_color = _text_color_for_background(background_color)
+    canvas.icon(26, y - 4, row.get("icon", ""), scale=2, color=row_color)
+    canvas.text(56, y, row.get("label", ""), scale=2, color=row_color)
+    canvas.text(170, y, row.get("value", ""), scale=2, color=row_color)
+
+
+def _wrap_text(text: str, scale: int, max_width: int, max_lines: int) -> list[str]:
+    words = text.split()
+    if not words:
+        return [""]
+
+    max_chars = max(1, max_width // (6 * scale))
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = word if current == "" else f"{current} {word}"
+        if len(candidate) <= max_chars:
+            current = candidate
+            continue
+        if current:
+            lines.append(current)
+        current = word
+        if len(lines) == max_lines:
+            break
+    if len(lines) < max_lines and current:
+        lines.append(current)
+    return lines[:max_lines]
 
 
 class Canvas:
@@ -104,6 +184,17 @@ class Canvas:
                 break
             self._glyph(x, top, glyph, scale, color)
             x += 6 * scale
+
+    def text_centered(
+        self,
+        center_x: int,
+        top: int,
+        text: str,
+        scale: int,
+        color: tuple[int, int, int],
+    ) -> None:
+        text_width = len(text) * 6 * scale
+        self.text(max(0, center_x - text_width // 2), top, text, scale=scale, color=color)
 
     def icon(self, left: int, top: int, name: str, scale: int, color: tuple[int, int, int]) -> None:
         glyph = ICONS.get(name)

--- a/inky_display/samples/owner_suite_morning.json
+++ b/inky_display/samples/owner_suite_morning.json
@@ -9,9 +9,9 @@
     {
       "type": "rows",
       "rows": [
-        {"icon": "mdi:weather-sunny", "label": "Weather", "value": "28F Clear", "level": "normal"},
-        {"label": "Blinds", "value": "Opening soon", "level": "emphasis"},
-        {"label": "Audio", "value": "News queued", "level": "normal"}
+        {"icon": "mdi:weather-sunny", "label": "Weather", "value": "45F Sunny", "level": "normal"},
+        {"label": "Quote", "value": "The star map can wait.", "level": "normal"},
+        {"label": "Status", "value": "All clear", "level": "normal"}
       ]
     }
   ],

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -367,7 +367,6 @@ script:
                 {% set rows = [
                   {'icon': weather_icon, 'label': 'Weather', 'value': weather_value, 'level': 'urgent' if weather_alert else 'normal'},
                   {'label': 'Quote', 'value': quote_value, 'level': 'normal'},
-                  {'label': 'Source', 'value': 'Sci-fi/fantasy', 'level': 'normal'},
                   {'label': 'Status', 'value': status_value, 'level': status_level}
                 ] %}
               {% endif %}

--- a/tests/test_inky_display_renderer.py
+++ b/tests/test_inky_display_renderer.py
@@ -138,3 +138,16 @@ def test_black_accent_emphasis_rows_keep_visible_text() -> None:
     pixels = _png_rgb(render_payload(validate_payload(data)))
 
     assert b"\xff\xff\xff" in pixels
+
+
+def test_quote_payload_uses_full_width_quote_layout_without_source_row() -> None:
+    payload = validate_payload(_sample("owner_suite_morning.json"))
+    rows = payload.sections[0]["rows"]
+
+    assert [row["label"] for row in rows] == ["Weather", "Quote", "Status"]
+    assert "Source" not in {row["label"] for row in rows}
+
+    pixels = _png_rgb(render_payload(payload))
+
+    assert b"\xd7\x00\x00" in pixels
+    assert b"\x00\x00\x00" in pixels

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -137,6 +137,7 @@ def test_owner_suite_night_preview_includes_current_and_tomorrow_weather() -> No
 def test_owner_suite_daytime_rows_use_calendar_or_quote_context_not_alarms() -> None:
     block = _script_block("publish_owner_suite_inky_display")
     daytime_block = block[block.index("{% else %}\n              {% if next_calendar.has_event %}") : block.index("            {% endif %}\n            {{ {")]
+    quote_block = daytime_block[daytime_block.index("{% else %}") :]
 
     assert "action: calendar.get_events" in block
     assert "response_variable: owner_suite_calendar_window" in block
@@ -148,6 +149,8 @@ def test_owner_suite_daytime_rows_use_calendar_or_quote_context_not_alarms() -> 
     assert "'value': next_calendar.place" in daytime_block
     assert "'label': 'Quote'" in daytime_block
     assert "'value': quote_value" in daytime_block
+    assert "'label': 'Source'" not in quote_block
+    assert "Sci-fi/fantasy" not in quote_block
     assert "'label': 'Alarm'" not in daytime_block
     assert "'label': 'Meeting'" not in daytime_block
 


### PR DESCRIPTION
## Summary
- remove the Source row from daytime quote fallback payloads
- add a dedicated full-width quote renderer layout for quote payloads
- update the morning sample and docs for the tighter quote layout

## Tests
- uv run --with pytest pytest
- python3 -m inky_display.cli inky_display/samples/owner_suite_morning.json /tmp/owner_suite_morning_quote.png

Refs #313