### PR TITLE
[codex] Fix #758 washer reminder media target

### DIFF
--- a/packages/cleaning.yaml
+++ b/packages/cleaning.yaml
@@ -272,7 +272,7 @@ automation:
                   - action: tts.google_say
                     continue_on_error: true
                     data:
-                      entity_id: media_player.everywhere_sonos
+                      entity_id: media_player.ma_group_everywhere
                       message: "Laundry has been sitting in the washer for an hour."
           - conditions:
               - condition: state

--- a/tests/test_laundry_plug_monitoring.py
+++ b/tests/test_laundry_plug_monitoring.py
@@ -128,7 +128,8 @@ def test_cleaning_package_notifies_from_power_based_running_sensors() -> None:
     assert "message: \"Laundry has been sitting in the washer for an hour." in washer_reminder
     assert "input_boolean.guest_mode" in washer_reminder
     assert "action: tts.google_say" in washer_reminder
-    assert "entity_id: media_player.everywhere_sonos" in washer_reminder
+    assert "entity_id: media_player.ma_group_everywhere" in washer_reminder
+    assert "entity_id: media_player.everywhere_sonos" not in washer_reminder
     assert "binary_sensor.front_load_washer_wash_completed" not in washer_reminder
 
     assert "binary_sensor.laundry_room_washing_machine_door_contact" in washer_cleared


### PR DESCRIPTION
## Summary

Fixes #758 by updating the washer-reminder TTS target from the retired `media_player.everywhere_sonos` entity to the live Music Assistant group `media_player.ma_group_everywhere`.

## Runtime evidence

Nightly Trace Review on 2026-06-19 confirmed the live HA state still has `media_player.everywhere_sonos` missing while `media_player.ma_group_everywhere` exists and is active. Live `/config/packages/cleaning.yaml` still referenced the retired target at the washer reminder TTS call, so the one-hour washer reminder could silently fail or log a service target error.

## Change

- Updated `packages/cleaning.yaml` washer reminder TTS target to `media_player.ma_group_everywhere`.
- Updated `tests/test_laundry_plug_monitoring.py` to require the Music Assistant group and reject the retired Sonos group in that automation block.

## Validation

- `uv run --with pytest pytest tests/test_laundry_plug_monitoring.py` - passed, 4 tests.
- `uv run --with pytest pytest` - passed, 516 tests.
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/cleaning.yaml --strict` - passed, no findings.
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml scripts.yaml packages/cleaning.yaml` - passed.
- `git diff --check` - passed.

## Config-check blocker

Containerized Home Assistant config check could not run locally because `podman machine start podman-machine-default` reported success, then the machine immediately returned to stopped/refused the configured socket. No HA config-check result is claimed in this PR.
