### PR TITLE
fix: stabilize Bayesian presence sensor against WiFi drop false positives

### DIFF
--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -722,7 +722,7 @@ binary_sensor:
         to_state: "home"
       - entity_id: sensor.wethop_ssid
         prob_given_true: 0.98
-        prob_given_false: 0.25  # elevated: travel router also broadcasts home SSID when away
+        prob_given_false: 0.60  # brief disconnects common at home; travel router guards false positives
         platform: state
         to_state: !secret home_ssid
       - entity_id: device_tracker.nigori_location_tracker
@@ -738,11 +738,6 @@ binary_sensor:
       - entity_id: input_boolean.trip
         prob_given_true: 0.01   # almost never on a trip when home
         prob_given_false: 0.15  # most non-home time is daily away (work, errands), not a trip
-        platform: state
-        to_state: "on"
-      - entity_id: input_boolean.trip
-        prob_given_true: 0.01   # almost never on a trip when home
-        prob_given_false: 0.15  # most non-home time is also not a trip (work, errands)
         platform: state
         to_state: "on"
 


### PR DESCRIPTION
## Summary

- **Bug 1:** Raise `wethop_ssid` `prob_given_false` from `0.25` → `0.60` — a brief WiFi disconnect (walking to basement, coverage edge) was applying a strong negative-evidence multiplier that, combined with `arrival_sensor_presence` being off, pushed the posterior below the 0.80 departure threshold. Vacuums ran 10× today as a result.
- **Bug 2:** Remove duplicate `input_boolean.trip` observation (copy-paste error introduced the same observation twice).

## Root cause detail

When `sensor.wethop_ssid` dropped to `Not Connected`, the Bayesian math produced:

```
P(home) = 1.53/2.53 = 0.60  ← below 0.80 threshold
```

...despite `device_tracker.wethop` (GPS) staying `home` all day. The SSID drop + always-off `arrival_sensor_presence` (Z2M issue, tracked separately) was enough to tip it over.

## Test plan

- [ ] Reload `binary_sensor` / restart HA and verify `binary_sensor.bayesian_zeke_home` remains `on` while home
- [ ] Confirm `automation.vacuum_leave_home` no longer fires spuriously during WiFi handoffs
- [ ] Confirm `device_tracker.bayesian_zeke_home` stays `home` during brief SSID drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)