### PR TITLE
Replace simple threshold templates with native helpers

### DIFF
--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -688,6 +688,21 @@ binary_sensor:
         sample_duration: 10800
         min_gradient: 0.000009
 
+  - platform: threshold
+    name: bathroom_humidity_high_threshold
+    entity_id: sensor.bathroom_humidity_delta
+    upper: 10
+
+  - platform: threshold
+    name: basement_bathroom_humidity_high_threshold
+    entity_id: sensor.basement_bathroom_humidity_delta
+    upper: 10
+
+  - platform: threshold
+    name: guest_bathroom_humidity_high_threshold
+    entity_id: sensor.guest_bathroom_humidity_delta
+    upper: 10
+
 ########################
 # Climate
 ########################
@@ -980,34 +995,71 @@ sensor:
 ## Templates
 ################################################
 template:
+  - sensor:
+      - name: bathroom_humidity_delta
+        unique_id: bathroom_humidity_delta
+        default_entity_id: sensor.bathroom_humidity_delta
+        unit_of_measurement: "%"
+        state_class: measurement
+        availability: >-
+          {{ has_value('sensor.owner_suite_bathroom_tph_humidity') and has_value('sensor.average_house_humidity') }}
+        state: >-
+          {{
+            (
+              states('sensor.owner_suite_bathroom_tph_humidity') | float(default=0)
+              - states('sensor.average_house_humidity') | float(default=0)
+            )
+          }}
+
+      - name: basement_bathroom_humidity_delta
+        unique_id: basement_bathroom_humidity_delta
+        default_entity_id: sensor.basement_bathroom_humidity_delta
+        unit_of_measurement: "%"
+        state_class: measurement
+        availability: >-
+          {{ has_value('sensor.basement_bathroom_tph_humidity') and has_value('sensor.average_house_humidity') }}
+        state: >-
+          {{
+            (
+              states('sensor.basement_bathroom_tph_humidity') | float(default=0)
+              - states('sensor.average_house_humidity') | float(default=0)
+            )
+          }}
+
+      - name: guest_bathroom_humidity_delta
+        unique_id: guest_bathroom_humidity_delta
+        default_entity_id: sensor.guest_bathroom_humidity_delta
+        unit_of_measurement: "%"
+        state_class: measurement
+        availability: >-
+          {{ has_value('sensor.guest_bathroom_tph_humidity') and has_value('sensor.average_house_humidity') }}
+        state: >-
+          {{
+            (
+              states('sensor.guest_bathroom_tph_humidity') | float(default=0)
+              - states('sensor.average_house_humidity') | float(default=0)
+            )
+          }}
+
   - binary_sensor:
       - default_entity_id: binary_sensor.bathroom_humidity_high
         unique_id: bathroom_humidity_high
-        state: >-
-          {% if (states('sensor.owner_suite_bathroom_tph_humidity')|float(default=0)) > (states('sensor.average_house_humidity')|float(default=0) + 10) %}
-            True
-          {% else %}
-            False
-          {% endif %}
+        availability: "{{ has_value('binary_sensor.bathroom_humidity_high_threshold') }}"
+        state: "{{ is_state('binary_sensor.bathroom_humidity_high_threshold', 'on') }}"
         name: bathroom_humidity_high
+
       - default_entity_id: binary_sensor.basement_bathroom_humidity_high
         unique_id: basement_bathroom_humidity_high
-        state: >-
-          {% if(states('sensor.basement_bathroom_tph_humidity')|float(default=0))> (states('sensor.average_house_humidity')|float(default=0) + 10) %}
-            True
-          {% else %}
-            False
-          {% endif %}
+        availability: "{{ has_value('binary_sensor.basement_bathroom_humidity_high_threshold') }}"
+        state: "{{ is_state('binary_sensor.basement_bathroom_humidity_high_threshold', 'on') }}"
         name: basement_bathroom_humidity_high
+
       - default_entity_id: binary_sensor.guest_bathroom_humidity_high
         unique_id: guest_bathroom_humidity_high
-        state: >-
-          {% if(states('sensor.guest_bathroom_tph_humidity')|float(default=0))> (states('sensor.average_house_humidity')|float(default=0) + 10) %}
-            True
-          {% else %}
-            False
-          {% endif %}
+        availability: "{{ has_value('binary_sensor.guest_bathroom_humidity_high_threshold') }}"
+        state: "{{ is_state('binary_sensor.guest_bathroom_humidity_high_threshold', 'on') }}"
         name: guest_bathroom_humidity_high
