### PR TITLE
Fix #712 Z2M availability roster drift

### DIFF
--- a/packages/z2m_availability.yaml
+++ b/packages/z2m_availability.yaml
@@ -262,6 +262,18 @@ mqtt:
       payload_available: "online"
       payload_not_available: "offline"
 
+    - name: "Z2M Basement/Mouse Bucket Availability"
+      unique_id: z2m_basement_mouse_bucket_availability
+      state_topic: "zigbee2mqtt/Basement/Mouse Bucket/availability"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
     - name: "Z2M Basement/North Hallway 1 Availability"
       unique_id: z2m_basement_north_hallway_1_availability
       state_topic: "zigbee2mqtt/Basement/North Hallway 1/availability"
@@ -649,18 +661,6 @@ mqtt:
     - name: "Z2M Dining Room/Wall Switch Availability"
       unique_id: z2m_dining_room_wall_switch_availability
       state_topic: "zigbee2mqtt/Dining Room/Wall Switch/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_available: "online"
-      payload_not_available: "offline"
-
-    - name: "Z2M Doorbell Availability"
-      unique_id: z2m_doorbell_availability
-      state_topic: "zigbee2mqtt/Doorbell/availability"
       value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
@@ -1345,6 +1345,18 @@ mqtt:
     - name: "Z2M Office/Motion Availability"
       unique_id: z2m_office_motion_availability
       state_topic: "zigbee2mqtt/Office/Motion/availability"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/Smoke Alarm Availability"
+      unique_id: z2m_office_smoke_alarm_availability
+      state_topic: "zigbee2mqtt/Office/Smoke Alarm/availability"
       value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"


### PR DESCRIPTION
Fixes #712.

## Summary
- add Z2M availability sensors for `Basement/Mouse Bucket` and `Office/Smoke Alarm`
- remove stale `Doorbell` availability sensor that is no longer in `zigbee2mqtt/configuration.yaml`
- keep the package count aligned with the configured Zigbee2MQTT friendly-name roster

## Evidence
- PR #711 failed pytest on the current `develop` merge base with missing Z2M availability sensors.
- Local comparison found two configured friendly names without sensors and one stale package topic not present in the roster.

## Validation
- `uv run --with pytest pytest tests/test_z2m_availability_package.py -q` -> 19 passed
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/z2m_availability.yaml` -> passed
- `git diff --check` -> passed
- `uv run --with pytest pytest` -> 447 passed
- Local Home Assistant check_config could not run because Docker is not installed in this environment; GitHub CI will run the repository check_config job.