### PR TITLE
Fix #732 preserve Z2M router roster on empty snapshots

### DIFF
--- a/packages/z2m_lifecycle.yaml
+++ b/packages/z2m_lifecycle.yaml
@@ -1062,16 +1062,14 @@ template:
 
           {% if is_devices_topic %}
             {% set payload = trigger.payload_json %}
-            {% if payload is mapping and payload.data is defined %}
+            {% if payload is mapping and payload.data is defined and payload.data is sequence and payload.data is not string and payload.data is not mapping %}
               {% set devices = payload.data %}
-              {% set has_device_snapshot = true %}
-            {% elif payload is sequence and payload is not string %}
+            {% elif payload is sequence and payload is not string and payload is not mapping %}
               {% set devices = payload %}
-              {% set has_device_snapshot = true %}
             {% else %}
               {% set devices = [] %}
-              {% set has_device_snapshot = false %}
             {% endif %}
+            {% set has_device_snapshot = devices | count > 0 %}
             {% if has_device_snapshot %}
               {% set routers = devices
                 | selectattr('type', 'eq', 'Router')

--- a/tests/test_z2m_lifecycle_package.py
+++ b/tests/test_z2m_lifecycle_package.py
@@ -86,13 +86,14 @@ def test_z2m_lifecycle_watchdog_uses_plain_bridge_state_trigger() -> None:
     assert 'value_template: "{{ value_json.state }}"' not in block
 
 
-def test_z2m_router_stats_preserves_roster_on_malformed_devices_response() -> None:
+def test_z2m_router_stats_preserves_roster_on_malformed_or_empty_devices_response() -> None:
     text = PACKAGE_PATH.read_text(encoding="utf-8")
     block = text.split("z2m_router_stats: >-", maxsplit=1)[1].split("  - binary_sensor:", maxsplit=1)[0]
 
     assert "current_attrs.get('routers', [])" in block
-    assert "{% set has_device_snapshot = true %}" in block
-    assert "{% set has_device_snapshot = false %}" in block
+    assert "payload.data is not mapping" in block
+    assert "payload is not mapping" in block
+    assert "{% set has_device_snapshot = devices | count > 0 %}" in block
     assert "{% if has_device_snapshot %}" in block
     assert "{% set routers = devices" in block
 


### PR DESCRIPTION
## Summary

Fixes #732.

- Preserve the previous Z2M router roster when `bridge/devices` or `bridge/response/devices` contains an empty device list.
- Reject mapping-shaped `data` payloads as malformed snapshots before router extraction.
- Extend regression coverage so malformed and empty snapshots both keep the last known router roster.

## Runtime evidence

Nightly Trace Review on 2026-05-31 confirmed the original fix from #733 was deployed but incomplete:

- Live `/config/packages/z2m_lifecycle.yaml` hash matched `origin/develop`.
- `binary_sensor.zigbee2mqtt_running=on` and `binary_sensor.z2m_bridge=on`.
- `sensor.z2m_router_total` still repeatedly alternated `95 -> 0`; recorder history had 155 samples in the reviewed 36-hour window.
- Logbook showed valid 95-router snapshots immediately followed by zero-router snapshots, including `95 -> 0` at `2026-05-31T15:16:38Z`, `2026-05-31T15:58:27Z`, and `2026-05-31T17:25:52Z`.
- `automation.refresh_z2m_lifecycle_inventory` traces finished successfully while downstream router state regressed, so successful traces alone were not sufficient.

The first fix preserved the old roster only for malformed payloads. Live behavior proves transient explicit empty lists must also preserve the last known roster.

## Spec alignment

`specs/z2m_lifecycle.allium` requires systemic bridge recovery to be based on real bridge degradation and explicitly documents `single_device_churn_never_triggers_host_restart`. A transient empty devices snapshot must not redefine a healthy mesh as zero routers.

## Validation

Passed locally:

- `uv run --with pytest pytest tests/test_z2m_lifecycle_package.py tests/test_z2m_lifecycle_allium_alignment.py -q` -> 10 passed
- `uv run --with pytest pytest` -> 467 passed
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/z2m_lifecycle.yaml`
- `uv run --with homeassistant==2026.5.0 python -m homeassistant --config . --script check_config` using the CI placeholder-secret preparation
- `git diff --check`

The YAML DRY verifier was also run on `packages/z2m_lifecycle.yaml`. Its strict mode still reports pre-existing duplicate reset/decommission blocks; this patch does not add duplication or refactor those behavior-sensitive paths.
