### PR TITLE
Fix #797 flight airport delay numeric template

### DIFF
--- a/packages/flight_status.yaml
+++ b/packages/flight_status.yaml
@@ -613,15 +613,19 @@ template:
         unique_id: next_travel_flight_airport_delay
         default_entity_id: sensor.next_travel_flight_airport_delay
         unit_of_measurement: "min"
+        availability: >-
+          {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') | default('', true) | upper %}
+          {% set tracked = states('text.flightradar24_airport_track') | upper %}
+          {{ origin not in ['', 'UNKNOWN', 'UNAVAILABLE']
+             and origin == tracked
+             and has_value('sensor.flightradar24_airport_departures_delay_average') }}
         state: >-
           {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') | default('') | upper %}
           {% set tracked = states('text.flightradar24_airport_track') | upper %}
-          {% if origin in ['', 'UNKNOWN', 'UNAVAILABLE'] %}
-            unknown
-          {% elif origin == tracked %}
+          {% if origin == tracked %}
             {{ states('sensor.flightradar24_airport_departures_delay_average') }}
           {% else %}
-            unavailable
+            {{ none }}
           {% endif %}
         attributes:
           summary: >-

--- a/tests/test_flight_status_package.py
+++ b/tests/test_flight_status_package.py
@@ -48,6 +48,22 @@ def test_flight_status_package_exposes_normalized_display_sensors() -> None:
         assert attribute in text
 
 
+def test_airport_delay_sensor_never_emits_non_numeric_fallback_state() -> None:
+    text = _package_text()
+
+    sensor_start = text.index("unique_id: next_travel_flight_airport_delay")
+    sensor_start = text.rindex("      - name:", 0, sensor_start)
+    sensor_end = text.index("      - name: Next Travel Flight Destination Weather", sensor_start)
+    sensor_block = text[sensor_start:sensor_end]
+
+    assert "availability: >-" in sensor_block
+    assert "has_value('sensor.flightradar24_airport_departures_delay_average')" in sensor_block
+    assert "origin not in ['', 'UNKNOWN', 'UNAVAILABLE']" in sensor_block
+    assert "{{ states('sensor.flightradar24_airport_departures_delay_average') }}" in sensor_block
+    assert "unknown" not in sensor_block[sensor_block.index("state: >-") : sensor_block.index("attributes:")]
+    assert "unavailable" not in sensor_block[sensor_block.index("state: >-") : sensor_block.index("attributes:")]
+
+
 def test_flight_status_keeps_calendar_fallback_when_live_api_is_unavailable() -> None:
     text = _package_text()
 


### PR DESCRIPTION
## Summary

Fixes #797 by making `sensor.next_travel_flight_airport_delay` unavailable when there is no active/trackable origin airport, instead of emitting non-numeric fallback strings from a numeric template sensor.

## Runtime evidence

Nightly Trace Review found live HA logging:

- `Received invalid sensor state: unknown for entity sensor.next_travel_flight_airport_delay, expected a number`
- Live state showed `sensor.next_travel_flight` was `none` with blank `origin_code`, while the airport delay source sensor was numeric.

## Changes

- Added an `availability` guard requiring a valid origin, matching FlightRadar24 tracked airport, and a valid delay-average source.
- Kept the numeric sensor state path numeric-only.
- Added a regression test preventing `unknown`/`unavailable` fallback strings in the numeric state template.

## Validation

- `uv run --with pytest pytest tests/test_flight_status_package.py`
- `uv run --with pytest pytest`
- `uvx yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `podman run --rm -v "$TMP_CONFIG:/config" ghcr.io/home-assistant/home-assistant:2026.5.1 python -m homeassistant --config /config --script check_config` with CI-style placeholder secrets in a temporary config copy
