### PR TITLE
Fix #797 flight airport delay numeric state

### DIFF
--- a/packages/flight_status.yaml
+++ b/packages/flight_status.yaml
@@ -613,16 +613,14 @@ template:
         unique_id: next_travel_flight_airport_delay
         default_entity_id: sensor.next_travel_flight_airport_delay
         unit_of_measurement: "min"
+        availability: >-
+          {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') | default('', true) | string | upper %}
+          {% set tracked = states('text.flightradar24_airport_track') | default('', true) | string | upper %}
+          {{ origin not in ['', 'NONE', 'UNKNOWN', 'UNAVAILABLE']
+             and origin == tracked
+             and has_value('sensor.flightradar24_airport_departures_delay_average') }}
         state: >-
-          {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') | default('') | upper %}
-          {% set tracked = states('text.flightradar24_airport_track') | upper %}
-          {% if origin in ['', 'UNKNOWN', 'UNAVAILABLE'] %}
-            unknown
-          {% elif origin == tracked %}
-            {{ states('sensor.flightradar24_airport_departures_delay_average') }}
-          {% else %}
-            unavailable
-          {% endif %}
+          {{ states('sensor.flightradar24_airport_departures_delay_average') | int(0) }}
         attributes:
           summary: >-
             {% set origin = state_attr('sensor.next_travel_flight', 'origin_code') | default('') | upper %}

--- a/tests/test_flight_status_package.py
+++ b/tests/test_flight_status_package.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -107,3 +108,25 @@ def test_june_calendar_formats_are_supported() -> None:
     assert "destination_alias_map" not in text
     assert "'PIT': {'name': 'Pittsburgh'" in text
     assert "route_destination_code = destination_name | regex_replace('[^A-Za-z]', '') | upper" in text
+
+
+def test_airport_delay_numeric_sensor_uses_availability_guard() -> None:
+    text = _package_text()
+    sensor_match = re.search(
+        r"name: Next Travel Flight Airport Delay(?P<body>.*?)\n\s+- name: Next Travel Flight Destination Weather",
+        text,
+        flags=re.DOTALL,
+    )
+    assert sensor_match is not None
+    sensor_body = sensor_match.group("body")
+    state_match = re.search(r"\n\s+state: >-\n(?P<state>.*?)(?:\n\s+attributes:)", sensor_body, flags=re.DOTALL)
+    assert state_match is not None
+    state_template = state_match.group("state")
+
+    assert "availability: >-" in sensor_body
+    assert "has_value('sensor.flightradar24_airport_departures_delay_average')" in sensor_body
+    assert "origin not in ['', 'NONE', 'UNKNOWN', 'UNAVAILABLE']" in sensor_body
+    assert "origin == tracked" in sensor_body
+    assert "states('sensor.flightradar24_airport_departures_delay_average') | int(0)" in state_template
+    assert "unknown" not in state_template.lower()
+    assert "unavailable" not in state_template.lower()


### PR DESCRIPTION
## Summary
- fixes #797 by moving no-flight / mismatched-airport cases into `availability`
- keeps `sensor.next_travel_flight_airport_delay` numeric-only when available
- adds regression coverage that the numeric state template cannot emit `unknown` or `unavailable`

## Runtime evidence
- Live HA log on 2026-06-23 reported: `Received invalid sensor state: unknown for entity sensor.next_travel_flight_airport_delay, expected a number`.
- Live state had `sensor.next_travel_flight=none`, blank origin, `text.flightradar24_airport_track=MSP`, and the airport-delay source entity was numeric.
- Live `packages/flight_status.yaml` matched `origin/develop`.

## Validation
- `uv run --with pytest pytest tests/test_flight_status_package.py` (8 passed)
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/flight_status.yaml` (passed)
- `uv run --with pytest pytest` (531 passed)
- Podman HA `check_config` with `ghcr.io/home-assistant/home-assistant:2026.5.1` (exit 0)
