### PR TITLE
Guard Bayesian sensor against trip false positives from travel router / parked car

### DIFF
--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -199,15 +199,15 @@ automation:
       #    - action: tts.google_say
       #      data:
       #        message: "Intruder Alert! Intruder Alert! You are detected and recorded."
-      - repeat:
-          count: 3
-          sequence:
-            - action: light.turn_on
-              continue_on_error: true
-              data:
-                entity_id: light.dining_room_lamps
-                flash: long
-            - delay: 00:00:02
+      # - repeat:
+      #     count: 3
+      #     sequence:
+      #       - action: light.turn_on
+      #         continue_on_error: true
+      #         data:
+      #           entity_id: light.dining_room_lamps
+      #           flash: long
+      #       - delay: 00:00:02
 
   - alias: send_notification_when_alarm_triggered
     id: send_notification_when_alarm_triggered

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -735,6 +735,11 @@ binary_sensor:
         prob_given_false: 0.05
         platform: state
         to_state: "on"
+      - entity_id: input_boolean.trip
+        prob_given_true: 0.01   # almost never on a trip when home
+        prob_given_false: 0.15  # most non-home time is also not a trip (work, errands)
+        platform: state
+        to_state: "on"
 
 ########################
 # Device Trackers
@@ -781,6 +786,7 @@ group:
       - device_tracker.wethop
       - sensor.wethop_ssid
       - binary_sensor.arrival_sensor_presence
+      - input_boolean.trip
       - sensor.zeke_speed
       - sensor.wethop_battery_state
       - sensor.wethop_activity


### PR DESCRIPTION
## Summary

- Adds `input_boolean.trip` as a Bayesian observation (`to_state: \"on\"`, `prob_given_true: 0.01`, `prob_given_false: 0.15`) in `bayesian_zeke_home`
- Also adds `input_boolean.trip` to `group.bayesian_inputs`
- Removes `light.dining_room_lamps` flash from `motion_detected_on_trip` alarm action

## Problem

When flying and leaving the car at home, three signals simultaneously produce false \"home\" evidence:
- UTR travel router broadcasts the home SSID → `sensor.wethop_ssid` observation fires
- Car stays home → `device_tracker.nigori_location_tracker` observation fires
- In-car arrival sensor stays on → `binary_sensor.arrival_presence` fires (prob_given_false 0.05 → factor ~20x)

Combined with GPS `not_home` (factor 0.005), the net result is **~89% probability — above the 0.80 threshold** — which would disarm the alarm while away.

A related symptom: when the Bayesian sensor false-positives while the user is in the basement watching TV, the alarm could arm → user walks upstairs → alarm trips → `motion_detected_on_trip` flashes `light.dining_room_lamps` three times. This was disruptive even when the alarm was behaving as designed.

## Fix

- `input_boolean.trip = on` contributes factor 0.067 (log −2.7), bringing the travel scenario to **~34%** — safely below threshold.
- The dining room lamp flash in `motion_detected_on_trip` is removed (commented out); alarm trigger + notification still fire normally.

**Circular dependency note:** `trip_mode_manager` reads `bayesian_zeke_home` and writes `input_boolean.trip`. The loop terminates safely: every branch that sets trip=on gates on `bayesian_zeke_home state: off`, so no threshold crossing can re-trigger the manager. GPS `home` factor (~1990) overrides trip mode instantly on real return.

Partially addresses #725

## Test plan

- [ ] Merge and deploy to HA instance
- [ ] Confirm `binary_sensor.bayesian_zeke_home` attributes show `input_boolean.trip` as an observation
- [ ] Verify probability stays below 0.80 when trip mode is on (simulate: enable trip mode, confirm alarm stays armed)
- [ ] Verify GPS home arrival still disarms instantly with trip mode on
- [ ] Confirm `motion_detected_on_trip` no longer flashes dining room lamps when alarm triggers; notifications still sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)