### PR TITLE
Add contextual arrival lighting tiers

### DIFF
--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -302,8 +302,12 @@ automation:
     trace:
       stored_traces: 10
     trigger:
+      # from: "on" guards against unknown/unavailable -> off on HA restart,
+      # which would otherwise overwrite a restored multi-day absence start
+      # with the restart time and misclassify the next arrival as quick/half-day.
       - trigger: state
         entity_id: binary_sensor.bayesian_zeke_home
+        from: "on"
         to: "off"
     action:
       - action: input_boolean.turn_off
@@ -967,8 +971,22 @@ script:
         {{ parsed if parsed is not none else as_timestamp(now()) }}
       absence_seconds: >-
         {{ [as_timestamp(now()) - (last_empty_timestamp | float(as_timestamp(now()))), 0] | max | int }}
+      # An arrival automation can re-fire from its GPS zone trigger while the
+      # house is still occupied (e.g. a GPS jitter re-enter). In that case the
+      # house never emptied, so the persisted last_empty timestamp is stale and
+      # would misclassify the re-entry as full/multi day. Treat presence that
+      # has already been established (Bayesian "on" for more than the grace
+      # window) as an occupied re-entry and force the minimal quick tier.
+      seconds_since_presence: >-
+        {% set lc = states.binary_sensor.bayesian_zeke_home.last_changed %}
+        {{ (as_timestamp(now()) - as_timestamp(lc)) | int if lc is not none else 0 }}
+      occupied_reentry: >-
+        {{ is_state('binary_sensor.bayesian_zeke_home', 'on')
+           and (seconds_since_presence | int(0)) > 300 }}
       arrival_tier: >-
-        {% if absence_seconds < 3600 %}
+        {% if occupied_reentry %}
+          quick_errand
+        {% elif absence_seconds < 3600 %}
           quick_errand
         {% elif absence_seconds < 28800 %}
           half_day
@@ -977,16 +995,22 @@ script:
         {% else %}
           multi_day
         {% endif %}
+      # Reached only when the caller passed no explicit light_scene (the
+      # explicit case is handled first in tier_light_scene).
       base_light_scene: >-
-        {% if light_scene is defined and light_scene | string | trim %}
-          {{ light_scene }}
-        {% elif normalized_mode == 'night' %}
+        {% if normalized_mode == 'night' %}
           scene.night_arrive_home
         {% else %}
           scene.arrive_home
         {% endif %}
+      # A caller that passes an explicit light_scene (e.g. the cloudy arrival,
+      # whose whole purpose is a bright dark-house scene) wins over the absence
+      # tier default. Absence tiering only picks the scene when the caller did
+      # not specify one; climate gating below still varies by tier independently.
       tier_light_scene: >-
-        {% if normalized_mode == 'night' and arrival_tier == 'quick_errand' %}
+        {% if light_scene is defined and light_scene | string | trim %}
+          {{ light_scene }}
+        {% elif normalized_mode == 'night' and arrival_tier == 'quick_errand' %}
           scene.night_arrive_home_quick
         {% elif normalized_mode == 'home' and arrival_tier == 'quick_errand' %}
           scene.arrive_home_quick

--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -96,6 +96,12 @@ homeassistant:
       <<: *customize
       friendly_name: Bayesian Presence Constraint
     ################################################
+    ## Input Datetime
+    ################################################
+    input_datetime.contextual_arrival_last_empty_at:
+      <<: *customize
+      friendly_name: "Contextual Arrival Last Empty House"
+    ################################################
     ## Input Numbers
     ################################################
 
@@ -185,9 +191,9 @@ automation:
           state: "off"
           # enabled: false
     action:
-      - action: script.house_transition
+      - action: script.contextual_arrival_transition
         data:
-          mode: home
+          requested_mode: home
           reason: cloudy_home_arrival
           light_scene: scene.cloudy_arrive_home
           light_transition: 30
@@ -217,9 +223,9 @@ automation:
           entity_id: sensor.wethop_activity
           state: "Automotive"
     action:
-      - action: script.house_transition
+      - action: script.contextual_arrival_transition
         data:
-          mode: home
+          requested_mode: home
           reason: default_arrive_home
       # - alias: "Notify action"
       #   action: notify.mobile_app_wethop
@@ -303,6 +309,11 @@ automation:
       - action: input_boolean.turn_off
         target:
           entity_id: input_boolean.bayesian_zeke_home
+      - action: input_datetime.set_datetime
+        target:
+          entity_id: input_datetime.contextual_arrival_last_empty_at
+        data:
+          datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
 
   - id: play_spotify_when_i_get_home
     alias: play_spotify_when_i_get_home
@@ -369,9 +380,9 @@ automation:
             - condition: sun
               before: sunrise
     action:
