### PR TITLE
Fix #758 washer reminder media target

### DIFF
--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -272,7 +272,7 @@ automation:
                   - action: tts.google_say
                     continue_on_error: true
                     data:
-                      entity_id: media_player.everywhere_sonos
+                      entity_id: media_player.ma_group_everywhere
                       message: "Laundry has been sitting in the washer for an hour."
           - conditions:
               - condition: state

--- a/tests/test_laundry_plug_monitoring.py
+++ b/tests/test_laundry_plug_monitoring.py
@@ -128,7 +128,8 @@ def test_cleaning_package_notifies_from_power_based_running_sensors() -> None:
     assert "message: \"Laundry has been sitting in the washer for an hour." in washer_reminder
     assert "input_boolean.guest_mode" in washer_reminder
     assert "action: tts.google_say" in washer_reminder
-    assert "entity_id: media_player.everywhere_sonos" in washer_reminder
+    assert "entity_id: media_player.ma_group_everywhere" in washer_reminder
+    assert "media_player.everywhere_sonos" not in washer_reminder
     assert "binary_sensor.front_load_washer_wash_completed" not in washer_reminder
 
     assert "binary_sensor.laundry_room_washing_machine_door_contact" in washer_cleared


### PR DESCRIPTION
## Summary
- replace the retired `media_player.everywhere_sonos` washer-reminder TTS target with `media_player.ma_group_everywhere`
- add regression coverage so the stale Sonos entity cannot return

Fixes #758.

## Runtime evidence
- Live HA state returns 404 for `media_player.everywhere_sonos`.
- Active `automation.washer_reminder` can reach the one-hour TTS escalation path when guest mode is off.
- Live `media_player.ma_group_everywhere` is the established Music Assistant whole-home target used elsewhere in the repo.

## Validation
- `uv run --with pytest pytest tests/test_laundry_plug_monitoring.py -q` -> 4 passed
- `uv run --with pytest pytest` -> 498 passed
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt` -> passed

## Validation notes
- Home Assistant container `check_config` could not run locally because Podman machine socket refused connections after startup (`dial tcp 127.0.0.1:53019: connect: connection refused`).