### PR TITLE
Fix #818 filter stale Inovelli LED targets

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1776,13 +1776,33 @@ script:
       stored_traces: 10
     variables:
       all_switches_led_color_off: >
-        {%- for device in states.number | select('match', '.*ledcolorwhenoff.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_switches_led_color_on: >
-        {%- for device in states.number | select('match', '.*ledcolorwhenon.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_switches_led_intensity_on: >
-        {%- for device in states.number | select('match', '.*ledintensitywhenon.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_switches_led_intensity_off: >
-        {%- for device in states.number | select('match', '.*ledintensitywhenoff.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
     sequence:
       - &trip_led_updates_allowed
         condition: state
@@ -1842,6 +1862,8 @@ script:
       all_off_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
           | rejectattr('entity_id', 'search', 'owner_suite_bathroom_vanity')
           | rejectattr('entity_id', 'search', 'owner_suite_closet')
@@ -1852,6 +1874,8 @@ script:
       all_on_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
           | rejectattr('entity_id', 'search', 'owner_suite_bathroom_vanity')
           | rejectattr('entity_id', 'search', 'owner_suite_closet')
@@ -1862,6 +1886,8 @@ script:
       all_switches_led_intensity_on: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
           | rejectattr('entity_id', 'search', 'owner_suite_bathroom_vanity')
           | rejectattr('entity_id', 'search', 'owner_suite_closet')
@@ -1872,6 +1898,8 @@ script:
       all_switches_led_intensity_off: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
           | rejectattr('entity_id', 'search', 'owner_suite_bathroom_vanity')
           | rejectattr('entity_id', 'search', 'owner_suite_closet')
@@ -1882,6 +1910,8 @@ script:
       all_day_mode_singletapbehavior_switches: >
         {%- for device in states.select
           | selectattr('entity_id', 'search', 'singletapbehavior')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'exhaust')
           | rejectattr('entity_id', 'search', 'fan_switch')
           | rejectattr('entity_id', 'search', 'overhead_outlet') -%}
@@ -1890,6 +1920,8 @@ script:
       all_day_mode_defaultlevellocal_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'defaultlevellocal')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'exhaust')
           | rejectattr('entity_id', 'search', 'fan_switch')
           | rejectattr('entity_id', 'search', 'overhead_outlet') -%}
@@ -1898,6 +1930,8 @@ script:
       all_day_mode_defaultlevelremote_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'defaultlevelremote')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'exhaust')
           | rejectattr('entity_id', 'search', 'fan_switch')
           | rejectattr('entity_id', 'search', 'overhead_outlet') -%}
@@ -2007,24 +2041,32 @@ script:
       owner_suite_day_mode_off_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', owner_suite_day_mode_entity_pattern) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_day_mode_on_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', owner_suite_day_mode_entity_pattern) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_day_mode_led_intensity_on_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', owner_suite_day_mode_entity_pattern) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_day_mode_led_intensity_off_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', owner_suite_day_mode_entity_pattern) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
@@ -2123,22 +2165,30 @@ script:
     variables:
       owner_suite_led_color_off_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledcolorwhenoff$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledcolorwhenoff$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_led_color_on_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledcolorwhenon$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledcolorwhenon$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_led_intensity_off_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenoff$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenoff$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_led_intensity_on_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenon$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenon$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
     sequence:
@@ -2182,24 +2232,32 @@ script:
       office_guest_room_off_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       office_guest_room_on_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       office_guest_room_led_intensity_on_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       office_guest_room_led_intensity_off_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
@@ -2244,20 +2302,52 @@ script:
       ha_write_delay: "00:00:01"
       mqtt_bind_delay: "00:00:03"
       all_inovelli_switches_energy_report_rate: >
