### PR TITLE
Fix #765 consolidate Tesla polling automations

### DIFF
--- a/packages/car.yaml
+++ b/packages/car.yaml
@@ -137,6 +137,7 @@ automation:
         id: early_morning
       - trigger: homeassistant
         event: start
+        alias: Planner startup reconciliation
         id: startup
       - trigger: state
         entity_id: binary_sensor.upcoming_trip_charging
@@ -182,7 +183,8 @@ automation:
         entity_id: device_tracker.nigori_location_tracker
         state: "home"
     action:
-      - choose:
+      - alias: Delay planner startup reconciliation
+        choose:
           - conditions:
               - condition: trigger
                 id: startup
@@ -432,9 +434,11 @@ automation:
           {{ is_state('input_boolean.tesla_managed_departure_active', 'on') and stored_departure_ts > 0 and stored_departure_ts | timestamp_local | as_datetime <= now() }}
       - trigger: homeassistant
         event: start
+        alias: Cleanup startup reconciliation
         id: startup
     action:
-      - choose:
+      - alias: Delay cleanup startup reconciliation
+        choose:
           - conditions:
               - condition: trigger
                 id: startup
@@ -603,45 +607,35 @@ automation:
         data:
           message: Close the garage door.
 
-  - alias: Tesla set polling time short on startup if charger is connected
-    id: tesla_short_polling_charger_connected
-    description: When HA starts up. We adjust the Polling Interval down from the configured value if we are connected to a charger
+  - alias: Tesla set polling time short on startup
+    id: tesla_short_polling_startup
+    description: When HA starts up, adjust the polling interval down if the charger is connected or the car is driving
+    mode: single
     trace:
       stored_traces: 10
     trigger:
       - trigger: homeassistant
         event: start
+        id: startup
     condition:
-      - condition: state
-        entity_id: binary_sensor.nigori_charging
-        state: "on"
+      - condition: or
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.nigori_charging
+            state: "on"
+          - condition: state
+            entity_id: binary_sensor.nigori_parking_brake
+            state: "off"
     action:
       - delay: "00:01:00"
       - action: tesla_custom.polling_interval
         data:
           scan_interval: 30
 
-  - alias: Tesla set polling time short on startup if car is driving
-    id: tesla_short_polling_driving
-    description: When HA starts up. We adjust the Polling Interval down from the configured value if we are driving
-    trace:
-      stored_traces: 10
-    trigger:
-      - trigger: homeassistant
-        event: start
-    condition:
-      - condition: state
-        entity_id: binary_sensor.nigori_parking_brake
-        state: "off"
-    action:
-      - delay: "00:01:00"
-      - action: tesla_custom.polling_interval
-        data:
-          scan_interval: 30
-
-  - alias: Tesla set polling time long when charger is disconnected
-    description: We adjust the Polling Interval up to the configured value if we are disconnecting from the charger
-    id: tesla_long_polling_charger_disconnected
+  - alias: Tesla set polling time long when idle and unplugged
+    description: Adjust the polling interval up to the configured value when the car is parked and the charger is disconnected
+    id: tesla_long_polling_idle_unplugged
+    mode: restart
     trace:
       stored_traces: 10
     trigger:
@@ -650,30 +644,21 @@ automation:
         to: "off"
         for:
           minutes: 15
-    condition:
-      - condition: state
-        entity_id: binary_sensor.nigori_parking_brake
-        state: "on"
-    action:
-      - action: tesla_custom.polling_interval
-        data:
-          scan_interval: 660
-
-  - alias: Tesla set polling time long when car is parked
-    description: We adjust the Polling Interval up to the configured value when we are parked if the charger is not connected
-    id: tesla_long_polling_charger_diconnected_parked
-    trace:
-      stored_traces: 10
-    trigger:
+        id: charger_disconnected
       - trigger: state
         entity_id: binary_sensor.nigori_parking_brake
         to: "on"
         for:
           minutes: 15
+        id: parked
     condition:
       - condition: state
         entity_id: binary_sensor.nigori_charging
         state: "off"
