### PR TITLE
Fix #643 owner suite Inovelli LED policy replay

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -515,6 +515,8 @@ automation:
             and to_state.state not in ['unavailable', 'unknown']
           }}
     action:
+      - delay:
+          seconds: 45
       - action: script.turn_on
         target:
           entity_id: script.replay_inovelli_led_policy_after_recovery
@@ -1960,7 +1962,7 @@ script:
         {{
           'owner_suite_fan_switch'
           if requested_scope == 'bedroom'
-          else '(owner_suite_bathroom_vanity|owner_suite_closet)'
+          else '(owner_suite_bathroom_|owner_suite_closet)'
         }}
       owner_suite_day_mode_script_entity: >-
         {{
@@ -2029,7 +2031,8 @@ script:
 
   apply_owner_suite_inovelli_led_policy:
     icon: mdi:light-switch
-    mode: restart
+    mode: queued
+    max: 10
     trace:
       stored_traces: 100
     fields:
@@ -2085,6 +2088,27 @@ script:
     icon: mdi:light-switch
     trace:
       stored_traces: 100
+    variables:
+      owner_suite_led_color_off_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledcolorwhenoff$') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      owner_suite_led_color_on_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledcolorwhenon$') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      owner_suite_led_intensity_off_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenoff$') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      owner_suite_led_intensity_on_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenon$') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
     sequence:
       - *trip_led_updates_allowed
       - action: logbook.log
@@ -2094,36 +2118,24 @@ script:
           message: "Setting owner suite switch LED colors to nighttime red"
           domain: script
       - action: number.set_value
-        target:
-          entity_id:
-            - number.owner_suite_closet_ledcolorwhenoff
-            - number.owner_suite_fan_switch_ledcolorwhenoff
-            - number.owner_suite_bathroom_vanity_ledcolorwhenoff
         data:
+          entity_id: >
+            {{ owner_suite_led_color_off_switches }}
           value: "0"
       - action: number.set_value
-        target:
-          entity_id:
-            - number.owner_suite_closet_ledintensitywhenoff
-            - number.owner_suite_fan_switch_ledintensitywhenoff
-            - number.owner_suite_bathroom_vanity_ledintensitywhenoff
         data:
+          entity_id: >
+            {{ owner_suite_led_intensity_off_switches }}
           value: "1"
       - action: number.set_value
-        target:
-          entity_id:
-            - number.owner_suite_closet_ledintensitywhenon
-            - number.owner_suite_fan_switch_ledintensitywhenon
-            - number.owner_suite_bathroom_vanity_ledintensitywhenon
         data:
+          entity_id: >
+            {{ owner_suite_led_intensity_on_switches }}
           value: "50"
       - action: number.set_value
-        target:
-          entity_id:
-            - number.owner_suite_closet_ledcolorwhenon
-            - number.owner_suite_fan_switch_ledcolorwhenon
-            - number.owner_suite_bathroom_vanity_ledcolorwhenon
         data:
+          entity_id: >
+            {{ owner_suite_led_color_on_switches }}
           value: "0"
 
   day_mode_switches_office_guest_room:
@@ -2812,6 +2824,20 @@ script:
     icon: mdi:light-switch
     trace:
       stored_traces: 100
+    variables:
+      owner_suite_led_intensity_off_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenoff$') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      owner_suite_led_intensity_on_switches: >
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenon$') -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
+      owner_suite_led_intensity_off_with_office: >-
+        {{ [owner_suite_led_intensity_off_switches, 'number.office_fan_switch_ledintensitywhenoff']
+          | reject('equalto', '') | join(', ') }}
     sequence:
       - action: retry.actions
         data:
@@ -2820,16 +2846,12 @@ script:
               data:
                 value: 0
               target:
-                entity_id:
-                  - number.owner_suite_closet_ledintensitywhenoff
-                  - number.owner_suite_fan_switch_ledintensitywhenoff
-                  - number.owner_suite_bathroom_vanity_ledintensitywhenoff
-                  - number.office_fan_switch_ledintensitywhenoff
+                entity_id: "{{ owner_suite_led_intensity_off_with_office }}"
             - action: number.set_value
               data:
                 value: 0
               target:
-                entity_id: number.owner_suite_fan_switch_ledintensitywhenon
+                entity_id: "{{ owner_suite_led_intensity_on_switches }}"
           initial_grace_period: 30
           expected_state: 0
       - repeat:
@@ -2838,12 +2860,9 @@ script:
             - delay:
                 seconds: 30
             - action: number.set_value
-              entity_id:
-                - number.owner_suite_closet_ledintensitywhenoff
-                - number.owner_suite_fan_switch_ledintensitywhenoff
-                - number.owner_suite_bathroom_vanity_ledintensitywhenoff
-                - number.office_fan_switch_ledintensitywhenoff
-                - number.owner_suite_fan_switch_ledintensitywhenon
+              entity_id: >-
+                {{ [owner_suite_led_intensity_off_with_office, owner_suite_led_intensity_on_switches]
+                  | reject('equalto', '') | join(', ') }}
               data:
                 value: 0
 

