### PR TITLE
docs: rtlamr2mqtt is a local add-on; note renamed gas-meter entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,7 @@ Software on the NUC:
   * [I Can't Believe It's Not Valetudo](https://github.com/Poeschl/Hassio-Addons/tree/master/ICantBelieveItsNotValetudo)
   * [Home Assistant Google Drive Backup](https://github.com/sabeechen/hassio-google-drive-backup)
   * [Matter Server](https://github.com/home-assistant/addons/tree/master/matter_server)
-* Running elsewhere
-  * [rtlamr](https://github.com/bemasher/rtlamr) - Runs on a Pi4 and collects ~~electrical~~ gas utility info.
+  * [rtlamr2mqtt](https://github.com/allangood/rtlamr2mqtt) - Local HA add-on (RTLAMR to MQTT bridge) that reads the gas utility meter via a USB RTL-SDR dongle and publishes to MQTT. Exposes `sensor.raw_house_gas_meter_reading` (and `..._last_seen`).
   * [Zigbee2MQTT](https://zigbee2mqtt.io/) - Zigbee control over MQTT
 
 ## Device Audit (2026-03-29)


### PR DESCRIPTION
## What

Updates the README's integration list: the rtlamr gas-meter reader no longer runs on a separate Pi4 — it's now a local Home Assistant add-on (**rtlamr2mqtt**) reading the meter via a USB RTL-SDR dongle and publishing over MQTT (EMQX).

Also documents the **current entity IDs**, since the add-on (v2026.5.9) renamed them:
- `sensor.raw_house_gas_meter_reading` — the meter value (ft³, `device_class: gas`, `total_increasing`)
- `sensor.raw_house_gas_meter_last_seen` — last-seen timestamp

The old `sensor.raw_house_gas_meter` is gone (it was an orphan from the previous naming scheme).

## Why

While debugging the gas meter dropping out, the root cause turned out to be a stalled RTL-SDR dongle (fixed by a host reboot) — but the README still described the old Pi4 setup and the stale entity ID, which made diagnosis harder. This brings the docs in line with the live system.

## Notes for reviewer

- Docs-only change (one line in `README.md`); no config or automation impact.
- Out of band (not in this PR, since it's runtime config, not repo state): the orphaned `sensor.raw_house_gas_meter` entity was removed from the registry, and EMQX got `EMQX_RETAINER__MAX_PUBLISH_RATE=infinity` so a host reboot's discovery flood no longer drops retained messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)