### PR TITLE
Fix #698 Tiki Time SomaFM stream playback

### DIFF
--- a/packages/tiki_time.yaml
+++ b/packages/tiki_time.yaml
@@ -349,7 +349,8 @@ script:
                 continue_on_error: true
                 data:
                   entity_id: media_player.ma_group_everywhere
-                  media_item: "somafm://radio/tikitime"
+                  media_item: "https://ice2.somafm.com/tikitime-128-mp3"
+                  media_type: radio
                   enqueue: replace
               - action: media_player.turn_on
                 target:

--- a/tests/test_tiki_time.py
+++ b/tests/test_tiki_time.py
@@ -36,7 +36,9 @@ def test_tiki_time_uses_shared_music_assistant_helpers() -> None:
     assert "Start the Tiki Time party mode" in block
     assert "action: script.music_assistant_play_item" in block
     assert "action: script.music_assistant_prepare_house_party_group" not in block
-    assert 'media_item: "somafm://radio/tikitime"' in block
+    assert 'media_item: "https://ice2.somafm.com/tikitime-128-mp3"' in block
+    assert "media_type: radio" in block
+    assert "somafm://radio/tikitime" not in block
     assert "media_player.ma_group_everywhere" in block
     assert "media_player.basement" in block
     assert "source: Photos" in block


### PR DESCRIPTION
## Summary
- Replace the Tiki Time `somafm://radio/tikitime` provider URI with a direct SomaFM Tiki Time stream URL.
- Pass `media_type: radio` to Music Assistant for the direct stream.
- Update the Tiki Time regression test to reject the old provider URI.

Fixes #698.

## Validation
- Verified the current SomaFM Tiki Time playlist exposes direct stream URLs via `https://somafm.com/tikitime.pls`.
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/tiki_time.yaml --strict`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/tiki_time.yaml`
- `uv run --with pytest pytest tests/test_tiki_time.py`
- `uv run --with pytest pytest`
- `uv run --with homeassistant==2026.5.0 python -m homeassistant --config /Users/rtclauss/Documents/New\ project --script check_config`

Note: the CI Docker image path could not be run locally because Docker is not installed in this environment; the Home Assistant config check was run through `uv` with the same 2026.5.0 Home Assistant version instead.