+
       - device_class: heat
         default_entity_id: binary_sensor.ecobee_aux
         unique_id: ecobee_aux

--- a/packages/room_confidence.yaml
+++ b/packages/room_confidence.yaml
@@ -81,6 +81,41 @@ homeassistant:
       icon: mdi:home-floor-b
 
 ################################################
+## Binary Sensors
+################################################
+
+binary_sensor:
+  - platform: threshold
+    name: bedroom_confident_occupancy_threshold
+    entity_id: sensor.bedroom_room_confidence
+    device_class: occupancy
+    upper: 49
+
+  - platform: threshold
+    name: office_confident_occupancy_threshold
+    entity_id: sensor.office_room_confidence
+    device_class: occupancy
+    upper: 49
+
+  - platform: threshold
+    name: den_confident_occupancy_threshold
+    entity_id: sensor.den_room_confidence
+    device_class: occupancy
+    upper: 49
+
+  - platform: threshold
+    name: dining_room_confident_occupancy_threshold
+    entity_id: sensor.dining_room_room_confidence
+    device_class: occupancy
+    upper: 49
+
+  - platform: threshold
+    name: basement_confident_occupancy_threshold
+    entity_id: sensor.basement_room_confidence
+    device_class: occupancy
+    upper: 49
+
+################################################
 ## Templates
 ################################################
 
@@ -418,24 +453,29 @@ template:
       - name: bedroom_confident_occupancy
         unique_id: bedroom_confident_occupancy
         device_class: occupancy
-        state: "{{ states('sensor.bedroom_room_confidence') | int(0) >= 50 }}"
+        availability: "{{ has_value('binary_sensor.bedroom_confident_occupancy_threshold') }}"
+        state: "{{ is_state('binary_sensor.bedroom_confident_occupancy_threshold', 'on') }}"
 
       - name: office_confident_occupancy
         unique_id: office_confident_occupancy
         device_class: occupancy
-        state: "{{ states('sensor.office_room_confidence') | int(0) >= 50 }}"
+        availability: "{{ has_value('binary_sensor.office_confident_occupancy_threshold') }}"
+        state: "{{ is_state('binary_sensor.office_confident_occupancy_threshold', 'on') }}"
 
       - name: den_confident_occupancy
         unique_id: den_confident_occupancy
         device_class: occupancy
-        state: "{{ states('sensor.den_room_confidence') | int(0) >= 50 }}"
+        availability: "{{ has_value('binary_sensor.den_confident_occupancy_threshold') }}"
+        state: "{{ is_state('binary_sensor.den_confident_occupancy_threshold', 'on') }}"
 
       - name: dining_room_confident_occupancy
         unique_id: dining_room_confident_occupancy
         device_class: occupancy
-        state: "{{ states('sensor.dining_room_room_confidence') | int(0) >= 50 }}"
+        availability: "{{ has_value('binary_sensor.dining_room_confident_occupancy_threshold') }}"
+        state: "{{ is_state('binary_sensor.dining_room_confident_occupancy_threshold', 'on') }}"
 
       - name: basement_confident_occupancy
         unique_id: basement_confident_occupancy
         device_class: occupancy
-        state: "{{ states('sensor.basement_room_confidence') | int(0) >= 50 }}"
+        availability: "{{ has_value('binary_sensor.basement_confident_occupancy_threshold') }}"
+        state: "{{ is_state('binary_sensor.basement_confident_occupancy_threshold', 'on') }}"

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1567,6 +1567,12 @@ automation:
 # Binary Sensors
 ########################
 binary_sensor:
+  - platform: threshold
+    name: any_egress_open_threshold
+    entity_id: sensor.open_egress_points
+    device_class: opening
+    upper: 0
+
   - platform: bayesian
     name: "Bayesian Bed Occupancy"
     unique_id: bayesian_bed_occupancy
@@ -2940,7 +2946,8 @@ template:
         unique_id: any_egress_open
         default_entity_id: binary_sensor.any_egress_open
         device_class: opening
-        state: "{{ states('sensor.open_egress_points') | int(0) > 0 }}"
+        availability: "{{ has_value('binary_sensor.any_egress_open_threshold') }}"
+        state: "{{ is_state('binary_sensor.any_egress_open_threshold', 'on') }}"
 
       - name: master_bed_occupancy
         unique_id: master_bed_occupancy

