### PR TITLE
Fix #805 Z2M availability aggregate template loop

### DIFF
--- a/packages/z2m_availability.yaml
+++ b/packages/z2m_availability.yaml
@@ -1883,6 +1883,171 @@ mqtt:
       payload_not_available: "offline"
 
 ################################################################
+## Group — explicit Z2M availability sources
+################################################################
+
+group:
+  z2m_availability_entities:
+    name: Z2M Availability Entities
+    entities:
+      - binary_sensor.z2m_bridge
+      - binary_sensor.z2m_arrival_sensor_availability
+      - binary_sensor.z2m_basement_bathroom_shower_availability
+      - binary_sensor.z2m_basement_bathroom_exhaust_availability
+      - binary_sensor.z2m_basement_bathroom_shower_switch_availability
+      - binary_sensor.z2m_basement_bathroom_tph_availability
+      - binary_sensor.z2m_basement_closet_tph_availability
+      - binary_sensor.z2m_basement_great_east_room_2_availability
+      - binary_sensor.z2m_basement_great_room_east_1_availability
+      - binary_sensor.z2m_basement_great_room_east_and_middle_switch_availability
+      - binary_sensor.z2m_basement_great_room_landing_switch_2_availability
+      - binary_sensor.z2m_basement_great_room_middle_1_availability
+      - binary_sensor.z2m_basement_great_room_middle_2_availability
+      - binary_sensor.z2m_basement_great_room_west_1_availability
+      - binary_sensor.z2m_basement_great_room_west_2_availability
+      - binary_sensor.z2m_basement_great_room_west_3_availability
+      - binary_sensor.z2m_basement_great_room_west_switch_availability
+      - binary_sensor.z2m_basement_landing_availability
+      - binary_sensor.z2m_basement_landing_1_availability
+      - binary_sensor.z2m_basement_landing_2_availability
+      - binary_sensor.z2m_basement_landing_switch_availability
+      - binary_sensor.z2m_basement_mouse_bucket_availability
+      - binary_sensor.z2m_basement_north_hallway_1_availability
+      - binary_sensor.z2m_basement_north_hallway_2_availability
+      - binary_sensor.z2m_basement_north_hallway_switch_availability
+      - binary_sensor.z2m_basement_overhead_outlet_availability
+      - binary_sensor.z2m_basement_stair_landing_availability
+      - binary_sensor.z2m_basement_sump_pump_availability
+      - binary_sensor.z2m_basement_tph_availability
+      - binary_sensor.z2m_basement_unfinished_leak_availability
+      - binary_sensor.z2m_basement_water_shutoff_availability
+      - binary_sensor.z2m_basement_window_availability
+      - binary_sensor.z2m_deck_flood_lights_availability
+      - binary_sensor.z2m_deck_kitchen_door_availability
+      - binary_sensor.z2m_deck_kitchen_door_light_availability
+      - binary_sensor.z2m_deck_string_availability
+      - binary_sensor.z2m_deck_tiki_room_door_availability
+      - binary_sensor.z2m_den_doors_availability
+      - binary_sensor.z2m_den_flood_1_availability
+      - binary_sensor.z2m_den_flood_2_availability
+      - binary_sensor.z2m_den_flood_switch_availability
+      - binary_sensor.z2m_den_lamp_availability
+      - binary_sensor.z2m_den_leather_chair_availability
+      - binary_sensor.z2m_den_motion_availability
+      - binary_sensor.z2m_den_sonos_controls_availability
+      - binary_sensor.z2m_dining_room_lamp_1_availability
+      - binary_sensor.z2m_dining_room_lamp_2_availability
+      - binary_sensor.z2m_dining_room_north_window_availability
+      - binary_sensor.z2m_dining_room_overhead_1_availability
+      - binary_sensor.z2m_dining_room_overhead_2_availability
+      - binary_sensor.z2m_dining_room_overhead_3_availability
+      - binary_sensor.z2m_dining_room_overhead_4_availability
+      - binary_sensor.z2m_dining_room_south_window_availability
+      - binary_sensor.z2m_dining_room_table_switch_availability
+      - binary_sensor.z2m_dining_room_wall_switch_availability
+      - binary_sensor.z2m_east_bed_button_availability
+      - binary_sensor.z2m_garage_back_door_availability
+      - binary_sensor.z2m_garage_overhead_switch_availability
+      - binary_sensor.z2m_garage_tph_availability
+      - binary_sensor.z2m_guest_bathroom_exhaust_availability
+      - binary_sensor.z2m_guest_bathroom_tph_availability
+      - binary_sensor.z2m_guest_bathroom_window_availability
+      - binary_sensor.z2m_guest_room_fan_switch_availability
+      - binary_sensor.z2m_guest_room_tph_availability
+      - binary_sensor.z2m_guest_room_window_availability
+      - binary_sensor.z2m_hall_button_availability
+      - binary_sensor.z2m_hall_foyer_switch_availability
+      - binary_sensor.z2m_hall_garage_entry_availability
+      - binary_sensor.z2m_hall_garage_laundry_switch_availability
+      - binary_sensor.z2m_hall_laundry_availability
+      - binary_sensor.z2m_hall_main_foyer_1_availability
+      - binary_sensor.z2m_hall_main_foyer_2_availability
+      - binary_sensor.z2m_hall_main_foyer_motion_availability
+      - binary_sensor.z2m_hall_stairway_availability
+      - binary_sensor.z2m_hall_transition_availability
+      - binary_sensor.z2m_hall_transition_switch_availability
+      - binary_sensor.z2m_hall_upstairs_1_availability
+      - binary_sensor.z2m_hall_upstairs_2_availability
+      - binary_sensor.z2m_hall_upstairs_linen_closet_tph_availability
+      - binary_sensor.z2m_hall_upstairs_motion_availability
+      - binary_sensor.z2m_hall_upstairs_switch_availability
+      - binary_sensor.z2m_kitchen_bay_light_availability
+      - binary_sensor.z2m_kitchen_bay_middle_window_availability
+      - binary_sensor.z2m_kitchen_bay_north_window_availability
+      - binary_sensor.z2m_kitchen_bay_south_window_availability
+      - binary_sensor.z2m_kitchen_bay_switch_availability
+      - binary_sensor.z2m_kitchen_deck_availability
+      - binary_sensor.z2m_kitchen_north_window_availability
+      - binary_sensor.z2m_kitchen_overhead_1_availability
+      - binary_sensor.z2m_kitchen_overhead_2_availability
+      - binary_sensor.z2m_kitchen_overhead_3_availability
+      - binary_sensor.z2m_kitchen_overhead_4_availability
+      - binary_sensor.z2m_kitchen_overhead_5_availability
+      - binary_sensor.z2m_kitchen_overhead_6_availability
+      - binary_sensor.z2m_kitchen_overhead_7_availability
+      - binary_sensor.z2m_kitchen_sink_overhead_availability
+      - binary_sensor.z2m_kitchen_sink_overhead_switch_availability
+      - binary_sensor.z2m_kitchen_south_window_availability
+      - binary_sensor.z2m_kitchen_switch_availability
+      - binary_sensor.z2m_kitchen_tph_availability
+      - binary_sensor.z2m_kitchen_under_cabinet_availability
+      - binary_sensor.z2m_laundry_room_dryer_availability
+      - binary_sensor.z2m_laundry_room_washing_machine_availability
+      - binary_sensor.z2m_laundry_room_washing_machine_door_availability
+      - binary_sensor.z2m_laundry_wall_switch_availability
+      - binary_sensor.z2m_laundry_washer_vibration_availability
+      - binary_sensor.z2m_mailbox_availability
+      - binary_sensor.z2m_main_foyer_front_door_availability
+      - binary_sensor.z2m_office_fan_switch_availability
+      - binary_sensor.z2m_office_floor_lamp_1_availability
+      - binary_sensor.z2m_office_floor_lamp_2_availability
+      - binary_sensor.z2m_office_light_button_1_availability
+      - binary_sensor.z2m_office_light_button_2_availability
+      - binary_sensor.z2m_office_motion_availability
+      - binary_sensor.z2m_office_smoke_alarm_availability
+      - binary_sensor.z2m_office_red_lava_lamp_availability
+      - binary_sensor.z2m_office_tph_availability
+      - binary_sensor.z2m_office_window_availability
+      - binary_sensor.z2m_outside_front_door_availability
+      - binary_sensor.z2m_outside_front_lights_availability
+      - binary_sensor.z2m_outside_north_west_garage_availability
+      - binary_sensor.z2m_outside_south_west_garage_availability
+      - binary_sensor.z2m_owner_suite_bathroom_bay_north_middle_window_availability
+      - binary_sensor.z2m_owner_suite_bathroom_bay_north_window_availability
+      - binary_sensor.z2m_owner_suite_bathroom_bay_south_middle_window_availability
+      - binary_sensor.z2m_owner_suite_bathroom_bay_south_window_availability
+      - binary_sensor.z2m_owner_suite_bathroom_exhaust_availability
+      - binary_sensor.z2m_owner_suite_bathroom_room_availability
+      - binary_sensor.z2m_owner_suite_bathroom_shower_availability
+      - binary_sensor.z2m_owner_suite_bathroom_shower_switch_availability
+      - binary_sensor.z2m_owner_suite_bathroom_tph_availability
+      - binary_sensor.z2m_owner_suite_bathroom_tub_1_availability
+      - binary_sensor.z2m_owner_suite_bathroom_tub_2_availability
+      - binary_sensor.z2m_owner_suite_bathroom_tub_switch_availability
+      - binary_sensor.z2m_owner_suite_bathroom_vanity_availability
+      - binary_sensor.z2m_owner_suite_blind_control_availability
+      - binary_sensor.z2m_owner_suite_cpap_plug_availability
+      - binary_sensor.z2m_owner_suite_closet_availability
+      - binary_sensor.z2m_owner_suite_cube_availability
+      - binary_sensor.z2m_owner_suite_fan_switch_availability
+      - binary_sensor.z2m_owner_suite_lamp_bulb_1_availability
+      - binary_sensor.z2m_owner_suite_lamp_bulb_2_availability
+      - binary_sensor.z2m_owner_suite_north_blind_availability
+      - binary_sensor.z2m_owner_suite_north_window_availability
+      - binary_sensor.z2m_owner_suite_south_blind_availability
+      - binary_sensor.z2m_owner_suite_south_window_availability
+      - binary_sensor.z2m_owner_suite_tph_availability
+      - binary_sensor.z2m_powder_room_window_availability
+      - binary_sensor.z2m_tiki_room_camera_availability
+      - binary_sensor.z2m_tiki_room_deck_availability
+      - binary_sensor.z2m_tiki_room_floor_lamp_availability
+      - binary_sensor.z2m_tiki_room_heater_availability
+      - binary_sensor.z2m_tiki_room_sonos_control_availability
+      - binary_sensor.z2m_tiki_room_tph_availability
+      - binary_sensor.z2m_unfinished_basement_window_availability
+      - binary_sensor.z2m_west_bed_button_availability
+
+################################################################
 ## Template sensors — aggregate Z2M availability status
 ################################################################
 
