### PR TITLE
Add per-device rate limit to PARASOLL auto-reconfigure

### DIFF
--- a/packages/parasoll_fix.yaml
+++ b/packages/parasoll_fix.yaml
@@ -208,6 +208,10 @@ automation:
         • contact_change   — PARASOLL state change (reconfigures only if bridge shows
                              genPollCtrl bound or power reporting absent; active contact
                              report already proves IAS zone is enrolled)
+      Rate limit: the first action stops the run if this device had a configure
+      attempt within the last hour, so a rejoin-looping or repeatedly-failing
+      sensor can trigger at most one configure/hour instead of flooding the
+      coordinator with binds (the failure mode that took the network down).
       Notifications gated by 1 h since last successful configure per device;
       contact_change is always silent.
     mode: queued
@@ -278,6 +282,56 @@ automation:
             {% endif %}
           {% endif %}
     action:
+      # ── Rate limit / circuit breaker (per device, ~1 configure per hour) ──────
+      # FIRST action, before any delay/MQTT wait/bind: if this device already had
+      # a configure attempt within the current hour bucket, stop immediately.
+      # input_text.parasoll_configure_state is stamped on every configure attempt
+      # (success, failure, or timeout), so a device that is rejoin-looping or
+      # repeatedly failing to bind is throttled to at most one configure per hour
+      # instead of firing on every announce — which is what previously let a
+      # single looping sensor flood the coordinator with timing-out binds and
+      # overflow this queue. Skipped runs exit in milliseconds, so the queue
+      # drains instead of piling up. A genuinely drifted device still self-heals;
+      # it just retries at most hourly. Fresh joins (no prior stamp) are never
+      # throttled. This reuses the same store + hour granularity as the
+      # notification cooldown below.
+      - variables:
+          _rl_ieee: >
+            {% if trigger.id == 'bridge_event' %}
+              {{ trigger.payload_json.data.ieee_address }}
+            {% else %}
+              {% set ns = namespace(value='') %}
+              {% for id_tuple in device_attr(trigger.entity_id, 'identifiers') | list %}
+                {% if id_tuple[0] == 'mqtt' %}
+                  {% set ns.value = id_tuple[1] | replace('zigbee2mqtt_', '') %}
+                {% endif %}
+              {% endfor %}
+              {{ ns.value }}
+            {% endif %}
+          _rl_prev_h: >
+            {% set raw = states('input_text.parasoll_configure_state') | trim %}
+            {% set key = _rl_ieee[-4:] %}
+            {% set ns = namespace(h=none) %}
+            {% if raw.startswith('{') %}
+              {% set ns.h = (raw | from_json).get(key) %}
+            {% else %}
+              {% for item in raw.split(',') if ':' in item %}
+                {% set parts = item.split(':') %}
+                {% if parts[0] | trim == key %}
+                  {% set ns.h = parts[1] | int(default=none) %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+            {{ ns.h }}
+          _rl_hours_since: >
+            {% if _rl_prev_h is none %}
+              9999
+            {% else %}
+              {{ ((now().timestamp() / 3600) | int % 10000 - _rl_prev_h | int) % 10000 }}
+            {% endif %}
+      - condition: template
+        value_template: "{{ _rl_hours_since | int >= 1 }}"
+
       # Join/announce: wait for Z2M to finish interview setup.
       # Contact-change: no delay — device is awake right now; every ms counts
       # before it goes back to sleep and Z2M loses the unbind command.

--- a/tests/test_parasoll_configure_state.py
+++ b/tests/test_parasoll_configure_state.py
@@ -103,6 +103,30 @@ def test_parasoll_needs_configure_checks_reporting_interval() -> None:
     assert "not _interval_ok" in text
 
 
+def test_parasoll_auto_reconfigure_has_per_device_rate_limit() -> None:
+    # A rejoin-looping sensor previously fired the automation on every announce,
+    # flooding the coordinator with timing-out binds and overflowing the queue.
+    # The first action must throttle each device to ~1 configure/hour.
+    text = PARASOLL_PATH.read_text(encoding="utf-8")
+
+    assert "_rl_hours_since" in text
+    assert '"{{ _rl_hours_since | int >= 1 }}"' in text
+
+
+def test_parasoll_rate_limit_runs_before_any_configure() -> None:
+    # The gate is only a circuit breaker if it exits BEFORE the delay, the
+    # bridge/devices wait, and the bind/configure MQTT requests.
+    text = PARASOLL_PATH.read_text(encoding="utf-8")
+
+    gate = text.index("_rl_hours_since")
+    # rindex: the automation's own unbind/configure (the script's appear earlier
+    # in the file, before the automation block and thus before the gate).
+    assert gate < text.rindex("zigbee2mqtt/bridge/request/device/unbind")
+    assert gate < text.rindex("zigbee2mqtt/bridge/request/device/configure")
+    # And before the action-block delay that waits on sleepy devices.
+    assert gate < text.index("5000 if trigger.id == 'bridge_event'")
+
+
 def test_parasoll_matches_stock_model_not_patched_converter() -> None:
     # The external converter has been removed; devices report the stock model
     # description "PARASOLL door/window sensor".  Matching the old "(patched)"


### PR DESCRIPTION
## Why

A live incident: one or two PARASOLL sensors got stuck in a **rejoin loop** (network address changing every ~17s, interview/bind failing). The auto-reconfigure automation triggers on **every** `zigbee2mqtt/bridge/event`, so each rejoin fired a run that issued unbind/configure/reporting binds — each timing out at 15s. That:
- overflowed the `queued`/`max: 30` automation (`failed_max_runs`), and
- saturated the coordinator's ZDO/bind request queue, which then starved **healthy** sensors too (a previously-fixed sensor started failing binds).

One looping device snowballed into a network-wide meltdown.

## Change

Add a circuit breaker as the **first action** of `parasoll_auto_reconfigure_on_join_or_announce`: if the device already had a configure attempt within the current hour bucket, the run **stops immediately** — before any delay, the `bridge/devices` wait, or any bind/configure MQTT request.

- Throttles a looping or repeatedly-failing device to **≤ 1 configure/hour**.
- Skipped runs exit in **milliseconds**, so the queue drains instead of piling up → no more `failed_max_runs`.
- **Fresh joins** (no prior stamp → `hours_since = 9999`) and **converged devices** (never stamp) are unaffected.
- Reuses the existing `input_text.parasoll_configure_state` stamp + hour granularity (same store the notification cooldown already uses) — **no new helper**.

## Validation

- Rendered the gate against three cases: not-in-store → proceed; configured this hour → **blocked**; configured ~2h ago → proceed.
- `uv run --with pytest pytest` → **530 passed** (2 new rate-limit tests: gate exists; gate runs before any unbind/configure/delay).
- yamllint (CI relaxed config) clean.

## Deployment note

The automation is currently **disabled** on the live system (during the incident). YAML automations restore their last on/off state on reload, so deploying this will **not** re-enable it. Re-enable only after the two looping sensors (`5b1c4a`, `da0b`) are force-removed and cleanly re-paired and the network is quiet.