### PR TITLE
Simplify holiday lighting orchestration

### DIFF
--- a/docs/holiday_calendar_coverage.md
+++ b/docs/holiday_calendar_coverage.md
@@ -1,0 +1,69 @@
+# Holiday Calendar Coverage
+
+Coverage window: 2026-05-29 through 2028-05-29.
+
+Holiday lighting is generated from the date rules in `packages/holidays.yaml`; no
+manual calendar event is required for those lighting scenes. If the same days
+are mirrored into a visible Home Assistant calendar, include the items below.
+`calendar.mn_holidays` remains the calendar source for Minnesota public-holiday
+workday and garbage pickup logic.
+
+The active outdoor holiday palette is intentionally applied every minute during
+the dark window. Christmas and Hogmanay use one-minute cadence when configured;
+other holidays may keep a scene for multiple trigger ticks according to their
+declared `cadence_minutes`.
+
+## Lighting Dates
+
+| Date | Holiday key | Label |
+| --- | --- | --- |
+| 2026-06-19 | juneteenth | Juneteenth |
+| 2026-07-04 | independence_day | Independence Day |
+| 2026-09-02 | sealand_independence_day | Sealand Independence Day |
+| 2026-09-07 | labor_day | Labor Day |
+| 2026-09-19 | talk_like_a_pirate_day | Talk Like a Pirate Day |
+| 2026-10-31 | halloween | Halloween |
+| 2026-11-11 | veterans_day | Veterans Day |
+| 2026-11-26 | thanksgiving | Thanksgiving |
+| 2026-11-30 | st_andrews_day | St Andrew's Day |
+| 2026-12-01/2026-12-31 | christmas_season | Christmas Season |
+| 2026-12-31 | hogmanay | Hogmanay |
+| 2027-01-01/2027-01-31 | national_curling_month | National Curling Month |
+| 2027-01-25 | burns_night | Burns Night |
+| 2027-02-02 | groundhog_day | Groundhog Day |
+| 2027-02-15 | presidents_day | Presidents' Day |
+| 2027-03-14 | pi_day | Pi Day |
+| 2027-04-06 | tartan_day | Tartan Day |
+| 2027-05-04 | star_wars_day | Star Wars Day |
+| 2027-05-11 | minnesota_statehood_day | Minnesota Statehood Day |
+| 2027-05-15 | minnesota_fishing_opener | Minnesota Fishing Opener |
+| 2027-05-31 | memorial_day | Memorial Day |
+| 2027-06-19 | juneteenth | Juneteenth |
+| 2027-07-04 | independence_day | Independence Day |
+| 2027-09-02 | sealand_independence_day | Sealand Independence Day |
+| 2027-09-06 | labor_day | Labor Day |
+| 2027-09-19 | talk_like_a_pirate_day | Talk Like a Pirate Day |
+| 2027-10-31 | halloween | Halloween |
+| 2027-11-11 | veterans_day | Veterans Day |
+| 2027-11-25 | thanksgiving | Thanksgiving |
+| 2027-11-30 | st_andrews_day | St Andrew's Day |
+| 2027-12-01/2027-12-31 | christmas_season | Christmas Season |
+| 2027-12-31 | hogmanay | Hogmanay |
+| 2028-01-01/2028-01-31 | national_curling_month | National Curling Month |
+| 2028-01-25 | burns_night | Burns Night |
+| 2028-02-02 | groundhog_day | Groundhog Day |
+| 2028-02-21 | presidents_day | Presidents' Day |
+| 2028-02-29 | leap_day | Leap Day |
+| 2028-03-14 | pi_day | Pi Day |
+| 2028-04-06 | tartan_day | Tartan Day |
+| 2028-05-04 | star_wars_day | Star Wars Day |
+| 2028-05-11 | minnesota_statehood_day | Minnesota Statehood Day |
+| 2028-05-13 | minnesota_fishing_opener | Minnesota Fishing Opener |
+| 2028-05-29 | memorial_day | Memorial Day |
+
+## Minnesota Public Calendar
+
+Confirm `calendar.mn_holidays` has the relevant Minnesota public holidays in
+this same window, including Juneteenth, Independence Day, Labor Day, Veterans
+Day, Thanksgiving, Christmas Day, New Year's Day, Presidents' Day, Memorial Day,
+and any observed weekday substitutions used by the source calendar.