-      - action: script.house_transition
+      - action: script.contextual_arrival_transition
         data:
-          mode: night
+          requested_mode: night
           reason: night_arrival
           light_transition: 30
       - action: vacuum.return_to_base
@@ -409,9 +420,9 @@ automation:
             - condition: sun
               before: sunrise
     action:
-      - action: script.house_transition
+      - action: script.contextual_arrival_transition
         data:
-          mode: night
+          requested_mode: night
           reason: bedroom_prep_arrival
           extra_scene: scene.bedroom_prep
       - action: notify.all
@@ -762,6 +773,15 @@ input_boolean:
 input_number: {}
 
 ########################
+# Input Datetime
+########################
+input_datetime:
+  contextual_arrival_last_empty_at:
+    name: "Contextual Arrival Last Empty House"
+    has_date: true
+    has_time: true
+
+########################
 # Input Select
 ########################
 input_select:
@@ -800,6 +820,12 @@ group:
 # Scenes
 ########################
 scene:
+  - name: arrive_home_quick
+    entities:
+      light.hall_foyer_switch:
+        state: "on"
+        brightness: 150
+
   - name: arrive_home
     entities:
       light.hall_foyer_switch:
@@ -812,6 +838,54 @@ scene:
         state: "off"
       switch.tiki_room_camera:
         state: "off"
+
+  - name: arrive_home_full_day
+    entities:
+      light.hall_foyer_switch:
+        state: "on"
+        brightness: 255
+      light.hall_transition_switch:
+        state: "on"
+        brightness: 220
+      light.kitchen_sink_overhead:
+        state: "on"
+        brightness: 220
+      light.den_all:
+        state: "on"
+      switch.livingroom_motion_detection:
+        state: "off"
+      switch.tiki_room_camera:
+        state: "off"
+
+  - name: arrive_home_multi_day
+    entities:
+      light.hall_all:
+        state: "on"
+        brightness: 255
+      light.kitchen_sink_overhead:
+        state: "on"
+        brightness: 255
+      light.den_all:
+        state: "on"
+      light.outside_front_hue:
+        state: "on"
+        brightness: 220
+      light.outside_front_door:
+        state: "on"
+        brightness: 220
+      switch.livingroom_motion_detection:
+        state: "off"
+      switch.tiki_room_camera:
+        state: "off"
+
+  - name: night_arrive_home_quick
+    entities:
+      light.hall_foyer_switch:
+        state: "on"
+        brightness: 120
+      light.outside_front_door:
+        state: "on"
+        brightness: 120
 
   - name: turn_on_cameras
     entities:
@@ -856,7 +930,109 @@ scene:
 # Scripts
 ########################
 script:
