### PR TITLE
Add admin health dashboard and digest (#111)

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  HOME_ASSISTANT_CHECK_CONFIG_IMAGE: ghcr.io/home-assistant/home-assistant:2026.5.0
+  HOME_ASSISTANT_CHECK_CONFIG_IMAGE: ghcr.io/home-assistant/home-assistant:2026.5.1
 
 concurrency:
   group: validate-home-assistant-config-${{ github.ref }}

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -243,6 +243,12 @@ lovelace:
       type: module
 
   dashboards:
+    admin-health:
+      mode: yaml
+      title: Admin Health
+      icon: mdi:heart-pulse
+      show_in_sidebar: true
+      filename: lovelace/admin_health.yaml
     db-guest:
       mode: yaml
       title: Guest

--- a/lovelace/admin_health.yaml
+++ b/lovelace/admin_health.yaml
@@ -1,0 +1,106 @@
+title: Admin Health
+views:
+  - title: Runtime
+    path: runtime
+    type: sections
+    icon: mdi:heart-pulse
+    max_columns: 3
+    badges:
+      - sensor.admin_health_issue_count
+      - sensor.admin_backup_status
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Runtime Health
+            icon: mdi:heart-pulse
+          - type: tile
+            entity: sensor.admin_health_issue_count
+            name: Issues
+            icon: mdi:heart-pulse
+          - type: tile
+            entity: sensor.admin_unavailable_entities
+            name: Unavailable
+            icon: mdi:cloud-alert
+          - type: tile
+            entity: sensor.admin_stale_entities
+            name: Stale
+            icon: mdi:timer-alert
+          - type: tile
+            entity: sensor.admin_updates_pending
+            name: Updates
+            icon: mdi:update
+          - type: tile
+            entity: sensor.admin_backup_status
+            name: Backups
+            icon: mdi:backup-restore
+
+      - type: grid
+        cards:
+          - type: heading
+            heading: Batteries and Zigbee
+            icon: mdi:battery-alert
+          - type: tile
+            entity: sensor.battery_low_20
+            name: Below 20%
+            icon: mdi:battery-20
+          - type: tile
+            entity: sensor.battery_low_10
+            name: Below 10%
+            icon: mdi:battery-10
+          - type: tile
+            entity: sensor.battery_dead
+            name: Offline Battery
+            icon: mdi:battery-off
+          - type: tile
+            entity: binary_sensor.z2m_devices_offline
+            name: Z2M Offline
+            icon: mdi:zigbee
+          - type: tile
+            entity: sensor.z2m_lifecycle_issues
+            name: Z2M Lifecycle
+            icon: mdi:zigbee
+
+      - type: grid
+        cards:
+          - type: heading
+            heading: Digest
+            icon: mdi:message-alert
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: automation.send_admin_health_daily_digest
+                name: Daily digest
+              - entity: sensor.admin_backup_status
+                name: Backup status
+              - type: attribute
+                entity: sensor.admin_backup_status
+                attribute: next_scheduled_automatic_backup
+                name: Next backup
+              - type: attribute
+                entity: sensor.admin_backup_status
+                attribute: last_successful_automatic_backup
+                name: Last successful backup
+
+      - type: grid
+        cards:
+          - type: heading
+            heading: Details
+            icon: mdi:clipboard-list
+          - type: markdown
+            content: >-
+              ## Current digest
+
+              {{ state_attr('sensor.admin_health_issue_count', 'digest') }}
+
+              ## Unavailable
+
+              {{ state_attr('sensor.admin_unavailable_entities', 'summary') or 'None' }}
+
+              ## Stale
+
+              {{ state_attr('sensor.admin_stale_entities', 'summary') or 'None' }}
+
+              ## Updates
+
+              {{ state_attr('sensor.admin_updates_pending', 'summary') or 'None' }}

--- a/packages/admin_health.yaml
+++ b/packages/admin_health.yaml
@@ -1,0 +1,316 @@
+# Home Assistant package for admin/runtime health.
+# It provides one aggregate dashboard surface and a daily digest for the
+# runtime signals that otherwise live across batteries, Z2M, updates, backups,
+# and stale/unavailable entity checks.
+
+################################################################
+## Packages / Admin Health
+################################################################
+
+################################################
+## Customize
+################################################
+
+homeassistant:
+  customize:
+    package.node_anchors:
+      customize: &customize
+        package: "admin_health"
+
+    automation.send_admin_health_daily_digest:
+      <<: *customize
+      friendly_name: "Send Admin Health Daily Digest"
+      icon: mdi:heart-pulse
+
+    sensor.admin_health_issue_count:
+      <<: *customize
+      friendly_name: "Admin Health Issue Count"
+      icon: mdi:heart-pulse
+
+    sensor.admin_unavailable_entities:
+      <<: *customize
+      friendly_name: "Unavailable Entities"
+      icon: mdi:cloud-alert
+
+    sensor.admin_stale_entities:
+      <<: *customize
+      friendly_name: "Stale Entities"
+      icon: mdi:timer-alert
+
+    sensor.admin_updates_pending:
+      <<: *customize
+      friendly_name: "Updates Pending"
+      icon: mdi:update
+
+    sensor.admin_backup_status:
+      <<: *customize
+      friendly_name: "Backup Status"
+      icon: mdi:backup-restore
+
+################################################
+## Template
+################################################
+
+template:
+  - sensor:
+      - name: admin_unavailable_entities
+        unique_id: admin_unavailable_entities
+        default_entity_id: sensor.admin_unavailable_entities
+        icon: mdi:cloud-alert
+        state: >-
+          {% set ignored = [
+            'sensor.admin_health_issue_count',
+            'sensor.admin_unavailable_entities',
+            'sensor.admin_stale_entities',
+            'sensor.admin_updates_pending',
+            'sensor.admin_backup_status'
+          ] %}
+          {% set entities = expand(
+            states.binary_sensor,
+            states.climate,
+            states.cover,
+            states.fan,
+            states.light,
+            states.lock,
+            states.media_player,
+            states.sensor,
+            states.switch,
+            states.update,
+            states.vacuum,
+            states.water_heater
+          )
+            | rejectattr('entity_id', 'in', ignored)
+            | rejectattr('attributes.hidden', 'eq', true)
+            | selectattr('state', 'in', ['unavailable', 'unknown'])
+            | sort(attribute='entity_id')
+            | list %}
+          {{ entities | count }}
+        attributes:
+          summary: >-
+            {% set ignored = [
+              'sensor.admin_health_issue_count',
+              'sensor.admin_unavailable_entities',
+              'sensor.admin_stale_entities',
+              'sensor.admin_updates_pending',
+              'sensor.admin_backup_status'
+            ] %}
+            {% set entities = expand(
+              states.binary_sensor,
+              states.climate,
+              states.cover,
+              states.fan,
+              states.light,
+              states.lock,
+              states.media_player,
+              states.sensor,
+              states.switch,
+              states.update,
+              states.vacuum,
+              states.water_heater
+            )
+              | rejectattr('entity_id', 'in', ignored)
+              | rejectattr('attributes.hidden', 'eq', true)
+              | selectattr('state', 'in', ['unavailable', 'unknown'])
+              | sort(attribute='entity_id')
+              | list %}
+            {% set ns = namespace(lines=[]) %}
+            {% for item in entities[:30] %}
+              {% set ns.lines = ns.lines + ['- ' ~ item.entity_id ~ ': ' ~ item.state] %}
+            {% endfor %}
+            {% if entities | count > 30 %}
+              {% set ns.lines = ns.lines + ['- ... ' ~ ((entities | count) - 30) ~ ' more'] %}
+            {% endif %}
+            {{ ns.lines | join('\n') }}
+
+      - name: admin_stale_entities
+        unique_id: admin_stale_entities
+        default_entity_id: sensor.admin_stale_entities
+        icon: mdi:timer-alert
+        state: >-
+          {% set stale_threshold_hours = 12 %}
+          {% set entities = expand(
+            states.binary_sensor,
+            states.device_tracker,
+            states.fan,
+            states.light,
+            states.lock,
+            states.media_player,
+            states.sensor,
+            states.switch,
+            states.vacuum
+          ) %}
+          {% set ns = namespace(count=0) %}
+          {% for item in entities if (
+            not is_state_attr(item.entity_id, 'hidden', true)
+            and (now() - as_local(item.last_reported) > timedelta(hours=stale_threshold_hours))
+            and item.attributes.device_class != 'connectivity'
+            and 'update' not in (item.entity_id | lower)
+            and 'heading' not in (item.entity_id | lower)
+            and 'alert' not in (item.entity_id | lower)
+            and 'season' not in (item.entity_id | lower)
+            and not (item.entity_id | lower).endswith('microphone')
+            and not (item.entity_id | lower).endswith('hacs')
+            and 'sonos' not in (item.entity_id | lower)
+          ) %}
+            {% set ns.count = ns.count + 1 %}
+          {% endfor %}
+          {{ ns.count }}
+        attributes:
+          stale_threshold_hours: 12
+          summary: >-
+            {% set stale_threshold_hours = 12 %}
+            {% set entities = expand(
+              states.binary_sensor,
+              states.device_tracker,
+              states.fan,
+              states.light,
+              states.lock,
+              states.media_player,
+              states.sensor,
+              states.switch,
+              states.vacuum
+            ) %}
+            {% set ns = namespace(lines=[]) %}
+            {% for item in entities if (
+              not is_state_attr(item.entity_id, 'hidden', true)
+              and (now() - as_local(item.last_reported) > timedelta(hours=stale_threshold_hours))
+              and item.attributes.device_class != 'connectivity'
+              and 'update' not in (item.entity_id | lower)
+              and 'heading' not in (item.entity_id | lower)
+              and 'alert' not in (item.entity_id | lower)
+              and 'season' not in (item.entity_id | lower)
+              and not (item.entity_id | lower).endswith('microphone')
+              and not (item.entity_id | lower).endswith('hacs')
+              and 'sonos' not in (item.entity_id | lower)
+            ) %}
+              {% if ns.lines | count < 30 %}
+                {% set ns.lines = ns.lines + ['- ' ~ item.entity_id] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.lines | join('\n') }}
+
+      - name: admin_updates_pending
+        unique_id: admin_updates_pending
+        default_entity_id: sensor.admin_updates_pending
+        icon: mdi:update
+        state: >-
+          {% set updates = states.update
+            | selectattr('state', 'eq', 'on')
+            | sort(attribute='entity_id')
+            | list %}
+          {{ updates | count }}
+        attributes:
+          summary: >-
+            {% set updates = states.update
+              | selectattr('state', 'eq', 'on')
+              | sort(attribute='entity_id')
+              | list %}
+            {% set ns = namespace(lines=[]) %}
+            {% for item in updates %}
+              {% set latest = state_attr(item.entity_id, 'latest_version') | default('', true) %}
+              {% set installed = state_attr(item.entity_id, 'installed_version') | default('', true) %}
+              {% set detail = ': ' ~ installed ~ ' -> ' ~ latest if latest or installed else '' %}
+              {% set ns.lines = ns.lines + ['- ' ~ item.entity_id ~ detail] %}
+            {% endfor %}
+            {{ ns.lines | join('\n') }}
+
+      - name: admin_backup_status
+        unique_id: admin_backup_status
+        default_entity_id: sensor.admin_backup_status
+        icon: mdi:backup-restore
+        state: >-
+          {% set automatic = state_attr('event.backup_automatic_backup', 'event_type') | default('', true) %}
+          {% set manager = states('sensor.backup_backup_manager_state') %}
+          {% if automatic %}
+            {{ automatic }}
+          {% elif manager not in ['unknown', 'unavailable', 'none', ''] %}
+            {{ manager }}
+          {% else %}
+            unknown
+          {% endif %}
+        attributes:
+          manager_state: "{{ states('sensor.backup_backup_manager_state') }}"
+          failed_reason: "{{ state_attr('event.backup_automatic_backup', 'failed_reason') | default('', true) }}"
+          next_scheduled_automatic_backup: "{{ states('sensor.backup_next_scheduled_automatic_backup') }}"
+          last_attempted_automatic_backup: "{{ states('sensor.backup_last_attempted_automatic_backup') }}"
+          last_successful_automatic_backup: "{{ states('sensor.backup_last_successful_automatic_backup') }}"
+
+      - name: admin_health_issue_count
+        unique_id: admin_health_issue_count
+        default_entity_id: sensor.admin_health_issue_count
+        icon: mdi:heart-pulse
+        state: >-
+          {% set unavailable = states('sensor.admin_unavailable_entities') | int(0) %}
+          {% set stale = states('sensor.admin_stale_entities') | int(0) %}
+          {% set low_batteries = states('sensor.battery_low_20') | int(0) %}
+          {% set offline_batteries = states('sensor.battery_dead') | int(0) %}
+          {% set updates = states('sensor.admin_updates_pending') | int(0) %}
+          {% set z2m_lifecycle = states('sensor.z2m_lifecycle_issues') | int(0) %}
+          {% set backup_failed = 1 if states('sensor.admin_backup_status') == 'failed' else 0 %}
+          {{ unavailable + stale + low_batteries + offline_batteries + updates + z2m_lifecycle + backup_failed }}
+        attributes:
+          digest: >-
+            {% set ns = namespace(lines=[]) %}
+            {% set unavailable = states('sensor.admin_unavailable_entities') | int(0) %}
+            {% set stale = states('sensor.admin_stale_entities') | int(0) %}
+            {% set low_batteries = states('sensor.battery_low_20') | int(0) %}
+            {% set offline_batteries = states('sensor.battery_dead') | int(0) %}
+            {% set updates = states('sensor.admin_updates_pending') | int(0) %}
+            {% set z2m_lifecycle = states('sensor.z2m_lifecycle_issues') | int(0) %}
+            {% set backup_status = states('sensor.admin_backup_status') %}
+            {% if unavailable > 0 %}
+              {% set ns.lines = ns.lines + ['Unavailable entities: ' ~ unavailable] %}
+            {% endif %}
+            {% if stale > 0 %}
+              {% set ns.lines = ns.lines + ['Stale entities: ' ~ stale] %}
+            {% endif %}
+            {% if low_batteries > 0 %}
+              {% set ns.lines = ns.lines + ['Low batteries below 20%: ' ~ low_batteries] %}
+            {% endif %}
+            {% if offline_batteries > 0 %}
+              {% set ns.lines = ns.lines + ['Offline battery devices: ' ~ offline_batteries] %}
+            {% endif %}
+            {% if updates > 0 %}
+              {% set ns.lines = ns.lines + ['Updates pending: ' ~ updates] %}
+            {% endif %}
+            {% if z2m_lifecycle > 0 %}
+              {% set ns.lines = ns.lines + ['Z2M lifecycle issues: ' ~ z2m_lifecycle] %}
+            {% endif %}
+            {% if backup_status == 'failed' %}
+              {% set reason = state_attr('sensor.admin_backup_status', 'failed_reason') | default('', true) %}
+              {% set ns.lines = ns.lines + ['Backup failed' ~ (': ' ~ reason if reason else '')] %}
+            {% endif %}
+            {{ ns.lines | join('\n') if ns.lines | count > 0 else 'All monitored runtime checks are healthy.' }}
+
+################################################
+## Automation
+################################################
+
+automation:
+  - id: send_admin_health_daily_digest
+    alias: send_admin_health_daily_digest
+    description: Send one daily runtime-health digest covering unavailable entities, stale devices, low batteries, updates, backups, and Z2M lifecycle issues.
+    mode: single
+    trace:
+      stored_traces: 10
+    trigger:
+      - trigger: time
+        at: "07:30:00"
+    variables:
+      issue_count: "{{ states('sensor.admin_health_issue_count') | int(0) }}"
+      digest_summary: "{{ state_attr('sensor.admin_health_issue_count', 'digest') | default('Admin health digest unavailable.', true) }}"
+      digest_title: >-
+        {{ 'Admin health clear' if issue_count == 0 else 'Admin health needs attention' }}
+    action:
+      - action: persistent_notification.create
+        data:
+          notification_id: admin-health-digest
+          title: "{{ digest_title }}"
+          message: "{{ digest_summary }}"
+      - continue_on_error: true
+        action: notify.all
+        data:
+          title: "{{ digest_title }}"
+          message: "{{ digest_summary }}"
+          data:
+            tag: admin-health-digest

