### PR TITLE
Shorten owner-suite flight weather warning

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -246,8 +246,11 @@ wake-up setup state.
 
 When `sensor.next_travel_flight` is inside its active travel window, `morning`,
 `up_for_day`, and `midday` modes use flight-oriented rows instead of the normal
-calendar/quote rows. Weather alerts, garage-door exceptions, and front-door
-exceptions still take display priority and keep an urgent status row visible.
+calendar/quote rows. Weather alerts, garage-door exceptions, front-door
+exceptions, and event-weather exceptions still take display priority and keep
+an urgent status row visible. When event-weather risk overlaps an active flight,
+the urgent status text stays short and destination-specific, such as
+`SEA Wx risk`.
 
 Flight rows use these normalized entities from `packages/flight_status.yaml`:
 

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -327,7 +327,7 @@ script:
               {% set status_value = 'Rain soon ' ~ precip_next_hour ~ '%' %}
               {% set status_level = 'urgent' %}
             {% elif event_weather %}
-              {% set status_value = 'Wx for ' ~ event_title %}
+              {% set status_value = (flight_destination | string | upper) ~ ' Wx risk' if flight_active and flight_destination not in ['', none, 'unknown', 'unavailable'] else 'Event Wx risk' %}
               {% set status_level = 'urgent' %}
             {% elif trip_mode %}
               {% set status_value = 'Trip mode' %}

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -253,7 +253,10 @@ def test_owner_suite_payload_warns_about_near_term_and_event_precipitation() -> 
     assert "event_start_dt" not in block
     assert "event.max_precip >= 40" in block
     assert "forecast.condition | default('', true) in precip_conditions" in block
-    assert "'Wx for ' ~ event_title" in block
+    assert "' Wx risk'" in block
+    assert "flight_active and flight_destination not in ['', none, 'unknown', 'unavailable']" in block
+    assert "else 'Event Wx risk'" in block
+    assert "'Wx for ' ~ event_title" not in block
 
 
 def test_owner_suite_payload_consumes_flight_status_sources() -> None:


### PR DESCRIPTION
## Summary
- shorten active-flight event-weather warnings to destination-specific text like `SEA Wx risk`
- use `Event Wx risk` as the non-flight fallback
- update owner-suite Inky docs and regression coverage

## Tests
- python3 -m pytest tests/test_inky_displays_package.py
- uv run --with pytest pytest

Refs #313