--- a/packages/holidays.yaml
+++ b/packages/holidays.yaml
@@ -28,21 +28,9 @@ homeassistant:
     ## Automations
     ################################################
 
-    automation.christmas_tree_on:
+    automation.christmas_lights_off:
       <<: *customize
-      friendly_name: "Turn on Christmas Tree"
-
-    automation.christmas_tree_off_midnight:
-      <<: *customize
-      friendly_name: "Turn off Christmas Tree"
-
-    automation.christmas_lights_off_bedroom_off:
-      <<: *customize
-      friendly_name: "Turn off Christmas Tree if bedroom lights turned off"
-
-    automation.toggle_christmas_automations_on_season_change:
-      <<: *customize
-      friendly_name: "Display Christmas tab"
+      friendly_name: "Turn off Christmas lights"
 
     automation.reset_after_holiday:
       <<: *customize
@@ -50,11 +38,7 @@ homeassistant:
 
     automation.outdoor_holiday_light_loop:
       <<: *customize
-      friendly_name: "Outdoor holiday lights"
-
-    automation.notify_holiday_lighting_day:
-      <<: *customize
-      friendly_name: "Notify holiday lighting day"
+      friendly_name: "Outdoor holiday lights at sunset"
 
     binary_sensor.christmas_season:
       <<: *customize
@@ -79,17 +63,13 @@ homeassistant:
       <<: *customize
       friendly_name: "Christmas Sensors"
 
-    group.christmas_automations:
-      <<: *customize
-      friendly_name: "Christmas Automations"
-
     ################################################
     ## Scripts
     ################################################
 
-    script.toggle_christmas_automation_during_christmas_season:
+    script.turn_off_christmas_lights:
       <<: *customize
-      friendly_name: "Toggle Christmas Automation Based on Boolean Sensor"
+      friendly_name: "Turn off Christmas lights"
 
     switch.christmas_tree:
       <<: *customize
@@ -117,86 +97,40 @@ homeassistant:
 # Automations
 ########################
 automation:
-  - id: christmas_tree_on
-    alias: christmas_tree_on
-    initial_state: false
-    trace:
-      stored_traces: 10
-    trigger:
-      - trigger: sun
-        event: sunset
-        offset: -00:45:00
-    action:
-      - action: switch.turn_on
-        target:
-          entity_id: switch.christmas_tree
-      - action: light.turn_on
-        target:
-          entity_id: light.christmas_lights
-      - action: notify.all
-        data:
-          message: Turning on Christmas Tree.
-
-  - id: christmas_tree_off_midnight
-    alias: christmas_tree_off_midnight
-    initial_state: false
+  - id: christmas_lights_off
+    alias: christmas_lights_off
     trace:
       stored_traces: 10
     trigger:
       - trigger: time
+        id: midnight
         at: 00:00:00
-    action:
-      - action: switch.turn_off
-        target:
-          entity_id: switch.christmas_tree
-      - action: light.turn_off
-        target:
-          entity_id: light.christmas_lights
-      - action: notify.all
-        data:
-          message: Turning off Christmas Tree.
-
-  - id: christmas_lights_off_bedroom_off
-    alias: christmas_lights_off_bedroom_off
-    initial_state: false
-    trace:
-      stored_traces: 10
-    trigger:
       - trigger: state
+        id: bedroom_lights_off
         entity_id: light.bedroom_lamp, light.bedroom_lamp_2
         to: "off"
-    action:
-      - action: switch.turn_off
-        target:
-          entity_id: switch.christmas_tree
-      - action: light.turn_off
-        target:
-          entity_id: light.christmas_lights
-
-  - id: toggle_christmas_automations_on_season_change
-    alias: toggle_christmas_automations_on_season_change
-    trace:
-      stored_traces: 10
-    trigger:
-      - trigger: state
-        entity_id: binary_sensor.christmas_season
-      - trigger: homeassistant
-        event: start
     condition:
