### PR TITLE
Consolidate arrival and departure presence events (#789)

### DIFF
--- a/packages/zone.yaml
+++ b/packages/zone.yaml
@@ -36,6 +36,14 @@ homeassistant:
     ################################################
     ## Automations
     ################################################
+    automation.zeke_arrival_emitter:
+      <<: *customize
+      friendly_name: Zeke Arrival Event Emitter
+      icon: mdi:home-import-outline
+    automation.zeke_departure_emitter:
+      <<: *customize
+      friendly_name: Zeke Departure Event Emitter
+      icon: mdi:home-export-outline
     automation.cloudy_home_arrival:
       <<: *customize
       friendly_name: Cloudy Day Arrival
@@ -166,19 +174,76 @@ homeassistant:
 ## Automation
 ################################################
 automation:
+  - id: zeke_arrival_emitter
+    alias: zeke_arrival_emitter
+    description: >-
+      Own the canonical Zeke arrival triggers and emit a shared event so each
+      downstream reaction can keep its own mode, trace history, and conditions.
+      Additional people should add their own emitter with the same event
+      contract and a distinct person value.
+    mode: parallel
+    trace:
+      stored_traces: 10
+    trigger:
+      - trigger: zone
+        id: tracker_entered_home
+        entity_id: device_tracker.bayesian_zeke_home
+        zone: zone.home
+        event: enter
+      - trigger: state
+        id: bayesian_presence_on
+        entity_id: binary_sensor.bayesian_zeke_home
+        from: "off"
+        to: "on"
+    action:
+      - event: zeke_arrival
+        event_data:
+          person: zeke
+          reason: zeke_arrival
+          source_trigger: "{{ trigger.id }}"
+          tracker_entity_id: device_tracker.bayesian_zeke_home
+          presence_entity_id: binary_sensor.bayesian_zeke_home
+
+  - id: zeke_departure_emitter
+    alias: zeke_departure_emitter
+    description: >-
+      Own the canonical Zeke departure triggers and emit a shared event so each
+      downstream reaction can keep its own mode, trace history, and conditions.
+      Additional people should add their own emitter with the same event
+      contract and a distinct person value.
+    mode: parallel
+    trace:
+      stored_traces: 10
+    trigger:
+      - trigger: zone
+        id: tracker_left_home
+        entity_id: device_tracker.bayesian_zeke_home
+        zone: zone.home
+        event: leave
+      - trigger: state
+        id: bayesian_presence_off
+        entity_id: binary_sensor.bayesian_zeke_home
+        from: "on"
+        to: "off"
+    action:
+      - event: zeke_departure
+        event_data:
+          person: zeke
+          reason: zeke_departure
+          source_trigger: "{{ trigger.id }}"
+          tracker_entity_id: device_tracker.bayesian_zeke_home
+          presence_entity_id: binary_sensor.bayesian_zeke_home
+
   - id: cloudy_home_arrival
     alias: cloudy_home_arrival
     trace:
       stored_traces: 10
     trigger:
-      - trigger: zone
-        entity_id: device_tracker.bayesian_zeke_home
-        zone: zone.home
-        event: enter
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "off"
-        to: "on"
+      - trigger: event
+        id: cloudy_home_arrival_signal
+        event_type: zeke_arrival
+        event_data:
+          person: zeke
     condition:
       condition: and
       conditions:
@@ -204,14 +269,11 @@ automation:
     trace:
       stored_traces: 10
     trigger:
-      - trigger: zone
-        entity_id: device_tracker.bayesian_zeke_home
-        zone: zone.home
-        event: enter
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "off"
-        to: "on"
+      - trigger: event
+        id: default_arrive_home_signal
+        event_type: zeke_arrival
+        event_data:
+          person: zeke
     condition:
       and:
         - condition: state
@@ -238,14 +300,11 @@ automation:
     trace:
       stored_traces: 10
     trigger:
-      - trigger: zone
-        entity_id: device_tracker.bayesian_zeke_home
-        zone: zone.home
-        event: leave
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "on"
-        to: "off"
+      - trigger: event
+        id: doors_open_departure_signal
+        event_type: zeke_departure
+        event_data:
+          person: zeke
     variables:
       open_egress_points: >-
         {{ state_attr('sensor.open_egress_points', 'friendly_names') | default('', true) }}
@@ -264,14 +323,11 @@ automation:
     trace:
       stored_traces: 10
     trigger:
-      - trigger: zone
-        entity_id: device_tracker.bayesian_zeke_home
-        zone: zone.home
-        event: leave
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "on"
-        to: "off"
+      - trigger: event
+        id: garage_door_departure_signal
+        event_type: zeke_departure
+        event_data:
+          person: zeke
     condition:
       - condition: state
         entity_id: cover.garage_door
@@ -302,13 +358,17 @@ automation:
     trace:
       stored_traces: 10
     trigger:
-      # from: "on" guards against unknown/unavailable -> off on HA restart,
-      # which would otherwise overwrite a restored multi-day absence start
-      # with the restart time and misclassify the next arrival as quick/half-day.
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "on"
-        to: "off"
+      - trigger: event
+        id: empty_house_tracker_signal
+        event_type: zeke_departure
+        event_data:
+          person: zeke
+    condition:
+      # Only the emitter's from:on -> off Bayesian source updates the empty-house
+      # timestamp; the GPS zone leave source can fire before the house is empty.
+      - alias: "Only update empty-house timestamp from Bayesian departure"
+        condition: template
+        value_template: "{{ trigger.event.data.source_trigger == 'bayesian_presence_off' }}"
     action:
       - action: input_boolean.turn_off
         target:
@@ -324,16 +384,14 @@ automation:
     trace:
       stored_traces: 10
     trigger:
-      - trigger: zone
-        entity_id: device_tracker.bayesian_zeke_home
-        zone: zone.home
-        event: enter
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "off"
-        to: "on"
+      - trigger: event
+        id: arrival_music_signal
+        event_type: zeke_arrival
+        event_data:
+          person: zeke
     condition:
-      - condition: state
+      - alias: "Arrival music allowed when guest mode is off"
+        condition: state
         entity_id: input_boolean.guest_mode
         state: "off"
       - condition: state
@@ -360,14 +418,11 @@ automation:
     trace:
       stored_traces: 50
     trigger:
-      - trigger: zone
-        entity_id: device_tracker.bayesian_zeke_home
-        zone: zone.home
-        event: enter
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "off"
-        to: "on"
+      - trigger: event
+        id: night_arrival_signal
+        event_type: zeke_arrival
+        event_data:
+          person: zeke
     condition:
       condition: and
       conditions:
@@ -401,14 +456,11 @@ automation:
     trace:
       stored_traces: 50
     trigger:
-      - trigger: zone
-        entity_id: device_tracker.bayesian_zeke_home
-        zone: zone.home
-        event: enter
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "off"
-        to: "on"
+      - trigger: event
+        id: bedroom_prep_arrival_signal
+        event_type: zeke_arrival
+        event_data:
+          person: zeke
     condition:
       condition: and
       conditions:
@@ -508,16 +560,14 @@ automation:
     trace:
       stored_traces: 10
     trigger:
-      - trigger: zone
-        entity_id: device_tracker.bayesian_zeke_home
-        zone: zone.home
-        event: leave
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "on"
-        to: "off"
+      - trigger: event
+        id: departure_house_transition_signal
+        event_type: zeke_departure
+        event_data:
+          person: zeke
     condition:
-      - condition: state
+      - alias: "Departure transition allowed when guest mode is off"
+        condition: state
         entity_id: input_boolean.guest_mode
         state: "off"
       - alias: "Primary tracker confirms departure"
@@ -625,14 +675,11 @@ automation:
     trace:
       stored_traces: 10
     trigger:
-      - trigger: zone
-        entity_id: device_tracker.bayesian_zeke_home
-        zone: zone.home
-        event: enter
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "off"
-        to: "on"
+      - trigger: event
+        id: vacuum_return_arrival_signal
+        event_type: zeke_arrival
+        event_data:
+          person: zeke
     action:
       - action: vacuum.return_to_base
         target:
@@ -656,12 +703,17 @@ automation:
     trace:
       stored_traces: 10
     trigger:
-      - trigger: state
-        entity_id: binary_sensor.bayesian_zeke_home
-        from: "on"
-        to: "off"
+      - trigger: event
+        id: vacuum_departure_signal
+        event_type: zeke_departure
+        event_data:
+          person: zeke
     condition:
-      - condition: state
+      - alias: "Only start departure vacuum from Bayesian departure"
+        condition: template
+        value_template: "{{ trigger.event.data.source_trigger == 'bayesian_presence_off' }}"
+      - alias: "Departure vacuum allowed when guest mode is off"
+        condition: state
         entity_id: input_boolean.guest_mode
         state: "off"
     action:

--- a/tests/test_house_mode_zone.py
+++ b/tests/test_house_mode_zone.py
@@ -155,12 +155,65 @@ def test_contextual_arrival_tracks_when_house_becomes_empty() -> None:
     assert "input_datetime.contextual_arrival_last_empty_at:" in text
     assert "has_date: true" in text
     assert "has_time: true" in text
-    assert "from: \"on\"" in block
-    assert "to: \"off\"" in block
+    assert "event_type: zeke_departure" in block
+    assert "source_trigger == 'bayesian_presence_off'" in block
     assert "action: input_boolean.turn_off" in block
     assert "action: input_datetime.set_datetime" in block
     assert "entity_id: input_datetime.contextual_arrival_last_empty_at" in block
     assert "now().strftime('%Y-%m-%d %H:%M:%S')" in block
+
+
+def test_presence_event_emitters_own_shared_arrival_and_departure_triggers() -> None:
+    arrival_emitter = _automation_block(ZONE_PATH, "zeke_arrival_emitter")
+    departure_emitter = _automation_block(ZONE_PATH, "zeke_departure_emitter")
+
+    assert "event: enter" in arrival_emitter
+    assert "id: tracker_entered_home" in arrival_emitter
+    assert "id: bayesian_presence_on" in arrival_emitter
+    assert "event: zeke_arrival" in arrival_emitter
+    assert "source_trigger: \"{{ trigger.id }}\"" in arrival_emitter
+
+    assert "event: leave" in departure_emitter
+    assert "id: tracker_left_home" in departure_emitter
+    assert "id: bayesian_presence_off" in departure_emitter
+    assert "event: zeke_departure" in departure_emitter
+    assert "source_trigger: \"{{ trigger.id }}\"" in departure_emitter
+
+
+def test_presence_event_consumers_keep_independent_traces_and_modes() -> None:
+    arrival_consumers = (
+        "cloudy_home_arrival",
+        "default_arrive_home",
+        "play_spotify_when_i_get_home",
+        "turn_on_lights_at_night_when_i_get_home",
+        "turn_on_bedroom_lights_at_night_when_i_get_home",
+        "vacuum_return_home",
+    )
+    departure_consumers = (
+        "doors_open_when_leaving_home",
+        "garage_door_open_when_leaving_home",
+        "input_boolean_tracker_off",
+        "turn_off_lights_when_i_leave",
+        "vacuum_leave_home",
+    )
+
+    for automation_id in arrival_consumers:
+        block = _automation_block(ZONE_PATH, automation_id)
+        trigger_block = block.split("condition:", 1)[0].split("action:", 1)[0]
+        assert "trace:" in block
+        assert "event_type: zeke_arrival" in trigger_block
+        assert "person: zeke" in trigger_block
+        assert "event: enter" not in trigger_block
+        assert "binary_sensor.bayesian_zeke_home" not in trigger_block
+
+    for automation_id in departure_consumers:
+        block = _automation_block(ZONE_PATH, automation_id)
+        trigger_block = block.split("condition:", 1)[0].split("action:", 1)[0]
+        assert "trace:" in block
+        assert "event_type: zeke_departure" in trigger_block
+        assert "person: zeke" in trigger_block
+        assert "event: leave" not in trigger_block
+        assert "binary_sensor.bayesian_zeke_home" not in trigger_block
 
 
 def test_arrival_automations_use_contextual_arrival_transition() -> None:


### PR DESCRIPTION
## Summary
- add Zeke arrival/departure emitter automations that own the shared home enter/leave and Bayesian on/off triggers
- move listed arrival/departure consumers to event triggers while preserving their independent modes, traces, and conditions
- keep state-only departure behavior for empty-house timestamp and vacuum start by filtering the emitted Bayesian source

Closes #789

## Coverage / tests
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/zone.yaml --strict`
- `python3 scripts/check_ha_python_support.py`
- `git diff --check`

## Validation note
- Home Assistant container `check_config` was attempted with a temporary CI-style config copy, but local Podman repeatedly stopped/reset its socket before the container could start. The initial run reached HA and failed only because direct worktree validation lacked CI placeholder secrets; the retried CI-style temp config could not launch due to Podman VM/socket failure.