### PR TITLE
fix: remove dining_room_lamps from sunset transition (#725)

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1593,7 +1593,7 @@ automation:
             - light.kitchen_sink_overhead
             - light.hall_all
             # - light.hall_all_downlights
-            - light.dining_room_lamps
+            # - light.dining_room_lamps
             - light.den_flood_switch
             # - light.kitchen_table
             # - light.living_room_lamps


### PR DESCRIPTION
## Summary

- Removes `light.dining_room_lamps` from the `transition_on_lights_when_home_near_sunset` automation's evening light-on action
- Dining room lamps were being switched on automatically ~2 hours before sunset every evening with a 90-minute fade-in transition
- Lamp is now commented out so it falls back to manual / direct-switch control only

Closes #725

## Test plan

- [ ] Confirm `automation.transition_on_lights_when_home_near_sunset` fires around sunset and does **not** turn on `light.dining_room_lamps`
- [ ] Confirm wall switch and button automations (`dining_room_switch_actions`, `toggle_dining_room`) still control the dining room lamps normally
- [ ] Confirm other lights in the sunset transition (kitchen, hall, den flood) still come on as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)