### PR TITLE
Fix #814 OctoPrint duration numeric availability

### DIFF
--- a/packages/octoprint.yaml
+++ b/packages/octoprint.yaml
@@ -281,13 +281,14 @@ template:
         unique_id: octoprint_time_elapsed
         unit_of_measurement: "s"
         availability: >
-          {{ not is_state('sensor.octoprint_start_time', 'unavailable') }}
+          {{ has_value('sensor.octoprint_start_time') }}
         state: >
-          {% set start = as_timestamp(states('sensor.octoprint_start_time'), default=none) %}
+          {% set start_raw = states('sensor.octoprint_start_time') %}
+          {% set start = as_timestamp(start_raw, default=none) %}
           {% if start is number %}
             {{ (as_timestamp(now()) - start) | int }}
           {% else %}
-            unknown
+            0
           {% endif %}
         attributes:
           start_time: "{{ states('sensor.octoprint_start_time') }}"
@@ -295,13 +296,15 @@ template:
         unique_id: octoprint_time_remaining
         unit_of_measurement: "s"
         availability: >
-          {{ not is_state('sensor.octoprint_estimated_finish_time', 'unavailable') }}
+          {{ has_value('sensor.octoprint_estimated_finish_time') }}
         state: >
-          {% set finish = as_timestamp(states('sensor.octoprint_estimated_finish_time'), default=none) %}
+          {% set finish_entity = 'sensor.octoprint_estimated_finish_time' %}
+          {% set finish_raw = states(finish_entity) %}
+          {% set finish = as_timestamp(finish_raw, default=none) %}
           {% if finish is number %}
             {{ (finish - as_timestamp(now())) | int }}
           {% else %}
-            unknown
+            0
           {% endif %}
         attributes:
           start_time: "{{ states('sensor.octoprint_estimated_finish_time') }}"

--- a/tests/test_runtime_log_regressions.py
+++ b/tests/test_runtime_log_regressions.py
@@ -84,6 +84,55 @@ def _top_level_mapping_block(path: Path, section_name: str, key_name: str) -> st
     return "\n".join(lines[start:end])
 
 
+def _template_sensor_block(path: Path, unique_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    marker = f"        unique_id: {unique_id}"
+    start = None
+
+    for index, line in enumerate(lines):
+        if line != marker:
+            continue
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("      - name: "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find template sensor {unique_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("      - name: "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _template_state_body(sensor_block: str) -> str:
+    lines = sensor_block.splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line == "        state: >":
+            start = index + 1
+            break
+
+    if start is None:
+        raise AssertionError("Template sensor block has no state template")
+
+    end = len(lines)
+    for index in range(start, len(lines)):
+        line = lines[index]
+        if line.startswith("        ") and not line.startswith("          ") and line.strip():
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
 def test_tesla_departure_planner_waits_for_helpers_on_startup() -> None:
     text = _read(CAR_PATH)
 
@@ -190,11 +239,22 @@ def test_raw_birdweather_top_50_feed_is_excluded_from_recorder() -> None:
 
 def test_octoprint_duration_templates_tolerate_unknown_timestamps() -> None:
     text = _read(OCTOPRINT_PATH)
+    elapsed_block = _template_sensor_block(OCTOPRINT_PATH, "octoprint_time_elapsed")
+    remaining_block = _template_sensor_block(OCTOPRINT_PATH, "octoprint_time_remaining")
+    elapsed_state = _template_state_body(elapsed_block).lower()
+    remaining_state = _template_state_body(remaining_block).lower()
 
-    assert "as_timestamp(states('sensor.octoprint_start_time'), default=none)" in text
-    assert "as_timestamp(states('sensor.octoprint_estimated_finish_time'), default=none)" in text
+    assert "start_raw = states('sensor.octoprint_start_time')" in text
+    assert "finish_entity = 'sensor.octoprint_estimated_finish_time'" in text
+    assert "finish_raw = states(finish_entity)" in text
+    assert "as_timestamp(start_raw, default=none)" in text
+    assert "as_timestamp(finish_raw, default=none)" in text
+    assert "{{ has_value('sensor.octoprint_start_time') }}" in elapsed_block
+    assert "{{ has_value('sensor.octoprint_estimated_finish_time') }}" in remaining_block
     assert "start is number" in text
     assert "finish is number" in text
+    assert "unknown" not in elapsed_state
+    assert "unknown" not in remaining_state
     assert "start_time: \"{{ states('sensor.octoprint_start_time') }}\"" in text
     assert "start_time: \"{{ states('sensor.octoprint_estimated_finish_time') }}\"" in text
 


### PR DESCRIPTION
## Summary

Fixes #814.

- gates OctoPrint duration template sensors with `has_value(...)` so `unknown` timestamp sources make the numeric sensors unavailable instead of invalid;
- keeps the `state` templates numeric-only;
- extends runtime regression coverage to assert the numeric state templates do not render `unknown`.

## Runtime evidence

Live HA 2026.6.4 logged current validator errors after template reload:

- `sensor.octoprint_time_elapsed`: `Received invalid sensor state: unknown ... expected a number`
- `sensor.octoprint_time_remaining`: same invalid numeric-state error

Live `/homeassistant/packages/octoprint.yaml` matched `origin/develop`, so this was not deployment drift.

## Validation

- `uv run --with pytest pytest tests/test_runtime_log_regressions.py -q` — 26 passed
- `uv run --with pytest pytest` — 536 passed
- `git diff --check` — passed
- Live HA config-check API — valid
- `uv run --with yamllint yamllint packages/octoprint.yaml` — blocked by pre-existing package lint issues outside the touched lines: line 2 long header, missing document start, and existing comment indentation warnings
- Local Podman HA container check — blocked by Podman socket connection refusals after VM restart; no generated `secrets.yaml` remains
