### PR TITLE
Add mail/package delivery state flow (#116)

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -950,6 +950,8 @@ automation:
 
   - id: mail_delivered
     alias: mail_delivered
+    mode: queued
+    max: 10
     trace:
       stored_traces: 10
     trigger:
@@ -957,25 +959,231 @@ automation:
         entity_id: binary_sensor.mailbox_contact
         from: "off"
         to: "on"
+        id: mailbox-open
+      - trigger: state
+        entity_id:
+          - binary_sensor.usps_mail_delivered
+          - binary_sensor.usps_image_updated
+          - binary_sensor.amazon_image_updated
+          - sensor.mail_amazon_packages_delivered
+          - sensor.mail_amazon_packages
+          - sensor.mail_fedex_delivered
+          - sensor.mail_fedex_packages
+          - sensor.mail_ups_delivered
+          - sensor.mail_ups_packages
+          - sensor.mail_usps_delivered
+          - sensor.mail_usps_mail
+          - sensor.mail_usps_packages
+        id: mail-and-packages-source
+    variables:
+      mail_source_entities:
+        - sensor.mail_usps_delivered
+        - sensor.mail_usps_mail
+      package_source_entities:
+        - sensor.mail_amazon_packages_delivered
+        - sensor.mail_amazon_packages
+        - sensor.mail_fedex_delivered
+        - sensor.mail_fedex_packages
+        - sensor.mail_ups_delivered
+        - sensor.mail_ups_packages
+        - sensor.mail_usps_packages
+      source_entities:
+        - binary_sensor.usps_mail_delivered
+        - binary_sensor.usps_image_updated
+        - binary_sensor.amazon_image_updated
+        - sensor.mail_amazon_packages_delivered
+        - sensor.mail_amazon_packages
+        - sensor.mail_fedex_delivered
+        - sensor.mail_fedex_packages
+        - sensor.mail_ups_delivered
+        - sensor.mail_ups_packages
+        - sensor.mail_usps_delivered
+        - sensor.mail_usps_mail
+        - sensor.mail_usps_packages
+      mail_count: >-
+        {% set count = namespace(value=0) %}
+        {% for entity_id in mail_source_entities %}
+          {% set count.value = count.value + states(entity_id) | int(0) %}
+        {% endfor %}
+        {{ count.value }}
+      package_count: >-
+        {% set count = namespace(value=0) %}
+        {% for entity_id in package_source_entities %}
+          {% set count.value = count.value + states(entity_id) | int(0) %}
+        {% endfor %}
+        {{ count.value }}
+      source_available: >-
+        {% set available = namespace(value=false) %}
+        {% for entity_id in source_entities %}
+          {% if states(entity_id) not in ['unavailable', 'unknown'] %}
+            {% set available.value = true %}
+          {% endif %}
+        {% endfor %}
+        {{ available.value }}
+      mail_detected: >-
+        {{ mail_count | int(0) > 0
+            or is_state('binary_sensor.usps_mail_delivered', 'on')
+            or is_state('binary_sensor.usps_image_updated', 'on') }}
+      package_detected: >-
+        {{ package_count | int(0) > 0
+            or is_state('binary_sensor.amazon_image_updated', 'on') }}
+      next_delivery_state: >-
+        {% if mail_detected and package_detected %}
+          mail_and_package_delivered
+        {% elif package_detected %}
+          package_delivered
+        {% elif mail_detected %}
+          mail_delivered
+        {% elif not source_available %}
+          source_unavailable
+        {% else %}
+          idle
+        {% endif %}
+      current_delivery_state: "{{ states('input_select.mail_package_state') }}"
+      delivery_title: >-
+        {% if next_delivery_state == 'mail_and_package_delivered' %}
+          Mail and package delivered
+        {% elif next_delivery_state == 'package_delivered' %}
+          Package delivered
+        {% else %}
+          Mail delivered
+        {% endif %}
+      delivery_message: >-
+        {% if next_delivery_state == 'mail_and_package_delivered' %}
+          Mail and packages are waiting outside or in the mailbox.
+        {% elif next_delivery_state == 'package_delivered' %}
+          A package is waiting outside.
+        {% elif next_delivery_state == 'mail_delivered' %}
+          Mail is waiting in the mailbox.
+        {% else %}
+          Mail delivery state changed.
+        {% endif %}
+      delivery_camera: >-
+        {% set preferred = [
+          'camera.mail_amazon_delivery_camera',
+          'camera.mail_ups_camera',
+          'camera.mail_fedex_delivery_camera',
+          'camera.mail_usps_camera',
+          'camera.mail_generic_delivery_camera'
+        ] %}
+        {% set camera = namespace(entity_id='') %}
+        {% for entity_id in preferred %}
+          {% if camera.entity_id == ''
+                and states(entity_id) not in ['unavailable', 'unknown'] %}
+            {% set camera.entity_id = entity_id %}
+          {% endif %}
+        {% endfor %}
+        {{ camera.entity_id }}
     condition:
-      - condition: and
-        conditions:
-          - alias: "Mailbox empty"
-            condition: state
-            entity_id: input_boolean.mail_delivered
-            state: "off"
-          - alias: "On a trip"
-            condition: state
-            entity_id: input_boolean.trip
-            state: "off"
+      - condition: state
+        entity_id: input_boolean.trip
+        state: "off"
     action:
-      - action: input_boolean.turn_on
-        target:
-          entity_id: input_boolean.mail_delivered
-      - action: notify.all
-        data:
-          message: >-
-            Mail delivered.
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: mailbox-open
+              - condition: or
+                conditions:
+                  - condition: state
+                    entity_id: input_boolean.mail_delivered
+                    state: "on"
+                  - condition: state
+                    entity_id: input_select.mail_package_state
+                    state:
+                      - mail_delivered
+                      - package_delivered
+                      - mail_and_package_delivered
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_state
+                data:
+                  option: retrieved
+              - action: input_boolean.turn_off
+                target:
+                  entity_id: input_boolean.mail_delivered
+              - action: notify.all
+                data:
+                  title: "Mail and packages retrieved"
+                  message: "Mailbox opened; pending mail/package state cleared."
+          - conditions:
+              - condition: trigger
+                id: mailbox-open
+              - condition: state
+                entity_id: input_boolean.mail_delivered
+                state: "off"
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_state
+                data:
+                  option: mail_delivered
+              - action: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.mail_delivered
+              - action: notify.all
+                data:
+                  title: "Mail delivered"
+                  message: "Mailbox opened; mail may be waiting."
+          - conditions:
+              - condition: template
+                value_template: >-
+                  {{ next_delivery_state in [
+                    'mail_delivered',
+                    'package_delivered',
+                    'mail_and_package_delivered'
+                  ] and current_delivery_state not in [
+                    next_delivery_state,
+                    'retrieved'
+                  ] }}
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_state
+                data:
+                  option: "{{ next_delivery_state }}"
+              - action: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.mail_delivered
+              - choose:
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ delivery_camera | trim != '' }}"
+                    sequence:
+                      - action: notify.all
+                        data:
+                          title: "{{ delivery_title }}"
+                          message: "{{ delivery_message }}"
+                          data:
+                            entity_id: "{{ delivery_camera }}"
+                default:
+                  - action: notify.all
+                    data:
+                      title: "{{ delivery_title }}"
+                      message: "{{ delivery_message }}"
+          - conditions:
+              - condition: template
+                value_template: >-
+                  {{ next_delivery_state == 'source_unavailable'
+                      and current_delivery_state == 'idle' }}
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_state
+                data:
+                  option: source_unavailable
+          - conditions:
+              - condition: template
+                value_template: >-
+                  {{ next_delivery_state == 'idle'
+                      and current_delivery_state == 'source_unavailable' }}
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_state
+                data:
+                  option: idle
 
   - id: office_light_control_button
     alias: office_light_control_button