-      - alias: "It's christmas"
-        condition: state
-        entity_id: binary_sensor.christmas_season
-        state: "on"
+      - condition: or
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.christmas_season
+            state: "on"
+          - condition: and
+            conditions:
+              - condition: trigger
+                id: midnight
+              - condition: template
+                value_template: "{{ now().month == 1 and now().day == 1 }}"
     action:
-      - action: script.toggle_christmas_automation_during_christmas_season
-        data:
-          entity_id: automation.christmas_tree_on
-      - action: script.toggle_christmas_automation_during_christmas_season
-        data:
-          entity_id: automation.christmas_tree_off_midnight
-      - action: script.toggle_christmas_automation_during_christmas_season
-        data:
-          entity_id: automation.christmas_lights_off_bedroom_off
+      - action: script.turn_off_christmas_lights
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: midnight
+            sequence:
+              - action: notify.all
+                data:
+                  message: Turning off Christmas Tree.
 
   - id: reset_after_holiday
     alias: reset_after_holiday
@@ -222,9 +156,15 @@ automation:
       stored_traces: 10
     trigger:
       - trigger: sun
+        id: sunset
         event: sunset
         offset: -00:45:00
+      - trigger: homeassistant
+        id: startup
+        event: start
+      # The shared holiday palette engine intentionally advances outdoor scenes.
       - trigger: time_pattern
+        id: rotate
         minutes: "/1"
     condition:
       - alias: "Dynamic outdoor holiday active"
@@ -242,32 +182,39 @@ automation:
             before: sunrise
             before_offset: 00:45:00
     action:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: sunset
+              - alias: "Notification message available"
+                condition: template
+                value_template: >-
+                  {{ state_attr('sensor.active_outdoor_holiday', 'notification_message') | default('', true) | trim != '' }}
+            sequence:
+              - action: notify.all
+                data:
+                  title: Holiday lighting
+                  message: "{{ state_attr('sensor.active_outdoor_holiday', 'notification_message') }}"
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: sunset
+              - condition: state
+                entity_id: binary_sensor.christmas_season
+                state: "on"
+            sequence:
+              - action: switch.turn_on
+                target:
+                  entity_id: switch.christmas_tree
+              - action: light.turn_on
+                target:
+                  entity_id: light.christmas_lights
+              - action: notify.all
+                data:
+                  message: Turning on Christmas Tree.
       - action: script.apply_outdoor_holiday_scene
         data:
           holiday_key: "{{ states('sensor.active_outdoor_holiday') | trim }}"
-
-  - id: notify_holiday_lighting_day
-    alias: notify_holiday_lighting_day
-    trace:
-      stored_traces: 10
-    trigger:
-      - trigger: sun
-        event: sunset
-        offset: -00:45:00
-    condition:
-      - alias: "Holiday lighting active today"
-        condition: template
-        value_template: >-
-          {{ states('sensor.active_outdoor_holiday') | trim not in ['none', 'unknown', 'unavailable', ''] }}
-      - alias: "Notification message available"
-        condition: template
-        value_template: >-
-          {{ state_attr('sensor.active_outdoor_holiday', 'notification_message') | default('', true) | trim != '' }}
-    action:
-      - action: notify.all
-        data:
-          title: Holiday lighting
-          message: "{{ state_attr('sensor.active_outdoor_holiday', 'notification_message') }}"
 
   - alias: Garbage Holiday Update
     id: garbage_holiday_update
@@ -342,11 +289,6 @@ group:
     entities:
       - switch.christmas_tree
       - light.christmas_lights
-  christmas_automations:
-    entities:
-      - automation.christmas_tree_on
-      - automation.christmas_tree_off_midnight
-      - automation.christmas_lights_off_bedroom_off
 
 ########################
 # Light
@@ -557,22 +499,16 @@ scene:
 # Scripts
 ########################
 script:
-  toggle_christmas_automation_during_christmas_season:
+  turn_off_christmas_lights:
     trace:
       stored_traces: 10
     sequence:
