### PR TITLE
Align owner suite vanity Adaptive Lighting

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -3,8 +3,8 @@ automation:
     alias: reconcile_owner_suite_adaptive_lighting
     description: >
       Reapply the Adaptive Lighting baselines after Home Assistant starts so
-      kitchen, den, basement, dining-room, and owner-suite tuning survive restarts
-      while preserving each room's intended scene and task-lighting behavior.
+      kitchen, den, basement, dining-room, owner-suite, and vanity tuning survive
+      restarts while preserving each room's intended scene and task-lighting behavior.
       The runtime dining-room Adaptive Lighting switch now uses the current dining-room entity id.
     mode: single
     trace:
@@ -57,6 +57,20 @@ automation:
           adapt_only_on_bare_turn_on: true
           only_once: false
           initial_transition: 2
+          sleep_transition: 2
+          transition: 5
+          sleep_brightness: 1
+          sleep_color_temp: 1000
+          detect_non_ha_changes: false
+      - action: adaptive_lighting.change_switch_settings
+        data:
+          entity_id: switch.adaptive_lighting_owner_suite_vanity
+          use_defaults: current
+          include_config_in_attributes: true
+          take_over_control: true
+          adapt_only_on_bare_turn_on: true
+          only_once: true
+          initial_transition: 1
           sleep_transition: 2
           transition: 5
           sleep_brightness: 1

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -38,6 +38,30 @@ def _automation_block(automation_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
+def _adaptive_lighting_settings_block(entity_id: str) -> str:
+    block = _automation_block("reconcile_owner_suite_adaptive_lighting")
+    lines = block.splitlines()
+    entity_line = f"          entity_id: {entity_id}"
+    try:
+        entity_index = lines.index(entity_line)
+    except ValueError as exc:
+        raise AssertionError(f"Could not find Adaptive Lighting settings for {entity_id}") from exc
+
+    start = entity_index
+    for candidate in range(entity_index, -1, -1):
+        if lines[candidate] == "      - action: adaptive_lighting.change_switch_settings":
+            start = candidate
+            break
+
+    end = len(lines)
+    for candidate in range(entity_index + 1, len(lines)):
+        if lines[candidate].startswith("      - "):
+            end = candidate
+            break
+
+    return "\n".join(lines[start:end])
+
+
 def test_owner_suite_adaptive_lighting_reconciles_supported_scene_safe_settings() -> None:
     block = _automation_block("reconcile_owner_suite_adaptive_lighting")
 
@@ -45,7 +69,7 @@ def test_owner_suite_adaptive_lighting_reconciles_supported_scene_safe_settings(
     assert "event: start" in block
     assert 'delay: "00:00:30"' in block
     assert "action: adaptive_lighting.change_switch_settings" in block
-    assert "kitchen, den, basement, dining-room, and owner-suite tuning survive restarts" in block
+    assert "kitchen, den, basement, dining-room, owner-suite, and vanity tuning survive" in block
     assert "entity_id: switch.adaptive_lighting_owner_suite" in block
     assert "use_defaults: current" in block
     assert "include_config_in_attributes: true" in block
@@ -59,6 +83,25 @@ def test_owner_suite_adaptive_lighting_reconciles_supported_scene_safe_settings(
     assert "sleep_color_temp: 1000" in block
     assert "detect_non_ha_changes: false" in block
     assert "event: adaptive_lighting_startup_reconciled" in block
+
+
+def test_owner_suite_vanity_adaptive_lighting_reconciles_scene_safe_baseline() -> None:
+    settings = _adaptive_lighting_settings_block("switch.adaptive_lighting_owner_suite_vanity")
+
+    for token in (
+        "use_defaults: current",
+        "include_config_in_attributes: true",
+        "take_over_control: true",
+        "adapt_only_on_bare_turn_on: true",
+        "only_once: true",
+        "initial_transition: 1",
+        "sleep_transition: 2",
+        "transition: 5",
+        "sleep_brightness: 1",
+        "sleep_color_temp: 1000",
+        "detect_non_ha_changes: false",
+    ):
+        assert token in settings
 
 
 def test_dining_room_adaptive_lighting_reconciles_current_switch_to_scene_safe_settings() -> None:


### PR DESCRIPTION
## Summary
- confirm the live Owner Suite Vanity Adaptive Lighting settings and add startup reconciliation for the requested baseline
- set vanity runtime behavior to take over control, adapt only on bare turn-on, adapt only once, use a 1s initial transition, 5s normal transition, and warm 1% sleep target
- add focused coverage for the vanity reconciliation block

Fixes #99.

## Live verification
- Before alignment, `switch.adaptive_lighting_owner_suite_vanity` reported `adapt_only_on_bare_turn_on: false`, `only_once: false`, and `transition: 45.0`.
- Applied the new baseline through `adaptive_lighting.change_switch_settings`; the live switch now reports `adapt_only_on_bare_turn_on: true`, `only_once: true`, `transition: 5.0`, `sleep_brightness: 1`, and `sleep_color_temp: 1000`.
- Existing vanity task-lighting floor `min_brightness: 75` was preserved by using `use_defaults: current`.

## Validation
- `uv run --with pytest pytest tests/test_adaptive_lighting_reconcile.py`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/adaptive_lighting.yaml --strict`
- `uv run --with pytest pytest`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt`
- `uv run --with homeassistant==2026.5.0 python -m homeassistant --config . --script check_config`
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `git diff --check`

Docker is not installed locally, so the HA config check was run through `uv` with the CI-pinned Home Assistant version instead of the Docker image.
