### PR TITLE
Add AppDaemon websocket reconnect watchdog (#702)

### DIFF
--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -133,6 +133,20 @@ homeassistant:
     ################################################
 
 ########################
+# Command Line
+########################
+command_line:
+  - sensor:
+      name: AppDaemon HASS websocket reconnect error
+      unique_id: appdaemon_hass_websocket_reconnect_error
+      command: >-
+        python3 /config/scripts/appdaemon_log_probe.py
+        --log /config/logs/appdaemon_error.log
+        --max-age-seconds 600
+      command_timeout: 10
+      scan_interval: 60
+
+########################
 # Alarm Panel
 ########################
 alarm_control_panel: []
@@ -504,20 +518,43 @@ automation:
         data:
           option: "{{ tariff }}"
 
-  - alias: Restart AppDaemon on HA Startup or load cells unavailable
-    description: When HA starts up, or bed load cells are unavailable restart AppDaemon
+  - alias: Restart AppDaemon on HA startup or websocket reconnect failure
+    description: >
+      Restart AppDaemon when HA starts, or when the AppDaemon add-on log reports
+      a recent HASS websocket reconnect failure.
     id: restart_appdaemon_on_ha_startup
     trace:
       stored_traces: 10
     trigger:
       - trigger: homeassistant
         event: start
+        id: ha_start
+
+      - trigger: state
+        entity_id: sensor.appdaemon_hass_websocket_reconnect_error
+        id: appdaemon_hass_websocket_reconnect_error
 
       # action:
       #   - action: notify.mobile_app_wethop
       #     data:
       #       message: >-
       #         Restarting AppDaemon. Check the Automation Log
+    condition:
+      - condition: template
+        value_template: >-
+          {% if trigger.id == 'ha_start' %}
+            true
+          {% elif trigger.id == 'appdaemon_hass_websocket_reconnect_error' %}
+            {% set state = trigger.to_state.state if trigger.to_state is not none else 'unknown' %}
+            {% set last_triggered = this.attributes.last_triggered %}
+            {{ state not in ['clear', 'unknown', 'unavailable', 'none', '']
+               and (
+                 last_triggered is none
+                 or (now() - last_triggered).total_seconds() > 600
+               ) }}
+          {% else %}
+            false
+          {% endif %}
     action:
       - action: hassio.addon_restart
         continue_on_error: true

--- a/scripts/appdaemon_log_probe.py
+++ b/scripts/appdaemon_log_probe.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Probe AppDaemon logs for recent HA websocket reconnect failures."""
+
+from __future__ import annotations
+
+import argparse
+from collections import deque
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_SIGNATURES = (
+    "Invalid response status",
+    "supervisor/core/api/websocket",
+    "Attempting reconnection",
+)
+
+
+def _parse_appdaemon_timestamp(line: str) -> datetime | None:
+    if len(line) < 19:
+        return None
+
+    try:
+        return datetime.strptime(line[:19], "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+
+
+def latest_recent_match(
+    log_path: Path,
+    *,
+    signatures: Iterable[str] = DEFAULT_SIGNATURES,
+    max_age_seconds: int = 600,
+    max_lines: int = 1000,
+    now: datetime | None = None,
+) -> str:
+    if not log_path.exists():
+        return "clear"
+
+    signatures = tuple(signatures)
+    current_time = now or datetime.now()
+
+    try:
+        with log_path.open(encoding="utf-8", errors="replace") as handle:
+            lines = deque(handle, maxlen=max_lines)
+    except OSError:
+        return "clear"
+
+    for line in reversed(lines):
+        if not any(signature in line for signature in signatures):
+            continue
+
+        timestamp = _parse_appdaemon_timestamp(line)
+        if timestamp is None:
+            continue
+
+        age_seconds = (current_time - timestamp).total_seconds()
+        if 0 <= age_seconds <= max_age_seconds:
+            return timestamp.strftime("%Y-%m-%d %H:%M:%S")
+
+        return "clear"
+
+    return "clear"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--log",
+        default="/config/logs/appdaemon_error.log",
+        type=Path,
+        help="AppDaemon error log path",
+    )
+    parser.add_argument(
+        "--max-age-seconds",
+        default=600,
+        type=int,
+        help="Ignore matching log lines older than this many seconds",
+    )
+    parser.add_argument(
+        "--max-lines",
+        default=1000,
+        type=int,
+        help="Only inspect this many lines from the end of the log",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    print(
+        latest_recent_match(
+            args.log,
+            max_age_seconds=args.max_age_seconds,
+            max_lines=args.max_lines,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_appdaemon_websocket_reconnect_restart.py
+++ b/tests/test_appdaemon_websocket_reconnect_restart.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib.util
+import re
+from datetime import datetime
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "appdaemon_log_probe.py"
+UTILITIES_PATH = ROOT / "packages" / "utilities.yaml"
+
+SPEC = importlib.util.spec_from_file_location("appdaemon_log_probe", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Could not load {MODULE_PATH}")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def _automation_block(automation_id: str) -> str:
+    lines = UTILITIES_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line != f"    id: {automation_id}":
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - alias: "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+
+    end = len(lines)
+    next_automation = re.compile(r"^  - alias: ")
+    for index in range(start + 1, len(lines)):
+        if next_automation.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_appdaemon_log_probe_reports_recent_websocket_502(tmp_path: Path) -> None:
+    now = datetime(2026, 5, 24, 9, 30, 0)
+    log_path = tmp_path / "appdaemon_error.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "2026-05-24 09:10:00.000 ERROR HASS: old unrelated error",
+                "2026-05-24 09:28:30.000 ERROR HASS: 502, "
+                "message='Invalid response status', "
+                "url='http://supervisor/core/api/websocket'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        MODULE.latest_recent_match(log_path, max_age_seconds=600, now=now)
+        == "2026-05-24 09:28:30"
+    )
+
+
+def test_appdaemon_log_probe_ignores_stale_or_missing_matches(tmp_path: Path) -> None:
+    now = datetime(2026, 5, 24, 9, 30, 0)
+    stale_log = tmp_path / "stale_appdaemon_error.log"
+    stale_log.write_text(
+        "2026-05-24 09:00:00.000 ERROR HASS: Attempting reconnection in 5.0s\n",
+        encoding="utf-8",
+    )
+
+    assert MODULE.latest_recent_match(stale_log, max_age_seconds=600, now=now) == "clear"
+    assert MODULE.latest_recent_match(tmp_path / "missing.log", now=now) == "clear"
+
+
+def test_utilities_defines_appdaemon_websocket_error_sensor() -> None:
+    text = UTILITIES_PATH.read_text(encoding="utf-8")
+
+    assert "command_line:" in text
+    assert "unique_id: appdaemon_hass_websocket_reconnect_error" in text
+    assert "python3 /config/scripts/appdaemon_log_probe.py" in text
+    assert "--log /config/logs/appdaemon_error.log" in text
+    assert "--max-age-seconds 600" in text
+    assert "scan_interval: 60" in text
+
+
+def test_existing_appdaemon_restart_automation_handles_websocket_errors() -> None:
+    block = _automation_block("restart_appdaemon_on_ha_startup")
+
+    assert "trigger: homeassistant" in block
+    assert "id: ha_start" in block
+    assert "trigger: state" in block
+    assert "entity_id: sensor.appdaemon_hass_websocket_reconnect_error" in block
+    assert "id: appdaemon_hass_websocket_reconnect_error" in block
+    assert "last_triggered" in block
+    assert "total_seconds() > 600" in block
+    assert "addon: a0d7b954_appdaemon" in block
+    assert block.count("action: hassio.addon_restart") == 1


### PR DESCRIPTION
Fixes #702.

## Summary
- add `scripts/appdaemon_log_probe.py` to report only recent AppDaemon HASS websocket reconnect/502 signatures from `/config/logs/appdaemon_error.log`
- add a `command_line` sensor in `packages/utilities.yaml` that polls that log probe every 60 seconds
- extend the existing `restart_appdaemon_on_ha_startup` automation with a throttled sensor trigger, keeping a single `hassio.addon_restart` action for AppDaemon
- add regression coverage for the probe and YAML wiring

## Notes
- The prior failure was in the AppDaemon add-on log, not HA core `system_log`, so this uses a command-line sensor rather than `system_log_event`.
- The restart condition ignores stale matches older than 10 minutes and also throttles restarts to avoid a tight restart loop if the log keeps updating.

## Validation
- `uv run --with pytest pytest tests/test_appdaemon_websocket_reconnect_restart.py tests/test_ha_2026_5_upgrade.py -q` -> 7 passed
- `uv run --with pytest pytest` -> 454 passed
- `python3 -m py_compile scripts/appdaemon_log_probe.py` -> passed
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/utilities.yaml` -> passed
- `uv run --with homeassistant==2026.5.0 python -m homeassistant --config . --script check_config` -> passed
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version` -> passed
- `git diff --check` -> passed

## DRY verifier
- `uv run --with pyyaml python /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/utilities.yaml --strict` scanned 1 file, parsed 21 candidates, parse errors 0.
- The AppDaemon restart block had no duplicate action/trigger findings introduced by this PR.
- Strict mode still reports pre-existing, unrelated duplication in `packages/utilities.yaml`: `trigger_winter_watermeter_flow` repeated water-meter light actions, repeated Home Assistant startup triggers across unrelated watchdog automations, and duplicated water-restore shutoff conditions. Deferred as out of scope for this bug fix because resolving those safely requires a broader utility-package behavior refactor.
