### PR TITLE
Normalize target entity service calls

### DIFF
--- a/packages/fans.yaml
+++ b/packages/fans.yaml
@@ -113,15 +113,15 @@ automation:
                 id: den-occupied
             sequence:
               - action: fan.turn_on
-                data:
+                target:
                   entity_id: fan.den_ceiling
-                  #speed: smart
+                #speed: smart
           - conditions:
               - condition: trigger
                 id: den-unoccupied
             sequence:
               - action: fan.turn_off
-                data:
+                target:
                   entity_id: fan.den_ceiling
 
 
@@ -343,8 +343,9 @@ automation:
                 id: bedroom-occupied
             sequence:
               - action: fan.turn_on
-                data:
+                target:
                   entity_id: fan.owner_suite
+                data:
                   percentage: 67
                   #speed: "medium"  # TODO have this change depending on the season: low in winter, medium spring/fall, high in summer
                   #speed: smart
@@ -353,10 +354,10 @@ automation:
                 id: bedroom-unoccupied
             sequence:
               - action: fan.turn_off
-                data:
+                target:
                   entity_id: fan.owner_suite
-                  #speed: "medium"  # TODO have this change depending on the season: low in winter, medium spring/fall, high in summer
-                  #speed: smart
+                #speed: "medium"  # TODO have this change depending on the season: low in winter, medium spring/fall, high in summer
+                #speed: smart
 
   # - alias: turn_off_fan_if_bedroom_unoccupied
   #   id: turn_off_fan_if_bedroom_unoccupied
@@ -411,7 +412,7 @@ automation:
                 id: office-occupied
             sequence:
               - action: fan.turn_on
-                data:
+                target:
                   entity_id: fan.office_ceiling_fan
       - choose:
           - conditions:
@@ -419,7 +420,7 @@ automation:
                 id: office-unoccupied
             sequence:
               - action: fan.turn_off
-                data:
+                target:
                   entity_id: fan.office_ceiling_fan
 
   # - alias: turn_off_fan_if_office_unoccupied

--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -208,12 +208,12 @@ automation:
         offset: +00:45:00
     action:
       - action: scene.turn_on
-        data:
+        target:
           entity_id: scene.reset_front_lights
       - delay:
           seconds: 15
       - action: light.turn_off
-        data:
+        target:
           entity_id: light.outside_front_hue
 
   - id: outdoor_holiday_light_loop

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -132,8 +132,9 @@ automation:
           - "unavailable"
     action:
       - action: media_player.volume_set
-        data:
+        target:
           entity_id: media_player.bedroom_sonos
+        data:
           # volume_level: >-
           # {{ (state_attr('media_player.bedroom', 'volume_level') + trigger.event.data.args.relative_degrees/1000) | round(2) | float(default=0) }}
           # Fixed: the inner float() call now carries its own default of 0 so that
@@ -157,7 +158,7 @@ automation:
         to: "tap"
     action:
       - action: media_player.media_play_pause
-        data:
+        target:
           entity_id: media_player.bedroom_sonos_2
 
   - id: bed_without_prep
@@ -189,13 +190,13 @@ automation:
             state: "playing"
     action:
       - action: script.turn_on
-        data:
+        target:
           entity_id: script.night_tv_mode_switches
       - action: script.apply_owner_suite_inovelli_led_policy
         data:
           policy: dark
       - action: script.turn_on
-        data:
+        target:
           entity_id: script.spotify_bedtime_volume
       # - delay: "00:10:00"
       # - action: switch.turn_on
@@ -223,7 +224,7 @@ automation:
           message: >-
             {{ "script.bedroom_playlist_" + (trigger.to_state.state | string) }}
       - action: script.turn_on
-        data:
+        target:
           entity_id: >-
             {{ "script.bedroom_playlist_" + (trigger.to_state.state | string) }}
 
@@ -242,7 +243,7 @@ automation:
         to: "slide"
     action:
       - action: media_player.media_next_track
-        data:
+        target:
           entity_id: media_player.bedroom_sonos_2
 
   - id: bedroom_music_shuffle
@@ -260,8 +261,9 @@ automation:
         to: "shake"
     action:
       - action: media_player.shuffle_set
-        data:
+        target:
           entity_id: media_player.bedroom_sonos_2
+        data:
           shuffle: >-
             {{ not (state_attr('media_player.bedroom_sonos_2', 'shuffle')) }}
 
@@ -1383,7 +1385,7 @@ script:
       stored_traces: 50
     sequence:
       - action: media_player.turn_on
-        data:
+        target:
           entity_id: media_player.basement
       - action: script.wait_for_basement_media_player_ready
       # - action: media_player.turn_on
