### PR TITLE
[codex] Fix washer reminder Music Assistant target

### DIFF
--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -272,7 +272,7 @@ automation:
                   - action: tts.google_say
                     continue_on_error: true
                     data:
-                      entity_id: media_player.everywhere_sonos
+                      entity_id: media_player.ma_group_everywhere
                       message: "Laundry has been sitting in the washer for an hour."
           - conditions:
               - condition: state

--- a/tests/test_laundry_plug_monitoring.py
+++ b/tests/test_laundry_plug_monitoring.py
@@ -128,7 +128,8 @@ def test_cleaning_package_notifies_from_power_based_running_sensors() -> None:
     assert "message: \"Laundry has been sitting in the washer for an hour." in washer_reminder
     assert "input_boolean.guest_mode" in washer_reminder
     assert "action: tts.google_say" in washer_reminder
-    assert "entity_id: media_player.everywhere_sonos" in washer_reminder
+    assert "entity_id: media_player.ma_group_everywhere" in washer_reminder
+    assert "media_player.everywhere_sonos" not in washer_reminder
     assert "binary_sensor.front_load_washer_wash_completed" not in washer_reminder
 
     assert "binary_sensor.laundry_room_washing_machine_door_contact" in washer_cleared


### PR DESCRIPTION
## Summary
- replace the retired washer-reminder Sonos playback target with the live Music Assistant everywhere group
- preserve the existing guest-mode privacy guard
- update laundry regression coverage to require the live target and reject the stale entity

Closes #758

## Runtime evidence
The live Repairs API reports `automation.washer_reminder` references missing `media_player.everywhere_sonos`. Live state contains `media_player.ma_group_everywhere`, already used by the established Music Assistant paths.

## Validation
- `uv run --with pytest pytest tests/test_laundry_plug_monitoring.py tests/test_media_player_music_assistant.py tests/test_laundry_lovelace_dashboard.py -q` (`29 passed`)
- `uv run --with pytest pytest` (`498 passed`)
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/cleaning.yaml`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/cleaning.yaml --min-occurrences 2`
- `git diff --check`
- `podman run --name ha-check-config --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:2026.5.1 python -m homeassistant --config /config --script check_config`
