### PR TITLE
Shorten owner suite Inky ATC delay label

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -255,7 +255,7 @@ Flight rows use these normalized entities from `packages/flight_status.yaml`:
 | --- | --- | --- |
 | Flight | `sensor.next_travel_flight` ident, destination code, and best departure time | `emphasis` |
 | Status | `sensor.next_travel_flight_live_status` plus FlightAware delay attributes | `urgent` for cancellation, diversion, or 30+ minute delay |
-| Airport Delays | `sensor.next_travel_flight_airport_delay` numeric average delay for the active origin airport | Compact value like `MSP 14m avg`; `urgent` at 30+ minutes; `Airport n/a` only when origin airport delay data is unavailable |
+| ATC Delay | `sensor.next_travel_flight_airport_delay` numeric average delay for the active origin airport | Compact value like `MSP 14m avg`; `urgent` at 30+ minutes; `Airport n/a` only when origin airport delay data is unavailable |
 | Dest Wx | `sensor.next_travel_flight_destination_weather` | `normal` |
 
 Required travel integrations and secrets:

--- a/inky_display/renderer.py
+++ b/inky_display/renderer.py
@@ -138,13 +138,7 @@ def _render_row(canvas: Canvas, row: dict[str, str], accent: str, y: int) -> Non
     label = row.get("label", "")
     canvas.icon(26, y - 4, row.get("icon", ""), scale=2, color=row_color)
     canvas.text(56, y, label, scale=2, color=row_color)
-    canvas.text(_row_value_left(label), y, row.get("value", ""), scale=2, color=row_color)
-
-
-def _row_value_left(label: str) -> int:
-    if label == "Airport Delays":
-        return 224
-    return 170
+    canvas.text(170, y, row.get("value", ""), scale=2, color=row_color)
 
 
 def _wrap_text(text: str, scale: int, max_width: int, max_lines: int) -> list[str]:

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -311,7 +311,7 @@ script:
             {% set travel_rows = [
               {'label': 'Flight', 'value': (flight_label ~ ' ' ~ flight_destination ~ ' ' ~ flight_time) | trim, 'level': 'emphasis'},
               {'label': 'Status', 'value': flight_delay_value, 'level': 'urgent' if flight_status in ['cancelled', 'diverted'] or delay_minutes | int(0) >= 30 else 'normal'},
-              {'label': 'Airport Delays', 'value': airport_value, 'level': airport_level},
+              {'label': 'ATC Delay', 'value': airport_value, 'level': airport_level},
               {'icon': weather_icon, 'label': 'Dest Wx', 'value': destination_weather if destination_weather not in ['unknown', 'unavailable', ''] else weather_value, 'level': 'normal'}
             ] %}
             {% if weather_alert %}
@@ -366,7 +366,7 @@ script:
               {% set rows = [
                 {'icon': weather_icon, 'label': 'Weather', 'value': weather_value, 'level': 'urgent' if weather_alert else 'normal'},
                 {'label': 'Flight', 'value': (flight_label ~ ' ' ~ flight_destination ~ ' ' ~ flight_time) | trim, 'level': 'emphasis'},
-                {'label': 'Airport Delays', 'value': airport_value, 'level': airport_level},
+                {'label': 'ATC Delay', 'value': airport_value, 'level': airport_level},
                 {'label': 'Status', 'value': status_value, 'level': status_level}
               ] %}
             {% else %}

--- a/tests/test_inky_display_renderer.py
+++ b/tests/test_inky_display_renderer.py
@@ -169,10 +169,6 @@ def test_footer_uses_larger_distance_legible_text_band() -> None:
     assert renderer.FOOTER_TEXT_SCALE == 2
 
 
-def test_airport_delays_label_reserves_space_for_value() -> None:
-    assert renderer._row_value_left("Airport Delays") > renderer._row_value_left("Airport")
-
-
 def test_renderer_prefers_trebuchet_then_verdana_font_stack() -> None:
     bold_stack = "\n".join(renderer.BOLD_FONT_CANDIDATES)
 

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -82,7 +82,7 @@ def test_owner_suite_payload_includes_modes_and_four_rows() -> None:
         "Meeting",
         "Status",
         "Flight",
-        "Airport Delays",
+        "ATC Delay",
         "Dest Wx",
         "Next",
         "Place",
@@ -171,7 +171,8 @@ def test_owner_suite_flight_rows_show_numeric_airport_delay() -> None:
     assert "airport_delay_minutes = airport_delay | int(default=none)" in block
     assert "airport_origin ~ ' ' ~ airport_delay_minutes ~ 'm avg'" in block
     assert "airport_level = 'urgent' if airport_delay_minutes is number and airport_delay_minutes >= 30 else 'normal'" in block
-    assert "'label': 'Airport Delays', 'value': airport_value, 'level': airport_level" in block
+    assert "'label': 'ATC Delay', 'value': airport_value, 'level': airport_level" in block
+    assert "'label': 'Airport Delays'," not in block
     assert "'label': 'Airport'," not in block
     assert "airport_delay == 'alert'" not in block
     assert "airport_summary" not in block


### PR DESCRIPTION
## Summary
- rename the owner-suite Inky flight row from `Airport Delays` to `ATC Delay`
- remove the extra renderer spacing needed by the longer label
- update docs and tests for the shorter label

## Tests
- python3 -m pytest tests/test_inky_displays_package.py tests/test_inky_display_renderer.py
- uv run --with pytest pytest

Refs #313