### PR TITLE
Stop pinning stale Spotify provider instance (fixes silent bedtime music)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,11 @@
 - Preserve color semantics: red means urgent/exception on the owner-suite board; yellow means emphasis/hospitality on the future office board.
 - Test renderer changes with `python3 -m pytest tests/test_inky_display_renderer.py tests/test_inky_display_service.py tests/test_inky_displays_package.py`. For physical changes, verify on the Pi Zero W and confirm the panel visibly changes, not just that `show()` returns.
 
+## Media / Music Assistant
+- Use `docs/music_assistant.md` as the source of truth before changing Music Assistant / Sonos playback, sync groups, bedtime/wake audio wiring, or Spotify URIs.
+- Never hardcode a `spotify--<instance>` provider-instance id; use bare `spotify:playlist:<id>` URIs and let MA route to the live instance (it changes on every MA re-onboard).
+- Always target the MA `*_sonos_2` entities (not bare `*_sonos`); set group volume on individual member entities, never the group entity.
+
 ## Local Runtime Targets
 - Keep machine-local runtime verification targets in `AGENTS.local.md`.
 - Do not commit `AGENTS.local.md` unless explicitly asked.

--- a/docs/music_assistant.md
+++ b/docs/music_assistant.md
@@ -1,0 +1,69 @@
+# Music Assistant & Sonos
+
+Source of truth for Music Assistant (MA) / Sonos playback mechanics: entity
+conventions, sync groups, Spotify URIs, volume, and re-onboard recovery.
+Behavior (what plays when) is owned by `specs/alarm_wakeup.allium` and
+`specs/night_routines.allium`; this doc covers the underlying MA/Sonos wiring.
+
+## Entity conventions
+
+- `media_player.*_sonos_2` is **Music Assistant's** player entity for each Sonos
+  speaker — NOT "Sonos v2". MA creates a `_2` entity for every Sonos it manages.
+  **Always target `_2` entities** in automations/scripts. The bare `*_sonos`
+  entities are the direct Sonos integration and are disabled.
+- Sync groups (MA Sonos sync-group players, renamed from MA defaults):
+  - `media_player.ma_group_everywhere` — bedroom, bathroom, office, den, tiki
+    (default whole-house target)
+  - `media_player.ma_group_guest` — bedroom, bathroom (used when guest mode is on)
+
+## NEVER hardcode a Spotify provider-instance id
+
+MA's internal Spotify URIs look like `spotify--<instance>://playlist/<id>`
+(e.g. `spotify--q7XNdM9r://...`). **`<instance>` changes whenever the Spotify
+provider is re-added or MA re-onboards.** Do not pin it anywhere in config.
+
+- Use the bare **`spotify:playlist:<id>`** form and let MA route to the live
+  instance. `script.music_assistant_play_item` normalizes
+  `spotify:user:<u>:playlist:<id>` → `spotify:playlist:<id>` and passes it through
+  unpinned.
+- History: a hardcoded `spotify--Tviw9k66` in `packages/media_player.yaml` went
+  stale after a re-onboard (live instance became `spotify--q7XNdM9r`), so every
+  Spotify bedtime/wake item resolved to **"No playable items found"** while the
+  library still listed the playlists with full track art. The playlists were
+  never dead — the instance id was. Fixed by de-pinning (PR #807, issue #802).
+- A stale `spotify--<instance>` provider-mapping can linger in the MA **library
+  DB** even when Settings → Providers shows only the new instance. It is harmless
+  once nothing references it; a Spotify library re-sync scrubs it cosmetically.
+
+## MA re-onboard recovery runbook
+
+A re-onboard (new MA config entry) can, in one event:
+1. **Purge the sync-group entities** (`ma_group_everywhere` / `ma_group_guest`).
+2. **Drop the entity_id renames** (groups come back as `everywhere_sonos` /
+   `guest_sonos`).
+3. Leave the **Spotify library temporarily unsynced** — personal playlists
+   resolve empty until the sync finishes (editorial + radio keep working).
+4. **Change the Spotify provider-instance id** (see section above).
+
+Recovery steps:
+1. `homeassistant.reload_config_entry` on the MA entry → re-registers any sync
+   group MA still has (returns under the **default** id `everywhere_sonos` /
+   `guest_sonos`).
+2. Recreate any group MA actually lost in the MA UI (Settings → Players → add
+   group): Everywhere = the 5 speakers above; Guest = bedroom + bathroom.
+3. Rename back: `everywhere_sonos` → `ma_group_everywhere`,
+   `guest_sonos` → `ma_group_guest` (entity-registry rename; updates no YAML, so
+   keep the names exact).
+4. Let the Spotify library finish syncing; personal playlists self-heal.
+5. Confirm no config pins a `spotify--<instance>` id — bare `spotify:` URIs only.
+
+## Group volume
+
+For group playback, set volume on the **individual member `_2` entities**, never
+on the group entity. Proportional scaling rounds to 0 below ~8%.
+
+## MA WebSocket API
+
+The MA server WS API requires a Home Assistant auth token that is not exposed to
+tooling (every command returns "Authentication required"), so **group creation
+cannot be automated** — recreate groups in the MA web UI.

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -818,12 +818,7 @@ script:
       raw_enqueue: "{{ enqueue | default('replace') }}"
       normalized_item: >-
         {%- set s = ('spotify:' ~ raw_item.split(':')[3] ~ ':' ~ raw_item.split(':')[4]) if (raw_item.startswith('spotify:user:') and (raw_item.split(':') | length) == 5) else raw_item -%}
-        {%- if s.startswith('spotify:') and not s.startswith('spotify--') -%}
-          {%- set parts = s.split(':') -%}
-          {{ 'spotify--Tviw9k66://' ~ parts[1] ~ '/' ~ parts[2] if parts | length >= 3 else s }}
-        {%- else -%}
-          {{ s }}
-        {%- endif %}
+        {{ s }}
     sequence:
       - choose:
           - conditions:
@@ -1792,7 +1787,7 @@ script:
               "https://ice1.somafm.com/missioncontrol-128-mp3",
               "https://ice1.somafm.com/spacestation-128-mp3",
               "https://ice1.somafm.com/vaporwaves-128-mp3",
-              "spotify--Tviw9k66://playlist/2I2cwYxeuLbIXaNRccMViZ"
+              "spotify:playlist:2I2cwYxeuLbIXaNRccMViZ"
               ] -%}
             {% set pindex = (range(0, (plists | length))|random) -%}
             {{ plists[pindex] }}

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -60,8 +60,11 @@ def test_music_assistant_item_helper_normalizes_spotify_uris() -> None:
     assert "Music Assistant URI, open.spotify.com URL, or plain item name" in block
     assert "raw_media_type" in block
     assert "music_assistant.play_media" in block
