### PR TITLE
Show numeric airport delay on owner suite Inky

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -255,7 +255,7 @@ Flight rows use these normalized entities from `packages/flight_status.yaml`:
 | --- | --- | --- |
 | Flight | `sensor.next_travel_flight` ident, destination code, and best departure time | `emphasis` |
 | Status | `sensor.next_travel_flight_live_status` plus FlightAware delay attributes | `urgent` for cancellation, diversion, or 30+ minute delay |
-| Airport | `sensor.next_travel_flight_airport_delay` | `urgent` when airport delay alerts are present; otherwise shows `Airport n/a` until a free delay source is configured |
+| Airport | `sensor.next_travel_flight_airport_delay` numeric average delay for the active origin airport | Compact value like `MSP 14m avg`; `urgent` at 30+ minutes; `Airport n/a` only when origin airport delay data is unavailable |
 | Dest Wx | `sensor.next_travel_flight_destination_weather` | `normal` |
 
 Required travel integrations and secrets:
@@ -268,10 +268,9 @@ Required travel integrations and secrets:
   FlightAware reports actual takeoff.
 - Open-Meteo destination weather does not require a key. It uses the destination
   airport coordinate map in `packages/flight_status.yaml`.
-- Add the built-in FAA Delays integration for `MSP` and `RST` from Settings >
-  Devices & services for richer airport-delay visibility elsewhere in Home
-  Assistant. The Inky flight row currently stays `Airport n/a` unless a free
-  airport-delay source is added later.
+- FlightRadar24 airport tracking must be pointed at the active origin airport
+  by `text.flightradar24_airport_track`. `sensor.next_travel_flight_airport_delay`
+  normalizes the tracked airport departure delay average for the Inky row.
 
 REST sensors require a Home Assistant restart after the package and secrets are
 deployed. Template-only changes can be reloaded, but the travel package includes

--- a/packages/flight_status.yaml
+++ b/packages/flight_status.yaml
@@ -39,6 +39,8 @@ automation:
   - alias: "FR24: Track upcoming travel flight"
     id: fr24_track_upcoming_travel_flight
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: state
         entity_id: sensor.next_travel_flight
@@ -70,6 +72,8 @@ automation:
   - alias: "FR24: Auto-track departure airport"
     id: fr24_auto_track_departure_airport
     mode: single
+    trace:
+      stored_traces: 100
     trigger:
       - trigger: homeassistant
         event: start

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -303,13 +303,15 @@ script:
             {% set delay_minutes = state_attr('sensor.next_travel_flight_live_status', 'departure_delay_minutes') %}
             {% set flight_delay_value = ('Delay ' ~ delay_minutes ~ 'm') if delay_minutes not in ['', none, 'unknown', 'unavailable'] and delay_minutes | int(0) > 0 else (flight_status | replace('_', ' ') | title) %}
             {% set airport_delay = states('sensor.next_travel_flight_airport_delay') %}
-            {% set airport_summary = state_attr('sensor.next_travel_flight_airport_delay', 'summary') | default('Airport n/a', true) %}
-            {% set airport_value = airport_summary if airport_delay == 'alert' else 'Airport n/a' %}
+            {% set airport_origin = state_attr('sensor.next_travel_flight', 'origin_code') | default('', true) | string | upper %}
+            {% set airport_delay_minutes = airport_delay | int(default=none) %}
+            {% set airport_value = (airport_origin ~ ' ' ~ airport_delay_minutes ~ 'm avg') if airport_delay_minutes is number and airport_origin not in ['', 'UNKNOWN', 'UNAVAILABLE'] else 'Airport n/a' %}
+            {% set airport_level = 'urgent' if airport_delay_minutes is number and airport_delay_minutes >= 30 else 'normal' %}
             {% set destination_weather = states('sensor.next_travel_flight_destination_weather') %}
             {% set travel_rows = [
               {'label': 'Flight', 'value': (flight_label ~ ' ' ~ flight_destination ~ ' ' ~ flight_time) | trim, 'level': 'emphasis'},
               {'label': 'Status', 'value': flight_delay_value, 'level': 'urgent' if flight_status in ['cancelled', 'diverted'] or delay_minutes | int(0) >= 30 else 'normal'},
-              {'label': 'Airport', 'value': airport_value, 'level': 'urgent' if airport_delay == 'alert' else 'normal'},
+              {'label': 'Airport', 'value': airport_value, 'level': airport_level},
               {'icon': weather_icon, 'label': 'Dest Wx', 'value': destination_weather if destination_weather not in ['unknown', 'unavailable', ''] else weather_value, 'level': 'normal'}
             ] %}
             {% if weather_alert %}
@@ -364,7 +366,7 @@ script:
               {% set rows = [
                 {'icon': weather_icon, 'label': 'Weather', 'value': weather_value, 'level': 'urgent' if weather_alert else 'normal'},
                 {'label': 'Flight', 'value': (flight_label ~ ' ' ~ flight_destination ~ ' ' ~ flight_time) | trim, 'level': 'emphasis'},
-                {'label': 'Airport', 'value': airport_value, 'level': 'urgent' if airport_delay == 'alert' else 'normal'},
+                {'label': 'Airport', 'value': airport_value, 'level': airport_level},
                 {'label': 'Status', 'value': status_value, 'level': status_level}
               ] %}
             {% else %}

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -165,6 +165,17 @@ def test_owner_suite_daytime_rows_use_calendar_or_quote_context_not_alarms() -> 
     assert "'label': 'Meeting'" not in daytime_block
 
 
+def test_owner_suite_flight_rows_show_numeric_airport_delay() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+
+    assert "airport_delay_minutes = airport_delay | int(default=none)" in block
+    assert "airport_origin ~ ' ' ~ airport_delay_minutes ~ 'm avg'" in block
+    assert "airport_level = 'urgent' if airport_delay_minutes is number and airport_delay_minutes >= 30 else 'normal'" in block
+    assert "'label': 'Airport', 'value': airport_value, 'level': airport_level" in block
+    assert "airport_delay == 'alert'" not in block
+    assert "airport_summary" not in block
+
+
 def test_owner_suite_quote_entries_load_from_curated_file() -> None:
     block = _script_block("publish_owner_suite_inky_display")
 


### PR DESCRIPTION
## Summary
- fix owner-suite Inky airport row to use numeric `sensor.next_travel_flight_airport_delay` values instead of waiting for a nonexistent `alert` state
- show compact airport text such as `MSP 14m avg`, with urgent styling at 30+ minutes
- document the FlightRadar24 airport delay source and add trace retention for new FR24 automations so the full suite stays green

## Live diagnosis
- `sensor.next_travel_flight_airport_delay` currently reports `14` with summary `MSP: 14 min avg delay (53/143 flights delayed)`
- the display showed `Airport n/a` because the payload builder only used the summary when the sensor state was exactly `alert`

## Tests
- python3 -m pytest tests/test_inky_displays_package.py tests/test_inky_display_renderer.py
- uv run --with pytest pytest

Refs #313