### PR TITLE
Add Inky quote speaker attribution

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -195,7 +195,8 @@ Current owner-suite rows:
 | Meeting | `input_datetime.next_work_meeting` when `input_boolean.special_meeting` is on | Night-only; shown when no urgent status is active |
 | Next | Next `calendar.ryan_claussen` event from `calendar.get_events` in the next 12 hours | Day-only; `emphasis` when an event is available |
 | Place | Location from the next `calendar.ryan_claussen` event | Day-only |
-| Quote | Original rotating sci-fi/fantasy fallback text | Day-only when no next event is available |
+| Quote | Rotating short sci-fi/fantasy quote | Day-only when no next event is available |
+| Speaker | Character attribution for the quote | Rendered under the centered quote, not as a standard row |
 | Status | First active status from weather alert, garage door, front door, rain in the next hour, precipitation/weather during the next `calendar.ryan_claussen` event, trip mode, vacation, otherwise `All clear` | `urgent` for alert/door/garage/rain/event weather, `emphasis` for trip/vacation |
 
 In `night_preview`, the owner-suite rows are current `Weather`, tomorrow's
@@ -208,10 +209,11 @@ with the legacy `forecast_json` attribute kept only as a fallback.
 In `morning`, `up_for_day`, and `midday`, alarm and meeting-alarm rows are not
 shown. Those modes use current `Weather`, next calendar event time/title,
 calendar event location, and `Status`. If no calendar event is available in the
-next 12 hours, the event rows fall back to an original rotating sci-fi/fantasy
-quote. The renderer gives quote payloads a dedicated full-width quote layout
-instead of spending a row on source/metadata text. This keeps the post-wakeup
-screen focused on what is next instead of repeating wake-up setup state.
+next 12 hours, the event rows fall back to a rotating sci-fi/fantasy quote with
+the character who said it. The renderer gives quote payloads a dedicated
+full-width quote layout instead of spending a row on source/metadata text. This
+keeps the post-wakeup screen focused on what is next instead of repeating
+wake-up setup state.
 
 When `sensor.next_travel_flight` is inside its active travel window, `morning`,
 `up_for_day`, and `midday` modes use flight-oriented rows instead of the normal