@@ -1110,6 +1318,11 @@ automation:
       - action: input_boolean.turn_off
         target:
           entity_id: input_boolean.mail_delivered
+      - action: input_select.select_option
+        target:
+          entity_id: input_select.mail_package_state
+        data:
+          option: idle
 
   - alias: guest_room_switch_actions
     id: guest_room_switch_actions
@@ -1640,6 +1853,18 @@ counter: {}
 # Input Select
 ########################
 input_select:
+  mail_package_state:
+    name: Mail and package state
+    icon: mdi:package-variant-closed-check
+    options:
+      - idle
+      - mail_delivered
+      - package_delivered
+      - mail_and_package_delivered
+      - retrieved
+      - source_unavailable
+    initial: idle
+
   chatgpt_bed_override:
     name: Bed override
     options:

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -981,12 +981,8 @@ automation:
         - sensor.mail_usps_mail
       package_source_entities:
         - sensor.mail_amazon_packages_delivered
-        - sensor.mail_amazon_packages
         - sensor.mail_fedex_delivered
-        - sensor.mail_fedex_packages
         - sensor.mail_ups_delivered
-        - sensor.mail_ups_packages
-        - sensor.mail_usps_packages
       source_entities:
         - binary_sensor.usps_mail_delivered
         - binary_sensor.usps_image_updated
