### PR TITLE
Fix #656 Inky weather fallback when Tomorrow.io is unavailable

### DIFF
--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -113,6 +113,8 @@ script:
     sequence:
       - variables:
           requested_mode: "{{ mode | default('auto', true) | string | trim }}"
+          owner_suite_daily_forecast: {}
+          owner_suite_hourly_forecast: {}
           resolved_mode: >-
             {% set requested = requested_mode %}
             {% set house_mode = states('input_select.house_mode') %}
@@ -137,18 +139,28 @@ script:
                is_state('binary_sensor.bayesian_zeke_home', 'on')
                and is_state('input_boolean.trip', 'off')
              ) }}
-      - action: weather.get_forecasts
-        target:
-          entity_id: weather.tomorrow_io_the_brewery_daily
-        data:
-          type: daily
-        response_variable: owner_suite_daily_forecast
-      - action: weather.get_forecasts
-        target:
-          entity_id: weather.tomorrow_io_the_brewery_daily
-        data:
-          type: hourly
-        response_variable: owner_suite_hourly_forecast
+      - choose:
+          - conditions:
+              - condition: not
+                conditions:
+                  - condition: state
+                    entity_id: weather.tomorrow_io_the_brewery_daily
+                    state:
+                      - "unknown"
+                      - "unavailable"
+            sequence:
+              - action: weather.get_forecasts
+                target:
+                  entity_id: weather.tomorrow_io_the_brewery_daily
+                data:
+                  type: daily
+                response_variable: owner_suite_daily_forecast
+              - action: weather.get_forecasts
+                target:
+                  entity_id: weather.tomorrow_io_the_brewery_daily
+                data:
+                  type: hourly
+                response_variable: owner_suite_hourly_forecast
       - action: calendar.get_events
         target:
           entity_id: calendar.ryan_claussen

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -116,6 +116,12 @@ def test_owner_suite_night_preview_includes_current_and_tomorrow_weather() -> No
     block = _script_block("publish_owner_suite_inky_display")
 
     assert "action: weather.get_forecasts" in block
+    assert "owner_suite_daily_forecast: {}" in block
+    assert "owner_suite_hourly_forecast: {}" in block
+    assert "condition: not" in block
+    assert "entity_id: weather.tomorrow_io_the_brewery_daily" in block
+    assert '  - "unknown"' in block
+    assert '  - "unavailable"' in block
     assert "type: daily" in block
     assert "response_variable: owner_suite_daily_forecast" in block
     assert "type: hourly" in block


### PR DESCRIPTION
## Summary
- Fixes #656.
- Initializes the owner-suite Inky forecast response variables to empty mappings before service calls.
- Guards the `weather.get_forecasts` response-data calls behind a native HA `not` + `state` condition so unavailable Tomorrow.io weather does not abort the publish script.
- Preserves the existing `sensor.active_weather_entity_id` `forecast_json` fallback and degraded `Tomorrow: Unavailable` rendering path.

## Runtime evidence
Live Home Assistant 2026.5.1 has `weather.tomorrow_io_the_brewery_daily` unavailable. The owner-suite Inky publish script fails with `Service call requested response data but did not match any entities`, and the publish automation logs the same downstream failure.

## Validation
- PASS: `uv run --with pytest pytest tests/test_inky_displays_package.py`
- PASS: `PYTHONPATH=. uv run --with pytest pytest tests/test_inky_display_renderer.py tests/test_inky_display_service.py`
- PASS: `ruby -e 'require "yaml"; YAML.load_file("packages/inky_displays.yaml"); puts "packages/inky_displays.yaml yaml ok"'`
- PASS: `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/inky_displays.yaml`
- PASS: `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/inky_displays.yaml --strict`
- BLOCKED: `uv run --with pytest pytest` reports only the known `tests/test_issue_617_timer_triggers.py` failures from #657 on current `origin/develop`; PR #658 fixes those without bundling unrelated changes here.
- BLOCKED: HA `check_config` against this branch alone would hit the same base fan-trigger defect until #658 lands.

## Dependency
This PR should be merged after #658 or rebased after #658 lands so full-suite and config-check validation run against a healthy `develop` base.
