### PR TITLE
Use sans-serif font stack for Inky renderer

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -107,6 +107,13 @@ the `mdi:` prefix so payloads stay aligned with Home Assistant icon names. The
 Pi renderer should support a small weather-first fallback icon set and skip
 unknown icons instead of failing the render.
 
+Material Design Icons are the preferred icon vocabulary for e-ink payloads
+because Home Assistant already uses MDI names and the weather set maps cleanly
+to the display's current weather rows. The renderer currently includes a small
+weather-first bitmap fallback for the MDI names below. A later icon-quality
+upgrade should render selected MDI SVG paths or an MDI icon font into the
+black/red/white palette instead of inventing a separate icon namespace.
+
 Initial weather icon names:
 
 - `mdi:weather-sunny`
@@ -129,6 +136,13 @@ Unknown content should be skipped, not rendered as an error screen.
 - Red on `owner_suite` means urgent or exceptional.
 - Yellow on `office` means emphasis or hospitality, not urgency.
 - Do not render rapidly changing clocks.
+
+Font preference for the owner-suite panel is Trebuchet Bold first, Verdana Bold
+second, then DejaVu Sans Condensed Bold as the open fallback available on the
+Pi. The renderer searches `INKY_FONT_BOLD` / `INKY_FONT_REGULAR` first, then
+common system paths for Trebuchet, Verdana, and DejaVu. Do not commit
+proprietary Trebuchet or Verdana font files to the repo; install/provide them
+locally on the Pi if those exact faces are required.
 
 ## Owner-Suite Modes
 

--- a/inky_display/renderer.py
+++ b/inky_display/renderer.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
 import binascii
+import os
+from pathlib import Path
 import struct
+from typing import Any
 import zlib
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ModuleNotFoundError:
+    Image = None
+    ImageDraw = None
+    ImageFont = None
 
 from .payload import DisplayPayload
 
@@ -155,7 +165,14 @@ class Canvas:
     def __init__(self, width: int, height: int) -> None:
         self.width = width
         self.height = height
-        self.pixels = bytearray(WHITE * width * height)
+        if Image is None or ImageDraw is None:
+            self.image = None
+            self.draw = None
+            self.pixels = bytearray(WHITE * width * height)
+        else:
+            self.image = Image.new("RGB", (width, height), WHITE)
+            self.draw = ImageDraw.Draw(self.image)
+            self.pixels = None
 
     def rectangle(
         self,
@@ -169,6 +186,11 @@ class Canvas:
         top = max(0, top)
         right = min(self.width, right)
         bottom = min(self.height, bottom)
+        if right <= left or bottom <= top:
+            return
+        if self.draw is not None:
+            self.draw.rectangle((left, top, right - 1, bottom - 1), fill=color)
+            return
         for y in range(top, bottom):
             for x in range(left, right):
                 self._set_pixel(x, y, color)
@@ -181,6 +203,13 @@ class Canvas:
         scale: int,
         color: tuple[int, int, int],
     ) -> None:
+        font = _font_for_scale(scale)
+        if font is not None:
+            assert self.draw is not None
+            text = _clip_text_to_width(self.draw, text, font, self.width - 8 - left)
+            self.draw.text((left, top), text, font=font, fill=color)
+            return
+
         x = left
         max_x = self.width - 8
         for char in text.upper():
@@ -198,6 +227,14 @@ class Canvas:
         scale: int,
         color: tuple[int, int, int],
     ) -> None:
