### PR TITLE
Clamp PARASOLL reporting interval to 14400s to stop drop-offs (#791)

### DIFF
--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -1,9 +1,18 @@
 # IKEA PARASOLL (E2013) — battery drain & drop-off fix
 #
 # Root cause (github.com/Koenkk/zigbee2mqtt/issues/22579):
-#   1. Battery drain: Z2M writes an aggressive genPollCtrl check-in interval.
-#   2. Drop off: a regression removed the ssIasZone cluster binding, so the
-#      device stops sending contact-state changes after a few hours.
+#   1. Drop off / marked offline: the factory MAXIMUM reporting interval of
+#      65000 s (~18 h) on ssIasZone/zoneStatus (and the battery attributes) is
+#      longer than any sane availability timeout, so a healthy sleepy device is
+#      marked offline.  The community fix (jhenkens' reporting-interval
+#      blueprint) clamps max to 14400 s (4 h); this package does the same via
+#      script.parasoll_enforce_intervals.
+#   2. Stuck state: a regression removed the ssIasZone binding and zoneStatus
+#      min reporting was not 0, so rapid open/close pairs were dropped.  The
+#      converter now binds ssIasZone on ep2 and sets zoneStatus min = 0.
+#   3. Battery drain: largely a downstream symptom of (1) — drop-offs trigger
+#      rejoin loops that burn the battery.  genPollCtrl is left unbound as a
+#      precaution.
 #
 # This package pairs with zigbee2mqtt/external_converters/parasoll.js.
 # Z2M 2.x auto-scans the external_converters/ subdirectory — no configuration.yaml
@@ -11,7 +20,8 @@
 # Deployment order:
 #   1. Ensure zigbee2mqtt/external_converters/parasoll.js is present.
 #   2. Restart Zigbee2MQTT.  Devices should show "PARASOLL door/window sensor (patched)".
-#   3. Run script.parasoll_reconfigure_all from Developer Tools or the UI.
+#   3. Run script.parasoll_reconfigure_all from Developer Tools or the UI.  This
+#      reconfigures every joined sensor AND enforces the 14400 s max intervals.
 #   4. For sensors that are fully unresponsive: pull the battery, reinsert, then
 #      the automation below handles them automatically as they re-join.
 
@@ -39,6 +49,67 @@ input_text:
 ################################################################
 
 script:
+  # Clamp the maximum reporting interval to 14400 s (4 h) on the three
+  # attributes whose factory default of 65000 s (~18 h) lets PARASOLL sensors be
+  # marked offline by availability checks (Koenkk/zigbee2mqtt#22579), and pin
+  # zoneStatus min to 0 so rapid open/close pairs are never dropped.  This is the
+  # actual drop-off fix; it mirrors jhenkens' reporting-interval blueprint.
+  # Commands are queued by Z2M for sleepy devices and applied on the next wakeup.
+  parasoll_enforce_intervals:
+    alias: "PARASOLL - Enforce Reporting Intervals"
+    description: >
+      Sets maximum_report_interval = 14400 s on ssIasZone/zoneStatus (ep2),
+      genPowerCfg/batteryPercentageRemaining (ep1) and genPowerCfg/batteryVoltage
+      (ep1) for a single PARASOLL sensor, identified by IEEE address.  Mins and
+      reportable changes are left at the herdsman-converters factory values
+      (zoneStatus min 0; battery min 3600, change 10).
+    fields:
+      ieee:
+        description: "IEEE address of the PARASOLL sensor."
+        required: true
+        example: "0x04e3e5fffec73748"
+    # parallel so the per-device loop in parasoll_reconfigure_all and the
+    # join/announce automation can both call it without serialising the fleet.
+    mode: parallel
+    max: 30
+    trace:
+      stored_traces: 10
+    sequence:
+      - repeat:
+          for_each:
+            - endpoint: 2
+              cluster: ssIasZone
+              attribute: zoneStatus
+              minimum: 0
+            - endpoint: 1
+              cluster: genPowerCfg
+              attribute: batteryPercentageRemaining
+              minimum: 3600
+              change: 10
+            - endpoint: 1
+              cluster: genPowerCfg
+              attribute: batteryVoltage
+              minimum: 3600
+              change: 10
+          sequence:
+            - action: mqtt.publish
+              data:
+                topic: zigbee2mqtt/bridge/request/device/reporting/configure
+                # reportable_change is omitted for zoneStatus (a bitmap) — it has
+                # no "change" key in the loop, matching the proven blueprint.
+                payload: >
+                  {"id": "{{ ieee }}",
+                   "endpoint": {{ repeat.item.endpoint }},
+                   "cluster": "{{ repeat.item.cluster }}",
+                   "attribute": "{{ repeat.item.attribute }}",
+                   "minimum_report_interval": {{ repeat.item.minimum }},
+                   "maximum_report_interval": 14400
+                   {%- if repeat.item.change is defined %},
+                   "reportable_change": {{ repeat.item.change }}
+                   {%- endif %}}
+            - delay:
+                milliseconds: 300
+
   parasoll_reconfigure_all:
     alias: "PARASOLL - Reconfigure All"
     description: >
@@ -102,6 +173,13 @@ script:
                 payload: '{"id": "{{ repeat.item.ieee }}"}'
             - delay:
                 milliseconds: 1500
+            # Clamp max reporting intervals to 14400 s AFTER configure, since
+            # configure re-applies the converter's factory 65000 s max.
+            - action: script.parasoll_enforce_intervals
+              data:
+                ieee: "{{ repeat.item.ieee }}"
+            - delay:
+                milliseconds: 500
 
 ################################################################
 ## Automations
@@ -113,11 +191,14 @@ automation:
     trace:
       stored_traces: 10
     description: >
-      Reconfigures PARASOLL sensors only when the Z2M bridge/devices binding
-      state shows a gap.  Three invariants are checked on every trigger:
-        • ssIasZone bound on ep1       — device will send contact-state reports
+      Reconfigures PARASOLL sensors only when the Z2M bridge/devices state shows
+      a gap.  Four invariants are checked on every trigger:
+        • ssIasZone bound on ep2       — device will send contact-state reports
         • genPollCtrl NOT bound on ep1 — no aggressive check-in → no battery drain
         • genPowerCfg has configured reportings — battery/voltage actively reported
+        • max reporting interval ≤ 14400 s on zoneStatus + battery attrs —
+          device reports often enough to never be marked offline (the actual
+          drop-off fix; without it the factory 65000 s default applies)
       Triggers:
         • device_interview — brand-new join (always reconfigures; no bindings yet)
         • device_announce  — re-join / reboot (reconfigures only if bridge shows gap)
@@ -246,11 +327,14 @@ automation:
 
       # ── Determine whether reconfiguration is actually needed ──────────────────
       # Parse the bridge/devices payload to find this device and inspect endpoints.
-      # Three invariants must hold for the device to be considered fully configured:
+      # Four invariants must hold for the device to be considered fully configured:
       #   _ias_ok      — ssIasZone is bound on ep2 (PARASOLL IAS zone cluster is on
       #                  endpoint 2, confirmed by Z2M Bind tab "Source endpoint 2")
       #   _pollctrl_ok — genPollCtrl is NOT bound on ep1 (no aggressive check-in)
       #   _power_ok    — genPowerCfg has at least one configured reporting on ep1
+      #   _interval_ok — max reporting interval ≤ 14400 s on zoneStatus (ep2) AND
+      #                  on both battery attrs (ep1); false means the factory
+      #                  65000 s default is still in effect → device drops off
       # device_interview always reconfigures (fresh join: no bindings exist yet).
       # If bridge/devices times out or device is absent, defaults to true (safe).
       - variables:
@@ -283,16 +367,50 @@ automation:
             {% else %}
               []
             {% endif %}
+          # Full reporting objects (cluster + attribute + intervals) for the
+          # _interval_ok check below.  _ep1_reportings above keeps only the
+          # cluster names and is used solely for _power_ok.
+          _ep1_reportings_full: >
+            {% if _z2m_device %}
+              {{ _z2m_device.get('endpoints', {}).get('1', {}).get('configured_reportings', []) }}
+            {% else %}
+              []
+            {% endif %}
+          _ep2_reportings_full: >
+            {% if _z2m_device %}
+              {{ _z2m_device.get('endpoints', {}).get('2', {}).get('configured_reportings', []) }}
+            {% else %}
+              []
+            {% endif %}
           _ias_ok: "{{ 'ssIasZone' in _ep2_bindings }}"
           _pollctrl_ok: "{{ 'genPollCtrl' not in _ep1_bindings }}"
           _power_ok: "{{ 'genPowerCfg' in _ep1_reportings }}"
+          _interval_ok: >
+            {% set ns = namespace(zone=false, bpct=false, bv=false) %}
+            {% for r in _ep2_reportings_full %}
+              {% if r.cluster == 'ssIasZone' and r.attribute == 'zoneStatus'
+                    and r.maximum_report_interval | int(99999) <= 14400 %}
+                {% set ns.zone = true %}
+              {% endif %}
+            {% endfor %}
+            {% for r in _ep1_reportings_full %}
+              {% if r.cluster == 'genPowerCfg' and r.attribute == 'batteryPercentageRemaining'
+                    and r.maximum_report_interval | int(99999) <= 14400 %}
+                {% set ns.bpct = true %}
+              {% endif %}
+              {% if r.cluster == 'genPowerCfg' and r.attribute == 'batteryVoltage'
+                    and r.maximum_report_interval | int(99999) <= 14400 %}
+                {% set ns.bv = true %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.zone and ns.bpct and ns.bv }}
           _needs_configure: >
             {% if trigger.id == 'bridge_event' and trigger.payload_json.type == 'device_interview' %}
               true
             {% elif _z2m_device is none %}
               true
             {% else %}
