### PR TITLE
Fix #772 verify Music Assistant wake-up playback

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1157,6 +1157,86 @@ script:
           media_id: "{{ radio_uri }}"
           media_type: radio
           enqueue: replace
+      - alias: "Verify wake-up radio playback started before ramping volume"
+        wait_for_trigger:
+          - trigger: state
+            entity_id:
+              - media_player.ma_group_everywhere
+              - media_player.ma_group_guest
+            to: "playing"
+          - trigger: state
+            entity_id:
+              - media_player.ma_group_everywhere
+              - media_player.ma_group_guest
+            to: "idle"
+          - trigger: state
+            entity_id:
+              - media_player.ma_group_everywhere
+              - media_player.ma_group_guest
+            to: "off"
+          - trigger: state
+            entity_id:
+              - media_player.ma_group_everywhere
+              - media_player.ma_group_guest
+            to: "unavailable"
+        timeout:
+          seconds: 20
+        continue_on_timeout: true
+      - if:
+          - condition: template
+            value_template: "{{ not is_state(playback_player, 'playing') }}"
+        then:
+          - alias: "Retry Music Assistant radio once after playback failed to start"
+            action: music_assistant.play_media
+            continue_on_error: true
+            target:
+              entity_id: "{{ playback_player }}"
+            data:
+              media_id: "{{ radio_uri }}"
+              media_type: radio
+              enqueue: replace
+          - wait_for_trigger:
+              - trigger: state
+                entity_id:
+                  - media_player.ma_group_everywhere
+                  - media_player.ma_group_guest
+                to: "playing"
+              - trigger: state
+                entity_id:
+                  - media_player.ma_group_everywhere
+                  - media_player.ma_group_guest
+                to: "idle"
+              - trigger: state
+                entity_id:
+                  - media_player.ma_group_everywhere
+                  - media_player.ma_group_guest
+                to: "off"
+              - trigger: state
+                entity_id:
+                  - media_player.ma_group_everywhere
+                  - media_player.ma_group_guest
+                to: "unavailable"
+            timeout:
+              seconds: 20
+            continue_on_timeout: true
+      - if:
+          - condition: template
+            value_template: "{{ not is_state(playback_player, 'playing') }}"
+        then:
+          - action: persistent_notification.create
+            data:
+              notification_id: music_assistant_radio_wake_up_failed
+              title: "Wake-up radio failed"
+              message: >-
+                Music Assistant did not start wake-up radio playback on {{ playback_player }} after one retry.
+          - action: logbook.log
+            data:
+              entity_id: script.music_assistant_radio_wake_up
+              domain: script
+              name: Radio wake-up via Music Assistant
+              message: "Music Assistant wake-up radio playback failed; skipped volume ramp."
+          - stop: "Music Assistant wake-up radio playback failed; skipped volume ramp."
+            error: true
       - repeat:
           sequence:
             - if:

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1135,6 +1135,13 @@ script:
       effective_k_factor: "{{ ramp_k_factor | default(120) | int(120) }}"
       group_members: >-
         {{ state_attr(playback_player, 'group_members') | default([playback_player]) }}
+      pre_playback_fingerprint: >-
+        {{ [
+          state_attr(playback_player, 'media_content_id') | default('', true),
+          state_attr(playback_player, 'media_title') | default('', true),
+          state_attr(playback_player, 'media_artist') | default('', true),
+          state_attr(playback_player, 'media_album_name') | default('', true)
+        ] | join('|') }}
     sequence:
       - alias: "Set each member directly to 0.01 — individual sets are absolute, no MA proportional scaling"
         continue_on_error: true
@@ -1158,33 +1165,62 @@ script:
           media_type: radio
           enqueue: replace
       - alias: "Verify wake-up radio playback started before ramping volume"
