### PR TITLE
[codex] Fix offline upstairs vacuum Spook warnings

### DIFF
--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -478,7 +478,6 @@ template:
   - trigger:
       - trigger: state
         entity_id:
-          - vacuum.valetudo_upstairs_vacuum
           - vacuum.valetudo_mainlevel
           - vacuum.valetudo_den
         to: "cleaning"

--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -481,6 +481,9 @@ template:
           - vacuum.valetudo_mainlevel
           - vacuum.valetudo_den
         to: "cleaning"
+      - trigger: mqtt
+        topic: valetudo/upstairs-vacuum/StatusStateAttribute/status
+        payload: cleaning
     sensor:
       - name: "Vacuum last ran"
         unique_id: vacuum_last_ran

--- a/packages/xiaomi_robot_vacuum.yaml
+++ b/packages/xiaomi_robot_vacuum.yaml
@@ -228,9 +228,10 @@ script:
     trace:
       stored_traces: 10
     sequence:
-      - action: vacuum.start
-        target:
-          entity_id: vacuum.valetudo_upstairs_vacuum
+      - action: mqtt.publish
+        data:
+          topic: valetudo/upstairs-vacuum/BasicControlCapability/operation/set
+          payload: START
 
   vacuum_main_and_upstairs_levels:
     alias: "Vacuum Main And Upstairs Levels"

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1564,15 +1564,10 @@ automation:
         then:
           - action: rest_command.reload_den_vacuum
             continue_on_error: true
-      - if:
-          - condition: not
-            conditions:
-              - condition: state
-                entity_id: vacuum.valetudo_upstairs_vacuum
-                state: unavailable
-        then:
-          - action: rest_command.reload_upstairs_vacuum
-            continue_on_error: true
+      # The upstairs robot may be absent from HA discovery when its MQTT
+      # configuration needs repair, so retry without checking its entity state.
+      - action: rest_command.reload_upstairs_vacuum
+        continue_on_error: true
 
 ########################
 # Binary Sensors

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -624,7 +624,10 @@ automation:
           entity_id:
             - vacuum.valetudo_den
             - vacuum.valetudo_mainlevel
-            - vacuum.valetudo_upstairs_vacuum
+      - action: mqtt.publish
+        data:
+          topic: valetudo/upstairs-vacuum/BasicControlCapability/operation/set
+          payload: HOME
       - action: switch.turn_off
         target:
           entity_id: switch.livingroom_motion_detection

--- a/tests/test_issue_vacuum_last_ran_timestamp.py
+++ b/tests/test_issue_vacuum_last_ran_timestamp.py
@@ -16,3 +16,12 @@ def test_vacuum_last_ran_is_a_timestamp_sensor_without_state_class() -> None:
     assert 'state_class:' not in text.split('unique_id: vacuum_last_ran', 1)[1].split(
         '########################', 1
     )[0]
+
+
+def test_vacuum_last_ran_uses_recovery_safe_upstairs_status_topic() -> None:
+    text = CLEANING_PATH.read_text(encoding="utf-8")
+    block = text.split('unique_id: vacuum_last_ran', 1)[0].rsplit('  - trigger:', 1)[1]
+
+    assert 'topic: valetudo/upstairs-vacuum/StatusStateAttribute/status' in block
+    assert 'payload: cleaning' in block
+    assert 'vacuum.valetudo_upstairs_vacuum' not in block

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -349,10 +349,10 @@ def test_valetudo_startup_reconfigure_skips_unavailable_vacuums() -> None:
     block = _automation_block(ZIGBEE_ZWAVE_PATH, "reconfigure_z2m_and_vacuums_on_startup")
 
     assert "entity_id: vacuum.valetudo_den" in block
-    assert "entity_id: vacuum.valetudo_upstairs_vacuum" in block
+    assert "entity_id: vacuum.valetudo_upstairs_vacuum" not in block
     assert "entity_id: vacuum.valetudo_mainlevel" not in block
-    assert block.count("condition: not") == 2
-    assert block.count("state: unavailable") == 2
+    assert block.count("condition: not") == 1
+    assert block.count("state: unavailable") == 1
     assert "action: rest_command.reload_main_level_vacuum" not in block
     assert "action: rest_command.reload_den_vacuum" in block
     assert "action: rest_command.reload_upstairs_vacuum" in block

--- a/tests/test_vacuum_whole_floor_policy.py
+++ b/tests/test_vacuum_whole_floor_policy.py
@@ -73,8 +73,19 @@ def test_whole_floor_helper_starts_both_levels() -> None:
 
     assert "entity_id: vacuum.valetudo_mainlevel" in main_level_block
     assert "action: vacuum.start" in main_level_block
-    assert "entity_id: vacuum.valetudo_upstairs_vacuum" in upstairs_block
-    assert "action: vacuum.start" in upstairs_block
+    assert "valetudo/upstairs-vacuum/BasicControlCapability/operation/set" in upstairs_block
+    assert "payload: START" in upstairs_block
+
+
+def test_upstairs_vacuum_entity_is_not_required_for_ha_automation_control() -> None:
+    stale_entity_id = "vacuum.valetudo_upstairs_vacuum"
+
+    for path in (VACUUM_PATH, ZONE_PATH, ROOT / "packages" / "cleaning.yaml", ROOT / "packages" / "zigbee_zwave.yaml"):
+        assert stale_entity_id not in path.read_text(encoding="utf-8")
+
+    return_home_block = _automation_block(ZONE_PATH, "vacuum_return_home")
+    assert "valetudo/upstairs-vacuum/BasicControlCapability/operation/set" in return_home_block
+    assert "payload: HOME" in return_home_block
 
 
 def test_departure_transition_no_longer_embeds_weekday_room_rotation() -> None:


### PR DESCRIPTION
## Summary

- replace upstairs full-floor and return-home entity calls with Valetudo MQTT `START` and `HOME` commands
- remove stale `vacuum.valetudo_upstairs_vacuum` dependencies from HA package triggers and startup checks
- keep the startup MQTT reconfigure retry unconditional so discovery can recover when the upstairs robot comes back online
- add regression coverage for the offline-discovery case

## Root cause

The upstairs Valetudo host is offline and its MQTT-discovered `vacuum.valetudo_upstairs_vacuum` entity is absent from Home Assistant. Spook therefore reports unknown entity references in the return-home automation and upstairs full-floor script even though Valetudo MQTT command topics remain the correct recovery-safe control path.

Closes #750

## Validation

- `uv run --with pytest pytest` (`490 passed`)
- `git diff --check`

## Review follow-up

- Preserve the house-wide vacuum timestamp for upstairs-only runs with an MQTT status trigger on `valetudo/upstairs-vacuum/StatusStateAttribute/status` when the robot reports `cleaning`.
- Keep the stale `vacuum.valetudo_upstairs_vacuum` dependency removed.

## Updated validation

- `uv run --with pytest pytest tests/test_issue_vacuum_last_ran_timestamp.py tests/test_vacuum_whole_floor_policy.py tests/test_runtime_log_regressions.py tests/test_issue_343_vacuum_stall_monitor.py -q` (37 passed)
- `uv run --with pytest pytest` (500 passed)
- YAML lint for `packages/cleaning.yaml`
- HA YAML DRY verifier for `packages/cleaning.yaml` (no findings)
- Home Assistant `2026.5.1` container `check_config`
- `git diff --check`