-              {{ not _ias_ok or not _pollctrl_ok or not _power_ok }}
+              {{ not _ias_ok or not _pollctrl_ok or not _power_ok or not _interval_ok }}
             {% endif %}
           # Notification cooldown: suppress within 1 h of last configure attempt.
           # Store format: <last4_ieee>:<mod_hour>,...  (wraps every ~416 days).
@@ -369,6 +487,13 @@ automation:
             timeout:
               seconds: 60
             continue_on_timeout: true
+
+          # Clamp max reporting intervals to 14400 s AFTER configure, since
+          # configure re-applies the converter's factory 65000 s max.  This is
+          # the actual drop-off fix (Koenkk/zigbee2mqtt#22579).
+          - action: script.parasoll_enforce_intervals
+            data:
+              ieee: "{{ _ieee }}"
 
           # ── Update persistent store (gates notification cooldown) ───────────────
           # Always stamp the device after a configure attempt so _can_notify

--- a/tests/test_parasoll_configure_state.py
+++ b/tests/test_parasoll_configure_state.py
@@ -4,6 +4,12 @@ from pathlib import Path
 
 
 PARASOLL_PATH = Path(__file__).resolve().parents[1] / "packages" / "parasoll_fix.yaml"
+CONVERTER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "zigbee2mqtt"
+    / "external_converters"
+    / "parasoll.js"
+)
 
 
 def test_parasoll_configure_state_uses_csv_within_ha_input_text_limit() -> None:
@@ -62,3 +68,51 @@ def test_parasoll_ias_ok_checks_ep2_not_ep1() -> None:
     assert "'ssIasZone' in _ep2_bindings" in text
     # Ensure we are NOT using ep1 for the IAS check
     assert "'ssIasZone' in _ep1_bindings" not in text
+
+
+def test_parasoll_enforce_intervals_clamps_max_to_14400() -> None:
+    # The actual drop-off fix (Koenkk/zigbee2mqtt#22579): the factory max report
+    # interval of 65000 s lets sleepy sensors be marked offline.  The enforce
+    # script must clamp it to 14400 s via Z2M's reporting/configure request.
+    text = PARASOLL_PATH.read_text(encoding="utf-8")
+
+    assert "parasoll_enforce_intervals:" in text
+    assert "zigbee2mqtt/bridge/request/device/reporting/configure" in text
+    assert '"maximum_report_interval": 14400' in text
+
+
+def test_parasoll_enforce_intervals_covers_all_three_attributes() -> None:
+    # zoneStatus on ep2 (min 0) plus both battery attrs on ep1 must be clamped.
+    text = PARASOLL_PATH.read_text(encoding="utf-8")
+
+    assert "attribute: zoneStatus" in text
+    assert "attribute: batteryPercentageRemaining" in text
+    assert "attribute: batteryVoltage" in text
+    assert "cluster: ssIasZone" in text
+    assert "cluster: genPowerCfg" in text
+
+
+def test_parasoll_enforce_intervals_invoked_by_script_and_automation() -> None:
+    # Both the bulk reconfigure script and the join/announce automation must call
+    # the shared enforce script so already-joined and newly-joined sensors converge.
+    text = PARASOLL_PATH.read_text(encoding="utf-8")
+
+    assert text.count("script.parasoll_enforce_intervals") >= 2
+
+
+def test_parasoll_needs_configure_checks_reporting_interval() -> None:
+    # The interval must be a configuration invariant, otherwise already-joined
+    # devices at the factory 65000 s default would never be reconfigured.
+    text = PARASOLL_PATH.read_text(encoding="utf-8")
+
+    assert "_interval_ok" in text
+    assert "not _interval_ok" in text
+
+
+def test_parasoll_converter_binds_ssiaszone_on_endpoint_2() -> None:
+    # bindCluster without endpointNames lands on the wrong (non-IAS) endpoint and
+    # is a no-op; PARASOLL's ssIasZone cluster is on ep2.  Mirrors upstream E2013.
+    text = CONVERTER_PATH.read_text(encoding="utf-8")
+
+    assert "deviceEndpoints" in text
+    assert 'endpointNames: ["2"]' in text

