### PR TITLE
Fix #758 washer reminder audio target

### DIFF
--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -272,7 +272,7 @@ automation:
                   - action: tts.google_say
                     continue_on_error: true
                     data:
-                      entity_id: media_player.everywhere_sonos
+                      entity_id: media_player.ma_group_everywhere
                       message: "Laundry has been sitting in the washer for an hour."
           - conditions:
               - condition: state

--- a/tests/test_laundry_plug_monitoring.py
+++ b/tests/test_laundry_plug_monitoring.py
@@ -128,7 +128,8 @@ def test_cleaning_package_notifies_from_power_based_running_sensors() -> None:
     assert "message: \"Laundry has been sitting in the washer for an hour." in washer_reminder
     assert "input_boolean.guest_mode" in washer_reminder
     assert "action: tts.google_say" in washer_reminder
-    assert "entity_id: media_player.everywhere_sonos" in washer_reminder
+    assert "entity_id: media_player.ma_group_everywhere" in washer_reminder
+    assert "media_player.everywhere_sonos" not in washer_reminder
     assert "binary_sensor.front_load_washer_wash_completed" not in washer_reminder
 
     assert "binary_sensor.laundry_room_washing_machine_door_contact" in washer_cleared


### PR DESCRIPTION
## Summary

- replace the retired `media_player.everywhere_sonos` washer-reminder TTS target with live `media_player.ma_group_everywhere`
- preserve the existing guest-mode guard for the one-hour audio escalation
- update laundry regression coverage so the stale Sonos entity cannot be reintroduced

Closes #758.

## Runtime evidence

Nightly Trace Review on 2026-06-09 confirmed the live Spook repair warning is still active for `automation.washer_reminder` because it references missing `media_player.everywhere_sonos`. Live `media_player.ma_group_everywhere` is available and is already the Music Assistant whole-home group used elsewhere in the repo.

## Validation

- `uv run --with pytest pytest tests/test_laundry_plug_monitoring.py -q`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/cleaning.yaml`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/cleaning.yaml --strict`
- `git diff --check`
- `uv run --with pytest pytest` (`506 passed`)
- Home Assistant container check_config using `ghcr.io/home-assistant/home-assistant:2026.5.1` against a temp config copy
