### PR TITLE
Guard Music Assistant playlists from personalized Spotify IDs

### DIFF
--- a/scripts/update_music_assistant_playlist.py
+++ b/scripts/update_music_assistant_playlist.py
@@ -22,6 +22,10 @@ SUPPORTED_PLAYLIST_SCRIPTS = {
 }
 
 SCRIPT_START_RE = re.compile(r"^  (?P<script>[A-Za-z0-9_]+):$")
+UNRESOLVABLE_PERSONALIZED_SPOTIFY_PLAYLIST_PATTERNS = (
+    "37i9dQZF1E",
+    "37i9dQZEVXc",
+)
 
 
 def append_item_to_playlist_config(content: str, script_id: str, item_uri: str) -> tuple[str, bool]:
@@ -30,6 +34,7 @@ def append_item_to_playlist_config(content: str, script_id: str, item_uri: str) 
         raise ValueError(f"Unsupported playlist target: {script_id}")
     if not item_uri or any(char in item_uri for char in ('"', "\n", "\r")):
         raise ValueError("Playlist items must be non-empty and single-line")
+    _reject_unresolvable_personalized_spotify_playlist(item_uri)
 
     lines = content.splitlines()
     start_index = _find_script_start(lines, script_id)
@@ -53,6 +58,16 @@ def append_item_to_playlist_config(content: str, script_id: str, item_uri: str) 
     if content.endswith("\n"):
         updated += "\n"
     return updated, True
+
+
+def _reject_unresolvable_personalized_spotify_playlist(item_uri: str) -> None:
+    if not any(pattern in item_uri for pattern in UNRESOLVABLE_PERSONALIZED_SPOTIFY_PLAYLIST_PATTERNS):
+        return
+
+    raise ValueError(
+        "Spotify personalized playlist IDs with 37i9dQZF1E* or 37i9dQZEVXc* "
+        "do not resolve through Music Assistant"
+    )
 
 
 def _find_script_start(lines: list[str], script_id: str) -> int:

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 MEDIA_PLAYER_PATH = Path(__file__).resolve().parents[1] / "packages" / "media_player.yaml"
 DASHBOARD_PATH = Path(__file__).resolve().parents[1] / ".storage" / "lovelace.ryan_new_mushroom"
+PERSONALIZED_SPOTIFY_PLAYLIST_MARKERS = ("37i9dQZF1E", "37i9dQZEVXc")
 
 
 def _script_block(script_id: str) -> str:
@@ -52,6 +53,14 @@ def _automation_block(automation_id: str) -> str:
             break
 
     return "\n".join(lines[start:end])
+
+
+def _active_playlist_items(script_id: str) -> list[str]:
+    block = _script_block(script_id)
+    match = re.search(r"\{%- set plists = \[(?P<items>.*?)\]\s*-%\}", block, re.DOTALL)
+    if match is None:
+        raise AssertionError(f"Could not find active plists block for {script_id!r}")
+    return re.findall(r'"([^"\n]+)"', match.group("items"))
 
 
 def test_music_assistant_item_helper_normalizes_spotify_uris() -> None:
@@ -313,6 +322,27 @@ def test_bedtime_playlist_includes_explicit_somafm_station_urls() -> None:
     assert 'media_item: "{{ playlist }}"' in block
     assert 'media_type: "{{ bedtime_media_type }}"' in block
     assert "'somafm.com' in playlist" in block
+
+
+def test_active_music_assistant_playlist_pools_exclude_personalized_spotify_ids() -> None:
+    for script_id in (
+        "bedroom_playlist_0",
+        "bedroom_playlist_1",
+        "bedroom_playlist_2",
+        "bedroom_playlist_3",
+        "bedroom_playlist_4",
+        "bedroom_playlist_5",
+        "spotify_arrival",
+        "spotify_bedtime",
+        "spotify_wake_up",
+    ):
+        active_items = _active_playlist_items(script_id)
+        blocked_items = [
+            item
+            for item in active_items
+            if any(marker in item for marker in PERSONALIZED_SPOTIFY_PLAYLIST_MARKERS)
+        ]
+        assert blocked_items == [], f"{script_id} has unresolvable Spotify items: {blocked_items}"
 
 
 def test_music_assistant_dashboard_exposes_player_card() -> None:

--- a/tests/test_update_music_assistant_playlist.py
+++ b/tests/test_update_music_assistant_playlist.py
@@ -70,6 +70,39 @@ def test_append_item_to_playlist_config_rejects_unknown_targets(media_player_con
         )
 
 
+@pytest.mark.parametrize(
+    "item_uri",
+    [
+        "spotify:playlist:37i9dQZF1E37INBdbw9l8Q",
+        "spotify:user:spotify:playlist:37i9dQZF1E4AQ4IdimJyYD",
+        "https://open.spotify.com/playlist/37i9dQZEVXcMDffrPenJPl",
+    ],
+)
+def test_append_item_to_playlist_config_rejects_personalized_spotify_ids(
+    media_player_config_text: str,
+    item_uri: str,
+) -> None:
+    with pytest.raises(ValueError, match="do not resolve through Music Assistant"):
+        append_item_to_playlist_config(
+            media_player_config_text,
+            "spotify_bedtime",
+            item_uri,
+        )
+
+
+def test_append_item_to_playlist_config_allows_editorial_spotify_ids(
+    media_player_config_text: str,
+) -> None:
+    updated, changed = append_item_to_playlist_config(
+        media_player_config_text,
+        "spotify_bedtime",
+        "spotify:playlist:37i9dQZF1DX4WYpdgoIcn6",
+    )
+
+    assert changed is True
+    assert '"spotify:playlist:37i9dQZF1DX4WYpdgoIcn6"' in _script_block(updated, "spotify_bedtime")
+
+
 def test_supported_playlist_scripts_cover_dashboard_targets() -> None:
     assert SUPPORTED_PLAYLIST_SCRIPTS == {
         "bedroom_playlist_0",


### PR DESCRIPTION
## Summary
- Reject Spotify personalized playlist IDs with `37i9dQZF1E*` or `37i9dQZEVXc*` in the Music Assistant playlist append helper.
- Add regression coverage for rejected personalized IDs, allowed editorial IDs, and active playlist pools.

Fixes #635

## Validation
- `uv run --with pytest pytest tests/test_update_music_assistant_playlist.py tests/test_media_player_music_assistant.py`
- `uv run --with pytest pytest`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt`
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`

## Not run
- Docker Home Assistant `check_config`: Docker is not installed in this local environment.