### PR TITLE
feat: cap office volume at 20% during morning wake-up ramp

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1143,14 +1143,14 @@ script:
           enqueue: replace
       - repeat:
           sequence:
-            - alias: "Ramp non-office members directly — individual sets bypass MA proportional group scaling"
+            - alias: "Ramp all wake-up group members — direct individual sets bypass MA proportional group scaling"
               continue_on_error: true
               action: media_player.volume_set
               target:
                 entity_id: "{{ group_members | reject('eq', 'media_player.office_sonos_2') | list }}"
               data:
                 volume_level: "{{ 0.01 * repeat.index }}"
-            - alias: "Ramp office — capped at 0.20"
+            - alias: "Office capped at 20% — bedroom wake-up should not disturb work-in-progress"
               continue_on_error: true
               action: media_player.volume_set
               target:

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1143,13 +1143,20 @@ script:
           enqueue: replace
       - repeat:
           sequence:
-            - alias: "Ramp each member directly — individual sets bypass MA proportional group scaling"
+            - alias: "Ramp non-office members directly — individual sets bypass MA proportional group scaling"
               continue_on_error: true
               action: media_player.volume_set
               target:
-                entity_id: "{{ group_members }}"
+                entity_id: "{{ group_members | reject('eq', 'media_player.office_sonos_2') | list }}"
               data:
                 volume_level: "{{ 0.01 * repeat.index }}"
+            - alias: "Ramp office — capped at 0.20"
+              continue_on_error: true
+              action: media_player.volume_set
+              target:
+                entity_id: media_player.office_sonos_2
+              data:
+                volume_level: "{{ [0.01 * repeat.index, 0.20] | min }}"
             - delay:
                 seconds: "{{ (1/(tan(repeat.index/effective_k_factor))) | round(0, 'ceil', 5)}}"
           until: "{{ repeat.index == effective_ramp_steps }}"

--- a/specs/alarm_wakeup.allium
+++ b/specs/alarm_wakeup.allium
@@ -88,6 +88,7 @@ config {
     snooze_duration: Duration = 8.minutes
     morning_blinds_delay: Duration = 175.seconds
     morning_light_ramp_duration: Duration = 3.minutes
+    office_wakeup_peak_volume: Percentage = 20%
 }
 
 ------------------------------------------------------------
@@ -264,6 +265,17 @@ rule PrepareMorningAudioGroup {
         -- Bathroom-triggered follow-up audio should stay independent from the
         -- owner-suite light ramp and should not depend on regrouping the wider
         -- bedroom wake-up audio zone.
+}
+
+rule RampWakeupVolumeByRoom {
+    when: WakeupAudioGroupPrepared(group)
+    ensures: WakeupVolumeRampStarted(group)
+    @guidance
+        -- All group members fade in from silence using a tan-curve ramp.
+        -- When the group is bedroom_bathroom_office_den, the office is capped
+        -- at config.office_wakeup_peak_volume; all other rooms ramp to the
+        -- full peak. This prevents the wake-up routine from disturbing
+        -- work-in-progress in the office.
 }
 
 rule ChooseWakeupPlaylistFromConfiguredPool {


### PR DESCRIPTION
Fixes #654

## Summary

- Splits the single `volume_set` call in `music_assistant_radio_wake_up`'s ramp loop into two: one for all non-office group members (unchanged behavior), and one for `media_player.office_sonos_2` capped at 0.20
- Uses `| reject('eq', 'media_player.office_sonos_2') | list` to safely exclude the office from the main call — no-ops cleanly when the office isn't in the group (e.g. guest mode)
- No change to ramp timing, step count, or any other player behavior

## Test plan

- [ ] Trigger a weekday wake-up and verify office peaks at 20% while bedroom/bathroom continue to 30%
- [ ] Verify guest-mode wake-up (uses `ma_group_guest`) is unaffected — office likely not a member but the reject filter handles it either way

🤖 Generated with [Claude Code](https://claude.ai/claude-code)