### PR TITLE
Fix #671 FR24 recorder attribute warnings

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -115,6 +115,10 @@ recorder:
       # Live Z2M decommission helpers keep large selection maps as attributes.
       # Recorder cannot persist those attributes and logs repeated size warnings.
       - sensor.z2m_lifecycle_issues
+      # Raw FlightRadar24 airport feeds carry full flight lists in attributes.
+      # Keep derived travel sensors recorded instead of these oversized feeds.
+      - sensor.flightradar24_airport_arrivals
+      - sensor.flightradar24_airport_departures
 
 influxdb:
   exclude:

--- a/packages/flight_status.yaml
+++ b/packages/flight_status.yaml
@@ -39,6 +39,8 @@ automation:
   - alias: "FR24: Track upcoming travel flight"
     id: fr24_track_upcoming_travel_flight
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.next_travel_flight
@@ -70,6 +72,8 @@ automation:
   - alias: "FR24: Auto-track departure airport"
     id: fr24_auto_track_departure_airport
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -123,6 +123,16 @@ def test_large_z2m_lifecycle_helper_is_excluded_from_recorder() -> None:
     assert "large selection maps as attributes" in recorder_block
 
 
+def test_raw_fr24_airport_feeds_are_excluded_from_recorder() -> None:
+    text = _read(CONFIGURATION_PATH)
+
+    recorder_block = text.split("recorder:\n", 1)[1].split("\ninfluxdb:", 1)[0]
+
+    assert "sensor.flightradar24_airport_arrivals" in recorder_block
+    assert "sensor.flightradar24_airport_departures" in recorder_block
+    assert "full flight lists in attributes" in recorder_block
+
+
 def test_garbage_notifications_use_computed_pickup_date_sensor() -> None:
     text = _read(UTILITIES_PATH)
 


### PR DESCRIPTION
Fixes #671.

## Summary
- Excludes raw `sensor.flightradar24_airport_arrivals` and `sensor.flightradar24_airport_departures` from Recorder so their oversized `flights` attributes stop generating repeated DB warnings.
- Keeps smaller derived travel sensors recordable for history and dashboards.
- Adds missing `stored_traces: 100` to the two FR24 automations introduced on `develop`, which the full suite caught via the repo trace-retention contract.
- Adds a regression test for the FR24 Recorder exclusions.

## Runtime evidence
Live Home Assistant 2026.5.1 repeatedly logged:

- `State attributes for sensor.flightradar24_airport_arrivals exceed maximum size of 16384 bytes`
- `State attributes for sensor.flightradar24_airport_departures exceed maximum size of 16384 bytes`

Live state showed the derived sensors were healthy and should remain recorded:

- `sensor.next_travel_flight_airport_delay`: `9`
- `sensor.next_travel_flight`: `DL877`
- `text.flightradar24_airport_track`: `MSP`

## Validation
- PASS: `uv run --with pytest pytest tests/test_runtime_log_regressions.py tests/test_trace_storage.py -q` (`21 passed`)
- PASS: `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml packages/flight_status.yaml`
- PASS: `git diff --check`
- PASS: `uv run --with pytest pytest` (`440 passed`)
- PASS: `uv run --python 3.14 --with homeassistant==2026.5.0 python -m homeassistant --config <tmp copy> --script check_config`
- BLOCKED: containerized CI-equivalent `podman run ... ghcr.io/home-assistant/home-assistant:2026.5.0 ... check_config` because local Podman is not connected to a VM/socket.
