### PR TITLE
Fix #730 duplicate Z2M Mouse Bucket availability sensor

### DIFF
--- a/packages/z2m_availability.yaml
+++ b/packages/z2m_availability.yaml
@@ -322,18 +322,6 @@ mqtt:
       payload_available: "online"
       payload_not_available: "offline"
 
-    - name: "Z2M Basement/Mouse Bucket Availability"
-      unique_id: z2m_basement_mouse_bucket_availability
-      state_topic: "zigbee2mqtt/Basement/Mouse Bucket/availability"
-      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_on: "online"
-      payload_off: "offline"
-      device_class: connectivity
-      availability_topic: "zigbee2mqtt/bridge/state"
-      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
-      payload_available: "online"
-      payload_not_available: "offline"
-
     - name: "Z2M Basement/Stair Landing Availability"
       unique_id: z2m_basement_stair_landing_availability
       state_topic: "zigbee2mqtt/Basement/Stair Landing/availability"


### PR DESCRIPTION
## Summary

Fixes #730.

- Removes the duplicate `Basement/Mouse Bucket` MQTT availability sensor block.
- Keeps the first matching sensor so the configured Zigbee2MQTT device remains covered.

## Evidence

Nightly Trace Review found `origin/develop` failing full pytest with:

- duplicate `z2m_basement_mouse_bucket_availability`
- 154 availability sensor topics for 153 configured Zigbee2MQTT devices

## Validation

- `uv run --with pytest pytest tests/test_z2m_availability_package.py -q` -> 19 passed
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/z2m_availability.yaml` -> passed
- `git diff --check` -> passed
- `uv run --with pytest pytest` -> 460 passed

Home Assistant `check_config` was not run locally because Docker is not installed in this Codex environment; CI should run the pinned HA check_config container.