@@ -1393,8 +1395,9 @@ script:
       - delay:
           seconds: 10
       - action: media_player.select_source
-        data:
+        target:
           entity_id: media_player.lg_webos_smart_tv
+        data:
           source: "HDMI 4"
       - delay:
           seconds: 2
@@ -1507,13 +1510,14 @@ script:
           seconds: 2
       - action: media_player.volume_set
         continue_on_error: true
-        data:
+        target:
           entity_id:
             - media_player.bedroom_sonos
             - media_player.bathroom_sonos_2
             - media_player.den_sonos
             - media_player.office_sonos
             - media_player.tiki_room_3
+        data:
           volume_level: 0.30
       - alias: "Play arrival music via Music Assistant"
         action: script.music_assistant_play_spotify_uri
@@ -1665,12 +1669,13 @@ script:
           seconds: 2
       - action: media_player.volume_set
         continue_on_error: true
-        data:
+        target:
           entity_id:
             - media_player.bedroom_sonos_2
             - media_player.bathroom_sonos_2
             - media_player.office_sonos_2
             - media_player.den_sonos_2
+        data:
           volume_level: 0.20
       - delay:
           seconds: 2
@@ -1755,13 +1760,15 @@ script:
                   sequence:
                     - action: media_player.volume_set
                       continue_on_error: true
-                      data:
+                      target:
                         entity_id: "{{ repeat.item.entity_id }}"
+                      data:
                         volume_level: "{{ repeat.item.volume_level }}"
               default:
                 - action: media_player.volume_set
-                  data:
+                  target:
                     entity_id: "{{ repeat.item.entity_id }}"
+                  data:
                     volume_level: "{{ repeat.item.volume_level }}"
 
   spotify_wake_up:

--- a/packages/tv.yaml
+++ b/packages/tv.yaml
@@ -239,10 +239,11 @@ automation:
     action:
       - action: media_player.volume_set
         continue_on_error: true
-        data:
+        target:
           entity_id:
             - media_player.bedroom_sonos_2
             - media_player.bathroom_sonos_2
+        data:
           volume_level: 0.02
       - action: scene.turn_on
         continue_on_error: true
@@ -374,7 +375,7 @@ automation:
     action:
       - action: media_player.media_pause
         continue_on_error: true
-        data:
+        target:
           entity_id:
             - media_player.office_sonos_2
             - media_player.den_sonos_2
@@ -388,7 +389,7 @@ automation:
           entity_id: script.night_tv_mode_switches
       - action: media_player.media_pause
         continue_on_error: true
-        data:
+        target:
           entity_id:
             - media_player.den_sonos_2
       - action: script.music_assistant_pause_house_audio
@@ -490,14 +491,15 @@ script:
       stored_traces: 50
     sequence:
       - action: media_player.turn_on
-        data:
+        target:
           entity_id: media_player.basement
       - action: script.wait_for_basement_media_player_ready
       - delay:
           seconds: 10
       - action: media_player.select_source
-        data:
+        target:
           entity_id: media_player.lg_webos_smart_tv
+        data:
           source: "HDMI 3"
 
   # Shared Plex-show launcher. Runs startup, selects Plex source, scans
@@ -516,8 +518,9 @@ script:
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
-        data:
+        target:
           entity_id: media_player.basement
+        data:
           source: "Plex"
       - delay:
           seconds: 2
@@ -526,8 +529,9 @@ script:
           entity_id: button.fermentor_scan_clients
       - action: script.wait_for_basement_plex_client_ready
       - action: media_player.play_media
-        data:
+        target:
           entity_id: media_player.plex_basement_apple_tv
+        data:
           media_content_type: EPISODE
           media_content_id: >-
             { "library_name": "TV", "show_name": "{{ show_name }}", "shuffle": "1" }
@@ -543,8 +547,9 @@ script:
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
-        data:
+        target:
           entity_id: media_player.basement
+        data:
           source: "YouTube TV"
 
   watch_youtube:
@@ -554,8 +559,9 @@ script:
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
-        data:
+        target:
           entity_id: media_player.basement
+        data:
           source: "YouTube"
 
   watch_netflix:
@@ -565,8 +571,9 @@ script:
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
-        data:
+        target:
           entity_id: media_player.basement
+        data:
           source: "Netflix"
       - delay:
           seconds: 2
@@ -580,8 +587,9 @@ script:
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
-        data:
+        target:
           entity_id: media_player.basement
+        data:
           source: "Plex"
       - delay:
           seconds: 2
@@ -595,8 +603,9 @@ script:
     sequence:
       - action: script.watch_basement_tv_startup
       - action: media_player.select_source
