### PR TITLE
Fix LG TV mirror optional notification fields

### DIFF
--- a/packages/alerts.yaml
+++ b/packages/alerts.yaml
@@ -244,8 +244,8 @@ automation:
     variables:
       notify_payload: "{{ trigger.event.data.service_data | default({}, true) }}"
       notify_message: "{{ notify_payload.message | default('', true) }}"
-      notify_title: "{{ notify_payload.title | default(none, true) }}"
-      notify_data: "{{ notify_payload.data | default(none, true) }}"
+      notify_title: "{{ notify_payload.title | default('', true) }}"
+      notify_data: "{{ notify_payload.data | default({}, true) }}"
     condition:
       - condition: state
         entity_id: media_player.lg_webos_smart_tv

--- a/tests/test_alerts_notify_groups.py
+++ b/tests/test_alerts_notify_groups.py
@@ -29,3 +29,11 @@ def test_shared_notifications_mirror_to_lg_tv_only_when_on() -> None:
     assert "entity_id: media_player.lg_webos_smart_tv" in text
     assert 'state: "on"' in text
     assert "action: notify.lg_webos_tv_oled65c4aua_dusqljr" in text
+
+
+def test_shared_notifications_mirror_defaults_optional_payload_fields() -> None:
+    text = ALERTS_PATH.read_text(encoding="utf-8")
+    mirror = text.split("id: mirror_shared_notifications_to_lg_tv_when_on", maxsplit=1)[1]
+
+    assert "notify_title: \"{{ notify_payload.title | default('', true) }}\"" in mirror
+    assert "notify_data: \"{{ notify_payload.data | default({}, true) }}\"" in mirror


### PR DESCRIPTION
## Summary

- default omitted LG mirror notification titles to an empty string
- default omitted LG mirror notification data to an empty mapping
- add a regression test for valid optional-field defaults

## Runtime evidence

Current Home Assistant logs show repeated `automation.mirror_shared_notifications_to_lg_tv_when_on` action failures when a shared notification omits `title`: `string value is None for dictionary value @ data[title]`. Live config contains the same null defaults fixed here.

Closes #745

## Validation

- `uv run --with pytest pytest tests/test_alerts_notify_groups.py`
- `uv run --with pytest pytest` (468 passed)
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt`
- `git diff --check`
- Home Assistant `2026.5.0` container `python -m homeassistant --config /config --script check_config`
- Home Assistant template evaluation for omitted optional fields: `""|{}`

## DRY verifier

`verify_ha_yaml_dry.py packages/alerts.yaml --strict` reports one pre-existing repeated delay entry inside `script.flash_lights`. The same finding is present on `origin/develop`; it is the intentional on-delay-off-delay single flash pulse documented in that script. Refactoring alarm behavior is deferred as out of scope for this LG-only fix.