-        wait_for_trigger:
-          - trigger: state
-            entity_id:
-              - media_player.ma_group_everywhere
-              - media_player.ma_group_guest
-            to: "playing"
-          - trigger: state
-            entity_id:
-              - media_player.ma_group_everywhere
-              - media_player.ma_group_guest
-            to: "idle"
-          - trigger: state
-            entity_id:
-              - media_player.ma_group_everywhere
-              - media_player.ma_group_guest
-            to: "off"
-          - trigger: state
-            entity_id:
-              - media_player.ma_group_everywhere
-              - media_player.ma_group_guest
-            to: "unavailable"
-        timeout:
-          seconds: 20
-        continue_on_timeout: true
+        choose:
+          - conditions:
+              - condition: state
+                entity_id: input_boolean.guest_mode
+                state: "on"
+            sequence:
+              - wait_for_trigger:
+                  - trigger: state
+                    entity_id: media_player.ma_group_guest
+                    to: "playing"
+                  - trigger: state
+                    entity_id: media_player.ma_group_guest
+                    to: "idle"
+                  - trigger: state
+                    entity_id: media_player.ma_group_guest
+                    to: "off"
+                  - trigger: state
+                    entity_id: media_player.ma_group_guest
+                    to: "unavailable"
+                timeout:
+                  seconds: 20
+                continue_on_timeout: true
+        default:
+          - wait_for_trigger:
+              - trigger: state
+                entity_id: media_player.ma_group_everywhere
+                to: "playing"
+              - trigger: state
+                entity_id: media_player.ma_group_everywhere
+                to: "idle"
+              - trigger: state
+                entity_id: media_player.ma_group_everywhere
+                to: "off"
+              - trigger: state
+                entity_id: media_player.ma_group_everywhere
+                to: "unavailable"
+            timeout:
+              seconds: 20
+            continue_on_timeout: true
+      - variables:
+          playback_fingerprint: >-
+            {{ [
+              state_attr(playback_player, 'media_content_id') | default('', true),
+              state_attr(playback_player, 'media_title') | default('', true),
+              state_attr(playback_player, 'media_artist') | default('', true),
+              state_attr(playback_player, 'media_album_name') | default('', true)
+            ] | join('|') }}
+          wakeup_playback_confirmed: >-
+            {{ is_state(playback_player, 'playing')
+               and (
+                 (state_attr(playback_player, 'media_content_id') | string) == (radio_uri | string)
+                 or playback_fingerprint != pre_playback_fingerprint
+               ) }}
       - if:
           - condition: template
-            value_template: "{{ not is_state(playback_player, 'playing') }}"
+            value_template: "{{ not wakeup_playback_confirmed }}"
         then:
           - alias: "Retry Music Assistant radio once after playback failed to start"
             action: music_assistant.play_media
@@ -1195,33 +1231,62 @@ script:
               media_id: "{{ radio_uri }}"
               media_type: radio
               enqueue: replace
-          - wait_for_trigger:
-              - trigger: state
-                entity_id:
-                  - media_player.ma_group_everywhere
-                  - media_player.ma_group_guest
-                to: "playing"
-              - trigger: state
-                entity_id:
-                  - media_player.ma_group_everywhere
-                  - media_player.ma_group_guest
-                to: "idle"
-              - trigger: state
-                entity_id:
-                  - media_player.ma_group_everywhere
-                  - media_player.ma_group_guest
-                to: "off"
-              - trigger: state
-                entity_id:
-                  - media_player.ma_group_everywhere
-                  - media_player.ma_group_guest
-                to: "unavailable"
-            timeout:
-              seconds: 20
-            continue_on_timeout: true
+          - choose:
+              - conditions:
+                  - condition: state
+                    entity_id: input_boolean.guest_mode
+                    state: "on"
+                sequence:
+                  - wait_for_trigger:
+                      - trigger: state
+                        entity_id: media_player.ma_group_guest
+                        to: "playing"
+                      - trigger: state
+                        entity_id: media_player.ma_group_guest
+                        to: "idle"
+                      - trigger: state
+                        entity_id: media_player.ma_group_guest
+                        to: "off"
+                      - trigger: state
+                        entity_id: media_player.ma_group_guest
+                        to: "unavailable"
+                    timeout:
+                      seconds: 20
+                    continue_on_timeout: true
+            default:
+              - wait_for_trigger:
+                  - trigger: state
+                    entity_id: media_player.ma_group_everywhere
+                    to: "playing"
+                  - trigger: state
+                    entity_id: media_player.ma_group_everywhere
+                    to: "idle"
+                  - trigger: state
+                    entity_id: media_player.ma_group_everywhere
+                    to: "off"
+                  - trigger: state
+                    entity_id: media_player.ma_group_everywhere
+                    to: "unavailable"
+                timeout:
+                  seconds: 20
+                continue_on_timeout: true
+          - variables:
+              playback_fingerprint: >-
+                {{ [
+                  state_attr(playback_player, 'media_content_id') | default('', true),
+                  state_attr(playback_player, 'media_title') | default('', true),
+                  state_attr(playback_player, 'media_artist') | default('', true),
+                  state_attr(playback_player, 'media_album_name') | default('', true)
+                ] | join('|') }}
+              wakeup_playback_confirmed: >-
+                {{ is_state(playback_player, 'playing')
+                   and (
+                     (state_attr(playback_player, 'media_content_id') | string) == (radio_uri | string)
+                     or playback_fingerprint != pre_playback_fingerprint
+                   ) }}
       - if:
           - condition: template
