### PR TITLE
Add Tiki Room/Deck Switch to Inovelli reset config

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -2289,6 +2289,7 @@ script:
             - select.den_flood_switch_smartbulbmode
             - select.kitchen_switch_smartbulbmode
             - select.kitchen_bay_switch_smartbulbmode
+            - select.tiki_room_deck_switch_smartbulbmode
         - option: "Disabled"
           entities:
             - select.deck_flood_lights_smartbulbmode
@@ -2331,6 +2332,7 @@ script:
             - select.den_flood_switch_outputmode
             - select.kitchen_switch_outputmode
             - select.kitchen_bay_switch_outputmode
+            - select.tiki_room_deck_switch_outputmode
         - option: "Exhaust Fan (On/Off)"
           entities:
             - select.guest_bathroom_exhaust_outputmode
@@ -2371,6 +2373,7 @@ script:
             - select.den_flood_switch_switchtype
             - select.kitchen_switch_switchtype
             - select.kitchen_bay_switch_switchtype
+            - select.tiki_room_deck_switch_switchtype
         - option: "Aux Switch"
           entities:
             - select.hall_transition_switch_switchtype
@@ -2591,6 +2594,13 @@ script:
         - from: "Owner Suite/Bathroom/Tub Switch"
           from_endpoint: 2
           to: "Owner Suite/Bathroom/Lights"
+          clusters:
+            - genLevelCtrl
+            - genOnOff
+        - from: "Tiki Room/Deck Switch"
+          from_endpoint: 2
+          to: "Deck/Tiki Room Door"
+          to_endpoint: 11
           clusters:
             - genLevelCtrl
             - genOnOff


### PR DESCRIPTION
## Summary
Configures the newly-added **Tiki Room/Deck Switch** (Inovelli 2-in-1 switch+dimmer, ieee `0x943469fffe0896c9`) in `script.reset_inovelli_switches` so its smart-bulb setup is replayed after a factory reset.

It drives a smart Zigbee bulb, so it was added to the replay lists matching its live config:

| Replay list | Value |
|---|---|
| SmartBulbMode | Smart Bulb Mode |
| OutputMode | Dimmer |
| SwitchType | Single Pole |
| Binding | `Tiki Room/Deck Switch` ep2 → `Deck/Tiki Room Door` (Hue) ep11 |

## Notes
- Direct single-bulb binding (like Kitchen/Bay Light, Den/Lamp), so no Zigbee group-membership entry is needed.
- Energy/power report rates are already zeroed for all switches via the existing wildcard steps — verified live (99 reporting entities, 0 non-zero), so no change required there.
- Wildcard-driven params (double-tap, singletapbehavior, bindingofftoonsynclevel) auto-include the new switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)