--- a/zigbee2mqtt/external_converters/parasoll.js
+++ b/zigbee2mqtt/external_converters/parasoll.js
@@ -1,11 +1,20 @@
 /**
  * IKEA PARASOLL (E2013) — patched external converter for Z2M 2.x
  *
- * Fixes two issues tracked in https://github.com/Koenkk/zigbee2mqtt/issues/22579:
- *  1. Battery drain: genPollCtrl cluster is intentionally excluded; the stock
- *     converter sets aggressive check-in intervals that drain the battery.
- *  2. Dropping off-network: explicitly binds the ssIasZone cluster so the
- *     device doesn't silently stop sending contact state changes after hours.
+ * Addresses the issues tracked in https://github.com/Koenkk/zigbee2mqtt/issues/22579:
+ *  1. Battery drain: genPollCtrl cluster is intentionally excluded; binding it
+ *     writes an aggressive check-in interval. Most of the measured drain in the
+ *     thread came from rejoin loops triggered by (2) below, so fixing (2) is the
+ *     bigger lever.
+ *  2. Stuck/dropped state: binds the ssIasZone cluster on endpoint 2 (a
+ *     regression had removed it) so the device keeps sending contact-state
+ *     changes, and sets zoneStatus min reporting to 0 so rapid open/close pairs
+ *     are never dropped.
+ *  3. Dropping off-network (the actual availability fix): the factory maximum
+ *     reporting interval of 65000 s (~18 h) is longer than any sane availability
+ *     timeout, so a healthy sleepy device gets marked offline. This converter
+ *     cannot clamp that on its own — script.parasoll_enforce_intervals in
+ *     packages/parasoll_fix.yaml clamps max to 14400 s (4 h) per device.
  *
  * Placement: /config/zigbee2mqtt/external_converters/parasoll.js
  * Z2M 2.x scans this folder automatically — no configuration.yaml entry needed.
@@ -17,6 +26,7 @@ const {
   battery,
   identify,
   bindCluster,
+  deviceEndpoints,
 } = require("zigbee-herdsman-converters/lib/modernExtend");
 
 module.exports = {
@@ -25,16 +35,27 @@ module.exports = {
   vendor: "IKEA of Sweden",
   description: "PARASOLL door/window sensor (patched)",
   extend: [
-    // Explicitly bind ssIasZone — the missing binding is the root cause of
-    // sensors silently stopping state reports after a few hours.
-    bindCluster({ cluster: "ssIasZone", clusterType: "input" }),
+    // PARASOLL's ssIasZone cluster lives on endpoint 2, so the endpoint map
+    // must be declared before bindCluster can target it by name.
+    deviceEndpoints({ endpoints: { "1": 1, "2": 2 } }),
+    // Explicitly bind ssIasZone on endpoint 2 — the missing binding (a
+    // regression in herdsman-converters PR #7220) is the root cause of sensors
+    // silently stopping state reports after a few hours. Without
+    // endpointNames: ["2"] this binds the wrong (non-IAS) endpoint and is a
+    // no-op; this mirrors the upstream stock E2013 definition.
+    bindCluster({
+      cluster: "ssIasZone",
+      clusterType: "input",
+      endpointNames: ["2"],
+    }),
     iasZoneAlarm({
       zoneType: "contact",
       zoneAttributes: ["alarm_1"],
-      // Required so configure sets up zoneStatus attribute reporting on ep2.
-      // Without this, sensors that have never had the interval bounded will
-      // silently oversleep at the factory default of 65000 s (~18 h) and drop
-      // off the network. The blueprint automation then tightens max to 14400 s.
+      // Sets up zoneStatus reporting on ep2 with min=0 (so rapid open/close
+      // pairs are never dropped). NOTE: this also writes the factory max of
+      // 65000 s (~18 h), which is longer than any sane availability timeout and
+      // is what lets sensors get marked offline. The script.parasoll_enforce_intervals
+      // automation (packages/parasoll_fix.yaml) then clamps max down to 14400 s.
       zoneStatusReporting: true,
     }),
     identify({ isSleepy: true }),


### PR DESCRIPTION
Fixes #791.

## Problem

Our PARASOLL setup implemented the **2024 external-converter theory** of [Koenkk/zigbee2mqtt#22579](https://github.com/Koenkk/zigbee2mqtt/issues/22579) (unbind `genPollCtrl`, re-bind `ssIasZone`) but never applied the fix the 606-comment thread actually converged on: clamping the factory **65000 s (~18 h)** `maximum_report_interval` down to **14400 s (4 h)**.

At 65000 s a healthy sleepy sensor reports too infrequently and gets marked **offline** by the availability check; the resulting rejoin loops are the main battery drain. Our automation only published `device/unbind` + `device/configure` (which *re-asserts* 65000 s) and never `device/reporting/configure`.

Verified against `zigbee-herdsman-converters`: `iasZoneAlarm({zoneStatusReporting: true})` → `zoneStatus {min 0, max 65000}`; `battery({voltageReporting: true})` → `{min 3600, max 65000, change 10}`.

## Changes

- **`packages/parasoll_fix.yaml`**
  - New shared `script.parasoll_enforce_intervals` (fields: `ieee`) that publishes `bridge/request/device/reporting/configure` with `maximum_report_interval: 14400` for `zoneStatus` (ep2, min 0, no reportable_change), `batteryPercentageRemaining` and `batteryVoltage` (ep1, min 3600, change 10). Values mirror jhenkens' proven blueprint.
  - Called after every `device/configure` in both `parasoll_reconfigure_all` and the join/announce automation (configure re-applies 65000 s, so the clamp must run after).
  - New `_interval_ok` invariant: a device whose `zoneStatus`/battery max is still > 14400 s is now treated as needing reconfigure, so already-joined sensors converge — not just fresh joins.
  - Fixed docstring: `ssIasZone` is checked on **ep2**, not ep1.
- **`zigbee2mqtt/external_converters/parasoll.js`**
  - Declare `deviceEndpoints({endpoints: {"1": 1, "2": 2}})` and bind `ssIasZone` with `endpointNames: ["2"]`. The prior `bindCluster` had no endpoint and was a no-op (the cluster is on ep2). Matches the now-fixed upstream stock E2013 definition.
- **`tests/test_parasoll_configure_state.py`** — regression tests: 14400 clamp present, all three attributes covered, enforce script invoked by both script and automation, interval is a configure invariant, converter binds on ep2.

## Validation

- `uv run --with pytest pytest` → **528 passed**.
- yamllint (CI relaxed config) clean; `node --check` on the converter clean.
- Rendered each `reporting/configure` payload from the real YAML (folded scalar + Jinja whitespace) and confirmed valid JSON; verified `_interval_ok` returns False at 65000 s / True at 14400 s.

## Deployment note

Sleepy devices apply the queued `reporting/configure` on next wake; `script.parasoll_reconfigure_all` can nudge the whole fleet. No re-pairing required.