-    assert "spotify--Tviw9k66://" in block
-    assert "s.startswith('spotify:')" in block
+    # Must NOT pin a Spotify provider-instance id: it changes on every MA
+    # re-onboard and goes stale (see docs/music_assistant.md). Use bare spotify: URIs.
+    assert "spotify--" not in block
+    # Still normalizes spotify:user:<u>:playlist:<id> -> bare spotify:playlist:<id>
+    assert "raw_item.startswith('spotify:user:')" in block
     assert "raw_item.startswith('https://open.spotify.com/')" not in block
 
 


### PR DESCRIPTION
## Problem

After a Music Assistant re-onboard, Spotify bedtime/wake playback failed silently with `No playable items found`, even though the MA library listed the playlists with full track artwork.

Root cause: MA replaced its Spotify provider instance `spotify--Tviw9k66` with a new one (`spotify--q7XNdM9r`), but `packages/media_player.yaml` **hardcoded the old instance ID**:

- `music_assistant_play_item` (L823) normalized every `spotify:…` item to `spotify--Tviw9k66://…`, forcing playback through the now-stale instance.
- One literal `spotify--Tviw9k66://playlist/…` entry sat in the bedtime rotation (L1795).

The playlists were never dead — the stale instance ID was. Confirmed: the same playlists resolve fine via `spotify--q7XNdM9r`, and bare `spotify:playlist:<id>` plays correctly.

## Fix

Stop pinning the provider instance — emit the bare `spotify:playlist:<id>` form and let MA route to whatever Spotify instance is live (re-onboard-proof).

- `music_assistant_play_item` normalizer: drop the `spotify--Tviw9k66://` rewrite, keep the `spotify:user:…:playlist:…` → `spotify:playlist:…` conversion.
- Bedtime rotation: de-pin the one literal entry.

## Follow-up

- The stale `Tviw9k66` provider-mapping remains in MA's library DB but is harmless once nothing references it; an optional Spotify library re-sync scrubs it.
- #801 (Lo-Fi Beats fallback) remains worthwhile as defense-in-depth.

Fixes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)
