### PR TITLE
Fix #721 thermostat stats DB rollback recovery

### DIFF
--- a/appdaemon/apps/thermostat_stats.py
+++ b/appdaemon/apps/thermostat_stats.py
@@ -162,7 +162,11 @@ class ThermostatStats(hass.Hass):
             if entity_id:
                 self.listen_state(self.state_changed, entity_id, attribute="all")
 
-        engine = sqlalchemy.create_engine(self.thermostat_database, echo=True)
+        engine = sqlalchemy.create_engine(
+            self.thermostat_database,
+            echo=True,
+            pool_pre_ping=True,
+        )
         Base.metadata.create_all(engine)
         self._ensure_optional_columns(engine)
 
@@ -437,5 +441,16 @@ class ThermostatStats(hass.Hass):
             aux_heat_on=aux_heat_on,
         )
 
+        self._commit_thermostat_change(temp_info)
+
+    def _commit_thermostat_change(self, temp_info):
         self.session.add(temp_info)
-        self.session.commit()
+        try:
+            self.session.commit()
+        except sqlalchemy.exc.SQLAlchemyError as err:
+            self.session.rollback()
+            self.log(
+                "ThermostatStats DB write failed; rolled back session and skipped sample: "
+                f"{err}",
+                level="WARNING",
+            )

