### PR TITLE
Add temporary Owner Suite blind forensics watcher (#781)

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -34,6 +34,10 @@ config:
 logger:
   #default: warn
   default: warning
+  logs:
+    # Temporary: blind-forensics diagnostic (see packages/blind_forensics.yaml).
+    # Remove once the unexpected Owner Suite blind opener is identified.
+    homeassistant.components.cover: debug
   # logs:
   #   custom_components.adaptive_lighting: debug
   #  default: warn

--- a/packages/blind_forensics.yaml
+++ b/packages/blind_forensics.yaml
@@ -27,7 +27,13 @@ automation:
           - cover.owner_suite_blinds_ha
           - cover.owner_suite_north_blind
           - cover.owner_suite_south_blind
+        # These FYRTUR/Z2M covers report closed->open directly (no opening/
+        # closing state) and the first transition carries the commanding
+        # service-call context, so open/closed already captures it. opening/
+        # closing are listed defensively in case future firmware reports them.
         to:
+          - opening
+          - closing
           - open
           - closed
     actions:

--- a/packages/blind_forensics.yaml
+++ b/packages/blind_forensics.yaml
@@ -1,0 +1,55 @@
+# TEMPORARY diagnostic package.
+#
+# Purpose: identify what opens the Owner Suite blinds. On 2026-06-19 at 05:32
+# local the blinds opened via a `cover.set_cover_position` service call whose
+# recorder context had NULL user_id and NULL parent_id, shared by nothing but
+# the three cover entities (i.e. a direct, user-less, parent-less call — not an
+# HA automation, not HomeKit, not a person/Alexa). This watcher captures the
+# full trigger context + position on every open/closed transition so the next
+# occurrence reveals its source.
+#
+# Remove this file AND the `homeassistant.components.cover: debug` entry under
+# `logger:` in configuration.yaml once the culprit is identified.
+automation:
+  - id: debug_owner_suite_blind_forensics
+    alias: "DEBUG Owner Suite blind move forensics"
+    description: >-
+      Temporary diagnostic. Logs full trigger context (id/parent/user) and
+      position on every Owner Suite blind open/closed transition. Safe to
+      delete once the unexpected opener is caught.
+    mode: parallel
+    max: 10
+    trace:
+      stored_traces: 50
+    triggers:
+      - trigger: state
+        entity_id:
+          - cover.owner_suite_blinds_ha
+          - cover.owner_suite_north_blind
+          - cover.owner_suite_south_blind
+        to:
+          - open
+          - closed
+    actions:
+      - action: logbook.log
+        data:
+          name: Blind Forensics
+          entity_id: "{{ trigger.entity_id }}"
+          message: >-
+            {{ trigger.from_state.state }}->{{ trigger.to_state.state }}
+            (pos {{ trigger.from_state.attributes.current_position | default('?') }}->{{ trigger.to_state.attributes.current_position | default('?') }})
+            ctx={{ trigger.to_state.context.id }}
+            parent={{ trigger.to_state.context.parent_id }}
+            user={{ trigger.to_state.context.user_id }}
+      - action: persistent_notification.create
+        data:
+          notification_id: "blind_forensics_{{ trigger.to_state.context.id }}"
+          title: "Blind {{ trigger.to_state.state }}: {{ trigger.to_state.name }}"
+          message: >-
+            {{ now().strftime('%Y-%m-%d %H:%M:%S') }} local |
+            {{ trigger.entity_id }}:
+            {{ trigger.from_state.state }}->{{ trigger.to_state.state }}
+            (position {{ trigger.from_state.attributes.current_position | default('?') }}->{{ trigger.to_state.attributes.current_position | default('?') }}) |
+            context.id={{ trigger.to_state.context.id }} |
+            context.parent_id={{ trigger.to_state.context.parent_id }} |
+            context.user_id={{ trigger.to_state.context.user_id }}


### PR DESCRIPTION
Refs #781

## What
Adds a **temporary** diagnostic to identify what opens the Owner Suite blinds early. The 2026-06-19 05:32 event was a user-less, parent-less `cover.set_cover_position` call that HA does not attribute to any automation / HomeKit / Alexa / user.

- `packages/blind_forensics.yaml` — `parallel`-mode watcher on `cover.owner_suite_blinds_ha` / north / south, firing only on `open`/`closed` transitions (so the wake-ramp's many position steps don't spam). Each transition writes a `logbook.log` entry and a `persistent_notification` capturing `context.id` / `context.parent_id` / `context.user_id` + position change + timestamp.
- `configuration.yaml` — `homeassistant.components.cover: debug` so the next command is captured in the HA log across restarts.

## How it helps
On the next blind movement you get a notification with the exact context. If it's the orphaned (null/null) signature again, the timestamp lets us pull fresh Zigbee2MQTT / HA logs while still buffered.

## Deploy / verify
After merge + host git-pull, run `automation.reload`; entity `automation.debug_owner_suite_blind_move_forensics` should be `on`.

## Cleanup (after the opener is found)
Delete `packages/blind_forensics.yaml` and remove the `homeassistant.components.cover: debug` logger entry from `configuration.yaml`. Tracked by #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)