### PR TITLE
feat: auto-track departure airport + live flight map card

### DIFF
--- a/lovelace/tiles/tiles_travel_flight.yaml
+++ b/lovelace/tiles/tiles_travel_flight.yaml
@@ -1,0 +1,44 @@
+# Travel flight live tile.
+# Shows FR24 live position map and key flight stats when a flight is tracked.
+# Sensors go 'none'/'unavailable' between trips — the tile is always present but harmlessly quiet.
+
+type: custom:vertical-stack-in-card
+title: Travel Flight
+cards:
+  - type: map
+    entities:
+      - entity: sensor.next_travel_flight_fr24_live
+    hours_to_show: 0
+    aspect_ratio: "16:9"
+
+  - type: glance
+    show_name: true
+    show_state: true
+    entities:
+      - entity: sensor.next_travel_flight
+        name: Flight
+      - entity: sensor.next_travel_flight_live_status
+        name: Status
+      - entity: sensor.next_travel_flight_fr24_live
+        name: FR24
+
+  - type: entities
+    entities:
+      - type: attribute
+        entity: sensor.next_travel_flight_fr24_live
+        attribute: altitude
+        name: Altitude
+        suffix: " ft"
+      - type: attribute
+        entity: sensor.next_travel_flight_fr24_live
+        attribute: ground_speed
+        name: Ground Speed
+        suffix: " kts"
+      - type: attribute
+        entity: sensor.next_travel_flight_live_status
+        attribute: estimated_arrival
+        name: Est. Arrival
+      - entity: sensor.next_travel_flight_airport_delay
+        name: Airport Delay
+      - entity: sensor.next_travel_flight_destination_weather
+        name: Dest. Weather

--- a/lovelace/views/view_home.yaml
+++ b/lovelace/views/view_home.yaml
@@ -11,6 +11,7 @@ cards:
   - !include /config/lovelace/tiles/tiles_master_bedroom.yaml
   - !include /config/lovelace/tiles/tiles_living_room.yaml
   - !include /config/lovelace/tiles/tiles_outside.yaml
+  - !include /config/lovelace/tiles/tiles_travel_flight.yaml
   - !include /config/lovelace/tiles/tiles_kitchen.yaml
   - !include /config/lovelace/tiles/tiles_office.yaml
   - !include /config/lovelace/tiles/tiles_bathroom.yaml

--- a/packages/flight_status.yaml
+++ b/packages/flight_status.yaml
@@ -67,6 +67,35 @@ automation:
                 data:
                   value: "{{ trigger.from_state.state }}"
 
+  - alias: "FR24: Auto-track departure airport"
+    id: fr24_auto_track_departure_airport
+    mode: single
+    trigger:
+      - trigger: homeassistant
+        event: start
+      - trigger: state
+        entity_id: sensor.next_travel_flight
+        attribute: origin_code
+    action:
+      - variables:
+          origin: "{{ state_attr('sensor.next_travel_flight', 'origin_code') | default('') | upper | trim }}"
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ origin not in ['', 'UNKNOWN', 'UNAVAILABLE'] }}"
+            sequence:
+              - action: text.set_value
+                target:
+                  entity_id: text.flightradar24_airport_track
+                data:
+                  value: "{{ origin }}"
+        default:
+          - action: text.set_value
+            target:
+              entity_id: text.flightradar24_airport_track
+            data:
+              value: "MSP"
+
 ################################################
 ## REST Commands
 ################################################

--- a/packages/flight_status.yaml
+++ b/packages/flight_status.yaml
@@ -78,11 +78,11 @@ automation:
         attribute: origin_code
     action:
       - variables:
-          origin: "{{ state_attr('sensor.next_travel_flight', 'origin_code') | default('') | upper | trim }}"
+          origin: "{{ state_attr('sensor.next_travel_flight', 'origin_code') | default('', true) | upper | trim }}"
       - choose:
           - conditions:
               - condition: template
-                value_template: "{{ origin not in ['', 'UNKNOWN', 'UNAVAILABLE'] }}"
+                value_template: "{{ origin not in ['', 'NONE', 'UNKNOWN', 'UNAVAILABLE'] }}"
             sequence:
               - action: text.set_value
                 target:


### PR DESCRIPTION
## Summary
- **Closes #666**: Adds `FR24: Auto-track departure airport` automation — fires on HA start and whenever `sensor.next_travel_flight`'s `origin_code` attribute changes. Sets `text.flightradar24_airport_track` to the departure airport so the delay sensor works for non-MSP origins (RST, etc.). Falls back to `MSP` when no flight is tracked.
- **Closes #667**: Adds `lovelace/tiles/tiles_travel_flight.yaml` — a map card showing the live position from `sensor.next_travel_flight_fr24_live`, a glance row with flight/status/FR24 state, and an entities list for altitude, ground speed, estimated arrival, airport delay, and destination weather. Tile is included in the Home dashboard view after `tiles_outside`.

## Test plan
- [ ] Reload config and confirm `text.flightradar24_airport_track` updates to `MSP` (the current DL877 departure) via the new automation
- [ ] Simulate a RST departure by temporarily changing origin_code; confirm automation switches track to RST and delay sensor shows `unavailable` (RST not tracked) rather than wrong MSP data
- [ ] On Thursday when DL877 is in the air, confirm map card shows aircraft position and altitude/speed populate
- [ ] Confirm tile renders on the Home dashboard without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)