-        data:
+        target:
           entity_id: media_player.basement
+        data:
           source: "F1 TV"
       - delay:
           seconds: 2

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -288,7 +288,7 @@ automation:
         to: "on"
     action:
       - action: input_boolean.turn_on
-        data:
+        target:
           entity_id: input_boolean.bayesian_zeke_home
 
   - alias: input_boolean_tracker_off
@@ -301,7 +301,7 @@ automation:
         to: "off"
     action:
       - action: input_boolean.turn_off
-        data:
+        target:
           entity_id: input_boolean.bayesian_zeke_home
 
   - id: play_spotify_when_i_get_home
@@ -375,7 +375,7 @@ automation:
           reason: night_arrival
           light_transition: 30
       - action: vacuum.return_to_base
-        data:
+        target:
           entity_id: all
       - action: input_boolean.turn_off
         target:
@@ -572,8 +572,9 @@ automation:
           }}
     action:
       - action: input_select.select_option
-        data:
+        target:
           entity_id: input_select.trip_origin
+        data:
           option: "{{ trigger.to_state.state }}"
 
   # - id: update_nest_eta

--- a/tests/test_issue_735_target_entity_id.py
+++ b/tests/test_issue_735_target_entity_id.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDITED_PACKAGES = [
+    ROOT / "packages" / "fans.yaml",
+    ROOT / "packages" / "holidays.yaml",
+    ROOT / "packages" / "zone.yaml",
+    ROOT / "packages" / "media_player.yaml",
+    ROOT / "packages" / "tv.yaml",
+]
+
+TARGETABLE_ACTIONS = {
+    "fan.turn_on",
+    "fan.turn_off",
+    "input_boolean.turn_off",
+    "input_boolean.turn_on",
+    "input_select.select_option",
+    "light.turn_off",
+    "media_player.media_next_track",
+    "media_player.media_pause",
+    "media_player.media_play_pause",
+    "media_player.play_media",
+    "media_player.select_source",
+    "media_player.shuffle_set",
+    "media_player.turn_on",
+    "media_player.volume_set",
+    "scene.turn_on",
+    "script.turn_on",
+    "vacuum.return_to_base",
+}
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _action_from_line(line: str) -> str | None:
+    stripped = line.strip()
+    for prefix in ("- action: ", "action: ", "- service: ", "service: "):
+        if stripped.startswith(prefix):
+            return stripped.removeprefix(prefix).strip().strip('"')
+    return None
+
+
+def _block_for_action(lines: list[str], start: int) -> list[str]:
+    base_indent = _indent(lines[start])
+    block = [lines[start]]
+
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and _indent(line) <= base_indent:
+            break
+        block.append(line)
+
+    return block
+
+
+def _data_block_has_entity_id(block: list[str]) -> bool:
+    for index, line in enumerate(block):
+        if line.strip() != "data:":
+            continue
+
+        data_indent = _indent(line)
+        for child in block[index + 1 :]:
+            stripped = child.strip()
+            if stripped and not stripped.startswith("#") and _indent(child) <= data_indent:
+                break
+            if stripped.startswith("entity_id:"):
+                return True
+
+    return False
+
+
+def test_targetable_services_do_not_put_entity_id_under_data() -> None:
+    offenders: list[str] = []
+
+    for package_path in AUDITED_PACKAGES:
+        lines = package_path.read_text().splitlines()
+        for index, line in enumerate(lines):
+            action = _action_from_line(line)
+            if action not in TARGETABLE_ACTIONS:
+                continue
+
+            if _data_block_has_entity_id(_block_for_action(lines, index)):
+                line_number = index + 1
+                offenders.append(f"{package_path.relative_to(ROOT)}:{line_number}: {action}")
+
+    assert offenders == []


### PR DESCRIPTION
## Summary

- Normalize low-risk Home Assistant service calls in `fans`, `holidays`, `zone`, `media_player`, and `tv` packages to use `target.entity_id` instead of `data.entity_id`.
- Preserve custom script payloads, `logbook.log` metadata, and custom integration service payloads where `entity_id` is intentionally service data.
- Add regression coverage to keep targetable services in the audited packages from reintroducing `data.entity_id`.

Closes #735.

## Tests

- `uv run --with pytest pytest tests/test_issue_735_target_entity_id.py`
- `uv run --with pytest pytest tests/test_media_player_music_assistant.py tests/test_tv_bed_prep_handoff.py tests/test_holiday_calendar_logic.py`
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt`

## Not Run

- Home Assistant Docker `check_config`; Docker is not available in this local environment. CI should run the configured container validation.
