### PR TITLE
Fix #688 F1 season results Recorder warning

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -123,6 +123,9 @@ recorder:
       # Keep smaller current/latest bird summary sensors recorded instead.
       - sensor.top_50_bird_species
       - sensor.top_50_bird_species_2
+      # F1 season results carry full race result lists in attributes.
+      # Keep compact F1 summary sensors recorded instead of this oversized feed.
+      - sensor.f1_season_results
 
 influxdb:
   exclude:

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -148,6 +148,15 @@ def test_raw_birdweather_top_50_feed_is_excluded_from_recorder() -> None:
     assert "full species list in attributes" in recorder_block
 
 
+def test_raw_f1_season_results_feed_is_excluded_from_recorder() -> None:
+    text = _read(CONFIGURATION_PATH)
+
+    recorder_block = text.split("recorder:\n", 1)[1].split("\ninfluxdb:", 1)[0]
+
+    assert "sensor.f1_season_results" in recorder_block
+    assert "full race result lists in attributes" in recorder_block
+
+
 def test_garbage_notifications_use_computed_pickup_date_sensor() -> None:
     text = _read(UTILITIES_PATH)
 


### PR DESCRIPTION
## Summary

Fixes #688.

- Exclude `sensor.f1_season_results` from Recorder because the live entity carries full race result lists in attributes.
- Keep the compact F1 summary sensors recorded.
- Add a regression test for the Recorder exclusion.

## Runtime evidence

Nightly Trace Review on 2026-05-15 found live HA Recorder warnings that `sensor.f1_season_results` attributes exceed 16,384 bytes. Live state confirmed the entity has a large `races` attribute with full result payloads.

## Validation

- `uv run --with pytest pytest tests/test_runtime_log_regressions.py -q` -> 22 passed
- `uv run --with pytest pytest` -> 444 passed
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml` -> passed
- full repo YAML lint -> passed

## Validation gap

- Docker-based Home Assistant `check_config` could not be run locally because Docker is not installed in this Codex host. CI should run the configured Docker check.