### PR TITLE
Exclude flights from Tesla charge planner via shared flight-recognition macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@
 !appdaemon/**
 !tests/
 !tests/*.py
+!custom_templates/
+!custom_templates/*.jinja
 !appdaemon/
 appdaemon/*
 !appdaemon/apps/

--- a/custom_templates/flight.jinja
+++ b/custom_templates/flight.jinja
@@ -1,0 +1,33 @@
+{#-
+  Shared flight-recognition macros.
+
+  These centralize the "does this calendar event look like a flight?" logic so
+  the Tesla charge planner (packages/car.yaml) can reuse the exact same rules
+  that travel/trip detection relies on. The boolean matches the inline flight
+  detection in packages/trips.yaml (route arrows, "flight to ...", "flight: ...
+  to ...", and itinerary markers such as Flighty/Gmail sync, booking codes, and
+  flight-time lines).
+
+  Output is exactly "True" or "False" so callers can compare with
+  `| trim | lower == 'true'`.
+-#}
+{%- macro looks_like_flight(summary, description='', location='') -%}
+  {%- set summary_text = summary | default('', true) | string -%}
+  {%- set summary_lower = summary_text | lower -%}
+  {%- set trip_text = [summary_text, description | default('', true) | string, location | default('', true) | string] | join(' ') | lower -%}
+  {%- set route_summary = '→' in summary_text -%}
+  {%- set named_flight = summary_lower.startswith('flight to ') or (summary_lower.startswith('flight: ') and ' to ' in summary_lower) -%}
+  {%- set itinerary_marker = 'synced by flighty' in trip_text or 'created from an email you received in gmail' in trip_text or 'booking code:' in trip_text or 'flight time ' in trip_text -%}
+  {{- route_summary or named_flight or itinerary_marker -}}
+{%- endmacro -%}
+{#-
+  skip_charging_event: True when the Tesla charge planner should ignore a
+  calendar event entirely. Flights are excluded regardless of origin airport
+  (the car never makes the long drive), and the existing manual `nocharge`
+  description tag is still honored as an explicit opt-out.
+-#}
+{%- macro skip_charging_event(summary, description='', location='') -%}
+  {%- set is_flight = looks_like_flight(summary, description, location) | trim | lower == 'true' -%}
+  {%- set is_nocharge = 'nocharge' in (description | default('', true) | string | lower) -%}
+  {{- is_flight or is_nocharge -}}
+{%- endmacro -%}

--- a/docs/tesla_departure_planner.md
+++ b/docs/tesla_departure_planner.md
@@ -29,6 +29,8 @@ The planner now normalizes Waze/Tesla duration inputs with Home Assistant's `as_
 
 The trip-selection template now only considers future departures inside the next 24 hours. Once a calendar departure is in the past, its `start_time` drops out of the planner inputs and the next planner recompute clears Tesla scheduled departure instead of leaving stale preconditioning or off-peak charging events behind.
 
+Flight events are excluded from charge planning entirely. `binary_sensor.upcoming_trip_charging` runs every candidate calendar event through the shared `skip_charging_event` macro in `custom_templates/flight.jinja`, which reuses the same flight-recognition rules as travel detection in `packages/trips.yaml` (route-arrow itineraries such as `✈ MSP→ATL`, `flight to …` / `flight: … to …` titles, and itinerary markers like "Synced by Flighty", "Created from an email you received in Gmail", booking codes, and flight-time lines). The macro is applied in all four template blocks (`state`, `entry`, `start_time`, `all_day`) so a flight never sets a trip distance, departure time, or preconditioning plan. This is intentionally origin-agnostic: unlike trip-mode detection, the charge planner ignores a flight regardless of whether it departs MSP, because the car never makes the long drive to the arrival city. Previously a far-destination flight (for example "Flight to Atlanta") fed the Waze drive distance to the arrival city, tripped the `>= 90 mi -> 100%` rule, and pinned the home Tesla to a 100% charge. The same macro still honors the manual `nocharge` description tag as an explicit opt-out.
+
 ### Alarm inputs
 
 - `input_boolean.weekday_alarm_on`

--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -990,11 +990,13 @@ template:
           {{ state_attr("sensor.waze_next_trip_distance", "distance") != None }}
         attributes:
           entry: >-
+            {% from 'flight.jinja' import skip_charging_event %}
             {% set now_local = now() %}
             {% set horizon = now_local + timedelta(hours=24) %}
             {% set ns = namespace(start=none, entry='None') %}
             {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-            {% if personal_start_raw not in [none, ''] %}
+            {% set personal_skip = skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) | trim | lower == 'true' %}
+            {% if personal_start_raw not in [none, ''] and not personal_skip %}
               {% set personal_start = personal_start_raw | as_datetime | as_local %}
               {% if personal_start is not none and personal_start > now_local and personal_start < horizon %}
                 {% set ns.start = personal_start %}
@@ -1002,7 +1004,8 @@ template:
               {% endif %}
             {% endif %}
             {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-            {% if work_start_raw not in [none, ''] %}
+            {% set work_skip = skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) | trim | lower == 'true' %}
+            {% if work_start_raw not in [none, ''] and not work_skip %}
               {% set work_start = work_start_raw | as_datetime | as_local %}
               {% if work_start is not none and work_start > now_local and work_start < horizon and (ns.start is none or work_start < ns.start) %}
                 {% set ns.start = work_start %}
@@ -1010,7 +1013,8 @@ template:
               {% endif %}
             {% endif %}
             {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-            {% if curling_start_raw not in [none, ''] %}
+            {% set curling_skip = skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) | trim | lower == 'true' %}
+            {% if curling_start_raw not in [none, ''] and not curling_skip %}
               {% set curling_start = curling_start_raw | as_datetime | as_local %}
               {% if curling_start is not none and curling_start > now_local and curling_start < horizon and (ns.start is none or curling_start < ns.start) %}
                 {% set ns.start = curling_start %}
@@ -1019,11 +1023,13 @@ template:
             {% endif %}
             {{ ns.entry }}
           start_time: >-
+            {% from 'flight.jinja' import skip_charging_event %}
             {% set now_local = now() %}
             {% set horizon = now_local + timedelta(hours=24) %}
             {% set ns = namespace(start=none, value='None') %}
             {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-            {% if personal_start_raw not in [none, ''] %}
+            {% set personal_skip = skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) | trim | lower == 'true' %}
+            {% if personal_start_raw not in [none, ''] and not personal_skip %}
               {% set personal_start = personal_start_raw | as_datetime | as_local %}
               {% if personal_start is not none and personal_start > now_local and personal_start < horizon %}
                 {% set ns.start = personal_start %}
@@ -1031,7 +1037,8 @@ template:
               {% endif %}
             {% endif %}
             {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-            {% if work_start_raw not in [none, ''] %}
+            {% set work_skip = skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) | trim | lower == 'true' %}
+            {% if work_start_raw not in [none, ''] and not work_skip %}
               {% set work_start = work_start_raw | as_datetime | as_local %}
               {% if work_start is not none and work_start > now_local and work_start < horizon and (ns.start is none or work_start < ns.start) %}
                 {% set ns.start = work_start %}
@@ -1039,7 +1046,8 @@ template:
               {% endif %}
             {% endif %}
             {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-            {% if curling_start_raw not in [none, ''] %}
+            {% set curling_skip = skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) | trim | lower == 'true' %}
+            {% if curling_start_raw not in [none, ''] and not curling_skip %}
               {% set curling_start = curling_start_raw | as_datetime | as_local %}
               {% if curling_start is not none and curling_start > now_local and curling_start < horizon and (ns.start is none or curling_start < ns.start) %}
                 {% set ns.start = curling_start %}
@@ -1048,11 +1056,13 @@ template:
             {% endif %}
             {{ ns.value }}
           all_day: >-
+            {% from 'flight.jinja' import skip_charging_event %}
             {% set now_local = now() %}
             {% set horizon = now_local + timedelta(hours=24) %}
             {% set ns = namespace(start=none, value='None') %}
             {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-            {% if personal_start_raw not in [none, ''] %}
+            {% set personal_skip = skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) | trim | lower == 'true' %}
+            {% if personal_start_raw not in [none, ''] and not personal_skip %}
               {% set personal_start = personal_start_raw | as_datetime | as_local %}
               {% if personal_start is not none and personal_start > now_local and personal_start < horizon %}
                 {% set ns.start = personal_start %}
@@ -1060,7 +1070,8 @@ template:
               {% endif %}
             {% endif %}
             {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-            {% if work_start_raw not in [none, ''] %}
+            {% set work_skip = skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) | trim | lower == 'true' %}
+            {% if work_start_raw not in [none, ''] and not work_skip %}
               {% set work_start = work_start_raw | as_datetime | as_local %}
               {% if work_start is not none and work_start > now_local and work_start < horizon and (ns.start is none or work_start < ns.start) %}
                 {% set ns.start = work_start %}
@@ -1068,7 +1079,8 @@ template:
               {% endif %}
             {% endif %}
             {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-            {% if curling_start_raw not in [none, ''] %}
+            {% set curling_skip = skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) | trim | lower == 'true' %}
+            {% if curling_start_raw not in [none, ''] and not curling_skip %}
               {% set curling_start = curling_start_raw | as_datetime | as_local %}
               {% if curling_start is not none and curling_start > now_local and curling_start < horizon and (ns.start is none or curling_start < ns.start) %}
                 {% set ns.start = curling_start %}
@@ -1077,12 +1089,13 @@ template:
             {% endif %}
             {{ ns.value }}
         state: >-
+          {% from 'flight.jinja' import skip_charging_event %}
           {% set now_local = now() %}
           {% set horizon = now_local + timedelta(hours=24) %}
           {% set ns = namespace(start=none, eligible=false) %}
           {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-          {% set personal_description = state_attr('calendar.ryan_claussen', 'description') | default('', true) | lower %}
-          {% if personal_start_raw not in [none, ''] and 'nocharge' not in personal_description %}
+          {% set personal_skip = skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) | trim | lower == 'true' %}
+          {% if personal_start_raw not in [none, ''] and not personal_skip %}
             {% set personal_start = personal_start_raw | as_datetime | as_local %}
             {% if personal_start is not none and personal_start > now_local and personal_start < horizon %}
               {% set ns.start = personal_start %}
@@ -1090,8 +1103,8 @@ template:
             {% endif %}
           {% endif %}
           {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-          {% set work_description = state_attr('binary_sensor.work_trip_today', 'description') | default('', true) | lower %}
-          {% if work_start_raw not in [none, ''] and 'nocharge' not in work_description %}
+          {% set work_skip = skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) | trim | lower == 'true' %}
+          {% if work_start_raw not in [none, ''] and not work_skip %}
             {% set work_start = work_start_raw | as_datetime | as_local %}
             {% if work_start is not none and work_start > now_local and work_start < horizon and (ns.start is none or work_start < ns.start) %}
               {% set ns.start = work_start %}
@@ -1099,8 +1112,8 @@ template:
             {% endif %}
           {% endif %}
           {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-          {% set curling_description = state_attr('calendar.curling', 'description') | default('', true) | lower %}
-          {% if curling_start_raw not in [none, ''] and 'nocharge' not in curling_description %}
+          {% set curling_skip = skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) | trim | lower == 'true' %}
+          {% if curling_start_raw not in [none, ''] and not curling_skip %}
             {% set curling_start = curling_start_raw | as_datetime | as_local %}
             {% if curling_start is not none and curling_start > now_local and curling_start < horizon and (ns.start is none or curling_start < ns.start) %}
               {% set ns.start = curling_start %}

--- a/tests/test_issue_tesla_planner_flight_exclusion.py
+++ b/tests/test_issue_tesla_planner_flight_exclusion.py
@@ -1,0 +1,126 @@
+"""Regression tests for the Tesla charge planner ignoring flights.
+
+Background: a "flight to Atlanta" (or any far-destination flight) on the
+calendar used to drive `binary_sensor.upcoming_trip_charging` on, because the
+Waze distance to the arrival city is huge. With the `>= 90 mi -> 100%` rule that
+pinned the home Tesla to a 100% charge while the car never left the garage.
+
+The fix reuses the same flight-recognition rules that travel detection uses
+(packages/trips.yaml) via a shared Jinja macro in custom_templates/flight.jinja,
+and applies it to every block of the charge-planner trip sensor so flights are
+excluded from charge planning regardless of origin airport.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CAR_PATH = ROOT / "packages" / "car.yaml"
+FLIGHT_MACRO_PATH = ROOT / "custom_templates" / "flight.jinja"
+
+
+def _looks_like_flight(summary: str, description: str = "", location: str = "") -> bool:
+    """Mirror of the looks_like_flight macro in custom_templates/flight.jinja.
+
+    Kept in lockstep with the Jinja rules (and with parse_flight_signals in
+    test_trips_flight_classification.py) so the planner's flight exclusion is
+    exercised without rendering Jinja in CI.
+    """
+    summary_text = summary or ""
+    summary_lower = summary_text.lower()
+    trip_text = " ".join(
+        part for part in [summary_text, description or "", location or ""]
+    ).lower()
+
+    route_summary = "→" in summary_text
+    named_flight = summary_lower.startswith("flight to ") or (
+        summary_lower.startswith("flight: ") and " to " in summary_lower
+    )
+    itinerary_marker = any(
+        marker in trip_text
+        for marker in (
+            "synced by flighty",
+            "created from an email you received in gmail",
+            "booking code:",
+            "flight time ",
+        )
+    )
+    return route_summary or named_flight or itinerary_marker
+
+
+def _skip_charging_event(summary: str, description: str = "", location: str = "") -> bool:
+    """Mirror of the skip_charging_event macro: flight OR manual nocharge tag."""
+    return _looks_like_flight(summary, description, location) or (
+        "nocharge" in (description or "").lower()
+    )
+
+
+def test_flight_macro_file_defines_shared_recognition_macros() -> None:
+    text = FLIGHT_MACRO_PATH.read_text(encoding="utf-8")
+
+    assert "macro looks_like_flight(summary, description='', location='')" in text
+    assert "macro skip_charging_event(summary, description='', location='')" in text
+    # The detection rules must match the travel-detection logic in trips.yaml.
+    assert "'→' in summary_text" in text
+    assert "summary_lower.startswith('flight to ')" in text
+    assert "summary_lower.startswith('flight: ') and ' to ' in summary_lower" in text
+    assert "synced by flighty" in text
+    assert "created from an email you received in gmail" in text
+    assert "booking code:" in text
+    assert "flight time " in text
+    # The manual nocharge opt-out is still honored by the shared macro.
+    assert "nocharge" in text
+
+
+def test_charge_planner_uses_shared_flight_macro_in_every_trip_block() -> None:
+    text = CAR_PATH.read_text(encoding="utf-8")
+
+    # The macro is imported and applied in all four template blocks
+    # (state + entry + start_time + all_day) of upcoming_trip_charging.
+    assert text.count("{% from 'flight.jinja' import skip_charging_event %}") == 4
+    assert text.count("skip_charging_event(state_attr('calendar.ryan_claussen'") == 4
+    assert text.count("skip_charging_event(state_attr('binary_sensor.work_trip_today'") == 4
+    assert text.count("skip_charging_event(state_attr('calendar.curling'") == 4
+
+    # The old bare per-calendar nocharge checks are gone; the macro now owns
+    # both flight and nocharge exclusion so every block stays consistent.
+    assert "'nocharge' not in personal_description" not in text
+    assert "'nocharge' not in work_description" not in text
+    assert "'nocharge' not in curling_description" not in text
+
+
+def test_flight_events_are_excluded_from_charge_planning() -> None:
+    # Outbound "flight to Atlanta" style event (the original bug).
+    assert _skip_charging_event("Flight to Atlanta (DL 2819)", "Synced by Flighty") is True
+    # Route-arrow itineraries, including legs that do not depart from MSP.
+    assert _skip_charging_event("✈ CMH→SLC • DL 1234", "Synced by Flighty") is True
+    assert _skip_charging_event("✈ SFO→MSP • DL 5678", "Synced by Flighty") is True
+    # Itinerary markers alone are enough.
+    assert _skip_charging_event("Trip", "Created from an email you received in Gmail") is True
+    # Manual opt-out still works.
+    assert _skip_charging_event("Road trip to Duluth", "nocharge please") is True
+
+
+def test_real_drives_still_count_toward_charge_planning() -> None:
+    # A genuine long drive with no flight signals and no nocharge tag must
+    # still be eligible so the planner can raise the charge limit.
+    assert _skip_charging_event("Curling bonspiel", location="Brookings, SD") is False
+    assert _skip_charging_event("Visit the cabin", "Up north for the weekend") is False
+
+
+def test_upcoming_trip_charging_state_still_gates_on_waze_distance() -> None:
+    # The flight exclusion must not disturb the existing distance gate.
+    text = CAR_PATH.read_text(encoding="utf-8")
+    state_block = re.search(
+        r"state: >-\n(.*?)\n      - default_entity_id: binary_sensor\.tesla_daily_plan_active",
+        text,
+        re.DOTALL,
+    )
+    assert state_block is not None
+    assert (
+        '{{ ns.eligible and (state_attr("sensor.waze_next_trip_distance", "distance") | int(0) > 45) }}'
+        in state_block.group(1)
+    )


### PR DESCRIPTION
## Problem

A far-destination flight on the calendar — e.g. a "Flight to Atlanta" — made the home Tesla charge to 100% even though the car never left the garage.

Root cause: the charge planner's `binary_sensor.upcoming_trip_charging` treats any calendar event in the next 24h with a Waze drive distance `> 45 mi` as a drivable trip. For a flight, `sensor.calendar_destination` points Waze at the **arrival city**, so the "drive" to Atlanta is ~1,100 mi, which trips the `>= 90 mi -> 100%` rule in `packages/car.yaml`. The planner had no flight awareness — the sophisticated flight detection only lived in `packages/trips.yaml`. The only existing mitigation was the manual `nocharge` description tag.

## Fix

Reuse the exact flight-recognition rules from travel detection by extracting them into a shared Jinja macro and applying them to the charge planner:

- **`custom_templates/flight.jinja`** (new): `looks_like_flight(summary, description, location)` mirrors the detection in `packages/trips.yaml` (route-arrow itineraries like `✈ MSP→ATL`, `flight to …` / `flight: … to …` titles, and itinerary markers such as "Synced by Flighty", "Created from an email you received in Gmail", booking codes, flight-time lines). A `skip_charging_event` helper combines that with the existing manual `nocharge` opt-out.
- **`packages/car.yaml`**: import and apply `skip_charging_event` in **all four** template blocks of `upcoming_trip_charging` (`state`, `entry`, `start_time`, `all_day`) so a flight never sets a trip distance, departure time, or preconditioning plan. This also fixes a latent inconsistency where the attribute blocks didn't apply the `nocharge` filter the `state` block did.

The exclusion is intentionally **origin-agnostic** — unlike trip-mode detection (which cares about MSP-origin), the charge planner ignores a flight regardless of departure airport, because the car never drives to the arrival city. This covers itineraries that don't depart MSP (e.g. `CMH→SLC`, `SFO→MSP`).

## Notes

- `packages/trips.yaml` keeps its inline copy of the detection for now — existing tests (`test_trips_flight_classification.py`) pin those literal strings — but the new macro is the shared single source the charge planner uses and trips.yaml can adopt later.
- `.gitignore` updated to allow `custom_templates/*.jinja` (allowlist-style ignore).
- Behavior documented in `docs/tesla_departure_planner.md`.

## Testing

- New `tests/test_issue_tesla_planner_flight_exclusion.py`: asserts the macro file + wiring (macro imported and applied in all 4 blocks, old inline `nocharge` checks removed, distance gate intact) and simulates the skip logic for the Atlanta/CMH/SLC/SFO flights, `nocharge` tags, and genuine drives.
- Verified the real `flight.jinja` macro renders `True`/`False` correctly for each case with Jinja2.
- Full suite: **503 passed**. `yamllint` clean on `packages/car.yaml`.

https://claude.ai/code/session_019LBCzvPYqtGHFVVnDDjjZf

---
_Generated by [Claude Code](https://claude.ai/code/session_019LBCzvPYqtGHFVVnDDjjZf)_