### PR TITLE
fix: revert fan_off_when_timer_ends to stable event trigger

### DIFF
--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -272,20 +272,34 @@ automation:
     trace:
       stored_traces: 100
     triggers:
-      - trigger: timer
-        entity_id: timer.owner_suite_fan_timer
-      - trigger: timer
-        entity_id: timer.owner_suite_bathroom_exhaust_timer
-      - trigger: timer
-        entity_id: timer.office_ceiling_fan_timer
-      - trigger: timer
-        entity_id: timer.basement_bathroom_exhaust_timer
-      - trigger: timer
-        entity_id: timer.den_ceiling_fan_timer
-      - trigger: timer
-        entity_id: timer.guest_room_fan_timer
-      - trigger: timer
-        entity_id: timer.guest_bathroom_exhaust_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.owner_suite_fan_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.owner_suite_bathroom_exhaust_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.office_ceiling_fan_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.basement_bathroom_exhaust_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.den_ceiling_fan_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.guest_room_fan_timer
+      - trigger: event
+        event_type: timer.finished
+        event_data:
+          entity_id: timer.guest_bathroom_exhaust_timer
     actions:
       - variables:
           fan_map:
@@ -298,7 +312,7 @@ automation:
             timer.guest_bathroom_exhaust_timer: fan.guest_bathroom_exhaust
       - action: fan.turn_off
         target:
-          entity_id: "{{ fan_map[trigger.entity_id] }}"
+          entity_id: "{{ fan_map[trigger.event.data.entity_id] }}"
 
   - alias: bedroom_fan_control
     id: bedroom_fan_control


### PR DESCRIPTION
## Summary

- Reverts all seven `trigger: timer` triggers back to `trigger: event` / `timer.finished` with `event_data.entity_id` filters
- Updates the fan-lookup template from `trigger.entity_id` → `trigger.event.data.entity_id` to match the event trigger variable

## Problem

PR #649 switched the triggers to the native `trigger: timer` platform. That platform requires the HA Labs **"New triggers and conditions"** feature flag (`new_triggers_conditions`), which is **not** enabled on the live instance. Every restart since #649 has left `automation.fan_off_when_timer_ends` in state `unavailable`, so fan and exhaust timer helpers no longer turn off their targets when timers expire.

## Test plan

- [ ] YAML lint / parse for `packages/fans.yaml`
- [ ] `ha_check_config`
- [ ] Automation loads without Repairs notice after HA reload
- [ ] Start a fan timer and confirm the target fan turns off when it expires
- [ ] Full `uv run --with pytest pytest`

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)