### PR TITLE
[codex] Fix under-bed light motion handling

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -2073,11 +2073,6 @@ automation:
     mode: restart
     trace:
       stored_traces: 50
-    variables:
-      under_bed_brightness_pct: >-
-        {{ state_attr('switch.adaptive_lighting_owner_suite', 'brightness_pct') | int(25) }}
-      under_bed_kelvin: >-
-        {{ state_attr('switch.adaptive_lighting_owner_suite', 'color_temp_kelvin') | int(2700) }}
     trigger:
       - trigger: state
         id: zone_1_on
@@ -2133,17 +2128,12 @@ automation:
               - condition: state
                 entity_id: light.owner_suite_lamps
                 state: "on"
-              - action: light.turn_off
-                target:
-                  entity_id: light.bed_lightstrip
               # Split the first 8 guaranteed LIFX Z zones into 4 logical bed quadrants.
               - action: lifx.set_state
                 target:
                   entity_id: light.bed_lightstrip
                 data:
                   power: true
-                  brightness_pct: "{{ under_bed_brightness_pct }}"
-                  kelvin: "{{ under_bed_kelvin }}"
                   zones: [0, 1]
           - conditions:
               - condition: trigger
@@ -2152,16 +2142,11 @@ automation:
               - condition: state
                 entity_id: light.owner_suite_lamps
                 state: "on"
-              - action: light.turn_off
-                target:
-                  entity_id: light.bed_lightstrip
               - action: lifx.set_state
                 target:
                   entity_id: light.bed_lightstrip
                 data:
                   power: true
-                  brightness_pct: "{{ under_bed_brightness_pct }}"
-                  kelvin: "{{ under_bed_kelvin }}"
                   zones: [2, 3]
           - conditions:
               - condition: trigger
@@ -2170,16 +2155,11 @@ automation:
               - condition: state
                 entity_id: light.owner_suite_lamps
                 state: "on"
-              - action: light.turn_off
-                target:
-                  entity_id: light.bed_lightstrip
               - action: lifx.set_state
                 target:
                   entity_id: light.bed_lightstrip
                 data:
                   power: true
-                  brightness_pct: "{{ under_bed_brightness_pct }}"
-                  kelvin: "{{ under_bed_kelvin }}"
                   zones: [4, 5]
           - conditions:
               - condition: trigger
@@ -2188,16 +2168,11 @@ automation:
               - condition: state
                 entity_id: light.owner_suite_lamps
                 state: "on"
-              - action: light.turn_off
-                target:
-                  entity_id: light.bed_lightstrip
               - action: lifx.set_state
                 target:
                   entity_id: light.bed_lightstrip
                 data:
                   power: true
-                  brightness_pct: "{{ under_bed_brightness_pct }}"
-                  kelvin: "{{ under_bed_kelvin }}"
                   zones: [6, 7]
           - conditions:
               - condition: trigger

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -2128,6 +2128,14 @@ automation:
               - condition: state
                 entity_id: light.owner_suite_lamps
                 state: "on"
+              - action: adaptive_lighting.apply
+                data:
+                  lights:
+                    - light.bed_lightstrip
+                  entity_id: switch.adaptive_lighting_owner_suite
+                  adapt_brightness: true
+                  adapt_color: true
+                  turn_on_lights: true
               # Split the first 8 guaranteed LIFX Z zones into 4 logical bed quadrants.
               - action: lifx.set_state
                 target:
@@ -2142,6 +2150,14 @@ automation:
               - condition: state
                 entity_id: light.owner_suite_lamps
                 state: "on"
+              - action: adaptive_lighting.apply
+                data:
+                  lights:
+                    - light.bed_lightstrip
+                  entity_id: switch.adaptive_lighting_owner_suite
+                  adapt_brightness: true
+                  adapt_color: true
+                  turn_on_lights: true
               - action: lifx.set_state
                 target:
                   entity_id: light.bed_lightstrip
@@ -2155,6 +2171,14 @@ automation:
               - condition: state
                 entity_id: light.owner_suite_lamps
                 state: "on"
+              - action: adaptive_lighting.apply
+                data:
+                  lights:
+                    - light.bed_lightstrip
+                  entity_id: switch.adaptive_lighting_owner_suite
+                  adapt_brightness: true
+                  adapt_color: true
+                  turn_on_lights: true
               - action: lifx.set_state
                 target:
                   entity_id: light.bed_lightstrip
@@ -2168,6 +2192,14 @@ automation:
               - condition: state
                 entity_id: light.owner_suite_lamps
                 state: "on"
