### PR TITLE
feat: track mouse bucket catches with counter and notification

### DIFF
--- a/packages/mouse_trap.yaml
+++ b/packages/mouse_trap.yaml
@@ -1,0 +1,40 @@
+homeassistant:
+  customize:
+    package.node_anchors:
+      customize: &customize
+        package: "mouse_trap"
+
+########################
+## Counter
+########################
+counter:
+  mice_caught:
+    name: "Mice Caught"
+    icon: mdi:rodent
+    minimum: 0
+    restore: true
+
+########################
+## Automation
+########################
+automation:
+  - alias: "Mouse Bucket — Notify and count on catch"
+    description: >
+      When the mouse bucket door sensor opens (closed→open), increment the
+      mice caught counter and send a notification with the running total.
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.basement_mouse_bucket_contact
+        from: "off"
+        to: "on"
+    action:
+      - action: counter.increment
+        target:
+          entity_id: counter.mice_caught
+      - action: notify.notify
+        data:
+          title: "Mouse Caught!"
+          message: >
+            The basement mouse bucket door opened.
+            Total caught: {{ states('counter.mice_caught') }}.
+    mode: single


### PR DESCRIPTION
## Summary

- Adds `packages/mouse_trap.yaml` for the basement bucket mouse trap
- `counter.mice_caught` tracks total catches and persists across HA restarts
- Automation fires on `binary_sensor.basement_mouse_bucket_contact` `off → on` (closed → open), increments the counter, and sends a `notify.notify` with the running total

Closes #669

## Notes

- The counter and automation were also created via the HA UI/API — remove those UI entries before merging to avoid duplicates
- Swap `notify.notify` for a specific device service (e.g. `notify.mobile_app_*`) if you want phone-targeted alerts
- Reset the counter from the HA dashboard (three-dot menu) after emptying the trap

## Test plan

- [ ] Trigger the sensor manually (e.g. open/close the door) and confirm a notification arrives
- [ ] Confirm `counter.mice_caught` increments each trigger
- [ ] Confirm counter survives an HA restart
- [ ] Confirm counter resets to 0 via the UI button

🤖 Generated with [Claude Code](https://claude.com/claude-code)