### PR TITLE
Use boolean flight macros in Tesla charge planner

### DIFF
--- a/custom_templates/flight.jinja
+++ b/custom_templates/flight.jinja
@@ -8,17 +8,17 @@
   to ...", and itinerary markers such as Flighty/Gmail sync, booking codes, and
   flight-time lines).
 
-  Output is exactly "True" or "False" so callers can compare with
-  `| trim | lower == 'true'`.
+  Use with Home Assistant's `as_function` filter so callers receive real
+  booleans instead of string output.
 -#}
-{%- macro looks_like_flight(summary, description='', location='') -%}
+{%- macro looks_like_flight(summary, description='', location='', returns=none) -%}
   {%- set summary_text = summary | default('', true) | string -%}
   {%- set summary_lower = summary_text | lower -%}
   {%- set trip_text = [summary_text, description | default('', true) | string, location | default('', true) | string] | join(' ') | lower -%}
   {%- set route_summary = '→' in summary_text -%}
   {%- set named_flight = summary_lower.startswith('flight to ') or (summary_lower.startswith('flight: ') and ' to ' in summary_lower) -%}
   {%- set itinerary_marker = 'synced by flighty' in trip_text or 'created from an email you received in gmail' in trip_text or 'booking code:' in trip_text or 'flight time ' in trip_text -%}
-  {{- route_summary or named_flight or itinerary_marker -}}
+  {%- do returns(route_summary or named_flight or itinerary_marker) -%}
 {%- endmacro -%}
 {#-
   skip_charging_event: True when the Tesla charge planner should ignore a
@@ -26,8 +26,9 @@
   (the car never makes the long drive), and the existing manual `nocharge`
   description tag is still honored as an explicit opt-out.
 -#}
-{%- macro skip_charging_event(summary, description='', location='') -%}
-  {%- set is_flight = looks_like_flight(summary, description, location) | trim | lower == 'true' -%}
+{%- macro skip_charging_event(summary, description='', location='', returns=none) -%}
+  {%- set flight_classifier = looks_like_flight | as_function -%}
+  {%- set is_flight = flight_classifier(summary, description, location) -%}
   {%- set is_nocharge = 'nocharge' in (description | default('', true) | string | lower) -%}
-  {{- is_flight or is_nocharge -}}
+  {%- do returns(is_flight or is_nocharge) -%}
 {%- endmacro -%}

--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -991,11 +991,12 @@ template:
         attributes:
           entry: >-
             {% from 'flight.jinja' import skip_charging_event %}
+            {% set should_skip_charging_event = skip_charging_event | as_function %}
             {% set now_local = now() %}
             {% set horizon = now_local + timedelta(hours=24) %}
             {% set ns = namespace(start=none, entry='None') %}
             {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-            {% set personal_skip = skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) | trim | lower == 'true' %}
+            {% set personal_skip = should_skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) %}
             {% if personal_start_raw not in [none, ''] and not personal_skip %}
               {% set personal_start = personal_start_raw | as_datetime | as_local %}
               {% if personal_start is not none and personal_start > now_local and personal_start < horizon %}
@@ -1004,7 +1005,7 @@ template:
               {% endif %}
             {% endif %}
             {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-            {% set work_skip = skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) | trim | lower == 'true' %}
+            {% set work_skip = should_skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) %}
             {% if work_start_raw not in [none, ''] and not work_skip %}
               {% set work_start = work_start_raw | as_datetime | as_local %}
               {% if work_start is not none and work_start > now_local and work_start < horizon and (ns.start is none or work_start < ns.start) %}
@@ -1013,7 +1014,7 @@ template:
               {% endif %}
             {% endif %}
             {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-            {% set curling_skip = skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) | trim | lower == 'true' %}
+            {% set curling_skip = should_skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) %}
             {% if curling_start_raw not in [none, ''] and not curling_skip %}
               {% set curling_start = curling_start_raw | as_datetime | as_local %}
               {% if curling_start is not none and curling_start > now_local and curling_start < horizon and (ns.start is none or curling_start < ns.start) %}
@@ -1024,11 +1025,12 @@ template:
             {{ ns.entry }}
           start_time: >-
             {% from 'flight.jinja' import skip_charging_event %}
+            {% set should_skip_charging_event = skip_charging_event | as_function %}
             {% set now_local = now() %}
             {% set horizon = now_local + timedelta(hours=24) %}
             {% set ns = namespace(start=none, value='None') %}
             {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-            {% set personal_skip = skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) | trim | lower == 'true' %}
