### PR TITLE
Fix #776 vacuum stall snapshot path

### DIFF
--- a/appdaemon/apps/vacuum_stall_monitor.py
+++ b/appdaemon/apps/vacuum_stall_monitor.py
@@ -21,8 +21,10 @@ except ImportError:  # pragma: no cover - lets pytest import the module locally.
         Hass = _HassBase
 
 
-MEDIA_ROOT = Path("/homeassistant/media")
-DEFAULT_STORAGE_ROOT = MEDIA_ROOT / "vacuum_stalls"
+APPDAEMON_MEDIA_ROOT = Path("/homeassistant/media")
+HOME_ASSISTANT_MEDIA_ROOT = Path("/config/media")
+MEDIA_ROOT = APPDAEMON_MEDIA_ROOT
+DEFAULT_STORAGE_ROOT = APPDAEMON_MEDIA_ROOT / "vacuum_stalls"
 SEGMENT_COLORS = (
     (25, 161, 161, 255),
     (122, 192, 55, 255),
@@ -497,10 +499,15 @@ def prune_sample_artifacts(samples_dir: Path, keep: int) -> None:
 
 def media_url_for(path: Path) -> str | None:
     try:
-        relative = path.relative_to(MEDIA_ROOT)
+        relative = path.relative_to(APPDAEMON_MEDIA_ROOT)
     except ValueError:
         return None
     return f"/media/local/{relative.as_posix()}"
+
+
+def home_assistant_snapshot_path_for(path: Path) -> str:
+    relative = path.relative_to(APPDAEMON_MEDIA_ROOT)
+    return str(HOME_ASSISTANT_MEDIA_ROOT / relative)
 
 
 class VacuumStallMonitor(hass.Hass):
@@ -609,7 +616,7 @@ class VacuumStallMonitor(hass.Hass):
         self.call_service(
             "camera/snapshot",
             entity_id=self.map_camera_entity,
-            filename=str(raw_png_path),
+            filename=home_assistant_snapshot_path_for(raw_png_path),
         )
         if not self._wait_for_file(raw_png_path):
             raise FileNotFoundError(f"Camera snapshot did not create {raw_png_path}")
@@ -628,7 +635,7 @@ class VacuumStallMonitor(hass.Hass):
                 self.call_service(
                     "camera/snapshot",
                     entity_id=self.rendered_camera_entity,
-                    filename=str(rendered_png_path),
+                    filename=home_assistant_snapshot_path_for(rendered_png_path),
                 )
                 if self._wait_for_file(rendered_png_path):
                     rendered_path = rendered_png_path

--- a/packages/z2m_availability.yaml
+++ b/packages/z2m_availability.yaml
@@ -706,6 +706,18 @@ mqtt:
       payload_available: "online"
       payload_not_available: "offline"
 
+    - name: "Z2M Garage/TPH Availability"
+      unique_id: z2m_garage_tph_availability
+      state_topic: "zigbee2mqtt/Garage/TPH/availability"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
     - name: "Z2M Guest Bathroom/Exhaust Availability"
       unique_id: z2m_guest_bathroom_exhaust_availability
       state_topic: "zigbee2mqtt/Guest Bathroom/Exhaust/availability"
@@ -1177,6 +1189,18 @@ mqtt:
     - name: "Z2M Kitchen/Switch Availability"
       unique_id: z2m_kitchen_switch_availability
       state_topic: "zigbee2mqtt/Kitchen/Switch/availability"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/TPH Availability"
+      unique_id: z2m_kitchen_tph_availability
+      state_topic: "zigbee2mqtt/Kitchen/TPH/availability"
       value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"

--- a/tests/test_issue_343_vacuum_stall_monitor.py
+++ b/tests/test_issue_343_vacuum_stall_monitor.py
@@ -115,6 +115,18 @@ def test_slug_from_vacuum_entity_drops_duplicate_valetudo_prefix() -> None:
     assert module.slug_from_vacuum_entity("vacuum.valetudo_upstairs_vacuum") == "upstairs_vacuum"
 
 
+def test_snapshot_service_path_uses_home_assistant_allowlisted_config_media_path() -> None:
+    module = _load_module()
+
+    local_path = Path("/homeassistant/media/vacuum_stalls/mainlevel/latest.png")
+
+    assert module.DEFAULT_STORAGE_ROOT == Path("/homeassistant/media/vacuum_stalls")
+    assert module.home_assistant_snapshot_path_for(local_path) == "/config/media/vacuum_stalls/mainlevel/latest.png"
+    assert module.media_url_for(local_path) == (
+        "/media/local/vacuum_stalls/mainlevel/latest.png"
+    )
+
+
 def test_extract_valetudo_map_and_render_png(tmp_path: Path) -> None:
     module = _load_module()
     map_data = {


### PR DESCRIPTION
## Summary
- Keep the AppDaemon vacuum stall monitor storage path on `/homeassistant/media/vacuum_stalls` so the AppDaemon process can wait for and read captured files.
- Translate only the HA `camera.snapshot` service filename to `/config/media/vacuum_stalls/...`, matching the existing HA allowlist.
- Add regression coverage for the AppDaemon-local path, HA service-call path, and `/media/local/...` notification URL mapping.
- Add the two missing Z2M availability sensors for `Kitchen/TPH` and `Garage/TPH` so the full PR pytest job covers the current Zigbee2MQTT friendly-name roster.

## Runtime evidence
Live HA 2026.6.3 still logs `camera.snapshot` service-call errors for the real AppDaemon caller path:

`Cannot write /homeassistant/media/vacuum_stalls/... no access to path; allowlist_external_dirs may need to be adjusted`

The prior direct `/config/media` probe passed, but it did not exercise AppDaemon's actual filename path. This PR preserves the AppDaemon mount path while sending HA an allowlisted `/config/media` filename.

The PR build also exposed the already-tracked #566 Z2M availability coverage break: `Kitchen/TPH` and `Garage/TPH` were present in `zigbee2mqtt/configuration.yaml` but missing from `packages/z2m_availability.yaml`.

Fixes #776.

## Validation
- `uv run --with pytest pytest tests/test_z2m_availability_package.py tests/test_issue_343_vacuum_stall_monitor.py` -> 27 passed
- `uv run --with pytest pytest` -> 517 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/z2m_availability.yaml appdaemon/apps/vacuum_stall_monitor.yaml` -> passed
- `podman run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:2026.5.1 python -m homeassistant --config /config --script check_config` -> passed

## Scope note
The Z2M sensor additions are included only because the existing #566 coverage failure was the sole remaining build break on this PR after the vacuum fix. No room behavior or automation action semantics changed.