### PR TITLE
Fix #680 FlightAware live-status Recorder payload

### DIFF
--- a/packages/flight_status.yaml
+++ b/packages/flight_status.yaml
@@ -426,8 +426,14 @@ template:
           flightaware_flight_json: >-
             {% set raw_payload = flightaware_raw_json | default('{}', true) %}
             {% set payload = raw_payload if raw_payload is mapping else raw_payload | from_json(default={}) %}
-            {% set flights = payload.flights if payload is mapping and payload.flights is sequence else [] %}
-            {{ (flights[0] if flights | count > 0 else {}) | to_json }}
+            {% if payload is mapping and payload.flights is sequence %}
+              {% set flights = payload.flights %}
+              {{ (flights[0] if flights | count > 0 else {}) | to_json }}
+            {% elif payload is mapping %}
+              {{ payload | to_json }}
+            {% else %}
+              {{ {} | to_json }}
+            {% endif %}
           flightaware_polled: "{{ should_poll_flightaware and flightaware_response is defined and flightaware_response.status in [200, '200'] }}"
     sensor:
       - name: Next Travel Flight Live Status
@@ -494,7 +500,7 @@ template:
             {% else %}
               {{ '' }}
             {% endif %}
-          raw_json: "{{ flightaware_raw_json }}"
+          raw_json: "{{ flightaware_flight_json }}"
           last_polled: >-
             {% if flightaware_polled %}
               {{ now().isoformat() }}

--- a/tests/test_flight_status_package.py
+++ b/tests/test_flight_status_package.py
@@ -61,6 +61,15 @@ def test_flight_status_keeps_calendar_fallback_when_live_api_is_unavailable() ->
     assert "active_window" in text
 
 
+def test_live_status_keeps_compact_raw_payload_for_recorder() -> None:
+    text = _package_text()
+
+    assert 'raw_json: "{{ flightaware_flight_json }}"' in text
+    assert 'raw_json: "{{ flightaware_raw_json }}"' not in text
+    assert "payload.flights is sequence" in text
+    assert "payload | to_json" in text
+
+
 def test_flightaware_polling_policy_avoids_unnecessary_calls() -> None:
     text = _package_text()
 


### PR DESCRIPTION
Fixes #680.

## Summary
- Store only the normalized first-flight object in `sensor.next_travel_flight_live_status.raw_json` instead of the full FlightAware API response.
- Preserve compatibility with the previous full-response shape so the next render can compact an existing oversized live attribute.
- Add regression coverage that prevents the full raw response from being stored again.

## Runtime evidence
- Live HA 2026.5.1 logged `State attributes for sensor.next_travel_flight_live_status exceed maximum size of 16384 bytes`.
- Live `sensor.next_travel_flight_live_status` attributes were about 26 KB because `raw_json` held the full FlightAware response.
- The extracted first-flight object needed by downstream templates was about 1.7 KB.

## Validation
- PASS: `uv run --with pytest pytest tests/test_flight_status_package.py -q` (`7 passed`)
- PASS: `ruby -e 'require "yaml"; YAML.load_file("packages/flight_status.yaml"); puts "packages/flight_status.yaml yaml ok"'`
- PASS: `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/flight_status.yaml`
- PASS: `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/flight_status.yaml --strict`
- PASS: `git diff --check`
- PASS: `uv run --with pytest pytest` (`442 passed`)
- PASS: `uv run --python 3.14 --with homeassistant==2026.5.0 python -m homeassistant --config <tmp copy> --script check_config`
- BLOCKED: containerized `podman run ghcr.io/home-assistant/home-assistant:2026.5.0 ... check_config`; local Podman is installed but not connected to a VM/socket.
