### PR TITLE
Fix #698 Tiki Time SomaFM playback

### DIFF
--- a/packages/tiki_time.yaml
+++ b/packages/tiki_time.yaml
@@ -349,7 +349,8 @@ script:
                 continue_on_error: true
                 data:
                   entity_id: media_player.ma_group_everywhere
-                  media_item: "somafm://radio/tikitime"
+                  media_item: "https://ice1.somafm.com/tikitime-128-mp3"
+                  media_type: radio
                   enqueue: replace
               - action: media_player.turn_on
                 target:

--- a/tests/test_tiki_time.py
+++ b/tests/test_tiki_time.py
@@ -36,7 +36,9 @@ def test_tiki_time_uses_shared_music_assistant_helpers() -> None:
     assert "Start the Tiki Time party mode" in block
     assert "action: script.music_assistant_play_item" in block
     assert "action: script.music_assistant_prepare_house_party_group" not in block
-    assert 'media_item: "somafm://radio/tikitime"' in block
+    assert 'media_item: "https://ice1.somafm.com/tikitime-128-mp3"' in block
+    assert "media_type: radio" in block
+    assert "somafm://radio/tikitime" not in block
     assert "media_player.ma_group_everywhere" in block
     assert "media_player.basement" in block
     assert "source: Photos" in block


### PR DESCRIPTION
## Summary
- Replace Tiki Time's SomaFM provider URI with a direct SomaFM Tiki Time stream URL.
- Pass `media_type: radio` through the existing Music Assistant helper, matching the direct-stream bedtime pattern.
- Update the Tiki Time regression test to prevent reintroducing `somafm://radio/tikitime`.

## Runtime evidence
- Live HA `update.somafm_update` is restored/unavailable as of 2026-05-20.
- Live `script.tiki_time` is loaded from package `tiki_time`, but the package still called `somafm://radio/tikitime`.
- SomaFM's current Tiki Time playlist exposes direct MP3 stream entries such as `ice6.somafm.com/tikitime-128-mp3`; this PR uses the existing repo convention of `https://ice1.somafm.com/...` direct station URLs.

## Validation
- `uv run --with pytest pytest tests/test_tiki_time.py`
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/tiki_time.yaml`

Docker is not available in this automation environment, so I could not run the local Home Assistant container `check_config`.

Closes #698