+        font = _font_for_scale(scale)
+        if font is not None:
+            assert self.draw is not None
+            text = _clip_text_to_width(self.draw, text, font, self.width - 16)
+            text_width = _text_width(self.draw, text, font)
+            self.draw.text((max(0, center_x - text_width // 2), top), text, font=font, fill=color)
+            return
+
         text_width = len(text) * 6 * scale
         self.text(max(0, center_x - text_width // 2), top, text, scale=scale, color=color)
 
@@ -208,6 +245,12 @@ class Canvas:
         self._glyph(left, top, glyph, scale, color)
 
     def to_png(self) -> bytes:
+        if self.image is None:
+            return self._legacy_to_png()
+        image = _threshold_palette(self.image)
+        return _image_to_png(image)
+
+    def _legacy_to_png(self) -> bytes:
         raw = bytearray()
         row_width = self.width * 3
         for y in range(self.height):
@@ -246,6 +289,10 @@ class Canvas:
                 )
 
     def _set_pixel(self, x: int, y: int, color: tuple[int, int, int]) -> None:
+        if self.image is not None:
+            self.image.putpixel((x, y), color)
+            return
+        assert self.pixels is not None
         index = (y * self.width + x) * 3
         self.pixels[index : index + 3] = bytes(color)
 
@@ -266,6 +313,118 @@ def _text_color_for_background(background: tuple[int, int, int]) -> tuple[int, i
     if background in {BLACK, RED}:
         return WHITE
     return BLACK
+
+
+FONT_SIZE_BY_SCALE = {
+    1: 11,
+    2: 17,
+    3: 34,
+    4: 38,
+}
+
+FONT_CACHE: dict[tuple[str, int], Any | None] = {}
+
+BOLD_FONT_CANDIDATES = (
+    "INKY_FONT_BOLD",
+    "/usr/share/fonts/truetype/msttcorefonts/trebucbd.ttf",
+    "/usr/share/fonts/truetype/msttcorefonts/Trebuchet_MS_Bold.ttf",
+    "/System/Library/Fonts/Supplemental/Trebuchet MS Bold.ttf",
+    "/Library/Fonts/Microsoft/Trebuchet MS Bold.ttf",
+    "/usr/share/fonts/truetype/msttcorefonts/verdanab.ttf",
+    "/System/Library/Fonts/Supplemental/Verdana Bold.ttf",
+    "/Library/Fonts/Microsoft/Verdana Bold.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansCondensed-Bold.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+)
+
+REGULAR_FONT_CANDIDATES = (
+    "INKY_FONT_REGULAR",
+    "/usr/share/fonts/truetype/msttcorefonts/trebuc.ttf",
+    "/usr/share/fonts/truetype/msttcorefonts/Trebuchet_MS.ttf",
+    "/System/Library/Fonts/Supplemental/Trebuchet MS.ttf",
+    "/Library/Fonts/Microsoft/Trebuchet MS.ttf",
+    "/usr/share/fonts/truetype/msttcorefonts/verdana.ttf",
+    "/System/Library/Fonts/Supplemental/Verdana.ttf",
+    "/Library/Fonts/Microsoft/Verdana.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansCondensed.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+)
+
+
+def _font_for_scale(scale: int) -> Any | None:
+    if ImageFont is None:
+        return None
+    style = "regular" if scale == 1 else "bold"
+    size = FONT_SIZE_BY_SCALE.get(scale, 17)
+    cache_key = (style, size)
+    if cache_key in FONT_CACHE:
+        return FONT_CACHE[cache_key]
+
+    candidates = REGULAR_FONT_CANDIDATES if style == "regular" else BOLD_FONT_CANDIDATES
+    for candidate in candidates:
+        font_path = os.environ.get(candidate) if candidate.startswith("INKY_FONT_") else candidate
+        if not font_path or not Path(font_path).exists():
+            continue
+        try:
+            FONT_CACHE[cache_key] = ImageFont.truetype(font_path, size=size)
+            return FONT_CACHE[cache_key]
+        except OSError:
+            continue
+
+    FONT_CACHE[cache_key] = None
+    return None
+
+
+def _clip_text_to_width(draw: Any, text: str, font: Any, max_width: int) -> str:
+    if _text_width(draw, text, font) <= max_width:
+        return text
+    suffix = "..."
+    clipped = text
+    while clipped and _text_width(draw, clipped + suffix, font) > max_width:
+        clipped = clipped[:-1].rstrip()
+    return clipped + suffix if clipped else ""
+
+
+def _text_width(draw: Any, text: str, font: Any) -> int:
+    box = draw.textbbox((0, 0), text, font=font)
+    return box[2] - box[0]
+
+
+def _threshold_palette(image: Any) -> Any:
+    assert Image is not None
+    output = Image.new("RGB", image.size, WHITE)
+    source = image.load()
+    target = output.load()
+    for y in range(image.height):
+        for x in range(image.width):
+            r, g, b = source[x, y]
+            if r > 150 and g < 110 and b < 110:
+                target[x, y] = RED
+            elif (r + g + b) // 3 < 190:
+                target[x, y] = BLACK
+            else:
+                target[x, y] = WHITE
+    return output
+
+
+def _image_to_png(image: Any) -> bytes:
+    raw = bytearray()
+    pixels = image.tobytes()
+    row_width = image.width * 3
+    for y in range(image.height):
+        row_start = y * row_width
+        raw.append(0)
+        raw.extend(pixels[row_start : row_start + row_width])
+
+    return (
+        PNG_SIGNATURE
+        + _chunk(
+            b"IHDR",
+            struct.pack(">IIBBBBB", image.width, image.height, 8, 2, 0, 0, 0),
+        )
+        + _chunk(b"IDAT", zlib.compress(bytes(raw), level=9))
+        + _chunk(b"IEND", b"")
+    )
 
 
 FONT: dict[str, tuple[str, ...]] = {

--- a/tests/test_inky_display_renderer.py
+++ b/tests/test_inky_display_renderer.py
@@ -8,6 +8,7 @@ import zlib
 import pytest
 
 from inky_display import HEIGHT, WIDTH, payload_hash, render_payload, validate_payload
+from inky_display import renderer
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -152,3 +153,11 @@ def test_quote_payload_uses_full_width_quote_layout_without_source_row() -> None
 
     assert b"\xd7\x00\x00" in pixels
     assert b"\x00\x00\x00" in pixels
+
+
+def test_renderer_prefers_trebuchet_then_verdana_font_stack() -> None:
+    bold_stack = "\n".join(renderer.BOLD_FONT_CANDIDATES)
+
+    assert "Trebuchet" in bold_stack
+    assert bold_stack.index("Trebuchet") < bold_stack.index("Verdana")
+    assert "DejaVuSansCondensed-Bold.ttf" in bold_stack


### PR DESCRIPTION
## Summary
- render text with a TrueType sans-serif stack when Pillow is available
- prefer Trebuchet Bold, then Verdana Bold, then DejaVu Sans Condensed as the Pi-safe fallback
- keep the existing dependency-free bitmap renderer as the fallback when Pillow/fonts are unavailable
- document the font preference and MDI weather-icon direction

## Tests
- uv run --with pytest pytest
- PYTHONPATH=. uv run --with pytest --with pillow pytest tests/test_inky_display_renderer.py
- python3 -m inky_display.cli inky_display/samples/owner_suite_morning.json /tmp/owner_suite_morning_font_stack.png

Refs #313