-            value_template: "{{ not is_state(playback_player, 'playing') }}"
+            value_template: "{{ not wakeup_playback_confirmed }}"
         then:
           - action: persistent_notification.create
             data:

--- a/specs/alarm_wakeup.allium
+++ b/specs/alarm_wakeup.allium
@@ -272,11 +272,13 @@ rule VerifyWakeupAudioPlaybackBeforeVolumeRamp {
     ensures: WakeupAudioPlaybackVerificationRequested(group)
     @guidance
         -- After requesting playback, the implementation verifies that the
-        -- selected wake-up audio group remains or becomes playing before
+        -- selected wake-up audio group is playing the requested wake-up source
+        -- or has changed media state from its pre-request playback before
         -- starting the volume ramp. If playback drops to idle, off, or
-        -- unavailable, it retries once. If playback still cannot be
-        -- established, the failure is surfaced and the ramp is skipped so the
-        -- alarm path does not appear successful while silent.
+        -- unavailable, or the request cannot be distinguished from pre-existing
+        -- playback, it retries once. If playback still cannot be established,
+        -- the failure is surfaced and the ramp is skipped so the alarm path
+        -- does not appear successful while silent.
 }
 
 rule RampWakeupVolumeByRoom {

--- a/specs/alarm_wakeup.allium
+++ b/specs/alarm_wakeup.allium
@@ -267,8 +267,20 @@ rule PrepareMorningAudioGroup {
         -- bedroom wake-up audio zone.
 }
 
-rule RampWakeupVolumeByRoom {
+rule VerifyWakeupAudioPlaybackBeforeVolumeRamp {
     when: WakeupAudioGroupPrepared(group)
+    ensures: WakeupAudioPlaybackVerificationRequested(group)
+    @guidance
+        -- After requesting playback, the implementation verifies that the
+        -- selected wake-up audio group remains or becomes playing before
+        -- starting the volume ramp. If playback drops to idle, off, or
+        -- unavailable, it retries once. If playback still cannot be
+        -- established, the failure is surfaced and the ramp is skipped so the
+        -- alarm path does not appear successful while silent.
+}
+
+rule RampWakeupVolumeByRoom {
+    when: WakeupAudioPlaybackVerified(group)
     ensures: WakeupVolumeRampStarted(group)
     @guidance
         -- All group members fade in from silence using a tan-curve ramp.
@@ -276,6 +288,11 @@ rule RampWakeupVolumeByRoom {
         -- at config.office_wakeup_peak_volume_percent; all other rooms ramp to the
         -- full peak. This prevents the wake-up routine from disturbing
         -- work-in-progress in the office.
+}
+
+rule RecoverFailedWakeupAudioPlayback {
+    when: WakeupAudioPlaybackFailed(group)
+    ensures: MorningAudioRecoveryApplied(radio_playback)
 }
 
 rule ChooseWakeupPlaylistFromConfiguredPool {

--- a/specs/allium_weed_config.json
+++ b/specs/allium_weed_config.json
@@ -41,5 +41,14 @@
       ]
     }
   ],
-  "classified_gaps": []
+  "classified_gaps": [
+    {
+      "spec": "specs/night_routines.allium",
+      "implementation_paths": [
+        "packages/media_player.yaml"
+      ],
+      "classification": "non-night-scope change",
+      "reason": "Issue #772 / PR #773 changes only Music Assistant wake-up radio verification in script.music_assistant_radio_wake_up; bedtime and goodnight behavior governed by night_routines.allium is unchanged."
+    }
+  ]
 }

--- a/tests/test_allium_weed_check.py
+++ b/tests/test_allium_weed_check.py
@@ -115,7 +115,18 @@ def test_classified_gap_allows_protected_implementation_change() -> None:
 def test_default_config_lists_existing_specs_and_scopes() -> None:
     scopes, classified_gaps = weed.load_config(weed.DEFAULT_CONFIG)
 