+            {% set personal_skip = should_skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) %}
             {% if personal_start_raw not in [none, ''] and not personal_skip %}
               {% set personal_start = personal_start_raw | as_datetime | as_local %}
               {% if personal_start is not none and personal_start > now_local and personal_start < horizon %}
@@ -1037,7 +1039,7 @@ template:
               {% endif %}
             {% endif %}
             {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-            {% set work_skip = skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) | trim | lower == 'true' %}
+            {% set work_skip = should_skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) %}
             {% if work_start_raw not in [none, ''] and not work_skip %}
               {% set work_start = work_start_raw | as_datetime | as_local %}
               {% if work_start is not none and work_start > now_local and work_start < horizon and (ns.start is none or work_start < ns.start) %}
@@ -1046,7 +1048,7 @@ template:
               {% endif %}
             {% endif %}
             {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-            {% set curling_skip = skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) | trim | lower == 'true' %}
+            {% set curling_skip = should_skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) %}
             {% if curling_start_raw not in [none, ''] and not curling_skip %}
               {% set curling_start = curling_start_raw | as_datetime | as_local %}
               {% if curling_start is not none and curling_start > now_local and curling_start < horizon and (ns.start is none or curling_start < ns.start) %}
@@ -1057,11 +1059,12 @@ template:
             {{ ns.value }}
           all_day: >-
             {% from 'flight.jinja' import skip_charging_event %}
+            {% set should_skip_charging_event = skip_charging_event | as_function %}
             {% set now_local = now() %}
             {% set horizon = now_local + timedelta(hours=24) %}
             {% set ns = namespace(start=none, value='None') %}
             {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-            {% set personal_skip = skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) | trim | lower == 'true' %}
+            {% set personal_skip = should_skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) %}
             {% if personal_start_raw not in [none, ''] and not personal_skip %}
               {% set personal_start = personal_start_raw | as_datetime | as_local %}
               {% if personal_start is not none and personal_start > now_local and personal_start < horizon %}
@@ -1070,7 +1073,7 @@ template:
               {% endif %}
             {% endif %}
             {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-            {% set work_skip = skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) | trim | lower == 'true' %}
+            {% set work_skip = should_skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) %}
             {% if work_start_raw not in [none, ''] and not work_skip %}
               {% set work_start = work_start_raw | as_datetime | as_local %}
               {% if work_start is not none and work_start > now_local and work_start < horizon and (ns.start is none or work_start < ns.start) %}
@@ -1079,7 +1082,7 @@ template:
               {% endif %}
             {% endif %}
             {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-            {% set curling_skip = skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) | trim | lower == 'true' %}
+            {% set curling_skip = should_skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) %}
             {% if curling_start_raw not in [none, ''] and not curling_skip %}
               {% set curling_start = curling_start_raw | as_datetime | as_local %}
               {% if curling_start is not none and curling_start > now_local and curling_start < horizon and (ns.start is none or curling_start < ns.start) %}
@@ -1090,11 +1093,12 @@ template:
             {{ ns.value }}
         state: >-
           {% from 'flight.jinja' import skip_charging_event %}
+          {% set should_skip_charging_event = skip_charging_event | as_function %}
           {% set now_local = now() %}
           {% set horizon = now_local + timedelta(hours=24) %}
           {% set ns = namespace(start=none, eligible=false) %}
           {% set personal_start_raw = state_attr('calendar.ryan_claussen', 'start_time') %}
-          {% set personal_skip = skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) | trim | lower == 'true' %}
+          {% set personal_skip = should_skip_charging_event(state_attr('calendar.ryan_claussen', 'message'), state_attr('calendar.ryan_claussen', 'description'), state_attr('calendar.ryan_claussen', 'location')) %}
           {% if personal_start_raw not in [none, ''] and not personal_skip %}
             {% set personal_start = personal_start_raw | as_datetime | as_local %}
             {% if personal_start is not none and personal_start > now_local and personal_start < horizon %}
@@ -1103,7 +1107,7 @@ template:
             {% endif %}
           {% endif %}
           {% set work_start_raw = state_attr('binary_sensor.work_trip_today', 'start_time') %}