-      - if:
-          - condition: state
-            entity_id: binary_sensor.christmas_season
-            state: "on"
-        then:
-          - action: automation.turn_on
-            target:
-              entity_id: "{{ entity_id }}"
-        else:
-          - action: automation.turn_off
-            target:
-              entity_id: "{{ entity_id }}"
+      - action: switch.turn_off
+        target:
+          entity_id: switch.christmas_tree
+      - action: light.turn_off
+        target:
+          entity_id: light.christmas_lights
 
   apply_outdoor_holiday_scene:
     mode: queued

--- a/tests/test_holiday_calendar_coverage.py
+++ b/tests/test_holiday_calendar_coverage.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COVERAGE_PATH = ROOT / "docs" / "holiday_calendar_coverage.md"
+HOLIDAYS_PATH = ROOT / "packages" / "holidays.yaml"
+
+COVERAGE_START = date(2026, 5, 29)
+COVERAGE_END = date(2028, 5, 29)
+
+
+def _nth_weekday(year: int, month: int, weekday: int, occurrence: int) -> date:
+    current = date(year, month, 1)
+    while current.weekday() != weekday:
+        current += timedelta(days=1)
+    return current + timedelta(weeks=occurrence - 1)
+
+
+def _last_weekday(year: int, month: int, weekday: int) -> date:
+    if month == 12:
+        current = date(year + 1, 1, 1) - timedelta(days=1)
+    else:
+        current = date(year, month + 1, 1) - timedelta(days=1)
+    while current.weekday() != weekday:
+        current -= timedelta(days=1)
+    return current
+
+
+def _in_window(day: date) -> bool:
+    return COVERAGE_START <= day <= COVERAGE_END
+
+
+def _coverage_entries() -> list[tuple[str, str]]:
+    entries: list[tuple[str, str]] = []
+
+    for year in range(COVERAGE_START.year, COVERAGE_END.year + 1):
+        fixed_dates = {
+            "burns_night": date(year, 1, 25),
+            "groundhog_day": date(year, 2, 2),
+            "leap_day": date(year, 2, 29) if year % 4 == 0 else None,
+            "pi_day": date(year, 3, 14),
+            "tartan_day": date(year, 4, 6),
+            "star_wars_day": date(year, 5, 4),
+            "minnesota_statehood_day": date(year, 5, 11),
+            "juneteenth": date(year, 6, 19),
+            "independence_day": date(year, 7, 4),
+            "sealand_independence_day": date(year, 9, 2),
+            "talk_like_a_pirate_day": date(year, 9, 19),
+            "veterans_day": date(year, 11, 11),
+            "halloween": date(year, 10, 31),
+            "st_andrews_day": date(year, 11, 30),
+            "hogmanay": date(year, 12, 31),
+        }
+
+        computed_dates = {
+            "presidents_day": _nth_weekday(year, 2, 0, 3),
+            "minnesota_fishing_opener": _last_weekday(year, 5, 0) - timedelta(days=16),
+            "memorial_day": _last_weekday(year, 5, 0),
+            "labor_day": _nth_weekday(year, 9, 0, 1),
+            "thanksgiving": _nth_weekday(year, 11, 3, 4),
+        }
+
+        for key, day in {**fixed_dates, **computed_dates}.items():
+            if day is not None and _in_window(day):
+                entries.append((day.isoformat(), key))
+
+        christmas_start = date(year, 12, 1)
+        christmas_end = date(year, 12, 31)
+        if _in_window(christmas_start) or _in_window(christmas_end):
+            entries.append(
+                (f"{christmas_start.isoformat()}/{christmas_end.isoformat()}", "christmas_season")
+            )
+
+        curling_start = date(year, 1, 1)
+        curling_end = date(year, 1, 31)
+        if _in_window(curling_start) or _in_window(curling_end):
+            entries.append(
+                (
+                    f"{curling_start.isoformat()}/{curling_end.isoformat()}",
+                    "national_curling_month",
+                )
+            )
+
+    return sorted(entries)
+
+
+def test_24_month_holiday_coverage_document_lists_every_lighting_observance() -> None:
+    coverage_text = COVERAGE_PATH.read_text(encoding="utf-8")
+    holidays_text = HOLIDAYS_PATH.read_text(encoding="utf-8")
+
+    assert "Coverage window: 2026-05-29 through 2028-05-29." in coverage_text
+
+    for day_or_range, holiday_key in _coverage_entries():
+        assert f"| {day_or_range} | {holiday_key} |" in coverage_text
+        assert f'"{holiday_key}": {{' in holidays_text
+
+
+def test_public_calendar_coverage_expectations_are_documented() -> None:
+    coverage_text = COVERAGE_PATH.read_text(encoding="utf-8")
+
+    assert "calendar.mn_holidays" in coverage_text
+    assert "observed weekday substitutions" in coverage_text
+    assert "intentionally applied every minute" in coverage_text
+    assert "declared `cadence_minutes`" in coverage_text

