### PR TITLE
Fix Inovelli reset replay test for Tiki Room/Deck Switch binding (#790)

### DIFF
--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -311,6 +311,13 @@ def test_reset_script_replays_current_live_group_memberships_and_bindings() -> N
             None,
             ("genLevelCtrl", "genOnOff"),
         ),
+        (
+            "Tiki Room/Deck Switch",
+            2,
+            "Deck/Tiki Room Door",
+            11,
+            ("genLevelCtrl", "genOnOff"),
+        ),
     }
 
     assert _parse_group_memberships(block) == expected_memberships


### PR DESCRIPTION
## Problem

`develop` has been red since [#790](https://github.com/rtclauss/hass-config/pull/790) ("Add Tiki Room/Deck Switch to Inovelli reset config", f96598e3). The last green commit was d4718ec7.

`tests/test_zigbee_zwave_inovelli_reset_replay.py::test_reset_script_replays_current_live_group_memberships_and_bindings` parses the `reset_inovelli_switches` script and asserts its bindings equal a hand-maintained `expected_bindings` set. #790 added the binding to the live script but not to the test mirror:

```
Extra items in the left set:
('Tiki Room/Deck Switch', 2, 'Deck/Tiki Room Door', 11, ('genLevelCtrl', 'genOnOff'))
```

## Fix

Add the matching tuple to `expected_bindings`. Verified against the live config (`packages/zigbee_zwave.yaml:2600`):

```yaml
- from: "Tiki Room/Deck Switch"
  from_endpoint: 2
  to: "Deck/Tiki Room Door"
  to_endpoint: 11
  clusters:
    - genLevelCtrl
    - genOnOff
```

This is a real, intentional binding from #790 — the test just wasn't updated. Group memberships already matched (only the bindings set was out of sync).

## Validation

`uv run --with pytest pytest` → **528 passed, 0 failed** (was 527/1). This restores `develop` to green.