### PR TITLE
Refactor Uplift desk auto move guard (#738)

### DIFF
--- a/packages/desk.yaml
+++ b/packages/desk.yaml
@@ -66,6 +66,10 @@ homeassistant:
       <<: *customize
       friendly_name: "Desk Auto Move Max"
 
+    script.uplift_desk_auto_move:
+      <<: *customize
+      friendly_name: "Desk Auto Move"
+
     script.uplift_desk_auto_move_preset_1:
       <<: *customize
       friendly_name: "Desk Auto Move Preset 1"
@@ -296,6 +300,32 @@ automation:
 # Script
 ########################
 script:
+  uplift_desk_auto_move:
+    alias: uplift_desk_auto_move
+    description: >
+      Shared automation-only guard that sends the desk to a requested native
+      Uplift button target when no other automated desk motion is in progress.
+    mode: single
+    trace:
+      stored_traces: 10
+    fields:
+      target_button:
+        name: Target button
+        required: true
+        selector:
+          entity:
+            domain: button
+    sequence:
+      - condition: state
+        entity_id: timer.uplift_desk_motion_window
+        state: "idle"
+      - action: button.press
+        target:
+          entity_id: "{{ target_button }}"
+      - action: timer.start
+        target:
+          entity_id: timer.uplift_desk_motion_window
+
   uplift_desk_auto_move_max:
     alias: uplift_desk_auto_move_max
     description: >
@@ -305,15 +335,9 @@ script:
     trace:
       stored_traces: 10
     sequence:
-      - condition: state
-        entity_id: timer.uplift_desk_motion_window
-        state: "idle"
-      - action: button.press
-        target:
-          entity_id: button.uplift_desk_75b205_move_to_max_height
-      - action: timer.start
-        target:
-          entity_id: timer.uplift_desk_motion_window
+      - action: script.uplift_desk_auto_move
+        data:
+          target_button: button.uplift_desk_75b205_move_to_max_height
 
   uplift_desk_auto_move_preset_1:
     alias: uplift_desk_auto_move_preset_1
@@ -324,15 +348,9 @@ script:
     trace:
       stored_traces: 10
     sequence:
-      - condition: state
-        entity_id: timer.uplift_desk_motion_window
-        state: "idle"
-      - action: button.press
-        target:
-          entity_id: button.uplift_desk_75b205_move_to_preset_1
-      - action: timer.start
-        target:
-          entity_id: timer.uplift_desk_motion_window
+      - action: script.uplift_desk_auto_move
+        data:
+          target_button: button.uplift_desk_75b205_move_to_preset_1
 
   uplift_desk_auto_move_preset_2:
     alias: uplift_desk_auto_move_preset_2
@@ -343,15 +361,9 @@ script:
     trace:
       stored_traces: 10
     sequence:
-      - condition: state
-        entity_id: timer.uplift_desk_motion_window
-        state: "idle"
-      - action: button.press
-        target:
-          entity_id: button.uplift_desk_75b205_move_to_preset_2
-      - action: timer.start
-        target:
-          entity_id: timer.uplift_desk_motion_window
+      - action: script.uplift_desk_auto_move
+        data:
+          target_button: button.uplift_desk_75b205_move_to_preset_2
 
   uplift_desk_manual_move_max:
     alias: uplift_desk_manual_move_max

--- a/tests/test_uplift_desk_native_component.py
+++ b/tests/test_uplift_desk_native_component.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -24,6 +25,35 @@ MANUAL_DESK_SCRIPTS = {
     "script.uplift_desk_manual_stop",
 }
 
+AUTO_DESK_WRAPPERS = {
+    "uplift_desk_auto_move_max": "button.uplift_desk_75b205_move_to_max_height",
+    "uplift_desk_auto_move_preset_1": "button.uplift_desk_75b205_move_to_preset_1",
+    "uplift_desk_auto_move_preset_2": "button.uplift_desk_75b205_move_to_preset_2",
+}
+
+
+def _script_block(script_id: str) -> str:
+    lines = DESK_PACKAGE.read_text(encoding="utf-8").splitlines()
+    start = None
+    needle = f"  {script_id}:"
+
+    for index, line in enumerate(lines):
+        if line == needle:
+            start = index
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find script id {script_id!r}")
+
+    end = len(lines)
+    next_script = re.compile(r"^  [A-Za-z0-9_]+:$")
+    for index in range(start + 1, len(lines)):
+        if next_script.match(lines[index]):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
 
 def test_desk_package_uses_native_uplift_component_buttons() -> None:
     text = DESK_PACKAGE.read_text(encoding="utf-8")
@@ -46,3 +76,22 @@ def test_office_dashboards_use_manual_desk_script_wrappers() -> None:
         assert '"service": "button.press"' not in text
         assert "button.uplift_desk_75b205_move_to_" not in text
         assert "button.uplift_desk_75b205_stop" not in text
+
+
+def test_auto_desk_wrappers_share_motion_guard() -> None:
+    shared = _script_block("uplift_desk_auto_move")
+
+    assert "entity_id: timer.uplift_desk_motion_window" in shared
+    assert 'state: "idle"' in shared
+    assert "action: button.press" in shared
+    assert 'entity_id: "{{ target_button }}"' in shared
+    assert "action: timer.start" in shared
+    assert shared.count("timer.uplift_desk_motion_window") == 2
+
+    for script_id, target_button in AUTO_DESK_WRAPPERS.items():
+        block = _script_block(script_id)
+
+        assert "action: script.uplift_desk_auto_move" in block
+        assert f"target_button: {target_button}" in block
+        assert "timer.uplift_desk_motion_window" not in block
+        assert "action: button.press" not in block


### PR DESCRIPTION
## Summary

Refs #738.

- Added a shared `script.uplift_desk_auto_move` guard for automation-driven Uplift desk moves.
- Kept the existing public max / preset wrapper script IDs stable, with each wrapper passing only its native Uplift button target.
- Added regression coverage proving the wrappers share the timer guard and no longer duplicate the button/timer sequence.

## DRY review

Latest requested scan:

- Scanned files: 49
- Parse errors: 0
- Duplicate full-block groups: 6
- Duplicate entry groups: 27, down from 29 before this refactor
- Intra-block duplicates: 2
- Central-script findings: 0

Classifications:

- Refactor now: Uplift desk auto-move scripts had duplicated guard/button/timer sequences; centralized in this PR.
- Leave duplicated: Uplift automation actions and guard conditions remain explicit because each automation documents a distinct trigger and priority check; hiding those in a generic router would make desk behavior harder to audit.
- Deferred with blocker: `trigger_winter_watermeter_flow` repeats on/off commands intentionally as a blink/flow/off sequence, and `script.reset_inovelli_switches` repeats pacing delays between distinct device writes. Removing those exact duplicates would change runtime timing/behavior; they need behavior-specific follow-up before changing.
- Follow-up: arrival/departure trigger consolidation, TV/media startup sequencing, and broader cross-package condition duplication remain candidates for separate behavior-focused PRs.

## Validation

- `uv run --with pytest pytest tests/test_uplift_desk_native_component.py` passed.
- `uv run --with pytest pytest` passed, 540 tests.
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/desk.yaml` passed.
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages automations.yaml scripts.yaml --min-occurrences 3` passed with the counts above.
- Home Assistant `check_config` not run locally because Docker is not installed in this environment; CI defines that validation through `ghcr.io/home-assistant/home-assistant:2026.5.1`.