--- a/inky_display/renderer.py
+++ b/inky_display/renderer.py
@@ -90,6 +90,7 @@ def _render_quote_layout(
     title = payload.title or payload.mode.replace("_", " ")
     subtitle = payload.subtitle
     quote = next((row.get("value", "") for row in rows if row.get("label") == "Quote"), "")
+    speaker = next((row.get("value", "") for row in rows if row.get("label") == "Speaker"), "")
     weather = next((row for row in rows if row.get("label") == "Weather"), None)
     status = next((row for row in rows if row.get("label") == "Status"), None)
 
@@ -101,7 +102,11 @@ def _render_quote_layout(
     quote_top = 100 if len(quote_lines) == 1 else 86
     for index, line in enumerate(quote_lines):
         canvas.text_centered(200, quote_top + index * 34, line, scale=3, color=BLACK)
-    canvas.rectangle(34, quote_top + len(quote_lines) * 34 + 8, 366, quote_top + len(quote_lines) * 34 + 12, accent)
+    attribution_top = quote_top + len(quote_lines) * 34 + 4
+    if speaker:
+        canvas.text_centered(200, attribution_top, f"- {speaker}", scale=1, color=BLACK)
+        attribution_top += 16
+    canvas.rectangle(34, attribution_top + 4, 366, attribution_top + 8, accent)
 
     y = 196
     for row in (weather, status):

--- a/inky_display/samples/owner_suite_morning.json
+++ b/inky_display/samples/owner_suite_morning.json
@@ -10,7 +10,8 @@
       "type": "rows",
       "rows": [
         {"icon": "mdi:weather-sunny", "label": "Weather", "value": "45F Sunny", "level": "normal"},
-        {"label": "Quote", "value": "The star map can wait.", "level": "normal"},
+        {"label": "Quote", "value": "Never tell me the odds.", "level": "normal"},
+        {"label": "Speaker", "value": "Han Solo", "level": "normal"},
         {"label": "Status", "value": "All clear", "level": "normal"}
       ]
     }

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -239,14 +239,16 @@ script:
                 {% set next_calendar.place = item_location if item_location != '' else 'No location' %}
               {% endif %}
             {% endfor %}
-            {% set quotes = [
-              'Airlocks favor optimism.',
-              'Dragons respect checklists.',
-              'The star map can wait.',
-              'Keep the spell simple.',
-              'Pack snacks for hyperspace.'
+            {% set quote_entries = [
+              {'quote': 'Never tell me the odds.', 'speaker': 'Han Solo'},
+              {'quote': 'I am no man.', 'speaker': 'Eowyn'},
+              {'quote': 'This is the way.', 'speaker': 'Din Djarin'},
+              {'quote': 'Tea. Earl Grey. Hot.', 'speaker': 'Jean-Luc Picard'},
+              {'quote': 'So say we all.', 'speaker': 'William Adama'}
             ] %}
-            {% set quote_value = quotes[(now().strftime('%j') | int) % (quotes | count)] %}
+            {% set quote_entry = quote_entries[(now().strftime('%j') | int) % (quote_entries | count)] %}
+            {% set quote_value = quote_entry.quote %}
+            {% set quote_speaker = quote_entry.speaker %}
             {% set garage_open = states('cover.garage_door') not in ['closed', 'closing'] %}
             {% set front_door_open = is_state('binary_sensor.main_foyer_front_door_contact', 'on') %}
             {% set weather_alert_state = states('sensor.nws_dakota_county_alerts_alerts_are_active') | lower %}
@@ -371,6 +373,7 @@ script:
                 {% set rows = [
                   {'icon': weather_icon, 'label': 'Weather', 'value': weather_value, 'level': 'urgent' if weather_alert else 'normal'},
                   {'label': 'Quote', 'value': quote_value, 'level': 'normal'},
+                  {'label': 'Speaker', 'value': quote_speaker, 'level': 'normal'},
                   {'label': 'Status', 'value': status_value, 'level': status_level}
                 ] %}
               {% endif %}

--- a/tests/test_inky_display_renderer.py
+++ b/tests/test_inky_display_renderer.py
@@ -144,7 +144,8 @@ def test_quote_payload_uses_full_width_quote_layout_without_source_row() -> None
     payload = validate_payload(_sample("owner_suite_morning.json"))
     rows = payload.sections[0]["rows"]
 
-    assert [row["label"] for row in rows] == ["Weather", "Quote", "Status"]
+    assert [row["label"] for row in rows] == ["Weather", "Quote", "Speaker", "Status"]
+    assert next(row["value"] for row in rows if row["label"] == "Speaker") == "Han Solo"
     assert "Source" not in {row["label"] for row in rows}
 
     pixels = _png_rgb(render_payload(payload))

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -149,8 +149,12 @@ def test_owner_suite_daytime_rows_use_calendar_or_quote_context_not_alarms() -> 
     assert "'value': next_calendar.place" in daytime_block
     assert "'label': 'Quote'" in daytime_block
     assert "'value': quote_value" in daytime_block
+    assert "'label': 'Speaker'" in quote_block
+    assert "'value': quote_speaker" in quote_block
     assert "'label': 'Source'" not in quote_block
     assert "Sci-fi/fantasy" not in quote_block
+    assert "'speaker': 'Han Solo'" in block
+    assert "'speaker': 'Jean-Luc Picard'" in block
     assert "'label': 'Alarm'" not in daytime_block
     assert "'label': 'Meeting'" not in daytime_block
 


### PR DESCRIPTION
## Summary
- rotate daytime fallback quotes as quote/speaker pairs
- include a Speaker payload row for quote fallback payloads
- render speaker attribution as small centered text under the quote instead of as a standard row
- update docs and the quote sample

## Tests
- uv run --with pytest pytest
- python3 -m inky_display.cli inky_display/samples/owner_suite_morning.json /tmp/owner_suite_morning_speaker.png

Refs #313