### PR TITLE
Fix #818 filter inactive Inovelli targets

### DIFF
--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1776,13 +1776,33 @@ script:
       stored_traces: 10
     variables:
       all_switches_led_color_off: >
-        {%- for device in states.number | select('match', '.*ledcolorwhenoff.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_switches_led_color_on: >
-        {%- for device in states.number | select('match', '.*ledcolorwhenon.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_switches_led_intensity_on: >
-        {%- for device in states.number | select('match', '.*ledintensitywhenon.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_switches_led_intensity_off: >
-        {%- for device in states.number | select('match', '.*ledintensitywhenoff.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
     sequence:
       - &trip_led_updates_allowed
         condition: state
@@ -1842,6 +1862,8 @@ script:
       all_off_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
           | rejectattr('entity_id', 'search', 'owner_suite_bathroom_vanity')
           | rejectattr('entity_id', 'search', 'owner_suite_closet')
@@ -1852,6 +1874,8 @@ script:
       all_on_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
           | rejectattr('entity_id', 'search', 'owner_suite_bathroom_vanity')
           | rejectattr('entity_id', 'search', 'owner_suite_closet')
@@ -1862,6 +1886,8 @@ script:
       all_switches_led_intensity_on: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
           | rejectattr('entity_id', 'search', 'owner_suite_bathroom_vanity')
           | rejectattr('entity_id', 'search', 'owner_suite_closet')
@@ -1872,6 +1898,8 @@ script:
       all_switches_led_intensity_off: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'owner_suite_fan_switch')
           | rejectattr('entity_id', 'search', 'owner_suite_bathroom_vanity')
           | rejectattr('entity_id', 'search', 'owner_suite_closet')
@@ -1882,6 +1910,8 @@ script:
       all_day_mode_singletapbehavior_switches: >
         {%- for device in states.select
           | selectattr('entity_id', 'search', 'singletapbehavior')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'exhaust')
           | rejectattr('entity_id', 'search', 'fan_switch')
           | rejectattr('entity_id', 'search', 'overhead_outlet') -%}
@@ -1890,6 +1920,8 @@ script:
       all_day_mode_defaultlevellocal_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'defaultlevellocal')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'exhaust')
           | rejectattr('entity_id', 'search', 'fan_switch')
           | rejectattr('entity_id', 'search', 'overhead_outlet') -%}
@@ -1898,6 +1930,8 @@ script:
       all_day_mode_defaultlevelremote_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'defaultlevelremote')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'exhaust')
           | rejectattr('entity_id', 'search', 'fan_switch')
           | rejectattr('entity_id', 'search', 'overhead_outlet') -%}
@@ -2007,24 +2041,32 @@ script:
       owner_suite_day_mode_off_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', owner_suite_day_mode_entity_pattern) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_day_mode_on_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', owner_suite_day_mode_entity_pattern) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_day_mode_led_intensity_on_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', owner_suite_day_mode_entity_pattern) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_day_mode_led_intensity_off_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', owner_suite_day_mode_entity_pattern) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
@@ -2123,22 +2165,30 @@ script:
     variables:
       owner_suite_led_color_off_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledcolorwhenoff$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledcolorwhenoff$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_led_color_on_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledcolorwhenon$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledcolorwhenon$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_led_intensity_off_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenoff$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenoff$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_led_intensity_on_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenon$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenon$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
     sequence:
@@ -2182,24 +2232,32 @@ script:
       office_guest_room_off_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       office_guest_room_on_led_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledcolorwhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       office_guest_room_led_intensity_on_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       office_guest_room_led_intensity_off_switches: >
         {%- for device in states.number
           | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | selectattr('entity_id', 'search', '(office_fan_switch|guest_room_fan_switch)') -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
@@ -2244,20 +2302,52 @@ script:
       ha_write_delay: "00:00:01"
       mqtt_bind_delay: "00:00:03"
       all_inovelli_switches_energy_report_rate: >
-        {%- for device in states.number | select('match', '.*periodicpowerandenergyreports.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'periodicpowerandenergyreports')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_active_energy_report_rate: >
-        {%- for device in states.number | select('match', '.*activeenergyreports.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'activeenergyreports')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_active_power_report_rate: >
-        {%- for device in states.number | select('match', '.*activepowerreports.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'activepowerreports')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_double_tap_up_mode: >
-        {%- for device in states.select | select('match', '.*_doubletapuptoparam55.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.select
+          | selectattr('entity_id', 'search', '_doubletapuptoparam55')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_double_tap_up_brightness: >
-        {%- for device in states.number | select('match', '.*brightnesslevelfordoubletapup.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.number
+          | selectattr('entity_id', 'search', 'brightnesslevelfordoubletapup')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_bindingofftoonsynclevel_mode: >
-        {%- for device in states.select | select('match', '.*bindingofftoonsynclevel.*')%}{%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}{%- if loop.last %}{% endif %}{%- endfor  %}
+        {%- for device in states.select
+          | selectattr('entity_id', 'search', 'bindingofftoonsynclevel')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
+          {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
+        {%- endfor %}
       all_inovelli_switches_singletapbehavior_mode: >
         {%- for device in states.select
           | selectattr('entity_id', 'search', 'singletapbehavior')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true)
           | rejectattr('entity_id', 'search', 'exhaust')
           | rejectattr('entity_id', 'search', 'fan_switch')
           | rejectattr('entity_id', 'search', 'overhead_outlet') -%}
@@ -2735,12 +2825,16 @@ script:
     variables:
       all_switches_led_intensity_on: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', 'ledintensitywhenon') -%}
+          | selectattr('entity_id', 'search', 'ledintensitywhenon')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       all_switches_led_intensity_off: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', 'ledintensitywhenoff') -%}
+          | selectattr('entity_id', 'search', 'ledintensitywhenoff')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
     sequence:
@@ -2876,12 +2970,16 @@ script:
     variables:
       owner_suite_led_intensity_off_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenoff$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenoff$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_led_intensity_on_switches: >
         {%- for device in states.number
-          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenon$') -%}
+          | selectattr('entity_id', 'search', '^number\\.owner_suite_.*ledintensitywhenon$')
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | rejectattr('attributes.restored', 'eq', true) -%}
           {%- if loop.first %}{%- else %}, {% endif %}{{ device.entity_id }}
         {%- endfor %}
       owner_suite_led_intensity_off_with_office: >-

--- a/tests/test_zigbee_zwave_inovelli_reset_replay.py
+++ b/tests/test_zigbee_zwave_inovelli_reset_replay.py
@@ -357,6 +357,20 @@ def test_inovelli_led_recovery_automation_watches_all_led_number_entities() -> N
         assert token in block
 
 
+def test_dynamic_inovelli_target_lists_exclude_inactive_restored_entities() -> None:
+    text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
+    loops = re.findall(
+        r"{%- for device in states\.(?:number|select)\n(?P<body>.*?){%- endfor %}",
+        text,
+        flags=re.DOTALL,
+    )
+
+    assert loops
+    for loop in loops:
+        assert "rejectattr('state', 'in', ['unknown', 'unavailable'])" in loop
+        assert "rejectattr('attributes.restored', 'eq', true)" in loop
+
+
 def test_inovelli_led_recovery_replays_trip_day_night_and_owner_suite_darkening() -> None:
     text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Fixes #818.

- filters all dynamic Inovelli `states.number` / `states.select` target lists to exclude `unknown`, `unavailable`, and restored entities
- covers scheduled day/night/trip LED policy scripts plus manual reset target lists
- adds regression coverage so broad dynamic Inovelli lists must keep the active-entity filters

## Runtime evidence

Nightly Trace Review found live HA 2026.6.4 warnings at 2026-06-28 08:00 from Inovelli LED policy service calls targeting restored/unavailable `0x943469fffe0895fb` entities, including `ledintensitywhenon`, `ledcolorwhenon`, `singletapbehavior`, `defaultlevellocal`, and `defaultlevelremote`. Live template evaluation of the new filter excluded the restored `0x943469fffe0895fb` targets.

## Validation

- `uv run --with pytest pytest tests/test_zigbee_zwave_inovelli_reset_replay.py tests/test_inovelli_day_mode_switches.py tests/test_issue_trip_led_suspend.py -q` — 29 passed
- `uv run --with pytest pytest tests/test_zigbee_zwave_inovelli_reset_replay.py tests/test_inovelli_day_mode_switches.py tests/test_issue_trip_led_suspend.py tests/test_zigbee_zwave_inovelli_day_mode.py tests/test_adaptive_lighting_inovelli_led_bar_sync.py -q` — 36 passed
- `uv run --with pytest pytest` — 540 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/zigbee_zwave.yaml` — passed
- YAML parse with `!secret` placeholder constructor — passed
- `git diff --check` — passed
- Live HA `/api/template` evaluation of representative filter — passed, restored `0x943469fffe0895fb` target excluded

## Validation notes

- HA YAML DRY verifier still reports the same pre-existing duplicate entries on `origin/develop` for the Inovelli package trip-mode guard/reset sequences; deferred to existing DRY cleanup scope to avoid broadening this runtime fix.
- Local Home Assistant container `check_config` was attempted with Podman against a temp config copy, but Podman could not connect to the default machine socket (`127.0.0.1:53019: connect: connection refused`) after `podman machine start`.
