### PR TITLE
Fix #698 Tiki Time SomaFM stream URI

### DIFF
--- a/packages/tiki_time.yaml
+++ b/packages/tiki_time.yaml
@@ -349,7 +349,7 @@ script:
                 continue_on_error: true
                 data:
                   entity_id: media_player.ma_group_everywhere
-                  media_item: "somafm://radio/tikitime"
+                  media_item: "https://ice2.somafm.com/tikitime-128-mp3"
                   enqueue: replace
               - action: media_player.turn_on
                 target:

--- a/tests/test_tiki_time.py
+++ b/tests/test_tiki_time.py
@@ -36,7 +36,8 @@ def test_tiki_time_uses_shared_music_assistant_helpers() -> None:
     assert "Start the Tiki Time party mode" in block
     assert "action: script.music_assistant_play_item" in block
     assert "action: script.music_assistant_prepare_house_party_group" not in block
-    assert 'media_item: "somafm://radio/tikitime"' in block
+    assert "somafm://radio" not in block
+    assert 'media_item: "https://ice2.somafm.com/tikitime-128-mp3"' in block
     assert "media_player.ma_group_everywhere" in block
     assert "media_player.basement" in block
     assert "source: Photos" in block


### PR DESCRIPTION
## Summary

Fixes #698 by replacing the Tiki Time Music Assistant media item from the SomaFM provider URI to a direct SomaFM stream URL:

- `somafm://radio/tikitime` -> `https://ice2.somafm.com/tikitime-128-mp3`
- Adds regression coverage so Tiki Time no longer depends on `somafm://radio` provider URIs.

## Runtime evidence

Nightly Trace Review found live HA 2026.5.1 has `update.somafm_update` unavailable after the SomaFM integration setup failure. The live config still had `packages/tiki_time.yaml` calling `script.music_assistant_play_item` with `media_item: "somafm://radio/tikitime"`, while recent bedtime audio fixes already moved SomaFM playback to direct streams.

I verified SomaFM's current Tiki Time playlist response advertises direct stream entries including `https://ice2.somafm.com/tikitime-128-mp3`. I did not trigger the live playback script because that would cause audible whole-house behavior.

## Validation

- `uv run --with pytest pytest tests/test_tiki_time.py tests/test_media_player_music_assistant.py` -> 27 passed
- `uv run --with pytest pytest` -> 443 passed
- `uvx --from yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/tiki_time.yaml` -> passed
- Live HA config API `POST /api/config/core/check_config` -> `result: valid`, no errors or warnings

## Notes

Docker is not installed in the local Codex environment, so I used the live HA config-check API instead of the CI container command.
