### PR TITLE
fix: cap office volume at 10% in all morning wake-up ramps

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -456,9 +456,16 @@ automation:
                     - action: media_player.volume_set
                       continue_on_error: true
                       target:
-                        entity_id: "{{ group_members }}"
+                        entity_id: "{{ group_members | reject('eq', 'media_player.office_sonos_2') | list }}"
                       data:
                         volume_level: "{{ [0.05 + (0.01 * repeat.index), 0.30] | min }}"
+                    - alias: "Office capped at 20% — bedroom wake-up should not disturb work-in-progress"
+                      continue_on_error: true
+                      action: media_player.volume_set
+                      target:
+                        entity_id: media_player.office_sonos_2
+                      data:
+                        volume_level: "{{ [0.05 + (0.01 * repeat.index), 0.20] | min }}"
                     - delay:
                         seconds: "{{ (1/(tan((repeat.index + 5)/60))) | round(0, 'ceil', 5) }}"
                   until: "{{ repeat.index == 25 }}"
@@ -481,9 +488,16 @@ automation:
                   action: media_player.volume_set
                   continue_on_error: true
                   target:
-                    entity_id: "{{ group_members }}"
+                    entity_id: "{{ group_members | reject('eq', 'media_player.office_sonos_2') | list }}"
                   data:
                     volume_level: "{{ 0.01 * repeat.index }}"
+                - alias: "Office capped at 20% — bedroom wake-up should not disturb work-in-progress"
+                  continue_on_error: true
+                  action: media_player.volume_set
+                  target:
+                    entity_id: media_player.office_sonos_2
+                  data:
+                    volume_level: "{{ [0.01 * repeat.index, 0.20] | min }}"
                 - delay:
                     # As time passes, the delay gets smaller and smaller. 60, 30s, 20s, 15s, 12s,..., 2s
                     seconds: "{{ (1/(tan(repeat.index/60))) | round(0, 'ceil', 5)}}"

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -459,13 +459,13 @@ automation:
                         entity_id: "{{ group_members | reject('eq', 'media_player.office_sonos_2') | list }}"
                       data:
                         volume_level: "{{ [0.05 + (0.01 * repeat.index), 0.30] | min }}"
-                    - alias: "Office capped at 12% — bedroom wake-up should not disturb work-in-progress"
+                    - alias: "Office capped at 10% — bedroom wake-up should not disturb work-in-progress"
                       continue_on_error: true
                       action: media_player.volume_set
                       target:
                         entity_id: media_player.office_sonos_2
                       data:
-                        volume_level: "{{ [0.05 + (0.01 * repeat.index), 0.12] | min }}"
+                        volume_level: "{{ [0.05 + (0.01 * repeat.index), 0.10] | min }}"
                     - delay:
                         seconds: "{{ (1/(tan((repeat.index + 5)/60))) | round(0, 'ceil', 5) }}"
                   until: "{{ repeat.index == 25 }}"
@@ -491,13 +491,13 @@ automation:
                     entity_id: "{{ group_members | reject('eq', 'media_player.office_sonos_2') | list }}"
                   data:
                     volume_level: "{{ 0.01 * repeat.index }}"
-                - alias: "Office capped at 12% — bedroom wake-up should not disturb work-in-progress"
+                - alias: "Office capped at 10% — bedroom wake-up should not disturb work-in-progress"
                   continue_on_error: true
                   action: media_player.volume_set
                   target:
                     entity_id: media_player.office_sonos_2
                   data:
-                    volume_level: "{{ [0.01 * repeat.index, 0.12] | min }}"
+                    volume_level: "{{ [0.01 * repeat.index, 0.10] | min }}"
                 - delay:
                     # As time passes, the delay gets smaller and smaller. 60, 30s, 20s, 15s, 12s,..., 2s
                     seconds: "{{ (1/(tan(repeat.index/60))) | round(0, 'ceil', 5)}}"
@@ -1176,13 +1176,13 @@ script:
                     entity_id: "{{ group_members | reject('eq', 'media_player.office_sonos_2') | list }}"
                   data:
                     volume_level: "{{ 0.01 * repeat.index }}"
-            - alias: "Office capped at 12% — bedroom wake-up should not disturb work-in-progress"
+            - alias: "Office capped at 10% — bedroom wake-up should not disturb work-in-progress"
               continue_on_error: true
               action: media_player.volume_set
               target:
                 entity_id: media_player.office_sonos_2
               data:
