### PR TITLE
Exclude ADS-B raw feeds from recorder and InfluxDB (#754)

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -126,6 +126,11 @@ recorder:
       # F1 season results carries full race result payloads in attributes.
       # Keep smaller current/next-session F1 sensors recorded instead.
       - sensor.f1_season_results
+      # ADS-B raw feeds carry full aircraft/photo/route payloads in attributes.
+      # Keep derived closest-aircraft sensors recorded instead of these oversized feeds.
+      - sensor.adsb_aircraft_raw
+      - sensor.closest_aircraft_photo_raw
+      - sensor.closest_aircraft_route_raw
 
 influxdb:
   exclude:
@@ -148,6 +153,11 @@ influxdb:
       # The Garden Birds MQTT sensor carries an attribute named "time"; InfluxDB
       # rejects fields with that reserved name and drops the entire batch.
       - sensor.garden_birds
+      # ADS-B raw feeds carry full aircraft/photo/route payloads in attributes.
+      # Keep derived closest-aircraft sensors shipped to InfluxDB instead.
+      - sensor.adsb_aircraft_raw
+      - sensor.closest_aircraft_photo_raw
+      - sensor.closest_aircraft_route_raw
 
 cloud:
   alexa:


### PR DESCRIPTION
## Summary
Closes #754. Excludes the three ADS-B raw feed sensors from both the recorder and InfluxDB to stop oversized-attribute write amplification.

## Why
`sensor.adsb_aircraft_raw` (`packages/airplanes.yaml`, `scan_interval: 15`) uses `value_template: "{{ value_json.now }}"` — an epoch timestamp that changes every poll — so it fires a `state_changed` event every 15s carrying the full `aircraft` list as an attribute (~2 KB at night, 15–40 KB midday). That payload was being written to the recorder DB and shipped to InfluxDB every 15s. `closest_aircraft_photo_raw` (`photos`) and `closest_aircraft_route_raw` (`response`) have the same shape.

This matches the established pattern already excluding `flightradar24_airport_*`, `top_50_bird_species*`, and `f1_season_results` for the same reason.

## Change
- `recorder: exclude: entities:` += the three raw feeds
- `influxdb: exclude: entities:` += the three raw feeds

## No behavior change
The `closest_aircraft_overhead` template sensor reads the **live attribute**, not recorder history — display and automations are unaffected.

## Validation
- `yamllint` on `configuration.yaml`: clean

## Note
Not the cause of the recent core-CPU spike (that was the admin-health package, reverted in #753) — this is a standing write-amplification cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)