### PR TITLE
Fix #657 fan timer setup on HA 2026.5

### DIFF
--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -272,20 +272,34 @@ automation:
     trace:
       stored_traces: 100
     triggers:
-      - trigger: timer
-        entity_id: timer.owner_suite_fan_timer
-      - trigger: timer
-        entity_id: timer.owner_suite_bathroom_exhaust_timer
-      - trigger: timer
-        entity_id: timer.office_ceiling_fan_timer
-      - trigger: timer
-        entity_id: timer.basement_bathroom_exhaust_timer
-      - trigger: timer
-        entity_id: timer.den_ceiling_fan_timer
-      - trigger: timer
-        entity_id: timer.guest_room_fan_timer
-      - trigger: timer
-        entity_id: timer.guest_bathroom_exhaust_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.owner_suite_fan_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.owner_suite_bathroom_exhaust_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.office_ceiling_fan_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.basement_bathroom_exhaust_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.den_ceiling_fan_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.guest_room_fan_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.guest_bathroom_exhaust_timer
     actions:
       - variables:
           fan_map:
@@ -298,7 +312,7 @@ automation:
             timer.guest_bathroom_exhaust_timer: fan.guest_bathroom_exhaust
       - action: fan.turn_off
         target:
-          entity_id: "{{ fan_map[trigger.entity_id] }}"
+          entity_id: "{{ fan_map[trigger.event.data.entity_id] }}"
 
   - alias: bedroom_fan_control
     id: bedroom_fan_control


### PR DESCRIPTION
## Summary
- Fixes #657.
- Replaces HA Labs-gated `trigger: timer` entries in `fan_off_when_timer_ends` with stable raw `timer.finished` event triggers.
- Maps timer entities from `trigger.event.data.entity_id`, matching the raw event payload.

## Runtime evidence
Live Home Assistant 2026.5.1 reports `automation.fan_off_when_timer_ends` as `unavailable`. The HA log says the automation failed setup because `Trigger 'timer' requires the experimental 'New triggers and conditions' feature to be enabled`.

## Validation
- PASS: `uv run --with pytest pytest tests/test_issue_617_timer_triggers.py`
- PASS: `ruby -e 'require "yaml"; YAML.load_file("packages/fans.yaml"); puts "packages/fans.yaml yaml ok"'`
- PASS: `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/fans.yaml`
- PASS: `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/fans.yaml --strict`
- PASS: `uv run --with pytest pytest` (`435 passed`)