-                volume_level: "{{ [0.01 * repeat.index, 0.12] | min }}"
+                volume_level: "{{ [0.01 * repeat.index, 0.10] | min }}"
             - delay:
                 seconds: "{{ (1/(tan(repeat.index/effective_k_factor))) | round(0, 'ceil', 5)}}"
           until: "{{ repeat.index == effective_ramp_steps }}"

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -459,7 +459,7 @@ automation:
                         entity_id: "{{ group_members | reject('eq', 'media_player.office_sonos_2') | list }}"
                       data:
                         volume_level: "{{ [0.05 + (0.01 * repeat.index), 0.30] | min }}"
-                    - alias: "Office capped at 20% — bedroom wake-up should not disturb work-in-progress"
+                    - alias: "Office capped at 12% — bedroom wake-up should not disturb work-in-progress"
                       continue_on_error: true
                       action: media_player.volume_set
                       target:
@@ -491,7 +491,7 @@ automation:
                     entity_id: "{{ group_members | reject('eq', 'media_player.office_sonos_2') | list }}"
                   data:
                     volume_level: "{{ 0.01 * repeat.index }}"
-                - alias: "Office capped at 20% — bedroom wake-up should not disturb work-in-progress"
+                - alias: "Office capped at 12% — bedroom wake-up should not disturb work-in-progress"
                   continue_on_error: true
                   action: media_player.volume_set
                   target:
@@ -1176,7 +1176,7 @@ script:
                     entity_id: "{{ group_members | reject('eq', 'media_player.office_sonos_2') | list }}"
                   data:
                     volume_level: "{{ 0.01 * repeat.index }}"
-            - alias: "Office capped at 20% — bedroom wake-up should not disturb work-in-progress"
+            - alias: "Office capped at 12% — bedroom wake-up should not disturb work-in-progress"
               continue_on_error: true
               action: media_player.volume_set
               target:

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -465,7 +465,7 @@ automation:
                       target:
                         entity_id: media_player.office_sonos_2
                       data:
-                        volume_level: "{{ [0.05 + (0.01 * repeat.index), 0.20] | min }}"
+                        volume_level: "{{ [0.05 + (0.01 * repeat.index), 0.12] | min }}"
                     - delay:
                         seconds: "{{ (1/(tan((repeat.index + 5)/60))) | round(0, 'ceil', 5) }}"
                   until: "{{ repeat.index == 25 }}"
@@ -497,7 +497,7 @@ automation:
                   target:
                     entity_id: media_player.office_sonos_2
                   data:
-                    volume_level: "{{ [0.01 * repeat.index, 0.20] | min }}"
+                    volume_level: "{{ [0.01 * repeat.index, 0.12] | min }}"
                 - delay:
                     # As time passes, the delay gets smaller and smaller. 60, 30s, 20s, 15s, 12s,..., 2s
                     seconds: "{{ (1/(tan(repeat.index/60))) | round(0, 'ceil', 5)}}"
@@ -1182,7 +1182,7 @@ script:
               target:
                 entity_id: media_player.office_sonos_2
               data:
-                volume_level: "{{ [0.01 * repeat.index, 0.20] | min }}"
+                volume_level: "{{ [0.01 * repeat.index, 0.12] | min }}"
             - delay:
                 seconds: "{{ (1/(tan(repeat.index/effective_k_factor))) | round(0, 'ceil', 5)}}"
           until: "{{ repeat.index == effective_ramp_steps }}"


### PR DESCRIPTION
## Summary

- \`play_music_in_bathroom_when_up\` had two volume ramp sequences that targeted all \`group_members\` (including \`office_sonos_2\`) with no cap — walking into the bathroom after the alarm overrode the office cap set during the radio wake-up ramp
- Both the **bathroom-was-playing** branch and the **default** branch now exclude \`office_sonos_2\` from the group target and set it separately with \`{{ [vol, 0.10] | min }}\`, matching the pattern in \`music_assistant_radio_wake_up\`
- Office cap in \`music_assistant_radio_wake_up\` also lowered to 10% (was 20%) to be consistent across all wake-up paths

## Root cause

Discovered via trace inspection: alarm fired at 8:20 AM → radio ramp correctly held office at 20% → at 8:36 AM bathroom occupancy triggered \`play_music_in_bathroom_when_up\` → Spotify ramp pushed office to 30% with no cap.

## Test plan

- [ ] Reload HA and confirm config validates cleanly
- [ ] Trigger \`automation.play_music_in_bathroom_when_up\` manually and watch trace — office should not exceed 0.10 at any ramp step
- [ ] Verify both branches (bathroom-was-playing and default) show the office cap step in the trace
- [ ] Verify \`script.music_assistant_radio_wake_up\` also holds office at 0.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)