### PR TITLE
Fix #682 BirdWeather top-50 Recorder warning

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -119,6 +119,10 @@ recorder:
       # Keep derived travel sensors recorded instead of these oversized feeds.
       - sensor.flightradar24_airport_arrivals
       - sensor.flightradar24_airport_departures
+      # BirdWeather top-50 feeds carry the full species list in attributes.
+      # Keep smaller current/latest bird summary sensors recorded instead.
+      - sensor.top_50_bird_species
+      - sensor.top_50_bird_species_2
 
 influxdb:
   exclude:

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -133,6 +133,16 @@ def test_raw_fr24_airport_feeds_are_excluded_from_recorder() -> None:
     assert "full flight lists in attributes" in recorder_block
 
 
+def test_raw_birdweather_top_50_feed_is_excluded_from_recorder() -> None:
+    text = _read(CONFIGURATION_PATH)
+
+    recorder_block = text.split("recorder:\n", 1)[1].split("\ninfluxdb:", 1)[0]
+
+    assert "sensor.top_50_bird_species" in recorder_block
+    assert "sensor.top_50_bird_species_2" in recorder_block
+    assert "full species list in attributes" in recorder_block
+
+
 def test_garbage_notifications_use_computed_pickup_date_sensor() -> None:
     text = _read(UTILITIES_PATH)
 

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -137,9 +137,14 @@ def test_raw_birdweather_top_50_feed_is_excluded_from_recorder() -> None:
     text = _read(CONFIGURATION_PATH)
 
     recorder_block = text.split("recorder:\n", 1)[1].split("\ninfluxdb:", 1)[0]
+    recorder_entities = {
+        line.strip().removeprefix("- ").strip()
+        for line in recorder_block.splitlines()
+        if line.strip().startswith("- ")
+    }
 
-    assert "sensor.top_50_bird_species" in recorder_block
-    assert "sensor.top_50_bird_species_2" in recorder_block
+    assert "sensor.top_50_bird_species" in recorder_entities
+    assert "sensor.top_50_bird_species_2" in recorder_entities
     assert "full species list in attributes" in recorder_block
 
 


### PR DESCRIPTION
Fixes #682.

## Summary
- Excludes the raw BirdWeather top-50 species REST sensor from Recorder.
- Covers both the default entity ID and current live suffixed entity ID.
- Keeps smaller current/latest bird summary sensors recordable.
- Adds a regression assertion for the Recorder exclusion.

## Runtime evidence
- Live HA 2026.5.1 logged `State attributes for sensor.top_50_bird_species_2 exceed maximum size of 16384 bytes`.
- Live `sensor.top_50_bird_species_2` attributes were about 17.2 KB because the `species` attribute stores the full top-50 list.
- Related sensors `sensor.garden_birds` and `sensor.latest_bird_detection_2` were small and healthy.

## Validation
- PASS: `uv run --with pytest pytest tests/test_runtime_log_regressions.py -q` (`21 passed`)
- PASS: `ruby -e 'require "yaml"; YAML.load_file("configuration.yaml"); puts "configuration.yaml yaml ok"'`
- PASS: `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' configuration.yaml`
- PASS: `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py configuration.yaml --strict`
- PASS: `git diff --check`
- PASS: `uv run --with pytest pytest` (`442 passed`)
- PASS: `uv run --python 3.14 --with homeassistant==2026.5.0 python -m homeassistant --config <tmp copy> --script check_config`
- BLOCKED: containerized `podman run ghcr.io/home-assistant/home-assistant:2026.5.0 ... check_config`; local Podman is installed but not connected to a VM/socket.
