### PR TITLE
[codex] Align uplift desk component controls

### DIFF
--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -135,8 +135,10 @@
                           },
                           "entities": [
                             "sensor.uplift_desk_75b205_height",
-                            "button.uplift_desk_75b205_move_to_preset_1",
-                            "button.uplift_desk_75b205_move_to_preset_2"
+                            "script.uplift_desk_manual_move_preset_1",
+                            "script.uplift_desk_manual_move_preset_2",
+                            "script.uplift_desk_manual_move_max",
+                            "script.uplift_desk_manual_stop"
                           ],
                           "background_color": "var(--ha-card-background, var(--card-background-color))",
                           "card_mod": {
@@ -1009,15 +1011,15 @@
                 },
                 {
                   "type": "tile",
-                  "entity": "button.uplift_desk_75b205_move_to_preset_1",
+                  "entity": "script.uplift_desk_manual_move_preset_1",
                   "name": "Sit",
                   "icon": "mdi:chair-rolling",
                   "hide_state": true,
                   "tap_action": {
                     "action": "call-service",
-                    "service": "button.press",
+                    "service": "script.turn_on",
                     "target": {
-                      "entity_id": "button.uplift_desk_75b205_move_to_preset_1"
+                      "entity_id": "script.uplift_desk_manual_move_preset_1"
                     }
                   },
                   "hold_action": {
@@ -1026,15 +1028,15 @@
                 },
                 {
                   "type": "tile",
-                  "entity": "button.uplift_desk_75b205_move_to_preset_2",
+                  "entity": "script.uplift_desk_manual_move_preset_2",
                   "name": "Stand",
                   "icon": "mdi:human-handsup",
                   "hide_state": true,
                   "tap_action": {
                     "action": "call-service",
-                    "service": "button.press",
+                    "service": "script.turn_on",
                     "target": {
-                      "entity_id": "button.uplift_desk_75b205_move_to_preset_2"
+                      "entity_id": "script.uplift_desk_manual_move_preset_2"
                     }
                   },
                   "hold_action": {
@@ -1043,15 +1045,49 @@
                 },
                 {
                   "type": "tile",
-                  "entity": "button.uplift_desk_75b205_move_to_max_height",
+                  "entity": "script.uplift_desk_manual_move_max",
                   "name": "Max Height",
                   "icon": "mdi:arrow-up-bold-box",
                   "hide_state": true,
                   "tap_action": {
                     "action": "call-service",
-                    "service": "button.press",
+                    "service": "script.turn_on",
                     "target": {
-                      "entity_id": "button.uplift_desk_75b205_move_to_max_height"
+                      "entity_id": "script.uplift_desk_manual_move_max"
+                    }
+                  },
+                  "hold_action": {
+                    "action": "more-info"
+                  }
+                },
+                {
+                  "type": "tile",
+                  "entity": "script.uplift_desk_manual_move_min",
+                  "name": "Min Height",
+                  "icon": "mdi:arrow-down-bold-box",
+                  "hide_state": true,
+                  "tap_action": {
+                    "action": "call-service",
+                    "service": "script.turn_on",
+                    "target": {
+                      "entity_id": "script.uplift_desk_manual_move_min"
+                    }
+                  },
+                  "hold_action": {
+                    "action": "more-info"
+                  }
+                },
+                {
+                  "type": "tile",
+                  "entity": "script.uplift_desk_manual_stop",
+                  "name": "Stop",
+                  "icon": "mdi:stop-circle",
+                  "hide_state": true,
+                  "tap_action": {
+                    "action": "call-service",
+                    "service": "script.turn_on",
+                    "target": {
+                      "entity_id": "script.uplift_desk_manual_stop"
                     }
                   },
                   "hold_action": {

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Software on the NUC:
   * ~~[Traccar](https://github.com/hassio-addons/addon-traccar) - Used with OBDII Sensor to track my car.~~ New car has built-in tracking
   * [JupyterLab Lite](https://github.com/hassio-addons/addon-jupyterlab-lite) Only sometimes when I need to figure out event correllation
   * [ESPHome](https://esphomelib.com/esphomeyaml/index.html) - Used for [Water Softener](https://github.com/rtclauss/hass-config/blob/main/packages/water_softener.yaml), [Bed Occupancy Sensor](https://github.com/rtclauss/hass-config/blob/main/esphome/bedloadcell1.yaml), and [BLE Proxy](https://github.com/rtclauss/hass-config/blob/main/esphome/bluetoothproxy1.yaml)
+  * [Uplift Desk custom component](https://github.com/rtclauss/hass-uplift-desk) - Fork used for standing desk entities and controls in `packages/desk.yaml`.
   * ~~[Zwave-JS](https://www.home-assistant.io/integrations/zwave_js)~~ Moving to Zigbee/Thread/Matter
   * [I Can't Believe It's Not Valetudo](https://github.com/Poeschl/Hassio-Addons/tree/master/ICantBelieveItsNotValetudo)
   * [Home Assistant Google Drive Backup](https://github.com/sabeechen/hassio-google-drive-backup)
@@ -272,6 +273,7 @@ replacement below.
 | <a id="live-localtuya"></a>LocalTuya / Good Earth | Good Earth / Tuya LED flat panels in kitchen and laundry areas. |
 | <a id="live-rachio"></a>Rachio | Rachio Gen 3 irrigation controller and zone switches. |
 | <a id="live-smartthings"></a>SmartThings | The modified SmartThings Arrival Sensor is still paired via Zigbee2MQTT. |
+| <a id="live-uplift-desk"></a>Uplift Desk | Office standing desk using the [`rtclauss/hass-uplift-desk`](https://github.com/rtclauss/hass-uplift-desk) custom component fork. |
 | <a id="live-tesla"></a>Tesla | Tesla Model 3 (`Nigori`) on the custom Tesla integration. |
 | <a id="live-unifi"></a>UniFi | The `unifi` integration is active for network entities, WLANs, and device trackers, although exact hardware model inventory is no longer fully represented in Home Assistant. |
 | <a id="live-adaptive-lighting"></a>Adaptive Lighting | Active room-specific Adaptive Lighting instances across the lighting stack. |

--- a/lovelace/tiles/tiles_office.yaml
+++ b/lovelace/tiles/tiles_office.yaml
@@ -81,35 +81,60 @@ cards:
   - type: horizontal-stack
     cards:
       - type: entity-button
-        entity: button.uplift_desk_75b205_move_to_preset_1
+        entity: script.uplift_desk_manual_move_preset_1
         name: Sit
         icon: mdi:chair-rolling
         tap_action:
           action: call-service
-          service: button.press
+          service: script.turn_on
           service_data:
-            entity_id: button.uplift_desk_75b205_move_to_preset_1
+            entity_id: script.uplift_desk_manual_move_preset_1
         hold_action:
           action: more-info
       - type: entity-button
-        entity: button.uplift_desk_75b205_move_to_preset_2
+        entity: script.uplift_desk_manual_move_preset_2
         name: Stand
         icon: mdi:human-handsup
         tap_action:
           action: call-service
-          service: button.press
+          service: script.turn_on
           service_data:
-            entity_id: button.uplift_desk_75b205_move_to_preset_2
+            entity_id: script.uplift_desk_manual_move_preset_2
         hold_action:
           action: more-info
       - type: entity-button
-        entity: button.uplift_desk_75b205_move_to_max_height
+        entity: script.uplift_desk_manual_move_max
         name: Max
         icon: mdi:arrow-up-bold-box
         tap_action:
           action: call-service
-          service: button.press
+          service: script.turn_on
           service_data:
-            entity_id: button.uplift_desk_75b205_move_to_max_height
+            entity_id: script.uplift_desk_manual_move_max
+        hold_action:
+          action: more-info
+
+  - type: horizontal-stack
+    cards:
+      - type: entity-button
+        entity: script.uplift_desk_manual_move_min
+        name: Min
+        icon: mdi:arrow-down-bold-box
+        tap_action:
+          action: call-service
+          service: script.turn_on
+          service_data:
+            entity_id: script.uplift_desk_manual_move_min
+        hold_action:
+          action: more-info
+      - type: entity-button
+        entity: script.uplift_desk_manual_stop
+        name: Stop
+        icon: mdi:stop-circle
+        tap_action:
+          action: call-service
+          service: script.turn_on
+          service_data:
+            entity_id: script.uplift_desk_manual_stop
         hold_action:
           action: more-info

--- a/packages/desk.yaml
+++ b/packages/desk.yaml
@@ -78,6 +78,10 @@ homeassistant:
       <<: *customize
       friendly_name: "Desk Manual Move Max"
 
+    script.uplift_desk_manual_move_min:
+      <<: *customize
+      friendly_name: "Desk Manual Move Min"
+
     script.uplift_desk_manual_move_preset_1:
       <<: *customize
       friendly_name: "Desk Manual Move Preset 1"
@@ -85,6 +89,10 @@ homeassistant:
     script.uplift_desk_manual_move_preset_2:
       <<: *customize
       friendly_name: "Desk Manual Move Preset 2"
+
+    script.uplift_desk_manual_stop:
+      <<: *customize
+      friendly_name: "Desk Manual Stop"
 
     ################################################
     ## Timer
@@ -360,6 +368,21 @@ script:
         target:
           entity_id: button.uplift_desk_75b205_move_to_max_height
 
+  uplift_desk_manual_move_min:
+    alias: uplift_desk_manual_move_min
+    description: >
+      Manual desk control for dashboards and UI buttons. This bypasses the
+      Home Assistant automation guard and sends the desk to the configured
+      minimum height immediately.
+    mode: single
+    icon: mdi:arrow-down-bold-box
+    trace:
+      stored_traces: 10
+    sequence:
+      - action: button.press
+        target:
+          entity_id: button.uplift_desk_75b205_move_to_min_height
+
   uplift_desk_manual_move_preset_1:
     alias: uplift_desk_manual_move_preset_1
     description: >
@@ -387,6 +410,20 @@ script:
       - action: button.press
         target:
           entity_id: button.uplift_desk_75b205_move_to_preset_2
+
+  uplift_desk_manual_stop:
+    alias: uplift_desk_manual_stop
+    description: >
+      Manual desk control for dashboards and UI buttons. This bypasses the
+      Home Assistant automation guard and stops desk motion immediately.
+    mode: single
+    icon: mdi:stop-circle
+    trace:
+      stored_traces: 10
+    sequence:
+      - action: button.press
+        target:
+          entity_id: button.uplift_desk_75b205_stop
 
 ########################
 # Timer

--- a/tests/test_uplift_desk_native_component.py
+++ b/tests/test_uplift_desk_native_component.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DESK_PACKAGE = ROOT / "packages" / "desk.yaml"
+OFFICE_TILE = ROOT / "lovelace" / "tiles" / "tiles_office.yaml"
+MUSHROOM_DASHBOARD = ROOT / ".storage" / "lovelace.ryan_new_mushroom"
+
+NATIVE_DESK_BUTTONS = {
+    "button.uplift_desk_75b205_move_to_max_height",
+    "button.uplift_desk_75b205_move_to_min_height",
+    "button.uplift_desk_75b205_move_to_preset_1",
+    "button.uplift_desk_75b205_move_to_preset_2",
+    "button.uplift_desk_75b205_stop",
+}
+
+MANUAL_DESK_SCRIPTS = {
+    "script.uplift_desk_manual_move_max",
+    "script.uplift_desk_manual_move_min",
+    "script.uplift_desk_manual_move_preset_1",
+    "script.uplift_desk_manual_move_preset_2",
+    "script.uplift_desk_manual_stop",
+}
+
+
+def test_desk_package_uses_native_uplift_component_buttons() -> None:
+    text = DESK_PACKAGE.read_text(encoding="utf-8")
+
+    for entity_id in NATIVE_DESK_BUTTONS:
+        assert entity_id in text
+
+    assert "shell_command.uplift_desk" not in text
+    assert "uplift_ble_remote.sh" not in text
+
+
+def test_office_dashboards_use_manual_desk_script_wrappers() -> None:
+    for path in (OFFICE_TILE, MUSHROOM_DASHBOARD):
+        text = path.read_text(encoding="utf-8")
+
+        for entity_id in MANUAL_DESK_SCRIPTS:
+            assert entity_id in text
+
+        assert "service: button.press" not in text
+        assert '"service": "button.press"' not in text
+        assert "button.uplift_desk_75b205_move_to_" not in text
+        assert "button.uplift_desk_75b205_stop" not in text


### PR DESCRIPTION
Closes #706.

## Summary
- Align the desk package with the re-added native Uplift Desk component entities.
- Add manual script wrappers for min-height and stop controls, and route office dashboard controls through those wrappers.
- Document the `rtclauss/hass-uplift-desk` fork in the README software list and live device audit.

## Root cause
The desk component was re-added, but parts of the configuration and dashboards still needed an explicit contract around the current native component entities and the custom fork source.

## Coverage and tests
- Added `tests/test_uplift_desk_native_component.py` to assert native Uplift button usage and dashboard script-wrapper usage.
- Ran `uv run --with pytest pytest`.

## Validation
- `uv run --with pytest pytest` passed: 447 tests.