@@ -1863,7 +1859,6 @@ input_select:
       - mail_and_package_delivered
       - retrieved
       - source_unavailable
-    initial: idle
 
   chatgpt_bed_override:
     name: Bed override

--- a/tests/test_mail_package_flow.py
+++ b/tests/test_mail_package_flow.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+
+ZIGBEE_ZWAVE_PATH = Path(__file__).resolve().parents[1] / "packages" / "zigbee_zwave.yaml"
+
+
+def _package_text() -> str:
+    return ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
+
+
+def _automation_block(automation_id: str) -> str:
+    lines = _package_text().splitlines()
+    id_line = f"  - id: {automation_id}"
+    start = None
+
+    for index, line in enumerate(lines):
+        if line != id_line:
+            continue
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_mail_package_state_helper_distinguishes_delivery_outcomes() -> None:
+    text = _package_text()
+
+    assert "mail_package_state:" in text
+    for option in (
+        "idle",
+        "mail_delivered",
+        "package_delivered",
+        "mail_and_package_delivered",
+        "retrieved",
+        "source_unavailable",
+    ):
+        assert f"      - {option}" in text
+
+
+def test_mail_delivery_flow_uses_mail_and_packages_without_spamming() -> None:
+    block = _automation_block("mail_delivered")
+
+    for entity_id in (
+        "binary_sensor.usps_mail_delivered",
+        "binary_sensor.usps_image_updated",
+        "binary_sensor.amazon_image_updated",
+        "sensor.mail_amazon_packages_delivered",
+        "sensor.mail_fedex_delivered",
+        "sensor.mail_ups_delivered",
+        "sensor.mail_usps_mail",
+        "sensor.mail_usps_packages",
+    ):
+        assert entity_id in block
+
+    assert "mode: queued" in block
+    assert "next_delivery_state" in block
+    assert "current_delivery_state not in" in block
+    assert "next_delivery_state," in block
+    assert "'retrieved'" in block
+
+
+def test_mailbox_open_marks_retrieval_when_delivery_is_pending() -> None:
+    block = _automation_block("mail_delivered")
+
+    assert "id: mailbox-open" in block
+    assert "entity_id: input_select.mail_package_state" in block
+    assert "option: retrieved" in block
+    assert "pending mail/package state cleared" in block
+    assert "action: input_boolean.turn_off" in block
+
+
+def test_mail_delivery_degrades_when_sources_or_cameras_are_unavailable() -> None:
+    block = _automation_block("mail_delivered")
+
+    assert "source_unavailable" in block
+    assert "states(entity_id) not in ['unavailable', 'unknown']" in block
+    assert "delivery_camera" in block
+    assert "camera.mail_amazon_delivery_camera" in block
+    assert "camera.mail_generic_delivery_camera" in block
+    assert 'value_template: "{{ delivery_camera | trim != \'\' }}"' in block
+
+
+def test_mail_reset_clears_compatibility_boolean_and_rich_state() -> None:
+    block = _automation_block("reset_mail_delivery")
+
+    assert "entity_id: input_boolean.mail_delivered" in block
+    assert "entity_id: input_select.mail_package_state" in block
+    assert "option: idle" in block

