### PR TITLE
Fix #744 Z2M router roster stale MQTT overwrite

### DIFF
--- a/packages/z2m_lifecycle.yaml
+++ b/packages/z2m_lifecycle.yaml
@@ -1043,6 +1043,8 @@ template:
         topic: zigbee2mqtt/+/+/availability
       - trigger: mqtt
         topic: zigbee2mqtt/+/+/+/availability
+      - trigger: mqtt
+        topic: zigbee2mqtt/+/+/+/+/availability
     variables:
       z2m_router_stats: >-
         {% set current_attrs = this.attributes if this is defined and this.attributes is defined else dict() %}

--- a/packages/z2m_lifecycle.yaml
+++ b/packages/z2m_lifecycle.yaml
@@ -1038,7 +1038,11 @@ template:
       - trigger: mqtt
         topic: zigbee2mqtt/bridge/response/devices
       - trigger: mqtt
-        topic: zigbee2mqtt/#
+        topic: zigbee2mqtt/+/availability
+      - trigger: mqtt
+        topic: zigbee2mqtt/+/+/availability
+      - trigger: mqtt
+        topic: zigbee2mqtt/+/+/+/availability
     variables:
       z2m_router_stats: >-
         {% set current_attrs = this.attributes if this is defined and this.attributes is defined else dict() %}

--- a/tests/test_z2m_lifecycle_package.py
+++ b/tests/test_z2m_lifecycle_package.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PATH = ROOT / "packages" / "z2m_lifecycle.yaml"
+AVAILABILITY_PACKAGE_PATH = ROOT / "packages" / "z2m_availability.yaml"
 Z2M_CONFIG_PATH = ROOT / "zigbee2mqtt" / "configuration.yaml"
 
 
@@ -88,14 +89,18 @@ def test_z2m_lifecycle_watchdog_uses_plain_bridge_state_trigger() -> None:
 
 def test_z2m_router_stats_preserves_roster_on_malformed_or_empty_devices_response() -> None:
     text = PACKAGE_PATH.read_text(encoding="utf-8")
+    availability_text = AVAILABILITY_PACKAGE_PATH.read_text(encoding="utf-8")
     triggers = text.split("z2m_router_stats: >-", maxsplit=1)[0].rsplit("\n  - trigger:\n", maxsplit=1)[1]
     block = text.split("z2m_router_stats: >-", maxsplit=1)[1].split("  - binary_sensor:", maxsplit=1)[0]
+    availability_depths = {
+        name.count("/") + 1
+        for name in re.findall(r'state_topic: "zigbee2mqtt/(.+)/availability"', availability_text)
+    }
 
     assert "current_attrs.get('routers', [])" in block
     assert "topic: zigbee2mqtt/#" not in triggers
-    assert "topic: zigbee2mqtt/+/availability" in triggers
-    assert "topic: zigbee2mqtt/+/+/availability" in triggers
-    assert "topic: zigbee2mqtt/+/+/+/availability" in triggers
+    for depth in availability_depths:
+        assert f"topic: zigbee2mqtt/{'/'.join('+' for _ in range(depth))}/availability" in triggers
     assert "payload.data is not mapping" in block
     assert "payload is not mapping" in block
     assert "{% set has_device_snapshot = devices | count > 0 %}" in block

--- a/tests/test_z2m_lifecycle_package.py
+++ b/tests/test_z2m_lifecycle_package.py
@@ -88,9 +88,14 @@ def test_z2m_lifecycle_watchdog_uses_plain_bridge_state_trigger() -> None:
 
 def test_z2m_router_stats_preserves_roster_on_malformed_or_empty_devices_response() -> None:
     text = PACKAGE_PATH.read_text(encoding="utf-8")
+    triggers = text.split("z2m_router_stats: >-", maxsplit=1)[0].rsplit("\n  - trigger:\n", maxsplit=1)[1]
     block = text.split("z2m_router_stats: >-", maxsplit=1)[1].split("  - binary_sensor:", maxsplit=1)[0]
 
     assert "current_attrs.get('routers', [])" in block
+    assert "topic: zigbee2mqtt/#" not in triggers
+    assert "topic: zigbee2mqtt/+/availability" in triggers
+    assert "topic: zigbee2mqtt/+/+/availability" in triggers
+    assert "topic: zigbee2mqtt/+/+/+/availability" in triggers
     assert "payload.data is not mapping" in block
     assert "payload is not mapping" in block
     assert "{% set has_device_snapshot = devices | count > 0 %}" in block


### PR DESCRIPTION
## Summary

Fixes #744.

- Narrow the Z2M router-health template MQTT triggers from broad `zigbee2mqtt/#` traffic to bridge roster snapshots plus availability-only topic depths used by the live topology.
- Prevent unrelated MQTT messages from completing with stale pre-snapshot attributes and resetting `sensor.z2m_router_total` from `95` to `0`.
- Add regression coverage that rejects the broad wildcard in the router-stats trigger block.

## Runtime evidence

- Live `/config/packages/z2m_lifecycle.yaml` hash matched current `origin/develop`.
- A retained `zigbee2mqtt/bridge/devices` payload contains 150 rows: 1 coordinator, 95 routers, and 54 end devices.
- Recorder history repeatedly showed `sensor.z2m_router_total: 95 -> 0` within fractions of a second.
- Stored traces for `automation.refresh_z2m_lifecycle_inventory` and `automation.sync_z2m_decommission_options` finished successfully, while recorder/logbook correlation showed the downstream state regression.
- Live router names use one or two embedded `/` segments, covered by the three scoped availability subscriptions.

## Validation

- `uv run --with pytest pytest tests/test_z2m_lifecycle_package.py tests/test_z2m_lifecycle_allium_alignment.py`
- `uv run --with pytest pytest` (`467 passed`)
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt`
- Home Assistant `2026.5.0` container `check_config`
- `git diff --check`
- DRY verifier baseline comparison: no new findings; pre-existing Z2M package findings deferred to #738.