### PR TITLE
Fix #797 flight airport delay numeric state

### DIFF
--- a/packages/flight_status.yaml
+++ b/packages/flight_status.yaml
@@ -613,16 +613,15 @@ template:
         unique_id: next_travel_flight_airport_delay
         default_entity_id: sensor.next_travel_flight_airport_delay
         unit_of_measurement: "min"
-        state: >-
+        availability: >-
           {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') | default('') | upper %}
           {% set tracked = states('text.flightradar24_airport_track') | upper %}
-          {% if origin in ['', 'UNKNOWN', 'UNAVAILABLE'] %}
-            unknown
-          {% elif origin == tracked %}
-            {{ states('sensor.flightradar24_airport_departures_delay_average') }}
-          {% else %}
-            unavailable
-          {% endif %}
+          {% set delay = states('sensor.flightradar24_airport_departures_delay_average') %}
+          {{ origin not in ['', 'UNKNOWN', 'UNAVAILABLE']
+             and origin == tracked
+             and delay not in ['', 'unknown', 'unavailable'] }}
+        state: >-
+          {{ states('sensor.flightradar24_airport_departures_delay_average') | int(0) }}
         attributes:
           summary: >-
             {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') | default('') | upper %}

--- a/tests/test_issue_797_flight_airport_delay.py
+++ b/tests/test_issue_797_flight_airport_delay.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FLIGHT_STATUS_PATH = ROOT / "packages" / "flight_status.yaml"
+
+
+def _airport_delay_sensor_block() -> str:
+    text = FLIGHT_STATUS_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"      - name: Next Travel Flight Airport Delay\n(?P<block>.*?)(?=\n      - name: )",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None
+    return match.group("block")
+
+
+def test_airport_delay_numeric_state_has_availability_guard() -> None:
+    block = _airport_delay_sensor_block()
+
+    assert "availability: >-" in block
+    assert "origin not in ['', 'UNKNOWN', 'UNAVAILABLE']" in block
+    assert "origin == tracked" in block
+    assert "delay not in ['', 'unknown', 'unavailable']" in block
+
+
+def test_airport_delay_state_template_is_numeric_only() -> None:
+    block = _airport_delay_sensor_block()
+    state_match = re.search(
+        r"\n        state: >-\n(?P<state>.*?)(?=\n        attributes:)",
+        block,
+        re.DOTALL,
+    )
+    assert state_match is not None
+    state_template = state_match.group("state")
+
+    assert "unknown" not in state_template
+    assert "unavailable" not in state_template
+    assert "states('sensor.flightradar24_airport_departures_delay_average') | int(0)" in state_template


### PR DESCRIPTION
## Summary

- move the no-flight, mismatched-airport, and missing-source cases for `sensor.next_travel_flight_airport_delay` into `availability`
- keep the numeric template sensor `state` numeric-only by rendering the FlightRadar24 average delay as an integer
- add regression coverage so text fallback states are not reintroduced into the numeric state template

Fixes #797.

## Runtime evidence

Nightly Trace Review found live Home Assistant logging:

`Received invalid sensor state: unknown for entity sensor.next_travel_flight_airport_delay, expected a number`

At review time, `sensor.next_travel_flight` was `none`, `text.flightradar24_airport_track` was `MSP`, `sensor.next_travel_flight_airport_delay` was `unknown`, and FlightRadar24 departure delay source sensors were numeric. The deployed live `packages/flight_status.yaml` matched the repo worktree before this fix.

## Validation

- `uv run --with pytest pytest tests/test_issue_797_flight_airport_delay.py tests/test_inky_displays_package.py -q` -> 19 passed
- `uv run --with yamllint yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}' packages/flight_status.yaml` -> passed
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/flight_status.yaml --strict` -> no findings
- `uv run --with pytest pytest` -> 532 passed
- `git diff --check` -> passed

## Not run / blocked

- Home Assistant container `check_config`: first run reached HA but failed on missing local placeholder secrets; after applying the CI placeholder-secret setup, Podman repeatedly refused its VM socket (`127.0.0.1:53019: connect: connection refused`). The Podman VM was stopped before ending the run.