--- a/tests/test_mail_package_flow.py
+++ b/tests/test_mail_package_flow.py
@@ -48,6 +48,7 @@ def test_mail_package_state_helper_distinguishes_delivery_outcomes() -> None:
         "source_unavailable",
     ):
         assert f"      - {option}" in text
+    assert "    initial: idle" not in text
 
 
 def test_mail_delivery_flow_uses_mail_and_packages_without_spamming() -> None:
@@ -70,6 +71,28 @@ def test_mail_delivery_flow_uses_mail_and_packages_without_spamming() -> None:
     assert "current_delivery_state not in" in block
     assert "next_delivery_state," in block
     assert "'retrieved'" in block
+
+
+def test_mail_delivery_uses_only_delivered_package_counters() -> None:
+    block = _automation_block("mail_delivered")
+    package_sources = block[
+        block.index("      package_source_entities:") : block.index("      source_entities:")
+    ]
+
+    for entity_id in (
+        "sensor.mail_amazon_packages_delivered",
+        "sensor.mail_fedex_delivered",
+        "sensor.mail_ups_delivered",
+    ):
+        assert entity_id in package_sources
+
+    for scheduled_entity_id in (
+        "sensor.mail_amazon_packages",
+        "sensor.mail_fedex_packages",
+        "sensor.mail_ups_packages",
+        "sensor.mail_usps_packages",
+    ):
+        assert f"        - {scheduled_entity_id}\n" not in package_sources
 
 
 def test_mailbox_open_marks_retrieval_when_delivery_is_pending() -> None:


### PR DESCRIPTION
## Summary

Fixes #116.

- Add a richer `input_select.mail_package_state` with `idle`, mail-only, package-only, combined, retrieved, and source-unavailable states.
- Expand the existing mailbox automation to consume Mail and Packages entities when available while preserving the existing `input_boolean.mail_delivered` compatibility helper.
- Treat a mailbox open as retrieval when a delivery is already pending, and reset both the legacy boolean and rich state overnight.
- Attach an available Mail and Packages camera to the notification when one is usable; otherwise send the same notification without a camera attachment.
- Address PR review feedback by allowing HA to restore the selected input state after restart and using only delivered/image-updated package signals for delivered notifications.
- Add regression coverage for the new state helper, no-spam state guard, delivered-only package counters, retrieval path, unavailable-source fallback, and reset behavior.

## Runtime evidence

Read-only live HA state on 2026-05-19 confirmed the Mail and Packages entities exist but are currently `unavailable`, including `sensor.mail_usps_mail`, package carrier sensors, and `camera.mail_*` entities. The implementation therefore degrades through `source_unavailable` and still supports the existing mailbox contact fallback.

## Validation

- `uv run --with pytest pytest tests/test_mail_package_flow.py` -> 5 passed before review fixes; 6 passed after review fixes via focused bundle below
- `uv run --with pytest pytest tests/test_mail_package_flow.py tests/test_window_egress_automation_coverage.py tests/test_runtime_log_regressions.py` -> 31 passed
- `uv run --with pytest pytest` -> 449 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/zigbee_zwave.yaml` -> passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt` -> passed
- `uv run --with homeassistant==2026.5.3 python -m homeassistant --config . --script check_config` -> passed
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version` -> passed; pinned Python 3.14.3 satisfies HA 2026.5.3
- `git diff --check` -> passed

## DRY verifier

`python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/zigbee_zwave.yaml --strict` parsed successfully with no full-block duplicates, but it still reports pre-existing Inovelli/reset script duplication in `packages/zigbee_zwave.yaml`. Those findings are unrelated to this mail/package flow and should remain with the existing broad DRY refactor work (#529) rather than expanding this issue.