--- a/tests/test_room_confidence.py
+++ b/tests/test_room_confidence.py
@@ -19,6 +19,15 @@ def _sensor_block(text: str, sensor_name: str) -> str:
     return text[start:next_sensor]
 
 
+def _threshold_binary_sensor_block(text: str, sensor_name: str) -> str:
+    marker = f"  - platform: threshold\n    name: {sensor_name}\n"
+    start = text.index(marker)
+    next_sensor = text.find("\n  - platform:", start + len(marker))
+    if next_sensor == -1:
+        return text[start:]
+    return text[start:next_sensor]
+
+
 def test_dining_room_confidence_entities_are_registered() -> None:
     text = _room_confidence_text()
 
@@ -46,10 +55,15 @@ def test_dining_room_confidence_uses_bermuda_area_without_local_motion_weight() 
 
 def test_dining_room_confident_occupancy_threshold_matches_other_rooms() -> None:
     text = _room_confidence_text()
-    block = _sensor_block(text, "dining_room_confident_occupancy")
+    helper_block = _threshold_binary_sensor_block(text, "dining_room_confident_occupancy_threshold")
+    public_block = _sensor_block(text, "dining_room_confident_occupancy")
 
-    assert "device_class: occupancy" in block
-    assert 'state: "{{ states(\'sensor.dining_room_room_confidence\') | int(0) >= 50 }}"' in block
+    assert "device_class: occupancy" in helper_block
+    assert "entity_id: sensor.dining_room_room_confidence" in helper_block
+    assert "upper: 49" in helper_block
+    assert "unique_id: dining_room_confident_occupancy" in public_block
+    assert "binary_sensor.dining_room_confident_occupancy_threshold" in public_block
+    assert "state: \"{{ states('sensor.dining_room_room_confidence') | int(0) >= 50 }}\"" not in text
 
 
 def test_dining_room_confidence_recomputes_when_proxy_status_changes() -> None:

--- a/tests/test_threshold_helpers.py
+++ b/tests/test_threshold_helpers.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIMATE_PATH = ROOT / "packages" / "climate.yaml"
+ZIGBEE_ZWAVE_PATH = ROOT / "packages" / "zigbee_zwave.yaml"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _threshold_binary_sensor_block(text: str, sensor_name: str) -> str:
+    marker = f"  - platform: threshold\n    name: {sensor_name}\n"
+    start = text.index(marker)
+    next_sensor = text.find("\n  - platform:", start + len(marker))
+    if next_sensor == -1:
+        return text[start:]
+    return text[start:next_sensor]
+
+
+def _template_sensor_block(text: str, sensor_name: str) -> str:
+    marker = f"      - name: {sensor_name}\n"
+    start = text.index(marker)
+    next_sensor = text.find("\n      - name:", start + len(marker))
+    if next_sensor == -1:
+        return text[start:]
+    return text[start:next_sensor]
+
+
+def _template_unique_id_block(text: str, unique_id: str) -> str:
+    marker = f"        unique_id: {unique_id}\n"
+    start = text.rfind("\n      - ", 0, text.index(marker))
+    next_sensor = text.find("\n      - ", start + len("\n      - "))
+    if next_sensor == -1:
+        return text[start:]
+    return text[start:next_sensor]
+
+
+def test_bathroom_humidity_high_uses_delta_threshold_helpers() -> None:
+    text = _text(CLIMATE_PATH)
+
+    cases = {
+        "bathroom_humidity_high_threshold": "sensor.bathroom_humidity_delta",
+        "basement_bathroom_humidity_high_threshold": "sensor.basement_bathroom_humidity_delta",
+        "guest_bathroom_humidity_high_threshold": "sensor.guest_bathroom_humidity_delta",
+    }
+
+    for binary_sensor, delta_sensor in cases.items():
+        block = _threshold_binary_sensor_block(text, binary_sensor)
+        assert f"entity_id: {delta_sensor}" in block
+        assert "upper: 10" in block
+
+    public_block = _template_unique_id_block(text, "bathroom_humidity_high")
+    assert "unique_id: bathroom_humidity_high" in public_block
+    assert "binary_sensor.bathroom_humidity_high_threshold" in public_block
+    assert "states('sensor.average_house_humidity')|float(default=0) + 10" not in text
+
+
+def test_bathroom_humidity_delta_sensors_have_availability_guards() -> None:
+    text = _text(CLIMATE_PATH)
+
+    cases = {
+        "bathroom_humidity_delta": "sensor.owner_suite_bathroom_tph_humidity",
+        "basement_bathroom_humidity_delta": "sensor.basement_bathroom_tph_humidity",
+        "guest_bathroom_humidity_delta": "sensor.guest_bathroom_tph_humidity",
+    }
+
+    for delta_sensor, humidity_sensor in cases.items():
+        block = _template_sensor_block(text, delta_sensor)
+        assert f"has_value('{humidity_sensor}')" in block
+        assert "has_value('sensor.average_house_humidity')" in block
+        assert f"states('{humidity_sensor}') | float(default=0)" in block
+        assert "states('sensor.average_house_humidity') | float(default=0)" in block
+        assert "| round(" not in block
+
+
+def test_any_egress_open_uses_native_threshold_helper() -> None:
+    text = _text(ZIGBEE_ZWAVE_PATH)
+    helper_block = _threshold_binary_sensor_block(text, "any_egress_open_threshold")
+    public_block = _template_sensor_block(text, "any_egress_open")
+
+    assert "entity_id: sensor.open_egress_points" in helper_block
+    assert "device_class: opening" in helper_block
+    assert "upper: 0" in helper_block
+    assert "unique_id: any_egress_open" in public_block
+    assert "binary_sensor.any_egress_open_threshold" in public_block
+    assert 'state: "{{ states(\'sensor.open_egress_points\') | int(0) > 0 }}"' not in text