--- a/tests/test_thermostat_stats_app.py
+++ b/tests/test_thermostat_stats_app.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_PATH = ROOT / "appdaemon" / "apps" / "thermostat_stats.py"
+
+
+def _load_thermostat_stats_module(monkeypatch):
+    hassapi = types.ModuleType("hassapi")
+    sqlalchemy = types.ModuleType("sqlalchemy")
+    sqlalchemy_ext = types.ModuleType("sqlalchemy.ext")
+    sqlalchemy_declarative = types.ModuleType("sqlalchemy.ext.declarative")
+    sqlalchemy_orm = types.ModuleType("sqlalchemy.orm")
+
+    class SQLAlchemyError(Exception):
+        pass
+
+    class OperationalError(SQLAlchemyError):
+        pass
+
+    class PendingRollbackError(SQLAlchemyError):
+        pass
+
+    class _Metadata:
+        def create_all(self, engine):
+            return None
+
+    def declarative_base():
+        class Base:
+            metadata = _Metadata()
+
+        return Base
+
+    def column(*args, **kwargs):
+        return None
+
+    sqlalchemy.Boolean = object
+    sqlalchemy.Column = column
+    sqlalchemy.DateTime = object
+    sqlalchemy.Float = object
+    sqlalchemy.Integer = object
+    sqlalchemy.String = object
+    sqlalchemy.Text = object
+    sqlalchemy.create_engine = Mock()
+    sqlalchemy.text = lambda statement: statement
+    sqlalchemy.exc = types.SimpleNamespace(
+        SQLAlchemyError=SQLAlchemyError,
+        OperationalError=OperationalError,
+        PendingRollbackError=PendingRollbackError,
+    )
+    sqlalchemy.orm = sqlalchemy_orm
+    sqlalchemy_orm.sessionmaker = Mock(return_value=Mock(return_value=Mock()))
+    sqlalchemy_declarative.declarative_base = declarative_base
+
+    class Hass:
+        pass
+
+    hassapi.Hass = Hass
+    monkeypatch.setitem(sys.modules, "hassapi", hassapi)
+    monkeypatch.setitem(sys.modules, "sqlalchemy", sqlalchemy)
+    monkeypatch.setitem(sys.modules, "sqlalchemy.ext", sqlalchemy_ext)
+    monkeypatch.setitem(sys.modules, "sqlalchemy.ext.declarative", sqlalchemy_declarative)
+    monkeypatch.setitem(sys.modules, "sqlalchemy.orm", sqlalchemy_orm)
+
+    spec = importlib.util.spec_from_file_location("thermostat_stats_test_module", APP_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_commit_rolls_back_session_after_database_failure(monkeypatch) -> None:
+    module = _load_thermostat_stats_module(monkeypatch)
+    app = module.ThermostatStats.__new__(module.ThermostatStats)
+    app.session = Mock()
+    app.session.commit.side_effect = module.sqlalchemy.exc.OperationalError(
+        "SSL connection has been closed unexpectedly"
+    )
+    app.log = Mock()
+
+    app._commit_thermostat_change(object())
+
+    app.session.add.assert_called_once()
+    app.session.rollback.assert_called_once()
+    app.log.assert_called_once()
+
+
+def test_commit_can_continue_after_rollback(monkeypatch) -> None:
+    module = _load_thermostat_stats_module(monkeypatch)
+    app = module.ThermostatStats.__new__(module.ThermostatStats)
+    app.session = Mock()
+    app.session.commit.side_effect = [
+        module.sqlalchemy.exc.PendingRollbackError("rolled back due to previous exception"),
+        None,
+    ]
+    app.log = Mock()
+
+    app._commit_thermostat_change(object())
+    app._commit_thermostat_change(object())
+
+    assert app.session.add.call_count == 2
+    assert app.session.commit.call_count == 2
+    app.session.rollback.assert_called_once()
+    app.log.assert_called_once()
+
+
+def test_initialize_uses_pool_pre_ping_for_database_engine(monkeypatch) -> None:
+    module = _load_thermostat_stats_module(monkeypatch)
+    app = module.ThermostatStats.__new__(module.ThermostatStats)
+    app.args = {
+        "house_average_temp": "sensor.average_house_temp",
+        "house_average_humidity": "sensor.average_house_humidity",
+        "thermostat_db": "postgresql://example/thermostat",
+        "thermostat": "climate.my_ecobee",
+        "sun": "sun.sun",
+        "outside_temp": "sensor.outside_temperature",
+        "outside_cloud_cover": "sensor.tomorrow_io_the_brewery_cloud_cover",
+        "outside_humidity": "sensor.outside_humidity",
+    }
+    app.listen_state = Mock()
+
+    create_engine = Mock(return_value=Mock())
+    monkeypatch.setattr(module.sqlalchemy, "create_engine", create_engine)
+    monkeypatch.setattr(module.Base.metadata, "create_all", Mock())
+    monkeypatch.setattr(module.ThermostatStats, "_ensure_optional_columns", Mock())
+    monkeypatch.setattr(module.sqlalchemy.orm, "sessionmaker", Mock(return_value=Mock(return_value=Mock())))
+
+    app.initialize()
+
+    create_engine.assert_called_once_with(
+        "postgresql://example/thermostat",
+        echo=True,
+        pool_pre_ping=True,
+    )


### PR DESCRIPTION
Fixes #721.

## Summary
- Enable SQLAlchemy `pool_pre_ping` for the AppDaemon thermostat stats database engine.
- Roll back the long-lived SQLAlchemy session when a thermostat sample commit fails, then log and skip only that sample.
- Add focused pytest coverage for rollback recovery and engine pre-ping.

## Runtime evidence
Nightly Trace Review on 2026-05-25 found live `/config/logs/appdaemon_error.log` repeatedly reporting `ThermostatStats.state_changed` failures for `sensor.average_house_temp`. The first write failed with `psycopg2.OperationalError: SSL connection has been closed unexpectedly`; later callbacks failed with SQLAlchemy `PendingRollbackError` because the session was never rolled back.

## Validation
- `uv run --with pytest pytest tests/test_thermostat_stats_app.py -q` -> 3 passed
- `python3 -m py_compile appdaemon/apps/thermostat_stats.py` -> passed
- `git diff --check` -> passed
- `uv run --with pytest pytest` -> 459 passed

## Runtime follow-up
After deploy/AppDaemon reload, verify `/config/logs/appdaemon_error.log` no longer accumulates `PendingRollbackError` for `thermostat_stats` after a transient PostgreSQL reconnect.