### PR TITLE
Fix #732 Z2M malformed device responses

### DIFF
--- a/packages/z2m_lifecycle.yaml
+++ b/packages/z2m_lifecycle.yaml
@@ -1064,17 +1064,22 @@ template:
             {% set payload = trigger.payload_json %}
             {% if payload is mapping and payload.data is defined %}
               {% set devices = payload.data %}
+              {% set has_device_snapshot = true %}
             {% elif payload is sequence and payload is not string %}
               {% set devices = payload %}
+              {% set has_device_snapshot = true %}
             {% else %}
               {% set devices = [] %}
+              {% set has_device_snapshot = false %}
             {% endif %}
-            {% set routers = devices
-              | selectattr('type', 'eq', 'Router')
-              | rejectattr('friendly_name', 'equalto', 'Coordinator')
-              | rejectattr('disabled', 'eq', true)
-              | map(attribute='friendly_name')
-              | list %}
+            {% if has_device_snapshot %}
+              {% set routers = devices
+                | selectattr('type', 'eq', 'Router')
+                | rejectattr('friendly_name', 'equalto', 'Coordinator')
+                | rejectattr('disabled', 'eq', true)
+                | map(attribute='friendly_name')
+                | list %}
+            {% endif %}
           {% endif %}
 
           {% if is_availability_topic %}

--- a/tests/test_z2m_lifecycle_package.py
+++ b/tests/test_z2m_lifecycle_package.py
@@ -86,6 +86,17 @@ def test_z2m_lifecycle_watchdog_uses_plain_bridge_state_trigger() -> None:
     assert 'value_template: "{{ value_json.state }}"' not in block
 
 
+def test_z2m_router_stats_preserves_roster_on_malformed_devices_response() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    block = text.split("z2m_router_stats: >-", maxsplit=1)[1].split("  - binary_sensor:", maxsplit=1)[0]
+
+    assert "current_attrs.get('routers', [])" in block
+    assert "{% set has_device_snapshot = true %}" in block
+    assert "{% set has_device_snapshot = false %}" in block
+    assert "{% if has_device_snapshot %}" in block
+    assert "{% set routers = devices" in block
+
+
 def test_z2m_ota_template_tracks_progress_attributes_not_simple_availability() -> None:
     text = PACKAGE_PATH.read_text(encoding="utf-8")
     template_block = text.split("z2m_ota_stats: >-", maxsplit=1)[1].split("  - trigger:", maxsplit=1)[0]


### PR DESCRIPTION
## Summary

Fixes #732.

- Preserves the previous Z2M router roster when `bridge/devices` or `bridge/response/devices` has a malformed/missing device snapshot.
- Keeps explicit empty snapshots authoritative, so a legitimate cleared Z2M roster can still reset router totals.
- Adds a regression test so the router-health template distinguishes valid snapshots from malformed payloads.

## Evidence

Nightly Trace Review found live HA oscillating `sensor.z2m_router_total` between `95` and `0` during the 2026-05-26 morning window while Zigbee2MQTT was running. The zero-router state retriggered `sync_z2m_decommission_options` and made the router-health guard unreliable.

## Validation

- `uv run --with pytest pytest tests/test_z2m_lifecycle_package.py tests/test_z2m_lifecycle_allium_alignment.py -q` -> 10 passed
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/z2m_lifecycle.yaml` -> passed
- `git diff --check` -> passed

Full `uv run --with pytest pytest` currently fails on `origin/develop` because of #730, fixed separately in PR #731. I did not bundle that availability duplicate fix into this PR.

Home Assistant `check_config` was not run locally because Docker is not installed in this Codex environment; CI should run the pinned HA check_config container.