@@ -1892,20 +2057,16 @@ template:
         unique_id: z2m_devices_offline
         device_class: problem
         state: >
-          {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')
-             | selectattr('entity_id', 'search', 'z2m_')
-             | selectattr('state', 'in', ['off', 'unavailable', 'unknown'])
+          {% set devices = expand('group.z2m_availability_entities') %}
+          {{ devices | selectattr('state', 'in', ['off', 'unavailable', 'unknown'])
              | list | count > 0 }}
         attributes:
           offline_devices: >
-            {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')
-               | selectattr('entity_id', 'search', 'z2m_')
-               | selectattr('state', 'in', ['off', 'unavailable', 'unknown'])
+            {% set devices = expand('group.z2m_availability_entities') %}
+            {{ devices | selectattr('state', 'in', ['off', 'unavailable', 'unknown'])
                | map(attribute='name') | list }}
           total_devices: >
-            {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')
-               | selectattr('entity_id', 'search', 'z2m_') | list | count }}
+            {{ expand('group.z2m_availability_entities') | list | count }}
           online_count: >
-            {{ states.binary_sensor | selectattr('attributes.device_class', 'eq', 'connectivity')
-               | selectattr('entity_id', 'search', 'z2m_')
+            {{ expand('group.z2m_availability_entities')
                | selectattr('state', 'eq', 'on') | list | count }}

--- a/tests/test_z2m_availability_package.py
+++ b/tests/test_z2m_availability_package.py
@@ -35,6 +35,25 @@ def _named_devices() -> list[str]:
     return names
 
 
+def _slugify_entity_name(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9_]+", "_", name.lower())
+    return re.sub(r"_+", "_", slug).strip("_")
+
+
+def _package_availability_entity_ids() -> list[str]:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    names = re.findall(r'^    - name: "([^"]+)"$', text, flags=re.MULTILINE)
+    return [f"binary_sensor.{_slugify_entity_name(name)}" for name in names]
+
+
+def _availability_group_entities() -> list[str]:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    group_start = text.index("  z2m_availability_entities:")
+    group_end = text.index("################################################################\n## Template sensors", group_start)
+    group_block = text[group_start:group_end]
+    return re.findall(r"^\s+- (binary_sensor\.z2m_[a-z0-9_]+)$", group_block, flags=re.MULTILINE)
+
+
 def test_package_file_exists() -> None:
     assert PACKAGE_PATH.exists(), f"Package file not found: {PACKAGE_PATH}"
 
@@ -109,11 +128,24 @@ def test_aggregate_template_has_attributes() -> None:
     assert "online_count:" in text
 
 
-def test_aggregate_template_searches_z2m_entities() -> None:
+def test_aggregate_uses_explicit_availability_group() -> None:
     text = PACKAGE_PATH.read_text(encoding="utf-8")
-    assert "selectattr('entity_id', 'search', 'z2m_')" in text
-    assert "selectattr('attributes.device_class', 'eq', 'connectivity')" in text
+    assert "group:" in text
+    assert "z2m_availability_entities:" in text
+    assert "expand('group.z2m_availability_entities')" in text
+
+
+def test_aggregate_does_not_scan_binary_sensor_domain() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+    aggregate_block = text.split("unique_id: z2m_devices_offline", 1)[1]
+    assert "states.binary_sensor" not in aggregate_block
+    assert "selectattr('entity_id', 'search', 'z2m_')" not in aggregate_block
+    assert "selectattr('attributes.device_class', 'eq', 'connectivity')" not in aggregate_block
     assert "selectattr('state', 'in', ['off', 'unavailable', 'unknown'])" in text
+
+
+def test_availability_group_matches_package_sensors() -> None:
+    assert _availability_group_entities() == _package_availability_entity_ids()
 
 
 def test_package_does_not_duplicate_z2m_lifecycle_sensors() -> None:


### PR DESCRIPTION
## Summary
- fixes #805 by replacing the broad `states.binary_sensor` aggregate scan with an explicit Z2M availability entity group
- keeps `offline_devices`, `total_devices`, and `online_count` semantics while excluding restored/stale entities that are no longer package-managed
- adds regression coverage that the aggregate does not scan the binary-sensor domain and that the group matches package MQTT sensors

## Runtime evidence
- Live HA logs on 2026-06-23 reported `Template loop detected while processing event` for `binary_sensor.z2m_devices_offline`.
- Live `packages/z2m_availability.yaml` matched `origin/develop`.
- Live HA state also showed restored stale Z2M availability entities being pulled into the aggregate by the broad domain scan.

## Validation
- `uv run --with pytest pytest tests/test_z2m_availability_package.py` (21 passed)
- `uv run --with pytest pytest` (532 passed)
- `python3 - <<'PY' ... yaml.safe_load('packages/z2m_availability.yaml') ... PY` (passed)
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/z2m_availability.yaml` (passed)
- Podman HA `check_config` with `ghcr.io/home-assistant/home-assistant:2026.5.1` (exit 0)