+      - alias: Confirm Tesla is parked before long polling
+        condition: state
+        entity_id: binary_sensor.nigori_parking_brake
+        state: "on"
     action:
       - action: tesla_custom.polling_interval
         data:

--- a/tests/test_issue_tesla_polling_dry.py
+++ b/tests/test_issue_tesla_polling_dry.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+CAR_PATH = Path(__file__).resolve().parents[1] / "packages" / "car.yaml"
+
+
+def _automation_block(automation_id: str) -> str:
+    text = CAR_PATH.read_text(encoding="utf-8")
+    automation_starts = [
+        match.start() for match in re.finditer(r"^  - (?:id|alias): ", text, re.MULTILINE)
+    ]
+
+    for index, start in enumerate(automation_starts):
+        end = (
+            automation_starts[index + 1]
+            if index + 1 < len(automation_starts)
+            else len(text)
+        )
+        block = text[start:end]
+        if re.search(rf"^    id: {re.escape(automation_id)}$", block, re.MULTILINE):
+            return block
+        if re.search(rf"^  - id: {re.escape(automation_id)}$", block, re.MULTILINE):
+            return block
+
+    raise AssertionError(f"Could not find automation block {automation_id!r}")
+
+
+def test_tesla_polling_legacy_duplicate_automation_ids_are_removed() -> None:
+    text = CAR_PATH.read_text(encoding="utf-8")
+
+    assert "tesla_short_polling_charger_connected" not in text
+    assert "tesla_short_polling_driving" not in text
+    assert "tesla_long_polling_charger_disconnected" not in text
+    assert "tesla_long_polling_charger_diconnected_parked" not in text
+
+
+def test_tesla_short_polling_startup_uses_one_native_or_condition() -> None:
+    block = _automation_block("tesla_short_polling_startup")
+
+    assert "trigger: homeassistant" in block
+    assert "event: start" in block
+    assert "condition: or" in block
+    assert "entity_id: binary_sensor.nigori_charging" in block
+    assert 'state: "on"' in block
+    assert "entity_id: binary_sensor.nigori_parking_brake" in block
+    assert 'state: "off"' in block
+    assert 'delay: "00:01:00"' in block
+    assert "action: tesla_custom.polling_interval" in block
+    assert "scan_interval: 30" in block
+
+
+def test_tesla_long_polling_waits_for_idle_and_unplugged_state() -> None:
+    block = _automation_block("tesla_long_polling_idle_unplugged")
+
+    assert "mode: restart" in block
+    assert block.count("trigger: state") == 2
+    assert "id: charger_disconnected" in block
+    assert "id: parked" in block
+    assert "entity_id: binary_sensor.nigori_charging" in block
+    assert "entity_id: binary_sensor.nigori_parking_brake" in block
+    assert block.count("minutes: 15") == 2
+    assert 'state: "off"' in block
+    assert 'state: "on"' in block
+    assert "action: tesla_custom.polling_interval" in block
+    assert "scan_interval: 660" in block


### PR DESCRIPTION
## Summary

- consolidate the duplicate Tesla short-poll startup automations into one startup automation with native OR state conditions
- consolidate the duplicate Tesla long-poll idle/unplugged automations into one trigger-id automation and remove the misspelled old automation id
- add regression coverage for the consolidated polling automation shape and legacy id removal

Closes #765.

## Validation

- `uv run --with pytest pytest tests/test_issue_tesla_polling_dry.py tests/test_tesla_charging_dashboard.py tests/test_issue_tesla_planner_flight_exclusion.py tests/test_issue_tesla_planner_home_condition.py`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/car.yaml --strict`
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `git diff --check`

## Local HA check_config

Attempted the repo-standard HA container check with `ghcr.io/home-assistant/home-assistant:2026.5.1`, but local Podman could not connect to the VM socket after `podman machine start` (`127.0.0.1:53019: connect: connection refused`). Docker is not installed locally. The older local HA virtualenv fallback also could not run because HA's dependency installer fails on this checkout path containing a space (`/Users/rtclauss/Documents/New`). CI should still run the container check on this PR.