### PR TITLE
Fix Bayesian WiFi observation: sensor.wethop_ssid instead of device_tracker.wethop_wifi

### DIFF
--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -720,11 +720,11 @@ binary_sensor:
         prob_given_false: 0.0005
         platform: state
         to_state: "home"
-      - entity_id: device_tracker.wethop_wifi
+      - entity_id: sensor.wethop_ssid
         prob_given_true: 0.98
         prob_given_false: 0.25
         platform: state
-        to_state: "home"
+        to_state: !secret home_ssid
       - entity_id: device_tracker.nigori_location_tracker
         prob_given_true: 0.95
         prob_given_false: 0.55
@@ -779,7 +779,7 @@ group:
     entities:
       - device_tracker.bayesian_zeke_home
       - device_tracker.wethop
-      - device_tracker.wethop_wifi
+      - sensor.wethop_ssid
       - binary_sensor.arrival_sensor_presence
       - sensor.zeke_speed
       - sensor.wethop_battery_state


### PR DESCRIPTION
## Summary

- Replace `device_tracker.wethop_wifi` (UniFi integration) with `sensor.wethop_ssid` (iOS Companion SSID sensor) in the `bayesian_zeke_home` Bayesian binary sensor observation
- Use `!secret home_ssid` for the SSID value so it never appears in YAML
- Update `group.bayesian_inputs` to reference `sensor.wethop_ssid` instead

**Root cause:** The UniFi integration does not reliably create device tracker entities for clients on 6 GHz / WiFi 7 bands, and was previously broken by iOS Private WiFi Address (MAC randomization). The iOS Companion `sensor.wethop_ssid` is a direct report of the phone's connected SSID with no dependency on UniFi.

**Required deployment step:** Add `home_ssid: barley` to `/config/secrets.yaml` on the HA instance (the real production file, not the gitignored placeholder) before restarting. Without this the Bayesian sensor will fail to load the new observation.

## Test plan

- [ ] Add `home_ssid: barley` to production `/config/secrets.yaml` on HA instance (via Studio Code Server or Samba share)
- [ ] Merge this PR and run the Git pull add-on to deploy
- [ ] Restart HA and confirm `binary_sensor.bayesian_zeke_home` attributes show `sensor.wethop_ssid` as an observation
- [ ] Confirm observation is `observed: true` when phone is connected to home WiFi

🤖 Generated with [Claude Code](https://claude.com/claude-code)