### PR TITLE
Fix #686: Guard OctoPrint duration templates

### DIFF
--- a/packages/octoprint.yaml
+++ b/packages/octoprint.yaml
@@ -281,10 +281,11 @@ template:
         unique_id: octoprint_time_elapsed
         unit_of_measurement: "s"
         availability: >
-          {{ not is_state('sensor.octoprint_start_time', 'unavailable') }}
+          {{ has_value('sensor.octoprint_start_time') }}
         state: >
-          {% set start = as_timestamp(states('sensor.octoprint_start_time')) %}
-          {% if is_number(start) %}
+          {% set start_value = states('sensor.octoprint_start_time') %}
+          {% set start = as_timestamp(start_value, default=none) %}
+          {% if start is not none %}
             {{ (as_timestamp(now()) - start) | int }}
           {% else %}
             unknown
@@ -295,10 +296,12 @@ template:
         unique_id: octoprint_time_remaining
         unit_of_measurement: "s"
         availability: >
-          {{ not is_state('sensor.octoprint_estimated_finish_time', 'unavailable') }}
+          {{ has_value('sensor.octoprint_estimated_finish_time') }}
         state: >
-          {% set finish = as_timestamp(states('sensor.octoprint_estimated_finish_time')) %}
-          {% if is_number(finish) %}
+          {% set finish_entity = 'sensor.octoprint_estimated_finish_time' %}
+          {% set finish_value = states(finish_entity) %}
+          {% set finish = as_timestamp(finish_value, default=none) %}
+          {% if finish is not none %}
             {{ (finish - as_timestamp(now())) | int }}
           {% else %}
             unknown

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -11,6 +11,7 @@ BIRDS_PATH = ROOT / "packages" / "birds.yaml"
 UTILITIES_PATH = ROOT / "packages" / "utilities.yaml"
 HOLIDAYS_PATH = ROOT / "packages" / "holidays.yaml"
 CONFIGURATION_PATH = ROOT / "configuration.yaml"
+OCTOPRINT_PATH = ROOT / "packages" / "octoprint.yaml"
 
 
 def _read(path: Path) -> str:
@@ -146,6 +147,31 @@ def test_raw_birdweather_top_50_feed_is_excluded_from_recorder() -> None:
     assert "sensor.top_50_bird_species" in recorder_entities
     assert "sensor.top_50_bird_species_2" in recorder_entities
     assert "full species list in attributes" in recorder_block
+
+
+def test_octoprint_duration_templates_handle_unknown_timestamps() -> None:
+    text = _read(OCTOPRINT_PATH)
+    elapsed_block = text.split('name: "OctoPrint Time Elapsed"', 1)[1].split(
+        'name: "OctoPrint Time Remaining"',
+        1,
+    )[0]
+    remaining_block = text.split('name: "OctoPrint Time Remaining"', 1)[1].split(
+        "\n########################\n# Weather",
+        1,
+    )[0]
+
+    assert "{{ has_value('sensor.octoprint_start_time') }}" in elapsed_block
+    assert "{% set start_value = states('sensor.octoprint_start_time') %}" in elapsed_block
+    assert "{% set start = as_timestamp(start_value, default=none) %}" in elapsed_block
+    assert "{% if start is not none %}" in elapsed_block
+    assert "{{ has_value('sensor.octoprint_estimated_finish_time') }}" in remaining_block
+    assert (
+        "{% set finish_entity = 'sensor.octoprint_estimated_finish_time' %}"
+        in remaining_block
+    )
+    assert "{% set finish_value = states(finish_entity) %}" in remaining_block
+    assert "{% set finish = as_timestamp(finish_value, default=none) %}" in remaining_block
+    assert "{% if finish is not none %}" in remaining_block
 
 
 def test_garbage_notifications_use_computed_pickup_date_sensor() -> None:


### PR DESCRIPTION
## Summary

Fixes #686 by making the OctoPrint elapsed/remaining template sensors tolerate `unknown` timestamp source sensors without raising template errors.

## Runtime evidence

Nightly Trace Review on 2026-05-16 confirmed live HA 2026.5.1 still has `sensor.octoprint_start_time` and `sensor.octoprint_estimated_finish_time` in `unknown`, while `sensor.octoprint_time_elapsed` and `sensor.octoprint_time_remaining` logged `as_timestamp` template errors because no default was specified.

## Fix

- Use `has_value()` for the OctoPrint timestamp sensor availability checks.
- Use `as_timestamp(..., default=none)` and explicit `none` checks before computing elapsed/remaining seconds.
- Add regression coverage for both template sensors.

## Validation

- `uv run --with pytest pytest tests/test_runtime_log_regressions.py -q` — 22 passed
- `uv run --with pytest pytest` — 444 passed
- `git diff --check` — passed
- `uv run --with yamllint yamllint packages/octoprint.yaml` — remaining failures are pre-existing file-level line/comment/document-start style issues; changed lines now pass line-length checks.
