### PR TITLE
Add dining room config-button Zigbee group bindings

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2380,6 +2380,11 @@ script:
             - select.hall_garage_laundry_switch_switchtype
             - select.hall_upstairs_switch_switchtype
             - select.hall_stairway_switchtype
+      inovelli_fan_control_mode_replay:
+        - option: "Toggle"
+          entities:
+            - select.dining_room_table_switch_fancontrolmode
+            - select.dining_room_wall_switch_fancontrolmode
       # Recreate switch endpoint memberships in Zigbee groups after a reset.
       # For smart-bulb groups, endpoint 1 receives group state so the switch
       # load/LED stays in sync while endpoint 2 remains the bound controller.
@@ -2513,6 +2518,18 @@ script:
             - genLevelCtrl
             - genOnOff
             - genScenes
+        - from: "Dining Room/Table Switch"
+          from_endpoint: 3
+          to: "Kitchen/All"
+          clusters:
+            - genLevelCtrl
+            - genOnOff
+        - from: "Dining Room/Wall Switch"
+          from_endpoint: 3
+          to: "Kitchen/All"
+          clusters:
+            - genLevelCtrl
+            - genOnOff
         - from: "Hall/Foyer Switch"
           from_endpoint: 2
           to: "Hall/All"
@@ -2630,35 +2647,11 @@ script:
           option: "Enabled"
       - delay: "{{ mqtt_bind_delay }}"
       - repeat:
-          for_each: "{{ inovelli_smart_bulb_mode_replay }}"
-          sequence:
-            - variables:
-                replay_option: "{{ repeat.item.option }}"
-                replay_entities: "{{ repeat.item.entities }}"
-            - repeat:
-                for_each: "{{ replay_entities }}"
-                sequence:
-                  - action: select.select_option
-                    data:
-                      entity_id: "{{ repeat.item }}"
-                      option: "{{ replay_option }}"
-                  - delay: "{{ ha_write_delay }}"
-      - repeat:
-          for_each: "{{ inovelli_output_mode_replay }}"
-          sequence:
-            - variables:
-                replay_option: "{{ repeat.item.option }}"
-                replay_entities: "{{ repeat.item.entities }}"
-            - repeat:
-                for_each: "{{ replay_entities }}"
-                sequence:
-                  - action: select.select_option
-                    data:
-                      entity_id: "{{ repeat.item }}"
-                      option: "{{ replay_option }}"
-                  - delay: "{{ ha_write_delay }}"
-      - repeat:
-          for_each: "{{ inovelli_switch_type_replay }}"
+          for_each: >
+            {{ inovelli_smart_bulb_mode_replay
+              + inovelli_output_mode_replay
+              + inovelli_switch_type_replay
+              + inovelli_fan_control_mode_replay }}
           sequence:
             - variables:
                 replay_option: "{{ repeat.item.option }}"
@@ -2722,7 +2715,7 @@ script:
           name: Zigbee2MQTT Reset
           message: >
             Replayed the saved Inovelli smart bulb modes, output modes, switch types,
-            group memberships, and bindings for switches and bulbs/groups.
+            fan control modes, group memberships, and bindings for switches and bulbs/groups.
 
   turn_off_all_inovelli_switch_leds:
     icon: mdi:light-switch-off

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -123,6 +123,7 @@ def test_reset_script_uses_static_replay_snapshot_instead_of_runtime_capture() -
     assert "inovelli_smart_bulb_mode_replay:" in block
     assert "inovelli_output_mode_replay:" in block
     assert "inovelli_switch_type_replay:" in block
+    assert "inovelli_fan_control_mode_replay:" in block
     assert "inovelli_group_membership_replay:" in block
     assert "inovelli_binding_replay:" in block
     assert "bridge/request/devices" not in block
@@ -141,6 +142,9 @@ def test_reset_script_replays_current_live_switch_modes_readably() -> None:
     assert 'option: "3-Way Aux Switch"' in block
     assert "select.garage_overhead_switch_switchtype" in block
     assert "select.hall_foyer_switch_switchtype" in block
+    assert 'option: "Toggle"' in block
+    assert "select.dining_room_table_switch_fancontrolmode" in block
+    assert "select.dining_room_wall_switch_fancontrolmode" in block
 
 
 def test_reset_script_does_not_restore_deck_flood_lights_smart_bulb_mode() -> None:
@@ -246,6 +250,20 @@ def test_reset_script_replays_current_live_group_memberships_and_bindings() -> N
             "Dining Room/Over Table",
             None,
             ("genLevelCtrl", "genOnOff", "genScenes"),
+        ),
+        (
+            "Dining Room/Table Switch",
+            3,
+            "Kitchen/All",
+            None,
+            ("genLevelCtrl", "genOnOff"),
+        ),
+        (
+            "Dining Room/Wall Switch",
+            3,
+            "Kitchen/All",
+            None,
+            ("genLevelCtrl", "genOnOff"),
         ),
         ("Hall/Foyer Switch", 2, "Hall/All", None, ("genLevelCtrl", "genOnOff")),
         (


### PR DESCRIPTION
## Summary
- Replace Home Assistant event mirroring with direct Zigbee2MQTT group binding replay.
- Bind Dining Room Table Switch and Wall Switch endpoint 3 (config button) to `Kitchen/All` for `genLevelCtrl` and `genOnOff`.
- Replay `fanControlMode: Toggle` for both dining-room switches before replaying Z2M bindings after a switch reset.
- Consolidate Inovelli select-option recovery into one replay pass and extend regression coverage.

Closes #342

## Why
Zigbee bindings let the source switch directly control the target group without a Home Assistant or Zigbee2MQTT software round trip. Inovelli documents endpoint 3 as the config-button binding endpoint, and Zigbee2MQTT exposes `fanControlMode: Toggle` for this use case.

References:
- https://www.zigbee2mqtt.io/guide/usage/binding.html
- https://www.zigbee2mqtt.io/devices/VZM31-SN.html
- https://help.inovelli.com/en/articles/9048636-blue-series-fan-light-module-setup-instructions-zigbee2mqtt

## Validation
- `uv run --with pytest pytest` (`485 passed`)
- `uv run --with pytest pytest tests/test_zigbee_zwave_inovelli_reset_replay.py tests/test_zigbee_zwave_den_bindings.py` (`13 passed`)
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt`
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `git diff --check`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/zigbee_zwave.yaml --strict` (same pre-existing findings as `origin/develop`; no new DRY findings)

## Not run locally
- Docker-based Home Assistant `check_config`: local environment does not have `docker`; CI runs the repository workflow check.