--- a/tests/test_admin_health_package.py
+++ b/tests/test_admin_health_package.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_PATH = ROOT / "packages" / "admin_health.yaml"
+CONFIGURATION_PATH = ROOT / "configuration.yaml"
+DASHBOARD_PATH = ROOT / "lovelace" / "admin_health.yaml"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _automation_block(path: Path, automation_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_admin_health_package_exposes_required_runtime_sources() -> None:
+    text = _read(PACKAGE_PATH)
+
+    for token in (
+        "unique_id: admin_health_issue_count",
+        "unique_id: admin_unavailable_entities",
+        "unique_id: admin_stale_entities",
+        "unique_id: admin_updates_pending",
+        "unique_id: admin_backup_status",
+        "sensor.battery_low_20",
+        "sensor.battery_dead",
+        "sensor.z2m_lifecycle_issues",
+        "event.backup_automatic_backup",
+        "sensor.backup_next_scheduled_automatic_backup",
+        "states.update",
+    ):
+        assert token in text
+
+
+def test_admin_health_digest_runs_once_daily_with_stable_notification_tag() -> None:
+    block = _automation_block(PACKAGE_PATH, "send_admin_health_daily_digest")
+
+    assert 'at: "07:30:00"' in block
+    assert "notification_id: admin-health-digest" in block
+    assert "tag: admin-health-digest" in block
+    assert "action: notify.all" in block
+    assert "continue_on_error: true" in block
+    assert "Admin health clear" in block
+    assert "Admin health needs attention" in block
+
+
+def test_admin_health_dashboard_is_registered_as_yaml_dashboard() -> None:
+    text = _read(CONFIGURATION_PATH)
+    dashboard_block = text.split("dashboards:\n", 1)[1].split("\nsystem_health:", 1)[0]
+
+    assert "admin-health:" in dashboard_block
+    assert "mode: yaml" in dashboard_block
+    assert "title: Admin Health" in dashboard_block
+    assert "show_in_sidebar: true" in dashboard_block
+    assert "filename: lovelace/admin_health.yaml" in dashboard_block
+
+
+def test_admin_health_dashboard_surfaces_runtime_cards() -> None:
+    text = _read(DASHBOARD_PATH)
+
+    for token in (
+        "type: sections",
+        "sensor.admin_health_issue_count",
+        "sensor.admin_unavailable_entities",
+        "sensor.admin_stale_entities",
+        "sensor.admin_updates_pending",
+        "sensor.admin_backup_status",
+        "sensor.battery_low_20",
+        "sensor.battery_low_10",
+        "sensor.battery_dead",
+        "binary_sensor.z2m_devices_offline",
+        "sensor.z2m_lifecycle_issues",
+        "automation.send_admin_health_daily_digest",
+    ):
+        assert token in text
+

--- a/tests/test_validate_config_workflow.py
+++ b/tests/test_validate_config_workflow.py
@@ -32,7 +32,7 @@ def test_home_assistant_config_check_does_not_depend_on_esphome_build() -> None:
 def test_home_assistant_config_check_pins_known_good_image() -> None:
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
 
-    assert "HOME_ASSISTANT_CHECK_CONFIG_IMAGE: ghcr.io/home-assistant/home-assistant:2026.5.0" in workflow_text
+    assert "HOME_ASSISTANT_CHECK_CONFIG_IMAGE: ghcr.io/home-assistant/home-assistant:2026.5.1" in workflow_text
     assert '"$HOME_ASSISTANT_CHECK_CONFIG_IMAGE" \\' in workflow_text
 
 


### PR DESCRIPTION
## Summary
- add an Admin Health YAML dashboard for runtime health review
- add admin health aggregate sensors and a daily digest automation
- include unavailable entities, stale entities, low/offline batteries, Z2M lifecycle issues, updates, and backup status
- bump the Home Assistant check_config image to 2026.5.1, matching the latest stable support check

Closes #111

## Validation
- uv run --with pytest pytest
- yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt lovelace/admin_health.yaml .github/workflows/validate-config.yml
- python3 scripts/check_ha_python_support.py --python-version-file .python-version
- python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/admin_health.yaml lovelace/admin_health.yaml configuration.yaml .github/workflows/validate-config.yml --strict

## Not run locally
- Docker-based Home Assistant check_config: docker is not installed in this environment; the PR workflow will run it.