### PR TITLE
Fix #566 Z2M availability roster coverage

### DIFF
--- a/packages/z2m_availability.yaml
+++ b/packages/z2m_availability.yaml
@@ -706,6 +706,18 @@ mqtt:
       payload_available: "online"
       payload_not_available: "offline"
 
+    - name: "Z2M Garage/TPH Availability"
+      unique_id: z2m_garage_tph_availability
+      state_topic: "zigbee2mqtt/Garage/TPH/availability"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
     - name: "Z2M Guest Bathroom/Exhaust Availability"
       unique_id: z2m_guest_bathroom_exhaust_availability
       state_topic: "zigbee2mqtt/Guest Bathroom/Exhaust/availability"
@@ -1177,6 +1189,18 @@ mqtt:
     - name: "Z2M Kitchen/Switch Availability"
       unique_id: z2m_kitchen_switch_availability
       state_topic: "zigbee2mqtt/Kitchen/Switch/availability"
+      value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_on: "online"
+      payload_off: "offline"
+      device_class: connectivity
+      availability_topic: "zigbee2mqtt/bridge/state"
+      availability_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
+      payload_available: "online"
+      payload_not_available: "offline"
+
+    - name: "Z2M Kitchen/TPH Availability"
+      unique_id: z2m_kitchen_tph_availability
+      state_topic: "zigbee2mqtt/Kitchen/TPH/availability"
       value_template: "{{ value_json.state if value_json is defined and value_json.state is defined else value }}"
       payload_on: "online"
       payload_off: "offline"


### PR DESCRIPTION
## Summary
- Add MQTT availability binary sensors for `Garage/TPH` and `Kitchen/TPH`.
- Bring `packages/z2m_availability.yaml` back into one-to-one coverage with named devices in `zigbee2mqtt/configuration.yaml`.
- Keep the aggregate availability monitor strict instead of suppressing missing-device failures.

Fixes #566.

## Evidence
Before this change, `uv run --with pytest pytest tests/test_z2m_availability_package.py` failed because the package had 153 device availability topics for 155 Zigbee2MQTT named devices. The missing friendly names were `Kitchen/TPH` and `Garage/TPH`.

## Validation
- `uv run --with pytest pytest tests/test_z2m_availability_package.py` -> 19 passed
- `uv run --with pytest pytest` -> 516 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/z2m_availability.yaml zigbee2mqtt/configuration.yaml` -> passed
- `podman run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:2026.5.1 python -m homeassistant --config /config --script check_config` -> passed

## Room/spec note
This is telemetry-only MQTT availability coverage. It does not change room-targeted actions, guest privacy behavior, automation triggers, or service calls.