-    assert classified_gaps == []
+    assert classified_gaps == [
+        {
+            "spec": "specs/night_routines.allium",
+            "implementation_paths": ["packages/media_player.yaml"],
+            "classification": "non-night-scope change",
+            "reason": (
+                "Issue #772 / PR #773 changes only Music Assistant wake-up radio "
+                "verification in script.music_assistant_radio_wake_up; bedtime and "
+                "goodnight behavior governed by night_routines.allium is unchanged."
+            ),
+        }
+    ]
     assert {scope.spec for scope in scopes} == {
         "specs/alarm_wakeup.allium",
         "specs/arrival_lighting.allium",

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -243,6 +243,26 @@ def test_radio_wakeup_ramps_legacy_and_music_assistant_bedroom_bathroom_players(
     assert 'volume_level: "{{ 0.01 * repeat.index }}"' in block
 
 
+def test_radio_wakeup_verifies_playback_before_volume_ramp() -> None:
+    block = _script_block("music_assistant_radio_wake_up")
+
+    for token in (
+        "Verify wake-up radio playback started before ramping volume",
+        "Retry Music Assistant radio once after playback failed to start",
+        "persistent_notification.create",
+        "music_assistant_radio_wake_up_failed",
+        "not is_state(playback_player, 'playing')",
+        "skipped volume ramp",
+        "error: true",
+    ):
+        assert token in block
+
+    assert block.count("action: music_assistant.play_media") == 2
+    assert block.count("wait_for_trigger:") == 2
+    assert block.index("Verify wake-up radio playback started") < block.index("- repeat:")
+    assert block.index("error: true") < block.index("- repeat:")
+
+
 def test_spotify_wakeup_uses_guest_aware_sync_group_without_manual_regrouping() -> None:
     block = _script_block("spotify_wake_up")
 

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -251,16 +251,20 @@ def test_radio_wakeup_verifies_playback_before_volume_ramp() -> None:
         "Retry Music Assistant radio once after playback failed to start",
         "persistent_notification.create",
         "music_assistant_radio_wake_up_failed",
-        "not is_state(playback_player, 'playing')",
+        "pre_playback_fingerprint",
+        "wakeup_playback_confirmed",
+        "media_content_id",
+        "playback_fingerprint != pre_playback_fingerprint",
         "skipped volume ramp",
         "error: true",
     ):
         assert token in block
 
     assert block.count("action: music_assistant.play_media") == 2
-    assert block.count("wait_for_trigger:") == 2
+    assert block.count("wait_for_trigger:") == 4
     assert block.index("Verify wake-up radio playback started") < block.index("- repeat:")
     assert block.index("error: true") < block.index("- repeat:")
+    assert "entity_id:\n              - media_player.ma_group_everywhere\n              - media_player.ma_group_guest" not in block
 
 
 def test_spotify_wakeup_uses_guest_aware_sync_group_without_manual_regrouping() -> None:


### PR DESCRIPTION
## Summary

- harden `script.music_assistant_radio_wake_up` so the wake-up volume ramp only starts after the selected Music Assistant sync group is still/again `playing`
- retry the radio playback call once when the selected group falls to `idle`/`off`/`unavailable`
- create a persistent notification, log the failure, and stop the script with an error if playback still cannot be established
- update `specs/alarm_wakeup.allium` so the behavioral contract requires playback verification before the wake-up volume ramp
- add regression coverage that keeps the verification/retry/failure path before the volume ramp

Closes #772.

## Runtime evidence

Nightly Trace Review on 2026-06-18 found the weekday alarm path triggered at 08:20 CDT, started `script.sonos_mpr_news_wake_up` and `script.music_assistant_radio_wake_up`, then logged a `music_assistant.play_media` failure resolving the TuneIn stream. Recorder/logbook history showed `media_player.ma_group_everywhere` transitioned to `idle` at 08:20:18 CDT while both scripts continued until 08:30:22 CDT, so the trace/script completion was not proof that MPR became audible.

Current live DNS resolution for the TuneIn host and `mass.local` has recovered, so this PR hardens the alarm script against the observed transient failure mode rather than changing the alarm schedule or room/guest guards.

## Validation

- `uv run --with pytest pytest tests/test_media_player_music_assistant.py tests/test_alarm_night_allium_alignment.py -q` (`38 passed`)
- `uv run --with pytest pytest tests/test_allium_weed_check.py tests/test_allium_specs.py tests/test_alarm_night_allium_alignment.py tests/test_media_player_music_assistant.py -q` (`52 passed`)
- `uv run --with pytest pytest` (`509 passed`)
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/media_player.yaml`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt`
- `python3 scripts/allium_weed_check.py --require-allium --format terminal --changed-from origin/develop` (passed with existing warnings/info only)
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version` (pinned Python 3.14.3 satisfies HA 2026.6.3)
- `git diff --check`

## Not run / blocked

- Home Assistant container `check_config`: local Podman reports the machine started, but the client still fails with `dial tcp 127.0.0.1:53019: connect: connection refused` before the HA container can start.
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/media_player.yaml --strict`: reports pre-existing duplicate entries in unrelated `play_video_games`, `spotify_arrival`, `spotify_bedtime`, and LoFi playlist paths. This PR leaves those out of scope to keep the runtime alarm fix isolated.