-  {}
+  contextual_arrival_transition:
+    alias: contextual_arrival_transition
+    description: >-
+      Apply absence-tiered arrival lighting and climate behavior before
+      delegating to the shared house transition script.
+    mode: restart
+    trace:
+      stored_traces: 10
+    fields:
+      requested_mode:
+        description: "Arrival mode to pass to house_transition: home or night."
+        example: home
+      reason:
+        description: Optional logbook reason for the arrival transition.
+        example: default_arrive_home
+      light_scene:
+        description: Optional base scene for half-day arrivals.
+        example: scene.cloudy_arrive_home
+      light_transition:
+        description: Optional base transition seconds.
+        example: 30
+      extra_scene:
+        description: Optional extra scene for non-quick arrivals.
+        example: scene.bedroom_prep
+      notify_message:
+        description: Optional notify.all message for the transition.
+        example: Cloudy day arrival.
+    variables:
+      normalized_mode: >-
+        {% set normalized = (requested_mode | default('home', true) | string | lower | trim) %}
+        {{ 'night' if normalized == 'night' else 'home' }}
+      last_empty_timestamp: >-
+        {% set raw = states('input_datetime.contextual_arrival_last_empty_at') %}
+        {% set parsed = as_timestamp(raw, default=none) %}
+        {{ parsed if parsed is not none else as_timestamp(now()) }}
+      absence_seconds: >-
+        {{ [as_timestamp(now()) - (last_empty_timestamp | float(as_timestamp(now()))), 0] | max | int }}
+      arrival_tier: >-
+        {% if absence_seconds < 3600 %}
+          quick_errand
+        {% elif absence_seconds < 28800 %}
+          half_day
+        {% elif absence_seconds < 86400 %}
+          full_day
+        {% else %}
+          multi_day
+        {% endif %}
+      base_light_scene: >-
+        {% if light_scene is defined and light_scene | string | trim %}
+          {{ light_scene }}
+        {% elif normalized_mode == 'night' %}
+          scene.night_arrive_home
+        {% else %}
+          scene.arrive_home
+        {% endif %}
+      tier_light_scene: >-
+        {% if normalized_mode == 'night' and arrival_tier == 'quick_errand' %}
+          scene.night_arrive_home_quick
+        {% elif normalized_mode == 'home' and arrival_tier == 'quick_errand' %}
+          scene.arrive_home_quick
+        {% elif normalized_mode == 'home' and arrival_tier == 'full_day' %}
+          scene.arrive_home_full_day
+        {% elif normalized_mode == 'home' and arrival_tier == 'multi_day' %}
+          scene.arrive_home_multi_day
+        {% else %}
+          {{ base_light_scene }}
+        {% endif %}
+      tier_light_transition: >-
+        {% set base = light_transition | default(30, true) | int(30) %}
+        {% if arrival_tier == 'quick_errand' %}
+          5
+        {% elif arrival_tier == 'multi_day' %}
+          120
+        {% elif arrival_tier == 'full_day' and base < 45 %}
+          45
+        {% else %}
+          {{ base }}
+        {% endif %}
+      tier_extra_scene: >-
+        {% if arrival_tier == 'quick_errand' %}
+          none
+        {% elif extra_scene is defined and extra_scene | string | trim %}
+          {{ extra_scene }}
+        {% else %}
+          none
+        {% endif %}
+      tier_apply_climate: "{{ arrival_tier in ['full_day', 'multi_day'] }}"
+      tier_notify_message: >-
+        {% if notify_message is defined and notify_message | string | trim %}
+          {{ notify_message }}
+        {% else %}
+          {{ '' }}
+        {% endif %}
+    sequence:
+      - action: script.house_transition
+        data:
+          mode: "{{ normalized_mode }}"
+          reason: "{{ reason | default('contextual_arrival', true) }}_{{ arrival_tier }}"
+          light_scene: "{{ tier_light_scene }}"
+          light_transition: "{{ tier_light_transition }}"
+          extra_scene: "{{ tier_extra_scene }}"
+          notify_message: "{{ tier_notify_message }}"
+          apply_climate: "{{ tier_apply_climate }}"
   # update_nest_eta:
   #   sequence:
   #     - action: nest.set_eta

--- a/tests/test_house_mode_zone.py
+++ b/tests/test_house_mode_zone.py
@@ -155,6 +155,7 @@ def test_contextual_arrival_tracks_when_house_becomes_empty() -> None:
     assert "input_datetime.contextual_arrival_last_empty_at:" in text
     assert "has_date: true" in text
     assert "has_time: true" in text
+    assert "from: \"on\"" in block
     assert "to: \"off\"" in block
     assert "action: input_boolean.turn_off" in block
     assert "action: input_datetime.set_datetime" in block
@@ -190,6 +191,27 @@ def test_contextual_arrival_script_tiers_lighting_and_climate_by_absence() -> No
     assert "tier_apply_climate: \"{{ arrival_tier in ['full_day', 'multi_day'] }}\"" in block
     assert "action: script.house_transition" in block
     assert "apply_climate: \"{{ tier_apply_climate }}\"" in block
+
+
+def test_contextual_arrival_treats_occupied_reentry_as_quick() -> None:
+    block = _zone_script_block("contextual_arrival_transition")
+
+    # An established-presence re-entry (Bayesian already "on") must not reuse the
+    # stale last_empty timestamp and escalate to full/multi day.
+    assert "occupied_reentry" in block
+    assert "seconds_since_presence" in block
+    assert "is_state('binary_sensor.bayesian_zeke_home', 'on')" in block
+    assert "{% if occupied_reentry %}" in block
+
+
+def test_contextual_arrival_explicit_light_scene_wins_over_tier() -> None:
+    block = _zone_script_block("contextual_arrival_transition")
+
+    tier_scene = block.split("tier_light_scene:", 1)[1].split("tier_light_transition:", 1)[0]
+    # The caller's explicit scene (e.g. the cloudy bright scene) must be the
+    # first branch so absence tiering never discards it.
+    first_branch = tier_scene.strip().splitlines()[1].strip()
+    assert first_branch == "{% if light_scene is defined and light_scene | string | trim %}"
 
 
 def test_contextual_arrival_scenes_avoid_guest_private_rooms() -> None:

--- a/tests/test_house_mode_zone.py
+++ b/tests/test_house_mode_zone.py
@@ -31,6 +31,51 @@ def _script_block(script_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
+def _zone_script_block(script_id: str) -> str:
+    lines = ZONE_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r}")
+
+    end = len(lines)
+    next_script = re.compile(r"^  [A-Za-z0-9_]+:$")
+    for index in range(start + 1, len(lines)):
+        if next_script.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _scene_block(scene_name: str) -> str:
+    lines = ZONE_PATH.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  - name: {scene_name}"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find scene {scene_name!r}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - name: "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
 def _automation_block(path: Path, automation_id: str) -> str:
     lines = path.read_text(encoding="utf-8").splitlines()
     start = None