--- a/tests/test_inovelli_day_mode_switches.py
+++ b/tests/test_inovelli_day_mode_switches.py
@@ -165,7 +165,7 @@ def test_owner_suite_bathroom_day_mode_script_targets_bathroom_and_closet_leds()
     assert "script.day_mode_switches_owner_suite_scope" in wrapper
     assert "scope: bathroom" in wrapper
     assert "requested_scope: \"{{ scope | default('bedroom') }}\"" in block
-    assert "owner_suite_bathroom_vanity|owner_suite_closet" in block
+    assert "owner_suite_bathroom_|owner_suite_closet" in block
     assert "owner_suite_fan_switch" in block
     assert "Setting owner suite bathroom and closet switch day mode colors" in block
     assert "Setting owner suite bedroom switch day mode colors" in block
@@ -178,6 +178,8 @@ def test_owner_suite_led_policy_dispatches_day_night_red_and_dark_modes() -> Non
     block = _script_block(ZIGBEE_ZWAVE_PATH, "apply_owner_suite_inovelli_led_policy")
 
     for token in (
+        "mode: queued",
+        "max: 10",
         "requested_policy",
         "requested_scope",
         "requested_policy == 'day'",
@@ -189,6 +191,22 @@ def test_owner_suite_led_policy_dispatches_day_night_red_and_dark_modes() -> Non
         "script.night_mode_switches_owner_suite",
         "requested_policy == 'dark'",
         "script.turn_off_owner_suite_inovelli_switch_leds",
+    ):
+        assert token in block
+
+
+def test_owner_suite_night_red_policy_targets_all_owner_suite_led_numbers() -> None:
+    block = _script_block(ZIGBEE_ZWAVE_PATH, "night_mode_switches_owner_suite")
+
+    for token in (
+        "^number\\\\.owner_suite_.*ledcolorwhenoff$",
+        "^number\\\\.owner_suite_.*ledcolorwhenon$",
+        "^number\\\\.owner_suite_.*ledintensitywhenoff$",
+        "^number\\\\.owner_suite_.*ledintensitywhenon$",
+        "{{ owner_suite_led_color_off_switches }}",
+        "{{ owner_suite_led_color_on_switches }}",
+        "{{ owner_suite_led_intensity_off_switches }}",
+        "{{ owner_suite_led_intensity_on_switches }}",
     ):
         assert token in block
 

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -321,10 +321,12 @@ def test_inovelli_led_recovery_automation_watches_all_led_number_entities() -> N
 
     for token in (
         "replay_inovelli_led_policy_on_recovery",
+        "mode: restart",
         "event_type: state_changed",
         "entity_id is match('^number\\\\..*_led(?:color|intensity)when(?:on|off)$')",
         "from_state.state == 'unavailable'",
         "to_state.state not in ['unavailable', 'unknown']",
+        "seconds: 45",
         "entity_id: script.replay_inovelli_led_policy_after_recovery",
     ):
         assert token in block
@@ -357,13 +359,13 @@ def test_inovelli_led_recovery_replays_trip_day_night_and_owner_suite_darkening(
 def test_owner_suite_led_darkening_excludes_unavailable_guest_room_switch() -> None:
     block = _script_block("turn_off_owner_suite_inovelli_switch_leds")
 
-    for entity_id in (
-        "number.owner_suite_closet_ledintensitywhenoff",
-        "number.owner_suite_fan_switch_ledintensitywhenoff",
-        "number.owner_suite_bathroom_vanity_ledintensitywhenoff",
+    for token in (
+        "^number\\\\.owner_suite_.*ledintensitywhenoff$",
+        "^number\\\\.owner_suite_.*ledintensitywhenon$",
+        "owner_suite_led_intensity_off_with_office",
         "number.office_fan_switch_ledintensitywhenoff",
     ):
-        assert entity_id in block
+        assert token in block
 
     assert "number.guest_room_fan_switch_ledintensitywhenoff" not in block
 


### PR DESCRIPTION
## Summary
- Fixes #643.
- Queue owner-suite LED policy calls so overlapping bedroom, bathroom, dark, and recovery policy requests do not cancel one another.
- Debounce LED-number recovery replay for 45 seconds before reapplying the current policy.
- Expand owner-suite bathroom day policy and owner-suite night/dark policies so tub/shower/exhaust/closet/fan LED number entities are covered consistently.

## Trace/history findings
- The May 6-7, 2026 HA traces showed `script.apply_owner_suite_inovelli_led_policy` running `policy: dark` repeatedly around 23:48-23:53 CT, with the final dark child script cancelled during a recovery replay storm.
- `script.turn_off_owner_suite_inovelli_switch_leds` only zeroed closet/fan/vanity `ledintensitywhenoff` plus fan `ledintensitywhenon`; closet and vanity could remain visibly lit when their `whenon` controls were active.
- Live history showed the owner-suite tub switch retaining `ledcolorwhenon=0` while the rest of the bathroom/closet day profile moved back to `170`, because the owner-suite bathroom policy pattern omitted tub.

## Tests
- `uv run --with pytest pytest tests/test_inovelli_day_mode_switches.py tests/test_zigbee_zwave_inovelli_reset_replay.py tests/test_runtime_log_regressions.py tests/test_issue_trip_led_suspend.py`
- `uv run --with pytest pytest`