-        {%- for device in states.number | select('match', '.*periodicpowerandenergyreports.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'periodicpowerandenergyreports')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_active_energy_report_rate: >
-        {%- for device in states.number | select('match', '.*activeenergyreports.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'activeenergyreports')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_active_power_report_rate: >
-        {%- for device in states.number | select('match', '.*activepowerreports.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'activepowerreports')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_double_tap_up_mode: >
-        {%- for device in states.select | select('match', '.*_doubletapuptoparam55.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.select
+          | selectattr('entity_id', 'search', '_doubletapuptoparam55')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_double_tap_up_brightness: >
-        {%- for device in states.number | select('match', '.*brightnesslevelfordoubletapup.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'brightnesslevelfordoubletapup')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_bindingofftoonsynclevel_mode: >
-        {%- for device in states.select | select('match', '.*bindingofftoonsynclevel.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.select
+          | selectattr('entity_id', 'search', 'bindingofftoonsynclevel')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_singletapbehavior_mode: >
         {%- for device in states.select
           | selectattr('entity_id', 'search', 'singletapbehavior')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'exhaust')
           | rejectattr('entity_id', 'search', 'fan_switch')
           | rejectattr('entity_id', 'search', 'overhead_outlet') -%}
@@ -2735,12 +2825,16 @@ script:
     variables:
       all_switches_led_intensity_on: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', 'ledintensitywhenon') -%}
+          | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       all_switches_led_intensity_off: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', 'ledintensitywhenoff') -%}
+          | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
     sequence:
@@ -2876,12 +2970,16 @@ script:
     variables:
       owner_suite_led_intensity_off_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenoff$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenoff$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_led_intensity_on_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenon$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenon$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_led_intensity_off_with_office: >-

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -432,6 +432,20 @@ def test_day_mode_default_switch_lists_filter_stale_entities_before_service_call
         assert "rejectattr('attributes.restored', 'eq', true)" in section
 
 
+def test_dynamic_inovelli_target_lists_exclude_inactive_restored_entities() -> None:
+    text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
+    loops = re.findall(
+        r"{%- for device in states\.(?:number|select)\n(?P<body>.*?){%- endfor %}",
+        text,
+        flags=re.DOTALL,
+    )
+
+    assert loops
+    for loop in loops:
+        assert "rejectattr('state', 'in', ['unknown', 'unavailable'])" in loop
+        assert "rejectattr('attributes.restored', 'eq', true)" in loop
+
+
 def test_reset_script_finishes_with_the_issue_aurora_led_effect() -> None:
     block = _script_block("reset_inovelli_switches")
     notification_text = INOVELLI_LED_NOTIFICATIONS_PATH.read_text(encoding="utf-8")

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -395,6 +395,43 @@ def test_owner_suite_led_darkening_excludes_unavailable_guest_room_switch() -> N
     assert "number.guest_room_fan_switch_ledintensitywhenoff" not in block
 
 
+def test_dynamic_inovelli_target_lists_skip_inactive_restore_state_entities() -> None:
+    script_ids = (
+        "night_tv_mode_switches",
+        "day_mode_switches_general",
+        "day_mode_switches_owner_suite_scope",
+        "night_mode_switches_owner_suite",
+        "day_mode_switches_office_guest_room",
+        "reset_inovelli_switches",
+        "turn_off_all_inovelli_switch_leds",
+        "turn_off_owner_suite_inovelli_switch_leds",
+    )
+
+    for script_id in script_ids:
+        block = _script_block(script_id)
+        assert "rejectattr('state', 'in', ['unknown', 'unavailable'])" in block, script_id
+        assert "rejectattr('attributes.restored', 'eq', true)" in block, script_id
+
+
+def test_day_mode_default_switch_lists_filter_stale_entities_before_service_calls() -> None:
+    block = _script_block("day_mode_switches_general")
+
+    for variable_name in (
+        "all_day_mode_singletapbehavior_switches",
+        "all_day_mode_defaultlevellocal_switches",
+        "all_day_mode_defaultlevelremote_switches",
+    ):
+        match = re.search(
+            rf"      {variable_name}: >\n(?P<section>.*?)(?=\n      [A-Za-z0-9_]+:|\n    sequence:)",
+            block,
+            re.S,
+        )
+        assert match is not None
+        section = match.group("section")
+        assert "rejectattr('state', 'in', ['unknown', 'unavailable'])" in section
+        assert "rejectattr('attributes.restored', 'eq', true)" in section
+
+
 def test_reset_script_finishes_with_the_issue_aurora_led_effect() -> None:
     block = _script_block("reset_inovelli_switches")
     notification_text = INOVELLI_LED_NOTIFICATIONS_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Fixes #818.
- Filters dynamic Inovelli LED/reset target lists so scripts skip entities in `unknown`/`unavailable` state and restored state placeholders.
- Adds regression coverage for the live stale-target failure mode, including day-mode default targets that produced the `0x943...` service warnings.
- Includes a catch-all guard (ported from the duplicate #827) asserting every `states.number`/`states.select` for-loop carries the inactive/restored filters.

## Runtime evidence
- Live HA 2026.6.4 logs on 2026-06-26 showed `homeassistant.helpers.service` warnings for Inovelli LED service calls against stale/restored `number.0x943469fffe0895fb_*` and `select.0x943469fffe0895fb_*` entities.
- Live `/config/packages/zigbee_zwave.yaml` matched the repo behavior: dynamic target lists were built from all matching `states.number`/`states.select` entries without filtering inactive/restored entities.

## Validation
- `uv run --with pytest pytest tests/test_zigbee_zwave_inovelli_reset_replay.py tests/test_inovelli_day_mode_switches.py tests/test_issue_trip_led_suspend.py -q` -> 30 passed.
- `uv run --with pytest pytest` -> 541 passed.
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt` -> passed.
- `git diff --check` -> passed.
- Local pinned Home Assistant container `check_config` could not run because the local Podman VM/socket failed after restart: `podman info` reported connection refused and `podman machine ssh podman-machine-default true` reset the connection. PR CI should run the pinned HA config check.