-          {% set work_skip = skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) | trim | lower == 'true' %}
+          {% set work_skip = should_skip_charging_event(state_attr('binary_sensor.work_trip_today', 'message'), state_attr('binary_sensor.work_trip_today', 'description'), state_attr('binary_sensor.work_trip_today', 'location')) %}
           {% if work_start_raw not in [none, ''] and not work_skip %}
             {% set work_start = work_start_raw | as_datetime | as_local %}
             {% if work_start is not none and work_start > now_local and work_start < horizon and (ns.start is none or work_start < ns.start) %}
@@ -1112,7 +1116,7 @@ template:
             {% endif %}
           {% endif %}
           {% set curling_start_raw = state_attr('calendar.curling', 'start_time') %}
-          {% set curling_skip = skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) | trim | lower == 'true' %}
+          {% set curling_skip = should_skip_charging_event(state_attr('calendar.curling', 'message'), state_attr('calendar.curling', 'description'), state_attr('calendar.curling', 'location')) %}
           {% if curling_start_raw not in [none, ''] and not curling_skip %}
             {% set curling_start = curling_start_raw | as_datetime | as_local %}
             {% if curling_start is not none and curling_start > now_local and curling_start < horizon and (ns.start is none or curling_start < ns.start) %}

--- a/tests/test_issue_tesla_planner_flight_exclusion.py
+++ b/tests/test_issue_tesla_planner_flight_exclusion.py
@@ -61,8 +61,11 @@ def _skip_charging_event(summary: str, description: str = "", location: str = ""
 def test_flight_macro_file_defines_shared_recognition_macros() -> None:
     text = FLIGHT_MACRO_PATH.read_text(encoding="utf-8")
 
-    assert "macro looks_like_flight(summary, description='', location='')" in text
-    assert "macro skip_charging_event(summary, description='', location='')" in text
+    assert "macro looks_like_flight(summary, description='', location='', returns=none)" in text
+    assert "macro skip_charging_event(summary, description='', location='', returns=none)" in text
+    assert "{%- do returns(route_summary or named_flight or itinerary_marker) -%}" in text
+    assert "{%- set flight_classifier = looks_like_flight | as_function -%}" in text
+    assert "{%- do returns(is_flight or is_nocharge) -%}" in text
     # The detection rules must match the travel-detection logic in trips.yaml.
     assert "'→' in summary_text" in text
     assert "summary_lower.startswith('flight to ')" in text
@@ -81,9 +84,13 @@ def test_charge_planner_uses_shared_flight_macro_in_every_trip_block() -> None:
     # The macro is imported and applied in all four template blocks
     # (state + entry + start_time + all_day) of upcoming_trip_charging.
     assert text.count("{% from 'flight.jinja' import skip_charging_event %}") == 4
-    assert text.count("skip_charging_event(state_attr('calendar.ryan_claussen'") == 4
-    assert text.count("skip_charging_event(state_attr('binary_sensor.work_trip_today'") == 4
-    assert text.count("skip_charging_event(state_attr('calendar.curling'") == 4
+    assert text.count(
+        "{% set should_skip_charging_event = skip_charging_event | as_function %}"
+    ) == 4
+    assert text.count("should_skip_charging_event(state_attr('calendar.ryan_claussen'") == 4
+    assert text.count("should_skip_charging_event(state_attr('binary_sensor.work_trip_today'") == 4
+    assert text.count("should_skip_charging_event(state_attr('calendar.curling'") == 4
+    assert "| trim | lower == 'true'" not in text
 
     # The old bare per-calendar nocharge checks are gone; the macro now owns
     # both flight and nocharge exclusion so every block stays consistent.


### PR DESCRIPTION
## Summary

- update `custom_templates/flight.jinja` to return real booleans through Home Assistant's `returns`/`as_function` macro pattern
- update the Tesla charge planner to call `should_skip_charging_event(...)` directly instead of comparing macro text output
- extend the regression test so future changes keep the boolean macro pattern and do not reintroduce `| trim | lower == 'true'`

## Why

PR #763 correctly centralized the Tesla charge-planner flight/nocharge exclusion, but the macro returned text and each caller had to normalize that text back into a boolean. Home Assistant supports boolean-returning custom template macros via `returns` and `as_function`, which is clearer and less brittle.

Related to #764. This prepares the shared macro for the later `packages/trips.yaml` simplification, but it does not close #764 because the trip package still needs to be refactored to consume the shared classifier.

## Validation

- `uv run --with pytest pytest tests/test_issue_tesla_planner_flight_exclusion.py tests/test_trips_flight_classification.py`
- `uv run --with pytest pytest`
- `git diff --check`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/car.yaml --strict` still reports the known pre-existing Tesla automation duplicate groups tracked separately in #765
