### PR TITLE
[codex] Add bathroom humidity hysteresis

### DIFF
--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -691,17 +691,20 @@ binary_sensor:
   - platform: threshold
     name: bathroom_humidity_high_threshold
     entity_id: sensor.bathroom_humidity_delta
-    upper: 10
+    upper: 8
+    hysteresis: 2
 
   - platform: threshold
     name: basement_bathroom_humidity_high_threshold
     entity_id: sensor.basement_bathroom_humidity_delta
-    upper: 10
+    upper: 8
+    hysteresis: 2
 
   - platform: threshold
     name: guest_bathroom_humidity_high_threshold
     entity_id: sensor.guest_bathroom_humidity_delta
-    upper: 10
+    upper: 8
+    hysteresis: 2
 
 ########################
 # Climate

--- a/tests/test_threshold_helpers.py
+++ b/tests/test_threshold_helpers.py
@@ -51,7 +51,9 @@ def test_bathroom_humidity_high_uses_delta_threshold_helpers() -> None:
     for binary_sensor, delta_sensor in cases.items():
         block = _threshold_binary_sensor_block(text, binary_sensor)
         assert f"entity_id: {delta_sensor}" in block
-        assert "upper: 10" in block
+        assert "upper: 8" in block
+        assert "hysteresis: 2" in block
+        assert "lower:" not in block
 
     public_block = _template_unique_id_block(text, "bathroom_humidity_high")
     assert "unique_id: bathroom_humidity_high" in public_block


### PR DESCRIPTION
## Summary
- Add hysteresis to the owner-suite, basement, and guest bathroom humidity threshold helpers.
- Keep the high-humidity binary sensors on until humidity delta falls below 6%, while still turning them on above 10%.
- Update threshold helper coverage so the hysteresis guard is tested.

## Root cause
Live Home Assistant history showed the owner-suite bathroom exhaust automation did fire, but the humidity-high binary sensor flapped around the 10% delta threshold. The fan turned on at 11:48:50 CT, humidity-high fell back to off at 11:52:43 CT, and the automation turned the fan off at 12:02:43 CT after its 10-minute normal-humidity delay. The bathroom humidity then rose again, but the fan was manually turned on at 12:09:21 CT before the next automation turn-on at 12:09:43 CT.

## Impact
This prevents short sensor dips from making the shower automation decide humidity is normal while the room is still materially humid. The fan now stays on until the bathroom is closer to whole-house humidity.

## Validation
- `uv run --with pytest pytest tests/test_threshold_helpers.py`
- `uv run --with pytest pytest`
