### PR TITLE
fix: correct timer trigger platform in fan_off_when_timer_ends

### DIFF
--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -272,27 +272,20 @@ automation:
     trace:
       stored_traces: 100
     triggers:
-      - trigger: timer.finished
-        target:
-          entity_id: timer.owner_suite_fan_timer
-      - trigger: timer.finished
-        target:
-          entity_id: timer.owner_suite_bathroom_exhaust_timer
-      - trigger: timer.finished
-        target:
-          entity_id: timer.office_ceiling_fan_timer
-      - trigger: timer.finished
-        target:
-          entity_id: timer.basement_bathroom_exhaust_timer
-      - trigger: timer.finished
-        target:
-          entity_id: timer.den_ceiling_fan_timer
-      - trigger: timer.finished
-        target:
-          entity_id: timer.guest_room_fan_timer
-      - trigger: timer.finished
-        target:
-          entity_id: timer.guest_bathroom_exhaust_timer
+      - trigger: timer
+        entity_id: timer.owner_suite_fan_timer
+      - trigger: timer
+        entity_id: timer.owner_suite_bathroom_exhaust_timer
+      - trigger: timer
+        entity_id: timer.office_ceiling_fan_timer
+      - trigger: timer
+        entity_id: timer.basement_bathroom_exhaust_timer
+      - trigger: timer
+        entity_id: timer.den_ceiling_fan_timer
+      - trigger: timer
+        entity_id: timer.guest_room_fan_timer
+      - trigger: timer
+        entity_id: timer.guest_bathroom_exhaust_timer
     actions:
       - variables:
           fan_map:


### PR DESCRIPTION
## Summary

- `trigger: timer.finished` is not a valid HA trigger platform — the correct name is `trigger: timer`
- `target:` is a service-call key and has no meaning on a trigger; `entity_id` belongs directly under the trigger
- The action template `{{ fan_map[trigger.entity_id] }}` was already correct and is unchanged

## Test plan

- [ ] Reload automations after merge — `fan_off_when_timer_ends` should appear as `idle` (not unavailable) in Developer Tools → Template
- [ ] Start `timer.owner_suite_fan_timer` for 1 min; confirm `fan.owner_suite` turns off when timer fires
- [ ] Repair panel entry for `fan_off_when_timer_ends` is gone

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)