### PR TITLE
Fix #828 NWS alert empty-list guards

### DIFF
--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -1065,141 +1065,142 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
           {% set state =  states['sensor.nws_dakota_county_alerts_alert_1'].attributes.alert_event %}
         {% else %}
           {% set state = 'unavailable' %}
         {% endif %}
         {{ mapper[state] if state in mapper else 'hass:alert-rhombus' }}
       state: >-
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) and (as_timestamp(state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0].endsExpires) - as_timestamp(now()) > 0)) %}
+        {% set alerts = state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) %}
+        {% if alerts | count > 0 and (as_timestamp(alerts[0].endsExpires) - as_timestamp(now()) > 0) %}
           on
         {% else %}
           off
         {% endif %}
       attributes:
         alert_id: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].id }}
           {% else %}
             None
           {% endif %}
         alert_event: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].event }}
           {% else %}
             None
           {% endif %}
         alert_area: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].area }}
           {% else %}
             None
           {% endif %}
         alert_NWSheadline: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}
           {% else %}
             None
           {% endif %}
         alert_description: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].description  }}
           {% else %}
             None
           {% endif %}
         alert_messageType: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].messageType }}
           {% else %}
             None
           {% endif %}
         alert_status: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].status }}
           {% else %}
             None
           {% endif %}
         alert_category: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].category }}
           {% else %}
             None
           {% endif %}
         alert_urgency: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].urgency }}
           {% else %}
             None
           {% endif %}
         alert_severity: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].severity }}
           {% else %}
             None
           {% endif %}
         alert_certainty: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].certainty }}
           {% else %}
             None
           {% endif %}
         alert_response: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].response }}
           {% else %}
             None
           {% endif %}
         alert_instruction: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].instruction }}
           {% else %}
             None
           {% endif %}
         alert_sent: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].sent }}
           {% else %}
             None
           {% endif %}
         alert_effective: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].effective }}
           {% else %}
             None
           {% endif %}
         alert_onset: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].onset }}
           {% else %}
             None
           {% endif %}
         alert_expires: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].expires }}
           {% else %}
             None
           {% endif %}
         alert_title: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].title }}
           {% else %}
             None
           {% endif %}
         alert_zoneid: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].zoneid }}
           {% else %}
             None
           {% endif %}
         display_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].title }}
           {% else %}
             None
           {% endif %}
         display_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[0].NWSheadline != "null" %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}<br>
             {% endif %}
@@ -1217,13 +1218,13 @@ template:
             None
           {% endif %}
         spoken_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             Attention!!! Weather alert for {{ state_attr('sensor.nws_dakota_county_alerts', 'friendly_name') }}. A {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].title }}. {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') | capitalize }}.
           {% else %}
             None
           {% endif %}
         spoken_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].description | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[0].instruction != None %}
               {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].instruction | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
@@ -1364,141 +1365,142 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
           {% set state =  states['sensor.nws_dakota_county_alerts_alert_2'].attributes.alert_event %}
         {% else %}
           {% set state = 'unavailable' %}
         {% endif %}
         {{ mapper[state] if state in mapper else 'hass:alert-rhombus' }}
       state: >-
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[1] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[1] != null) and (as_timestamp(state_attr('sensor.nws_dakota_county_alerts', 'alerts')[1].endsExpires) - as_timestamp(now()) > 0)) %}
+        {% set alerts = state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) %}
+        {% if alerts | count > 1 and (as_timestamp(alerts[1].endsExpires) - as_timestamp(now()) > 0) %}
           on
         {% else %}
           off
         {% endif %}
       attributes:
         alert_id: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].id }}
           {% else %}
             None
           {% endif %}
         alert_event: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].event }}
           {% else %}
             None
           {% endif %}
         alert_area: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].area }}
           {% else %}
             None
           {% endif %}
         alert_NWSheadline: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}
           {% else %}
             None
           {% endif %}
         alert_description: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].description  }}
           {% else %}
             None
           {% endif %}
         alert_messageType: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].messageType }}
           {% else %}
             None
           {% endif %}
         alert_status: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].status }}
           {% else %}
             None
           {% endif %}
         alert_category: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].category }}
           {% else %}
             None
           {% endif %}
         alert_urgency: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].urgency }}
           {% else %}
             None
           {% endif %}
         alert_severity: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].severity }}
           {% else %}
             None
           {% endif %}
         alert_certainty: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].certainty }}
           {% else %}
             None
           {% endif %}
         alert_response: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].response }}
           {% else %}
             None
           {% endif %}
         alert_instruction: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].instruction }}
           {% else %}
             None
           {% endif %}
         alert_sent: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].sent }}
           {% else %}
             None
           {% endif %}
         alert_effective: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].effective }}
           {% else %}
             None
           {% endif %}
         alert_onset: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].onset }}
           {% else %}
             None
           {% endif %}
         alert_expires: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].expires }}
           {% else %}
             None
           {% endif %}
         alert_title: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].title }}
           {% else %}
             None
           {% endif %}
         alert_zoneid: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].zoneid }}
           {% else %}
             None
           {% endif %}
         display_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].title }}
           {% else %}
             None
           {% endif %}
         display_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[1].NWSheadline != "null" %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}<br>
             {% endif %}
