### PR TITLE
Fix #688 exclude F1 season results from Recorder

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -123,6 +123,9 @@ recorder:
       # Keep smaller current/latest bird summary sensors recorded instead.
       - sensor.top_50_bird_species
       - sensor.top_50_bird_species_2
+      # F1 season results carries full race result payloads in attributes.
+      # Keep smaller current/next-session F1 sensors recorded instead.
+      - sensor.f1_season_results
 
 influxdb:
   exclude:

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -148,6 +148,20 @@ def test_raw_birdweather_top_50_feed_is_excluded_from_recorder() -> None:
     assert "full species list in attributes" in recorder_block
 
 
+def test_raw_f1_season_results_feed_is_excluded_from_recorder() -> None:
+    text = _read(CONFIGURATION_PATH)
+
+    recorder_block = text.split("recorder:\n", 1)[1].split("\ninfluxdb:", 1)[0]
+    recorder_entities = {
+        line.strip().removeprefix("- ").strip()
+        for line in recorder_block.splitlines()
+        if line.strip().startswith("- ")
+    }
+
+    assert "sensor.f1_season_results" in recorder_entities
+    assert "full race result payloads in attributes" in recorder_block
+
+
 def test_garbage_notifications_use_computed_pickup_date_sensor() -> None:
     text = _read(UTILITIES_PATH)
 


### PR DESCRIPTION
## Summary

Fixes #688 by excluding `sensor.f1_season_results` from Recorder. The entity carries full race result payloads in attributes and currently exceeds Home Assistant Recorder's 16,384-byte attribute limit.

## Runtime evidence

Nightly Trace Review on 2026-05-18 found live HA 2026.5.1 still has:

- `sensor.f1_season_results` state `4`
- attributes containing `races`
- serialized attributes around 19,344 bytes

That is above Recorder's attribute storage limit and matches the existing runtime warning tracked in #688.

## Validation

- `uv run --with pytest pytest tests/test_runtime_log_regressions.py` -> 22 passed
- `uv run --with pytest pytest` -> 444 passed
- `uvx --from yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml` -> passed
- `git diff --check` -> passed

## Notes

Docker is not installed in the local Codex environment, so the local CI container `check_config` command was unavailable. This change follows the existing Recorder exclusion pattern for FR24 and BirdWeather oversized raw feeds.
