### PR TITLE
[codex] Migrate Lovelace YAML dashboard configuration

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -186,7 +186,7 @@ panel_custom:
       ingress: core_configurator
 
 lovelace:
-  mode: yaml
+  resource_mode: yaml
   resources:
     - url: /hacsfiles/logbook-card/logbook-card.js
       type: module

--- a/tests/test_ha_2026_8_upgrade.py
+++ b/tests/test_ha_2026_8_upgrade.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGURATION_PATH = ROOT / "configuration.yaml"
+
+
+def _lovelace_block() -> str:
+    text = CONFIGURATION_PATH.read_text(encoding="utf-8")
+    match = re.search(r"^lovelace:\n(.*?)(?=^\S|\Z)", text, re.MULTILINE | re.DOTALL)
+    if match is None:
+        raise AssertionError("Could not find lovelace block in configuration.yaml")
+    return match.group(0)
+
+
+def test_lovelace_yaml_resources_use_resource_mode() -> None:
+    block = _lovelace_block()
+
+    assert "\n  mode: yaml\n" not in block
+    assert "\n  resource_mode: yaml\n" in block
+
+
+def test_yaml_dashboards_are_declared_individually() -> None:
+    block = _lovelace_block()
+
+    assert re.search(
+        r"^    db-guest:\n"
+        r"      mode: yaml\n"
+        r"      title: Guest\n"
+        r"      icon: mdi:bag-checked\n"
+        r"      show_in_sidebar: false\n"
+        r"      filename: ui-guest.yaml$",
+        block,
+        re.MULTILINE,
+    )


### PR DESCRIPTION
## Summary
- replace deprecated top-level `lovelace.mode: yaml` with `lovelace.resource_mode: yaml`
- preserve YAML-loaded dashboard resources and individually declared YAML dashboards
- add Home Assistant 2026.8 regression coverage for the Lovelace migration

## Root cause
Home Assistant 2026.8 removes the legacy top-level `lovelace.mode: yaml` option. This repository still used that option to load dashboard resources, even though its YAML dashboards were already declared individually.

## Validation
- `git diff --check`
- `uv run --with pytest pytest` (`491 passed`)
- connected Home Assistant `ha_check_config` (`Configuration is valid`)
