### PR TITLE
fix: move entity_id from data: to target: in night_mode_switches_owner_suite

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2118,24 +2118,28 @@ script:
           message: "Setting owner suite switch LED colors to nighttime red"
           domain: script
       - action: number.set_value
-        data:
+        target:
           entity_id: >
             {{ owner_suite_led_color_off_switches }}
+        data:
           value: "0"
       - action: number.set_value
-        data:
+        target:
           entity_id: >
             {{ owner_suite_led_intensity_off_switches }}
+        data:
           value: "1"
       - action: number.set_value
-        data:
+        target:
           entity_id: >
             {{ owner_suite_led_intensity_on_switches }}
+        data:
           value: "50"
       - action: number.set_value
-        data:
+        target:
           entity_id: >
             {{ owner_suite_led_color_on_switches }}
+        data:
           value: "0"
 
   day_mode_switches_office_guest_room:


### PR DESCRIPTION
## Summary

- All four `number.set_value` calls in `night_mode_switches_owner_suite` had `entity_id:` nested inside `data:` — the deprecated HA format
- Moves `entity_id` to a `target:` block in each call, which is the correct modern form
- No behavior change; this is a forward-compatibility fix before HA removes legacy `entity_id`-in-data support

Closes #651

## Test plan

- [ ] Reload the `zigbee_zwave` package in HA and confirm no config errors
- [ ] Trigger `night_mode_switches_owner_suite` and verify owner suite switch LEDs change to nighttime red (color `0`, intensity off `1`, intensity on `50`)
- [ ] Check the script trace to confirm all four `number.set_value` calls resolve the template entity lists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)