### PR TITLE
Fix #688: Exclude F1 season results from Recorder

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -123,6 +123,9 @@ recorder:
       # Keep smaller current/latest bird summary sensors recorded instead.
       - sensor.top_50_bird_species
       - sensor.top_50_bird_species_2
+      # F1 season results carries the full race list in attributes.
+      # Keep live dashboard state available without Recorder size warnings.
+      - sensor.f1_season_results
 
 influxdb:
   exclude:

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -148,6 +148,20 @@ def test_raw_birdweather_top_50_feed_is_excluded_from_recorder() -> None:
     assert "full species list in attributes" in recorder_block
 
 
+def test_f1_season_results_feed_is_excluded_from_recorder() -> None:
+    text = _read(CONFIGURATION_PATH)
+
+    recorder_block = text.split("recorder:\n", 1)[1].split("\ninfluxdb:", 1)[0]
+    recorder_entities = {
+        line.strip().removeprefix("- ").strip()
+        for line in recorder_block.splitlines()
+        if line.strip().startswith("- ")
+    }
+
+    assert "sensor.f1_season_results" in recorder_entities
+    assert "full race list in attributes" in recorder_block
+
+
 def test_garbage_notifications_use_computed_pickup_date_sensor() -> None:
     text = _read(UTILITIES_PATH)
 


### PR DESCRIPTION
## Summary

Fixes #688 by excluding `sensor.f1_season_results` from Recorder while leaving the live F1 dashboard/state sensor available.

## Runtime evidence

Nightly Trace Review on 2026-05-16 confirmed live HA 2026.5.1 still has `sensor.f1_season_results` loaded with a `races` attribute around 19 KB. The current live error log contains Recorder warnings that Home Assistant cannot store the entity attributes because they exceed 16,384 bytes.

## Fix

- Add `sensor.f1_season_results` to the Recorder entity exclusion list.
- Add regression coverage so future recorder-exclusion cleanup does not reintroduce this warning.

## Validation

- `uv run --with pytest pytest tests/test_runtime_log_regressions.py -q` — 22 passed
- `uv run --with pytest pytest` — 444 passed
- `git diff --check` — passed
- `uv run --with yamllint yamllint configuration.yaml` — failed on existing repository style violations outside this change (document start/comments/line length); no new changed lines were reported by `git diff --check`.