@@ -1516,13 +1518,13 @@ template:
             None
           {% endif %}
         spoken_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             Attention!!! Weather alert for {{ state_attr('sensor.nws_dakota_county_alerts', 'friendly_name') }}. A {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].title }}. {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') | capitalize }}.
           {% else %}
             None
           {% endif %}
         spoken_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 1 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].description | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[1].instruction != None %}
               {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].instruction | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
@@ -1663,141 +1665,142 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
           {% set state =  states['sensor.nws_dakota_county_alerts_alert_3'].attributes.alert_event %}
         {% else %}
           {% set state = 'unavailable' %}
         {% endif %}
         {{ mapper[state] if state in mapper else 'hass:alert-rhombus' }}
       state: >-
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[2] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[2] != null) and (as_timestamp(state_attr('sensor.nws_dakota_county_alerts', 'alerts')[2].endsExpires) - as_timestamp(now()) > 0)) %}
+        {% set alerts = state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) %}
+        {% if alerts | count > 2 and (as_timestamp(alerts[2].endsExpires) - as_timestamp(now()) > 0) %}
           on
         {% else %}
           off
         {% endif %}
       attributes:
         alert_id: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].id }}
           {% else %}
             None
           {% endif %}
         alert_event: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].event }}
           {% else %}
             None
           {% endif %}
         alert_area: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].area }}
           {% else %}
             None
           {% endif %}
         alert_NWSheadline: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}
           {% else %}
             None
           {% endif %}
         alert_description: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].description  }}
           {% else %}
             None
           {% endif %}
         alert_messageType: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].messageType }}
           {% else %}
             None
           {% endif %}
         alert_status: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].status }}
           {% else %}
             None
           {% endif %}
         alert_category: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].category }}
           {% else %}
             None
           {% endif %}
         alert_urgency: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].urgency }}
           {% else %}
             None
           {% endif %}
         alert_severity: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].severity }}
           {% else %}
             None
           {% endif %}
         alert_certainty: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].certainty }}
           {% else %}
             None
           {% endif %}
         alert_response: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].response }}
           {% else %}
             None
           {% endif %}
         alert_instruction: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].instruction }}
           {% else %}
             None
           {% endif %}
         alert_sent: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].sent }}
           {% else %}
             None
           {% endif %}
         alert_effective: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].effective }}
           {% else %}
             None
           {% endif %}
         alert_onset: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].onset }}
           {% else %}
             None
           {% endif %}
         alert_expires: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].expires }}
           {% else %}
             None
           {% endif %}
         alert_title: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].title }}
           {% else %}
             None
           {% endif %}
         alert_zoneid: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].zoneid }}
           {% else %}
             None
           {% endif %}
         display_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].title }}
           {% else %}
             None
           {% endif %}
         display_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[2].NWSheadline != "null" %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}<br>
             {% endif %}
@@ -1815,13 +1818,13 @@ template:
             None
           {% endif %}
         spoken_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             Attention!!! Weather alert for {{ state_attr('sensor.nws_dakota_county_alerts', 'friendly_name') }}. A {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].title }}. {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') | capitalize }}.
           {% else %}
             None
           {% endif %}
         spoken_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 2 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].description | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[2].instruction != None %}
               {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].instruction | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
