### PR TITLE
Fix #758 washer reminder Music Assistant target

### DIFF
--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -272,7 +272,7 @@ automation:
                   - action: tts.google_say
                     continue_on_error: true
                     data:
-                      entity_id: media_player.everywhere_sonos
+                      entity_id: media_player.ma_group_everywhere
                       message: "Laundry has been sitting in the washer for an hour."
           - conditions:
               - condition: state

--- a/tests/test_laundry_plug_monitoring.py
+++ b/tests/test_laundry_plug_monitoring.py
@@ -128,7 +128,8 @@ def test_cleaning_package_notifies_from_power_based_running_sensors() -> None:
     assert "message: \"Laundry has been sitting in the washer for an hour." in washer_reminder
     assert "input_boolean.guest_mode" in washer_reminder
     assert "action: tts.google_say" in washer_reminder
-    assert "entity_id: media_player.everywhere_sonos" in washer_reminder
+    assert "entity_id: media_player.ma_group_everywhere" in washer_reminder
+    assert "media_player.everywhere_sonos" not in washer_reminder
     assert "binary_sensor.front_load_washer_wash_completed" not in washer_reminder
 
     assert "binary_sensor.laundry_room_washing_machine_door_contact" in washer_cleared


### PR DESCRIPTION
## Summary
- replace the retired washer reminder TTS target `media_player.everywhere_sonos` with live Music Assistant group `media_player.ma_group_everywhere`
- preserve the existing guest-mode guard around the audio reminder
- update laundry regression coverage so the stale Sonos group is not reintroduced

Fixes #758.

## Runtime evidence
- Live Home Assistant reports `automation.washer_reminder` is enabled.
- Live `media_player.everywhere_sonos` returns 404 / is absent.
- Live `media_player.ma_group_everywhere` exists and is currently available as the established whole-home Music Assistant group.
- Live `input_boolean.guest_mode` is off during inspection; the existing guard remains unchanged so audio escalation is still suppressed when guest mode is on.

## Validation
- `uv run --with pytest pytest tests/test_laundry_plug_monitoring.py -q` (4 passed)
- `uv run --with pytest pytest` (512 passed)
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/cleaning.yaml`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/cleaning.yaml --strict` (no findings)
- `git diff --check`

## Not run
- Home Assistant container `check_config`: local Podman VM started, but Podman client could not connect to the default machine socket (`127.0.0.1:53019: connect: connection refused`) before the HA container could start.
