### PR TITLE
Expand owner suite Inky quote rotation

### DIFF
--- a/data/inky_owner_suite_quotes.yaml
+++ b/data/inky_owner_suite_quotes.yaml
@@ -1,0 +1,30 @@
+# Curated owner-suite Inky display quotes.
+#
+# Keep entries short. The 400x300 physical panel renders quote text as at most
+# two centered lines, so tests enforce conservative quote and speaker limits.
+- quote: Never tell me the odds.
+  speaker: Han Solo
+- quote: I am no man.
+  speaker: Eowyn
+- quote: This is the way.
+  speaker: Din Djarin
+- quote: Tea. Earl Grey. Hot.
+  speaker: Jean-Luc Picard
+- quote: So say we all.
+  speaker: William Adama
+- quote: Money is a sign of poverty.
+  speaker: The Culture
+- quote: Just read the instructions.
+  speaker: Jernau Gurgeh
+- quote: Goddamnit, Donut.
+  speaker: Carl
+- quote: Mongo is appalled!
+  speaker: Princess Donut
+- quote: Don't panic.
+  speaker: The Guide
+- quote: Mostly harmless.
+  speaker: The Guide
+- quote: Ook.
+  speaker: The Librarian
+- quote: The turtle moves.
+  speaker: Brutha

--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -217,6 +217,17 @@ Current owner-suite rows:
 | Speaker | Character attribution for the quote | Rendered under the centered quote, not as a standard row |
 | Status | First active status from weather alert, garage door, front door, rain in the next hour, precipitation/weather during the next `calendar.ryan_claussen` event, trip mode, vacation, otherwise `All clear` | `urgent` for alert/door/garage/rain/event weather, `emphasis` for trip/vacation |
 
+The quote source is the curated local file
+`data/inky_owner_suite_quotes.yaml`, included by
+`script.publish_owner_suite_inky_display` as `quote_entries`. There is no
+external quote API and no runtime scraping. Keep entries short enough for the
+`400x300` panel, use the in-universe speaker/character for attribution, and
+avoid adding long copyrighted excerpts. Tests enforce conservative quote and
+speaker length limits so entries cannot overrun the physical screen. Current
+quote families include Star Wars, The Lord of the Rings, Star Trek, Battlestar
+Galactica, The Culture, Dungeon Crawler Carl, The Hitchhiker's Guide to the
+Galaxy, and Discworld.
+
 In `night_preview`, the owner-suite rows are current `Weather`, tomorrow's
 daily forecast from `weather.get_forecasts`, next `Alarm`, and either the
 meeting alarm or urgent `Status`. Meeting alarm details are night-only, and

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -115,6 +115,7 @@ script:
           requested_mode: "{{ mode | default('auto', true) | string | trim }}"
           owner_suite_daily_forecast: {}
           owner_suite_hourly_forecast: {}
+          quote_entries: !include ../data/inky_owner_suite_quotes.yaml
           resolved_mode: >-
             {% set requested = requested_mode %}
             {% set house_mode = states('input_select.house_mode') %}
@@ -251,13 +252,6 @@ script:
                 {% set next_calendar.place = item_location if item_location != '' else 'No location' %}
               {% endif %}
             {% endfor %}
-            {% set quote_entries = [
-              {'quote': 'Never tell me the odds.', 'speaker': 'Han Solo'},
-              {'quote': 'I am no man.', 'speaker': 'Eowyn'},
-              {'quote': 'This is the way.', 'speaker': 'Din Djarin'},
-              {'quote': 'Tea. Earl Grey. Hot.', 'speaker': 'Jean-Luc Picard'},
-              {'quote': 'So say we all.', 'speaker': 'William Adama'}
-            ] %}
             {% set quote_entry = quote_entries[(now().strftime('%j') | int) % (quote_entries | count)] %}
             {% set quote_value = quote_entry.quote %}
             {% set quote_speaker = quote_entry.speaker %}

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PATH = ROOT / "packages" / "inky_displays.yaml"
 DOC_PATH = ROOT / "docs" / "inky_displays.md"
+QUOTE_PATH = ROOT / "data" / "inky_owner_suite_quotes.yaml"
 
 
 def _package_text() -> str:
@@ -159,10 +161,45 @@ def test_owner_suite_daytime_rows_use_calendar_or_quote_context_not_alarms() -> 
     assert "'value': quote_speaker" in quote_block
     assert "'label': 'Source'" not in quote_block
     assert "Sci-fi/fantasy" not in quote_block
-    assert "'speaker': 'Han Solo'" in block
-    assert "'speaker': 'Jean-Luc Picard'" in block
     assert "'label': 'Alarm'" not in daytime_block
     assert "'label': 'Meeting'" not in daytime_block
+
+
+def test_owner_suite_quote_entries_load_from_curated_file() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+
+    assert "quote_entries: !include ../data/inky_owner_suite_quotes.yaml" in block
+    assert "{% set quote_entries = [" not in block
+
+
+def test_owner_suite_quote_file_stays_screen_safe() -> None:
+    text = QUOTE_PATH.read_text(encoding="utf-8")
+    quotes = re.findall(r"^-\s+quote:\s+(.+)$", text, flags=re.MULTILINE)
+    speakers = re.findall(r"^\s+speaker:\s+(.+)$", text, flags=re.MULTILINE)
+
+    assert len(quotes) >= 10
+    assert len(quotes) == len(speakers)
+
+    for quote in quotes:
+        clean_quote = quote.strip("\"'")
+        assert len(clean_quote) <= 34
+
+    for speaker in speakers:
+        clean_speaker = speaker.strip("\"'")
+        assert len(clean_speaker) <= 24
+
+    for required_speaker in (
+        "Han Solo",
+        "Jean-Luc Picard",
+        "The Culture",
+        "Jernau Gurgeh",
+        "Carl",
+        "Princess Donut",
+        "The Guide",
+        "The Librarian",
+        "Brutha",
+    ):
+        assert f"speaker: {required_speaker}" in text
 
 
 def test_owner_suite_payload_maps_weather_icons_and_exceptions() -> None:


### PR DESCRIPTION
## Summary
- document that owner-suite Inky quotes come from the static `quote_entries` list in `packages/inky_displays.yaml`
- add short attributed quote entries for The Culture, Dungeon Crawler Carl, Douglas Adams / Hitchhiker's Guide, and Terry Pratchett / Discworld
- extend quote coverage tests for the new speakers

## Tests
- python3 -m pytest tests/test_inky_displays_package.py tests/test_inky_display_renderer.py
- uv run --with pytest pytest

Refs #313