@@ -1962,141 +1965,142 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
           {% set state =  states['sensor.nws_dakota_county_alerts_alert_4'].attributes.alert_event %}
         {% else %}
           {% set state = 'unavailable' %}
         {% endif %}
         {{ mapper[state] if state in mapper else 'hass:alert-rhombus' }}
       state: >-
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[3] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[3] != null) and (as_timestamp(state_attr('sensor.nws_dakota_county_alerts', 'alerts')[3].endsExpires) - as_timestamp(now()) > 0)) %}
+        {% set alerts = state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) %}
+        {% if alerts | count > 3 and (as_timestamp(alerts[3].endsExpires) - as_timestamp(now()) > 0) %}
           on
         {% else %}
           off
         {% endif %}
       attributes:
         alert_id: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].id }}
           {% else %}
             None
           {% endif %}
         alert_event: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].event }}
           {% else %}
             None
           {% endif %}
         alert_area: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].area }}
           {% else %}
             None
           {% endif %}
         alert_NWSheadline: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}
           {% else %}
             None
           {% endif %}
         alert_description: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].description  }}
           {% else %}
             None
           {% endif %}
         alert_messageType: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].messageType }}
           {% else %}
             None
           {% endif %}
         alert_status: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].status }}
           {% else %}
             None
           {% endif %}
         alert_category: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].category }}
           {% else %}
             None
           {% endif %}
         alert_urgency: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].urgency }}
           {% else %}
             None
           {% endif %}
         alert_severity: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].severity }}
           {% else %}
             None
           {% endif %}
         alert_certainty: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].certainty }}
           {% else %}
             None
           {% endif %}
         alert_response: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].response }}
           {% else %}
             None
           {% endif %}
         alert_instruction: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].instruction }}
           {% else %}
             None
           {% endif %}
         alert_sent: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].sent }}
           {% else %}
             None
           {% endif %}
         alert_effective: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].effective }}
           {% else %}
             None
           {% endif %}
         alert_onset: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].onset }}
           {% else %}
             None
           {% endif %}
         alert_expires: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].expires }}
           {% else %}
             None
           {% endif %}
         alert_title: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].title }}
           {% else %}
             None
           {% endif %}
         alert_zoneid: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].zoneid }}
           {% else %}
             None
           {% endif %}
         display_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].title }}
           {% else %}
             None
           {% endif %}
         display_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[3].NWSheadline != "null" %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}<br>
             {% endif %}
@@ -2114,13 +2118,13 @@ template:
             None
           {% endif %}
         spoken_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             Attention!!! Weather alert for {{ state_attr('sensor.nws_dakota_county_alerts', 'friendly_name') }}. A {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].title }}. {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') | capitalize }}.
           {% else %}
             None
           {% endif %}
         spoken_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 3 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].description | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[3].instruction != None %}
               {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].instruction | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
@@ -2261,141 +2265,142 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
           {% set state =  states['sensor.nws_dakota_county_alerts_alert_5'].attributes.alert_event %}
         {% else %}
           {% set state = 'unavailable' %}
         {% endif %}
         {{ mapper[state] if state in mapper else 'hass:alert-rhombus' }}
       state: >-
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[4] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[4] != null) and (as_timestamp(state_attr('sensor.nws_dakota_county_alerts', 'alerts')[4].endsExpires) - as_timestamp(now()) > 0)) %}
+        {% set alerts = state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) %}
+        {% if alerts | count > 4 and (as_timestamp(alerts[4].endsExpires) - as_timestamp(now()) > 0) %}
           on
         {% else %}
           off
         {% endif %}
       attributes:
         alert_id: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].id }}
           {% else %}
             None
           {% endif %}
         alert_event: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].event }}
           {% else %}
             None
           {% endif %}
         alert_area: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].area }}
           {% else %}
             None
           {% endif %}
         alert_NWSheadline: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}
           {% else %}
             None
           {% endif %}
         alert_description: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].description  }}
           {% else %}
             None
           {% endif %}
         alert_messageType: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].messageType }}
           {% else %}
             None
           {% endif %}
         alert_status: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].status }}
           {% else %}
             None
           {% endif %}
         alert_category: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].category }}
           {% else %}
             None
           {% endif %}
         alert_urgency: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].urgency }}
           {% else %}
             None
           {% endif %}
         alert_severity: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].severity }}
           {% else %}
             None
           {% endif %}
         alert_certainty: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].certainty }}
           {% else %}
             None
           {% endif %}
         alert_response: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].response }}
           {% else %}
             None
           {% endif %}
         alert_instruction: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].instruction }}
           {% else %}
             None
           {% endif %}
         alert_sent: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].sent }}
           {% else %}
             None
           {% endif %}
         alert_effective: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].effective }}
           {% else %}
             None
           {% endif %}
         alert_onset: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].onset }}
           {% else %}
             None
           {% endif %}
         alert_expires: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].expires }}
           {% else %}
             None
           {% endif %}
         alert_title: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].title }}
           {% else %}
             None
           {% endif %}
         alert_zoneid: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].zoneid }}
           {% else %}
             None
           {% endif %}
         display_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].title }}
           {% else %}
             None
           {% endif %}
         display_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[4].NWSheadline != "null" %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}<br>
             {% endif %}
@@ -2413,13 +2418,13 @@ template:
             None
           {% endif %}
         spoken_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             Attention!!! Weather alert for {{ state_attr('sensor.nws_dakota_county_alerts', 'friendly_name') }}. A {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].title }}. {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') | capitalize }}.
           {% else %}
             None
           {% endif %}
         spoken_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].description | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[4].instruction != None %}
               {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].instruction | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
@@ -2605,7 +2610,7 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
           {% if states('sensor.nws_dakota_county_alerts_alert_1_most_recent_active_alert') == '' and states('sensor.nws_dakota_county_alerts_alert_1') != 'on' %}
             {% set state = 'unavailable' %}
           {% elif states('sensor.nws_dakota_county_alerts_alert_1_most_recent_active_alert') == 'unavailable' and states('sensor.nws_dakota_county_alerts_alert_1') != 'on' %}