@@ -101,6 +146,63 @@ def test_departure_waits_for_primary_tracker_to_leave_home() -> None:
     assert "Primary tracker confirms departure" in block
     assert "device_tracker.bayesian_zeke_home" in block
     assert "not is_state('device_tracker.bayesian_zeke_home', 'home')" in block
+
+
+def test_contextual_arrival_tracks_when_house_becomes_empty() -> None:
+    text = ZONE_PATH.read_text(encoding="utf-8")
+    block = _automation_block(ZONE_PATH, "input_boolean_tracker_off")
+
+    assert "input_datetime.contextual_arrival_last_empty_at:" in text
+    assert "has_date: true" in text
+    assert "has_time: true" in text
+    assert "to: \"off\"" in block
+    assert "action: input_boolean.turn_off" in block
+    assert "action: input_datetime.set_datetime" in block
+    assert "entity_id: input_datetime.contextual_arrival_last_empty_at" in block
+    assert "now().strftime('%Y-%m-%d %H:%M:%S')" in block
+
+
+def test_arrival_automations_use_contextual_arrival_transition() -> None:
+    for automation_id in (
+        "cloudy_home_arrival",
+        "default_arrive_home",
+        "turn_on_lights_at_night_when_i_get_home",
+        "turn_on_bedroom_lights_at_night_when_i_get_home",
+    ):
+        block = _automation_block(ZONE_PATH, automation_id)
+        assert "action: script.contextual_arrival_transition" in block
+        assert "action: script.house_transition" not in block
+
+
+def test_contextual_arrival_script_tiers_lighting_and_climate_by_absence() -> None:
+    block = _zone_script_block("contextual_arrival_transition")
+
+    for threshold in ("3600", "28800", "86400"):
+        assert threshold in block
+
+    for tier in ("quick_errand", "half_day", "full_day", "multi_day"):
+        assert tier in block
+
+    assert "scene.arrive_home_quick" in block
+    assert "scene.night_arrive_home_quick" in block
+    assert "scene.arrive_home_full_day" in block
+    assert "scene.arrive_home_multi_day" in block
+    assert "tier_apply_climate: \"{{ arrival_tier in ['full_day', 'multi_day'] }}\"" in block
+    assert "action: script.house_transition" in block
+    assert "apply_climate: \"{{ tier_apply_climate }}\"" in block
+
+
+def test_contextual_arrival_scenes_avoid_guest_private_rooms() -> None:
+    for scene_name in (
+        "arrive_home_quick",
+        "arrive_home_full_day",
+        "arrive_home_multi_day",
+        "night_arrive_home_quick",
+    ):
+        block = _scene_block(scene_name)
+        assert "light.office" not in block
+        assert "light.guest_room" not in block
+        assert "media_player." not in block
 
 
 def test_house_transition_guest_mode_grouping_never_unjoins_den() -> None:


### PR DESCRIPTION
## Summary
- Track when the Bayesian home sensor last marked the house empty.
- Route existing arrival lighting automations through a contextual arrival wrapper that chooses quick, half-day, full-day, and multi-day lighting tiers.
- Gate Ecobee resume behavior so quick errands and half-day returns do not force climate recovery, while full-day and multi-day returns do.

Fixes #376.

## Room/spec notes
- Read `docs/room_intent.yaml`; new tier scenes avoid dedicated guest-private rooms and media actions.
- Read `specs/arrival_lighting.allium`; this change leaves adaptive-lighting correction behavior in `packages/adaptive_lighting.yaml` unchanged and only adjusts the scene/house-transition layer.

## Validation
- `uv run --with pytest pytest tests/test_house_mode_zone.py -q` -> 10 passed
- `uv run --with pytest pytest` -> 521 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/zone.yaml` -> passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt` -> passed
- `uv run python scripts/check_ha_python_support.py --python-version-file .python-version` -> passed
- `podman run --name ha-check-config --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:2026.5.1 python -m homeassistant --config /config --script check_config` -> passed
- `git diff --check` -> passed

## DRY verifier
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/zone.yaml --strict` still reports pre-existing duplicate arrival/departure trigger patterns in `packages/zone.yaml`.
- I removed the new duplicate introduced during development by folding the timestamp write into `input_boolean_tracker_off`.
- Deferred blocker: resolving the remaining verifier findings requires a broader consolidation of long-standing arrival, departure, music, and vacuum automations, which would change behavior outside #376.
