### PR TITLE
Guard Valetudo startup reloads (#691)

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1546,9 +1546,8 @@ automation:
   - id: reconfigure_z2m_and_vacuums_on_startup
     alias: reconfigure_z2m_and_vacuums_on_startup
     # Reconfigures Zigbee2MQTT and all Valetudo vacuums after HA startup.
-    # Fixed: added continue_on_error: true to each rest_command so that a single
-    # unreachable vacuum (e.g. den vacuum offline at boot) does not abort the
-    # sequence and leave the remaining vacuums un-reconfigured.
+    # Main-level Valetudo reload is intentionally skipped until its current
+    # endpoint is verified; the old .local hostname does not resolve from HA.
     trace:
       stored_traces: 10
     trigger:
@@ -1556,12 +1555,24 @@ automation:
         event: start
     action:
       - delay: "00:01:00"
-      - action: rest_command.reload_den_vacuum
-        continue_on_error: true
-      - action: rest_command.reload_upstairs_vacuum
-        continue_on_error: true
-      - action: rest_command.reload_main_level_vacuum
-        continue_on_error: true
+      - if:
+          - condition: not
+            conditions:
+              - condition: state
+                entity_id: vacuum.valetudo_den
+                state: unavailable
+        then:
+          - action: rest_command.reload_den_vacuum
+            continue_on_error: true
+      - if:
+          - condition: not
+            conditions:
+              - condition: state
+                entity_id: vacuum.valetudo_upstairs_vacuum
+                state: unavailable
+        then:
+          - action: rest_command.reload_upstairs_vacuum
+            continue_on_error: true
 
 ########################
 # Binary Sensors
@@ -2908,17 +2919,17 @@ rest_command:
       authorization: !secret proxmoxve_api_token
     payload: "command=shutdown"
   reload_den_vacuum:
-    url: http://valetudo-yummyhurtfulhornet.local/api/v2/valetudo/config/interfaces/mqtt
+    url: http://192.168.1.245/api/v2/valetudo/config/interfaces/mqtt
     method: PUT
     content_type: application/json
     verify_ssl: false
-    payload: '{"enabled":true,"connection":{"host":"10.254.254.11","port":1883,"tls":{"enabled":false,"ca":"","ignoreCertificateErrors":false},"authentication":{"credentials":{"enabled":true,"username":"<redacted>","password":"<redacted>"},"clientCertificate":{"enabled":false,"certificate":"","key":""}}},"identity":{"identifier":"den"},"interfaces":{"homie":{"enabled":false,"addICBINVMapProperty":false,"cleanAttributesOnShutdown":false},"homeassistant":{"enabled":true,"cleanAutoconfOnShutdown":false}},"customizations":{"topicPrefix":"","provideMapData":true},"optionalExposedCapabilities":["CurrentStatisticsCapability","ConsumableMonitoringCapability","TotalStatisticsCapability"]}'
+    payload: '{"enabled":true,"connection":{"host":"192.168.1.11","port":1883,"tls":{"enabled":false,"ca":"","ignoreCertificateErrors":false},"authentication":{"credentials":{"enabled":true,"username":"<redacted>","password":"<redacted>"},"clientCertificate":{"enabled":false,"certificate":"","key":""}}},"identity":{"identifier":"den"},"interfaces":{"homie":{"enabled":false,"addICBINVMapProperty":false,"cleanAttributesOnShutdown":false},"homeassistant":{"enabled":true,"cleanAutoconfOnShutdown":false}},"customizations":{"topicPrefix":"","provideMapData":true},"optionalExposedCapabilities":["CurrentStatisticsCapability","ConsumableMonitoringCapability","TotalStatisticsCapability"]}'
   reload_upstairs_vacuum:
-    url: http://valetudo-zestycurvycaribou.local/api/v2/valetudo/config/interfaces/mqtt
+    url: http://192.168.1.163/api/v2/valetudo/config/interfaces/mqtt
     method: PUT
     content_type: application/json
     verify_ssl: false
-    payload: '{"enabled":true,"connection":{"host":"10.24.1.11","port":1883,"tls":{"enabled":false,"ca":"","ignoreCertificateErrors":false},"authentication":{"credentials":{"enabled":true,"username":"<redacted>","password":"<redacted>"},"clientCertificate":{"enabled":false,"certificate":"","key":""}}},"identity":{"identifier":"upstairs-vacuum"},"interfaces":{"homie":{"enabled":false,"addICBINVMapProperty":false,"cleanAttributesOnShutdown":false},"homeassistant":{"enabled":true,"cleanAutoconfOnShutdown":false}},"customizations":{"topicPrefix":"","provideMapData":true},"optionalExposedCapabilities":["CurrentStatisticsCapability","ConsumableMonitoringCapability","TotalStatisticsCapability"]}'
+    payload: '{"enabled":true,"connection":{"host":"192.168.1.11","port":1883,"tls":{"enabled":false,"ca":"","ignoreCertificateErrors":false},"authentication":{"credentials":{"enabled":true,"username":"<redacted>","password":"<redacted>"},"clientCertificate":{"enabled":false,"certificate":"","key":""}}},"identity":{"identifier":"upstairs-vacuum"},"interfaces":{"homie":{"enabled":false,"addICBINVMapProperty":false,"cleanAttributesOnShutdown":false},"homeassistant":{"enabled":true,"cleanAutoconfOnShutdown":false}},"customizations":{"topicPrefix":"","provideMapData":true},"optionalExposedCapabilities":["CurrentStatisticsCapability","ConsumableMonitoringCapability","TotalStatisticsCapability"]}'
   reload_main_level_vacuum:
     url: http://valetudo-activeexoticlion.local/api/v2/valetudo/config/interfaces/mqtt
     method: PUT

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -44,6 +44,45 @@ def _automation_block(path: Path, automation_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
+def _top_level_mapping_block(path: Path, section_name: str, key_name: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    section_header = f"{section_name}:"
+    section_start = None
+
+    for index, line in enumerate(lines):
+        if line == section_header:
+            section_start = index
+            break
+
+    if section_start is None:
+        raise AssertionError(f"Could not find section {section_name!r} in {path.name}")
+
+    key_line = f"  {key_name}:"
+    start = None
+    for index in range(section_start + 1, len(lines)):
+        line = lines[index]
+        if line and not line.startswith(" "):
+            break
+        if line == key_line:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find {section_name}.{key_name} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line.startswith("  ") and not line.startswith("    ") and line.strip():
+            end = index
+            break
+        if line and not line.startswith(" "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
 def test_tesla_departure_planner_waits_for_helpers_on_startup() -> None:
     text = _read(CAR_PATH)
 
@@ -278,3 +317,37 @@ def test_light_package_uses_kelvin_color_temperature_keys() -> None:
     assert "\n        color_temp:" not in text
     assert "color_temp_kelvin: 2000" in text
     assert "color_temp_kelvin: 2591" in text
+
+
+def test_valetudo_startup_reconfigure_skips_unavailable_vacuums() -> None:
+    block = _automation_block(ZIGBEE_ZWAVE_PATH, "reconfigure_z2m_and_vacuums_on_startup")
+
+    assert "entity_id: vacuum.valetudo_den" in block
+    assert "entity_id: vacuum.valetudo_upstairs_vacuum" in block
+    assert "entity_id: vacuum.valetudo_mainlevel" not in block
+    assert block.count("condition: not") == 2
+    assert block.count("state: unavailable") == 2
+    assert "action: rest_command.reload_main_level_vacuum" not in block
+    assert "action: rest_command.reload_den_vacuum" in block
+    assert "action: rest_command.reload_upstairs_vacuum" in block
+    assert block.count("continue_on_error: true") == 2
+
+
+def test_valetudo_reload_commands_use_verified_runtime_endpoints() -> None:
+    den = _top_level_mapping_block(ZIGBEE_ZWAVE_PATH, "rest_command", "reload_den_vacuum")
+    upstairs = _top_level_mapping_block(
+        ZIGBEE_ZWAVE_PATH,
+        "rest_command",
+        "reload_upstairs_vacuum",
+    )
+
+    assert "http://192.168.1.245/api/v2/valetudo/config/interfaces/mqtt" in den
+    assert '"host":"192.168.1.11"' in den
+    assert '"identity":{"identifier":"den"}' in den
+    assert "valetudo-yummyhurtfulhornet.local" not in den
+    assert '"host":"10.254.254.11"' not in den
+
+    assert "http://192.168.1.163/api/v2/valetudo/config/interfaces/mqtt" in upstairs
+    assert '"host":"192.168.1.11"' in upstairs
+    assert '"identity":{"identifier":"upstairs-vacuum"}' in upstairs
+    assert "valetudo-zestycurvycaribou.local" not in upstairs


### PR DESCRIPTION
## Summary

Refs #691.

- Use live-verified Valetudo IP endpoints for the den and upstairs startup MQTT reloads.
- Correct the Valetudo MQTT listener host in those reload payloads to the HA interface the robots currently report using.
- Skip startup reloads when the corresponding vacuum entity is unavailable, and stop calling the unverified main-level Valetudo endpoint at startup until its current endpoint is confirmed.
- Add regression tests for the guarded startup automation and verified reload endpoints.

## Runtime evidence

Read-only runtime checks from the HA host on 2026-05-16 found:

- `den` Valetudo identity at `192.168.1.245`, current MQTT host `192.168.1.11`.
- `upstairs-vacuum` Valetudo identity at `192.168.1.163`, current MQTT host `192.168.1.11`.
- `valetudo-zestycurvycaribou.local` and `valetudo-activeexoticlion.local` did not resolve from the HA host.
- `vacuum.valetudo_mainlevel` and its map/entities were unavailable, so the startup path avoids that unverified endpoint instead of logging a known failure.

## Validation

- `uv run --with pytest pytest tests/test_runtime_log_regressions.py -q` -> 23 passed
- `uv run --with pytest pytest` -> 445 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt` -> passed
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version` -> passed; pinned Python 3.14.3 satisfies Home Assistant 2026.5.2 requirement
- `git diff --check` -> passed

## Validation gaps

- Docker is not installed in this local environment, so Docker-based Home Assistant `check_config` was not run locally. CI should run the configured check.
- `homeassistant-yaml-dry-verifier` on `packages/zigbee_zwave.yaml --strict` still reports pre-existing Inovelli LED/reset script duplication unrelated to the Valetudo startup block. Deferred to the existing DRY cleanup issue #529 rather than broadening this bug fix.