+              - action: adaptive_lighting.apply
+                data:
+                  lights:
+                    - light.bed_lightstrip
+                  entity_id: switch.adaptive_lighting_owner_suite
+                  adapt_brightness: true
+                  adapt_color: true
+                  turn_on_lights: true
               - action: lifx.set_state
                 target:
                   entity_id: light.bed_lightstrip

--- a/packages/z2m_availability.yaml
+++ b/packages/z2m_availability.yaml
@@ -310,6 +310,18 @@ mqtt:
       payload_available: "online"
       payload_not_available: "offline"
 
+    - name: "Z2M Basement/Mouse Bucket Availability"
+      unique_id: z2m_basement_mouse_bucket_availability
+      state_topic: "zigbee2mqtt/Basement/Mouse Bucket/availability"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
     - name: "Z2M Basement/Stair Landing Availability"
       unique_id: z2m_basement_stair_landing_availability
       state_topic: "zigbee2mqtt/Basement/Stair Landing/availability"
@@ -649,18 +661,6 @@ mqtt:
     - name: "Z2M Dining Room/Wall Switch Availability"
       unique_id: z2m_dining_room_wall_switch_availability
       state_topic: "zigbee2mqtt/Dining Room/Wall Switch/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_available: "online"
-      payload_not_available: "offline"
-
-    - name: "Z2M Doorbell Availability"
-      unique_id: z2m_doorbell_availability
-      state_topic: "zigbee2mqtt/Doorbell/availability"
       value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"
@@ -1345,6 +1345,18 @@ mqtt:
     - name: "Z2M Office/Motion Availability"
       unique_id: z2m_office_motion_availability
       state_topic: "zigbee2mqtt/Office/Motion/availability"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Office/Smoke Alarm Availability"
+      unique_id: z2m_office_smoke_alarm_availability
+      state_topic: "zigbee2mqtt/Office/Smoke Alarm/availability"
       value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"

--- a/tests/test_owner_suite_under_bed_light.py
+++ b/tests/test_owner_suite_under_bed_light.py
@@ -35,6 +35,7 @@ def test_under_bed_zone_motion_does_not_turn_strip_off_before_zone_update() -> N
 
     assert "action: light.turn_off" not in zone_section
     assert "entity_id: light.bed_lightstrip" in zone_section
+    assert zone_section.count("action: adaptive_lighting.apply") == 4
     assert zone_section.count("action: lifx.set_state") == 4
 
 

--- a/tests/test_owner_suite_under_bed_light.py
+++ b/tests/test_owner_suite_under_bed_light.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+LIGHT_PATH = Path(__file__).resolve().parents[1] / "packages" / "light.yaml"
+
+
+def _automation_block(automation_id: str) -> str:
+    lines = LIGHT_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line != f"  - id: {automation_id}":
+            continue
+        start = index
+        break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_under_bed_zone_motion_does_not_turn_strip_off_before_zone_update() -> None:
+    block = _automation_block("toggle_on_under_bed_on_motion")
+    actions = block.split("    action:", 1)[1]
+    zone_section = actions.split("id: zone_1_on", 1)[1].split("id: motion_on", 1)[0]
+
+    assert "action: light.turn_off" not in zone_section
+    assert "entity_id: light.bed_lightstrip" in zone_section
+    assert zone_section.count("action: lifx.set_state") == 4
+
+
+def test_under_bed_zone_lifx_calls_only_use_supported_zone_fields() -> None:
+    block = _automation_block("toggle_on_under_bed_on_motion")
+    actions = block.split("    action:", 1)[1]
+    zone_section = actions.split("id: zone_1_on", 1)[1].split("id: motion_on", 1)[0]
+
+    assert "brightness_pct:" not in zone_section
+    assert "kelvin:" not in zone_section
+    assert "power: true" in zone_section
+    assert "zones: [0, 1]" in zone_section
+    assert "zones: [2, 3]" in zone_section
+    assert "zones: [4, 5]" in zone_section
+    assert "zones: [6, 7]" in zone_section


### PR DESCRIPTION
## Summary
- Fix owner-suite under-bed zone motion so entering the room no longer turns the bed strip off before updating a LIFX zone
- Remove unsupported kelvin and brightness_pct fields from lifx.set_state calls, matching the live HA service schema
- Reconcile Z2M availability roster drift found by the required full test run: add Basement/Mouse Bucket and Office/Smoke Alarm, remove stale Doorbell
- Add regression tests for the under-bed automation behavior

## Root Cause
Today’s Home Assistant trace showed automation.toggle_on_under_bed_on_motion turned off light.bed_lightstrip, then failed lifx.set_state with extra keys not allowed @ data[kelvin]. That left the strip off instead of on when entering the room.

Closes #714

## Validation
- uv run --with pytest pytest
- 449 passed