### PR DESCRIPTION
## Summary

Closes #736.

This replaces practical threshold-style template math with native `threshold` binary sensors while preserving existing public entity IDs through a helper-backed pattern.

Changes made:
- Added internal native threshold helpers for room-confidence occupancy thresholds in `packages/room_confidence.yaml`, using `upper: 49` to preserve the old `>= 50` score behavior.
- Kept the existing public `unique_id` template binary sensors as stable aliases to those helpers so entity registry IDs, dashboards, and automations continue to work.
- Converted bathroom humidity-high threshold math in `packages/climate.yaml` to internal threshold helpers backed by explicit humidity delta template sensors.
- Added availability guards to humidity delta sensors and public alias sensors so missing room/house humidity inputs do not produce misleading false/off states.
- Added an internal native threshold helper for `any_egress_open` in `packages/zigbee_zwave.yaml`, with the existing public unique-ID entity aliasing it.
- Added focused regression coverage for the helper-backed shape and entity-ID-preservation behavior.

## Why this change is worth doing

The previous template binary sensors encoded numeric threshold behavior directly in Jinja. Native threshold helpers are schema-validated by Home Assistant, easier to inspect in the UI/service model, and avoid template-default behavior where missing values can silently collapse into false/off states. Because YAML threshold entities do not expose `unique_id`, this PR keeps the existing public unique-ID template entities and delegates only the threshold decision to native helpers. That avoids entity registry churn while still removing threshold math from the public templates.

## DRY verifier

Command run:

```bash
python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/room_confidence.yaml packages/climate.yaml packages/zigbee_zwave.yaml --min-occurrences 2
```

Result:
- Total files scanned: 3
- Parse errors: 0
- Duplicate full-block groups: 0
- Duplicate entry groups: 5
- Intra-block duplicates: 1
- Central script findings: 0

Findings were pre-existing and outside the threshold-helper scope:
- Repeated Inovelli script sequence entries in `packages/zigbee_zwave.yaml`: deferred to the DRY cleanup issue because changing shared LED switch scripts would be behavior-sensitive and is not required for issue #736.
- Repeated `reset_inovelli_switches` entries in `packages/zigbee_zwave.yaml`: deferred to the DRY cleanup issue because this is the known intra-block cleanup candidate and should be handled with focused switch reset coverage.
- Repeated climate window prompt conditions in `packages/climate.yaml`: deferred because issue #736 only changes humidity threshold helpers and merging prompt conditions would broaden the behavior surface.

## Validation

Passed locally:

```bash
uv run --with pytest pytest
```

Result: 465 passed.

Also passed locally:

```bash
git diff --check
```

Home Assistant config validation was attempted locally with Podman, but the local runtime was unavailable:
- `podman-machine-default` reported started successfully, then immediately inspected as `stopped`; the Podman API socket refused connections.
- `codex-hw-preview` entered CoreOS emergency mode due an Ignition/root filesystem failure.
- Stale/attempted Podman VM processes were cleaned up afterward, and both inspected as stopped.

Passed in CI:
- Pytest
- YAML Lint
- Home Assistant Check Config
- CodeQL