--- a/tests/test_holiday_calendar_logic.py
+++ b/tests/test_holiday_calendar_logic.py
@@ -138,8 +138,10 @@ def test_unified_holiday_registry_includes_legacy_holidays() -> None:
 def test_holiday_lighting_notification_only_sends_on_holiday_days() -> None:
     text = _text()
 
-    assert "- id: notify_holiday_lighting_day" in text
     assert "entity_id: sensor.active_holiday_lighting" not in text
+    assert "- id: outdoor_holiday_light_loop" in text
+    assert "condition: trigger" in text
+    assert "id: sunset" in text
     assert "states('sensor.active_outdoor_holiday') | trim not in ['none', 'unknown', 'unavailable', '']" in text
     assert "state_attr('sensor.active_outdoor_holiday', 'notification_message')" in text
     assert "action: notify.all" in text

--- a/tests/test_holidays_scene_rotation.py
+++ b/tests/test_holidays_scene_rotation.py
@@ -45,16 +45,23 @@ def test_single_outdoor_holiday_loop_replaces_legacy_holiday_loop_automations() 
 def test_outdoor_holiday_loop_uses_active_outdoor_holiday_selector_and_script() -> None:
     block = _automation_block("outdoor_holiday_light_loop")
 
+    assert "trigger: time_pattern" in block
     assert 'minutes: "/1"' in block
+    assert "event: start" in block
     assert "states('sensor.active_outdoor_holiday') | trim" in block
     assert "action: script.apply_outdoor_holiday_scene" in block
     assert 'holiday_key: "{{ states(\'sensor.active_outdoor_holiday\') | trim }}"' in block
 
 
-def test_christmas_toggle_only_manages_tree_automations() -> None:
-    block = _automation_block("toggle_christmas_automations_on_season_change")
+def test_christmas_tree_behavior_uses_explicit_conditions_not_automation_toggles() -> None:
+    text = HOLIDAYS_PATH.read_text(encoding="utf-8")
+    block = _automation_block("christmas_lights_off")
 
-    assert "automation.christmas_tree_on" in block
-    assert "automation.christmas_tree_off_midnight" in block
-    assert "automation.christmas_lights_off_bedroom_off" in block
-    assert "automation.christmas_outside_light_loop_1" not in block
+    assert "initial_state: false" not in text
+    assert "automation.turn_on" not in text
+    assert "automation.turn_off" not in text
+    assert "toggle_christmas_automation_during_christmas_season" not in text
+    assert "entity_id: binary_sensor.christmas_season" in block
+    assert "id: midnight" in block
+    assert "now().month == 1 and now().day == 1" in block
+    assert "action: script.turn_off_christmas_lights" in block

--- a/tests/test_repair_regressions.py
+++ b/tests/test_repair_regressions.py
@@ -55,7 +55,6 @@ def _scene_block(scene_name: str) -> str:
 def test_dynamic_action_scripts_use_explicit_native_actions() -> None:
     for path, script_name, action_name in (
         (CURLING_PATH, "toggle_curling_automation_on_curling_season", "automation.turn_on"),
-        (HOLIDAYS_PATH, "toggle_christmas_automation_during_christmas_season", "automation.turn_on"),
         (WEATHER_PATH, "nws_dakota_county_alerts_popup_on_wx_alert", "persistent_notification.create"),
     ):
         block = _script_block(path, script_name)
@@ -67,6 +66,11 @@ def test_dynamic_action_scripts_use_explicit_native_actions() -> None:
     assert "persistent_notification.dismiss" in weather_block
     assert "condition: not" in weather_block
     assert 'state: "0"' in weather_block