@@ -2791,7 +2796,7 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
           {% if states('sensor.nws_dakota_county_alerts_alert_2_most_recent_active_alert') == '' and states('sensor.nws_dakota_county_alerts_alert_2') != 'on' %}
             {% set state = 'unavailable' %}
           {% elif states('sensor.nws_dakota_county_alerts_alert_2_most_recent_active_alert') == 'unavailable' and states('sensor.nws_dakota_county_alerts_alert_2') != 'on' %}
@@ -2977,7 +2982,7 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
           {% if states('sensor.nws_dakota_county_alerts_alert_3_most_recent_active_alert') == '' and states('sensor.nws_dakota_county_alerts_alert_3') != 'on' %}
             {% set state = 'unavailable' %}
           {% elif states('sensor.nws_dakota_county_alerts_alert_3_most_recent_active_alert') == 'unavailable' and states('sensor.nws_dakota_county_alerts_alert_3') != 'on' %}
@@ -3163,7 +3168,7 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
           {% if states('sensor.nws_dakota_county_alerts_alert_4_most_recent_active_alert') == '' and states('sensor.nws_dakota_county_alerts_alert_4') != 'on' %}
             {% set state = 'unavailable' %}
           {% elif states('sensor.nws_dakota_county_alerts_alert_4_most_recent_active_alert') == 'unavailable' and states('sensor.nws_dakota_county_alerts_alert_4') != 'on' %}
@@ -3349,7 +3354,7 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}
           {% if states('sensor.nws_dakota_county_alerts_alert_5_most_recent_active_alert') == '' and states('sensor.nws_dakota_county_alerts_alert_5') != 'on' %}
             {% set state = 'unavailable' %}
           {% elif states('sensor.nws_dakota_county_alerts_alert_5_most_recent_active_alert') == 'unavailable' and states('sensor.nws_dakota_county_alerts_alert_5') != 'on' %}

--- a/tests/test_issue_weatheralerts_yaml_deprecation.py
+++ b/tests/test_issue_weatheralerts_yaml_deprecation.py
@@ -87,3 +87,14 @@ def test_weather_package_restores_legacy_nws_raw_source_from_ui_managed_payload(
     assert "raw_ends_expires = alert.get('EndsExpires', alert.get('endsExpires', none))" in text
     assert "raw_ends_expires not in [none, '', 'null', 'None', 'NULL']" in text
     assert "else (ends if ends is not none else expires)" in text
+
+
+def test_legacy_nws_alert_slots_do_not_index_empty_alert_lists() -> None:
+    text = WEATHER_PATH.read_text(encoding="utf-8")
+
+    assert "is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or" not in text
+    assert "state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null" not in text
+    assert "{% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 0 %}" in text
+    assert "{% if states('sensor.nws_dakota_county_alerts') | int(default=0) > 4 %}" in text
+    assert "{% if alerts | count > 0 and (as_timestamp(alerts[0].endsExpires)" in text
+    assert "{% if alerts | count > 4 and (as_timestamp(alerts[4].endsExpires)" in text


### PR DESCRIPTION
## Summary

Fixes #828.

- Guards each legacy `nws_dakota_county_alerts_alert_*` slot by the current raw alert count/list length before reading indexed alert attributes.
- Removes the stale `slot is on OR count` guard pattern that allowed old slot state to index an empty `alerts` list.
- Adds regression coverage so the zero-alert guard pattern is not reintroduced.

## Runtime evidence

Nightly Trace Review found current live HA template errors on 2026-06-28:

- `Template variable error: homeassistant.helpers.template.Wrapper object has no element 0`
- `TemplateError('UndefinedError: homeassistant.helpers.template.Wrapper object has no element 0') ... entity 'sensor.nws_dakota_county_alerts_alert_1'`

Live `/homeassistant/packages/weather.yaml` matched the repo hash, so this was not deployment drift. The failing path was the restored NWS compatibility source from #757 / PR #774 when the backing alert list was empty but a legacy slot still had prior `on` state.

## Validation

- `uv run --with pytest pytest tests/test_issue_weatheralerts_yaml_deprecation.py tests/test_weather_package.py -q` - 6 passed
- `python3 - <<'PY' ... yaml.safe_load('packages/weather.yaml') ... PY` - passed
- `git diff --check` - passed
- `uv run --with pytest pytest` - 540 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/weather.yaml` - passed
- Live HA `homeassistant.check_config` service - accepted / returned `[]`
- HA YAML DRY verifier on `packages/weather.yaml` - blocked by pre-existing duplicate trigger/condition findings that are identical on `origin/develop`
