### PR TITLE
Fix #686 OctoPrint timestamp template errors

### DIFF
--- a/packages/octoprint.yaml
+++ b/packages/octoprint.yaml
@@ -283,28 +283,28 @@ template:
         availability: >
           {{ not is_state('sensor.octoprint_start_time', 'unavailable') }}
         state: >
-          {% set start = as_timestamp(states('sensor.octoprint_start_time')) %}
-          {% if is_number(start) %}
+          {% set start = as_timestamp(states('sensor.octoprint_start_time'), default=none) %}
+          {% if start is number %}
             {{ (as_timestamp(now()) - start) | int }}
           {% else %}
             unknown
           {% endif %}
         attributes:
-          start_time: "states('sensor.octoprint_start_time')"
+          start_time: "{{ states('sensor.octoprint_start_time') }}"
       - name: "OctoPrint Time Remaining"
         unique_id: octoprint_time_remaining
         unit_of_measurement: "s"
         availability: >
           {{ not is_state('sensor.octoprint_estimated_finish_time', 'unavailable') }}
         state: >
-          {% set finish = as_timestamp(states('sensor.octoprint_estimated_finish_time')) %}
-          {% if is_number(finish) %}
+          {% set finish = as_timestamp(states('sensor.octoprint_estimated_finish_time'), default=none) %}
+          {% if finish is number %}
             {{ (finish - as_timestamp(now())) | int }}
           {% else %}
             unknown
           {% endif %}
         attributes:
-          start_time: "states('sensor.octoprint_estimated_finish_time')"
+          start_time: "{{ states('sensor.octoprint_estimated_finish_time') }}"
 
 ########################
 # Weather

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -11,6 +11,7 @@ BIRDS_PATH = ROOT / "packages" / "birds.yaml"
 UTILITIES_PATH = ROOT / "packages" / "utilities.yaml"
 HOLIDAYS_PATH = ROOT / "packages" / "holidays.yaml"
 CONFIGURATION_PATH = ROOT / "configuration.yaml"
+OCTOPRINT_PATH = ROOT / "packages" / "octoprint.yaml"
 
 
 def _read(path: Path) -> str:
@@ -146,6 +147,17 @@ def test_raw_birdweather_top_50_feed_is_excluded_from_recorder() -> None:
     assert "sensor.top_50_bird_species" in recorder_entities
     assert "sensor.top_50_bird_species_2" in recorder_entities
     assert "full species list in attributes" in recorder_block
+
+
+def test_octoprint_duration_templates_tolerate_unknown_timestamps() -> None:
+    text = _read(OCTOPRINT_PATH)
+
+    assert "as_timestamp(states('sensor.octoprint_start_time'), default=none)" in text
+    assert "as_timestamp(states('sensor.octoprint_estimated_finish_time'), default=none)" in text
+    assert "start is number" in text
+    assert "finish is number" in text
+    assert "start_time: \"{{ states('sensor.octoprint_start_time') }}\"" in text
+    assert "start_time: \"{{ states('sensor.octoprint_estimated_finish_time') }}\"" in text
 
 
 def test_garbage_notifications_use_computed_pickup_date_sensor() -> None:


### PR DESCRIPTION
## Summary

Fixes #686.

- Make the OctoPrint elapsed/remaining duration templates tolerate `unknown` timestamp source states with `as_timestamp(..., default=none)`.
- Render the source timestamp attributes instead of the literal `states(...)` expression.
- Add a regression test for the safe timestamp handling.

## Runtime evidence

Nightly Trace Review on 2026-05-15 found live HA startup errors while OctoPrint timestamp entities were `unknown`:

- `sensor.octoprint_start_time=unknown`
- `sensor.octoprint_estimated_finish_time=unknown`
- `sensor.octoprint_time_elapsed` and `sensor.octoprint_time_remaining` raised `TemplateError` from `as_timestamp` without a default.

## Validation

- `uv run --with pytest pytest tests/test_runtime_log_regressions.py -q` -> 22 passed
- `uv run --with pytest pytest` -> 444 passed
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/octoprint.yaml` -> passed
- Full repo YAML lint -> passed

## Validation gap

- Docker-based Home Assistant `check_config` could not be run locally because Docker is not installed in this Codex host. The PR is scoped to HA template YAML and CI should run the configured Docker check.