+
+    holidays_text = HOLIDAYS_PATH.read_text(encoding="utf-8")
+    assert "toggle_christmas_automation_during_christmas_season" not in holidays_text
+    assert "automation.turn_on" not in holidays_text
+    assert "automation.turn_off" not in holidays_text
 
 
 def test_camera_security_references_use_current_entities() -> None:


### PR DESCRIPTION
## Summary

Closes #737.

This simplifies holiday lighting orchestration around one explicit runtime model instead of hidden automation enabled/disabled state, while preserving intentional continuous outdoor palette rotation.

Changes made:
- Removed `initial_state: false` Christmas automation toggling and the `toggle_christmas_automation_during_christmas_season` script.
- Replaced the separate Christmas-off automations with one `christmas_lights_off` automation that uses trigger IDs and an explicit Christmas-season gate.
- Preserved the Dec 31 to Jan 1 midnight shutdown path even after `binary_sensor.christmas_season` turns off.
- Added `script.turn_off_christmas_lights` so the shared Christmas tree/light shutdown path is defined once.
- Folded sunset holiday notification and Christmas tree turn-on into `outdoor_holiday_light_loop`, while preserving the existing `sensor.active_outdoor_holiday` selector and palette-driven `script.apply_outdoor_holiday_scene` behavior.
- Preserved the intentional one-minute outdoor palette loop. The shared loop advances Christmas and all other active holiday palettes according to each definition's `cadence_minutes`, including Hogmanay's fast midnight window.
- Documented 2026-05-29 through 2028-05-29 holiday coverage in `docs/holiday_calendar_coverage.md`.
- Added tests that verify coverage documentation, no hidden Christmas automation toggles, intentional continuous palette rotation, the Jan 1 midnight shutdown edge, and preserved palette/notification behavior.

## Why

The old Christmas model depended on automations being enabled or disabled by another automation, which makes restart behavior harder to reason about because runtime state can diverge from YAML. Explicit conditions keep the behavior visible in the automations themselves and avoid needing a separate orchestration script just to decide whether Christmas hardware actions are allowed.

The outdoor palette loop is intentionally retained. It is the shared state transition that advances continuously changing outdoor lights for Christmas and the other holiday palettes. Consolidation removes duplicated orchestration without flattening those distinct holiday definitions.

## Repo-wide holiday audit

The shared outdoor palette engine covers the holiday-lighting definitions in `packages/holidays.yaml`, including Christmas, Halloween, St Andrew's Day, Burns Night, National Curling Month, Presidents' Day, Hogmanay, and the other registered observances.

Separate calendar-aware behavior remains separate where it has a different purpose:
- `calendar.mn_holidays` garbage pickup shifting in `packages/holidays.yaml`.
- `calendar.mn_holidays` workday/alarm logic in `packages/workday.yaml`.
- Minnesota holiday EV tariff documentation.
- Christmas tree switch state in zone scenes.

## DRY verifier

Command run:

```bash
python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/holidays.yaml --min-occurrences 2
```

Result:
- Total files scanned: 1
- Parse errors: 0
- Duplicate full-block groups: 0
- Duplicate entry groups: 0
- Intra-block duplicates: 0
- Central script findings: 0

Resolution status:
- Repeated Christmas-off actions: resolved by `script.turn_off_christmas_lights` and one trigger-ID automation.
- Repeated sunset holiday actions/triggers: resolved by folding notification and tree-on handling into the shared outdoor holiday automation.
- Continuous palette advancement: retained intentionally as the one-minute trigger on the shared holiday engine.

## Validation

Passed locally:

```bash
uv run --with pytest pytest
```

Result: 467 passed.

Passed locally:

```bash
git diff --check
```

Home Assistant config validation was attempted locally with Podman, but the local Podman VM is still unavailable:
- `podman-machine-default` reports started successfully, then immediately inspects as `stopped`.
- Podman API socket refuses connections, so no HA check container can be started locally.
- The machine was explicitly stopped/inspected afterward and no matching Podman VM processes were left running.

The PR should run the repository's CI Home Assistant config check with the configured HA image.
