### PR TITLE
fix: move entity_id under target in turn_off_owner_suite_inovelli_switch_leds repeat block

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2860,9 +2860,10 @@ script:
             - delay:
                 seconds: 30
             - action: number.set_value
-              entity_id: >-
-                {{ [owner_suite_led_intensity_off_with_office, owner_suite_led_intensity_on_switches]
-                  | reject('equalto', '') | join(', ') }}
+              target:
+                entity_id: >-
+                  {{ [owner_suite_led_intensity_off_with_office, owner_suite_led_intensity_on_switches]
+                    | reject('equalto', '') | join(', ') }}
               data:
                 value: 0
 


### PR DESCRIPTION
## Summary

- PR #644 refactored the `repeat` block to use template-based entity lists but left `entity_id:` at the action root instead of inside `target:` — HA rejects this at schema validation time, preventing the script from loading
- Every caller (`apply_owner_suite_inovelli_led_policy`, `goodnight_integrity`, `replay_inovelli_led_policy_after_recovery`, `owner_suite_bed_strip_off_when_lamps_off`) was hitting "Action not found" errors as a result
- One-line fix: wrap the `entity_id` template inside `target:`

## Test plan

- [ ] Reload scripts after merge — `turn_off_owner_suite_inovelli_switch_leds` should appear in Developer Tools → Services
- [ ] Run `script.turn_off_owner_suite_inovelli_switch_leds` manually; confirm all owner suite LED intensity numbers are set to 0
- [ ] Confirm the repeat block also zeroes them 30s later
- [ ] Repair panel entries for `turn_off_owner_suite_inovelli_switch_leds` and `owner_suite_bed_strip_off_when_lamps_off` are both gone

Closes #647
Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)