### PR TITLE
Fix #828 NWS alert empty-list guards

### DIFF
--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -1065,141 +1065,143 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
           {% set state =  states['sensor.nws_dakota_county_alerts_alert_1'].attributes.alert_event %}
         {% else %}
           {% set state = 'unavailable' %}
         {% endif %}
         {{ mapper[state] if state in mapper else 'hass:alert-rhombus' }}
       state: >-
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) and (as_timestamp(state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0].endsExpires) - as_timestamp(now()) > 0)) %}
+        {% set alerts = state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) %}
+        {% set alert = alerts[0] if alerts is sequence and (alerts | count) > 0 else none %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and alert is mapping %}
           on
         {% else %}
           off
         {% endif %}
       attributes:
         alert_id: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].id }}
           {% else %}
             None
           {% endif %}
         alert_event: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].event }}
           {% else %}
             None
           {% endif %}
         alert_area: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].area }}
           {% else %}
             None
           {% endif %}
         alert_NWSheadline: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}
           {% else %}
             None
           {% endif %}
         alert_description: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].description  }}
           {% else %}
             None
           {% endif %}
         alert_messageType: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].messageType }}
           {% else %}
             None
           {% endif %}
         alert_status: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].status }}
           {% else %}
             None
           {% endif %}
         alert_category: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].category }}
           {% else %}
             None
           {% endif %}
         alert_urgency: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].urgency }}
           {% else %}
             None
           {% endif %}
         alert_severity: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].severity }}
           {% else %}
             None
           {% endif %}
         alert_certainty: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].certainty }}
           {% else %}
             None
           {% endif %}
         alert_response: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].response }}
           {% else %}
             None
           {% endif %}
         alert_instruction: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].instruction }}
           {% else %}
             None
           {% endif %}
         alert_sent: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].sent }}
           {% else %}
             None
           {% endif %}
         alert_effective: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].effective }}
           {% else %}
             None
           {% endif %}
         alert_onset: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].onset }}
           {% else %}
             None
           {% endif %}
         alert_expires: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].expires }}
           {% else %}
             None
           {% endif %}
         alert_title: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].title }}
           {% else %}
             None
           {% endif %}
         alert_zoneid: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].zoneid }}
           {% else %}
             None
           {% endif %}
         display_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].title }}
           {% else %}
             None
           {% endif %}
         display_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[0].NWSheadline != "null" %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}<br>
             {% endif %}
@@ -1217,13 +1219,13 @@ template:
             None
           {% endif %}
         spoken_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             Attention!!! Weather alert for {{ state_attr('sensor.nws_dakota_county_alerts', 'friendly_name') }}. A {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].title }}. {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') | capitalize }}.
           {% else %}
             None
           {% endif %}
         spoken_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_1', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 0)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].description | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[0].instruction != None %}
               {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[0].instruction | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
@@ -1364,141 +1366,143 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
           {% set state =  states['sensor.nws_dakota_county_alerts_alert_2'].attributes.alert_event %}
         {% else %}
           {% set state = 'unavailable' %}
         {% endif %}
         {{ mapper[state] if state in mapper else 'hass:alert-rhombus' }}
       state: >-
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[1] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[1] != null) and (as_timestamp(state_attr('sensor.nws_dakota_county_alerts', 'alerts')[1].endsExpires) - as_timestamp(now()) > 0)) %}
+        {% set alerts = state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) %}
+        {% set alert = alerts[1] if alerts is sequence and (alerts | count) > 1 else none %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and alert is mapping %}
           on
         {% else %}
           off
         {% endif %}
       attributes:
         alert_id: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].id }}
           {% else %}
             None
           {% endif %}
         alert_event: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].event }}
           {% else %}
             None
           {% endif %}
         alert_area: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].area }}
           {% else %}
             None
           {% endif %}
         alert_NWSheadline: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}
           {% else %}
             None
           {% endif %}
         alert_description: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].description  }}
           {% else %}
             None
           {% endif %}
         alert_messageType: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].messageType }}
           {% else %}
             None
           {% endif %}
         alert_status: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].status }}
           {% else %}
             None
           {% endif %}
         alert_category: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].category }}
           {% else %}
             None
           {% endif %}
         alert_urgency: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].urgency }}
           {% else %}
             None
           {% endif %}
         alert_severity: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].severity }}
           {% else %}
             None
           {% endif %}
         alert_certainty: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].certainty }}
           {% else %}
             None
           {% endif %}
         alert_response: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].response }}
           {% else %}
             None
           {% endif %}
         alert_instruction: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].instruction }}
           {% else %}
             None
           {% endif %}
         alert_sent: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].sent }}
           {% else %}
             None
           {% endif %}
         alert_effective: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].effective }}
           {% else %}
             None
           {% endif %}
         alert_onset: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].onset }}
           {% else %}
             None
           {% endif %}
         alert_expires: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].expires }}
           {% else %}
             None
           {% endif %}
         alert_title: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].title }}
           {% else %}
             None
           {% endif %}
         alert_zoneid: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].zoneid }}
           {% else %}
             None
           {% endif %}
         display_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].title }}
           {% else %}
             None
           {% endif %}
         display_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[1].NWSheadline != "null" %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}<br>
             {% endif %}
@@ -1516,13 +1520,13 @@ template:
             None
           {% endif %}
         spoken_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             Attention!!! Weather alert for {{ state_attr('sensor.nws_dakota_county_alerts', 'friendly_name') }}. A {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].title }}. {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') | capitalize }}.
           {% else %}
             None
           {% endif %}
         spoken_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_2', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 1)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 1) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].description | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[1].instruction != None %}
               {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[1].instruction | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
@@ -1663,141 +1667,143 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
           {% set state =  states['sensor.nws_dakota_county_alerts_alert_3'].attributes.alert_event %}
         {% else %}
           {% set state = 'unavailable' %}
         {% endif %}
         {{ mapper[state] if state in mapper else 'hass:alert-rhombus' }}
       state: >-
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[2] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[2] != null) and (as_timestamp(state_attr('sensor.nws_dakota_county_alerts', 'alerts')[2].endsExpires) - as_timestamp(now()) > 0)) %}
+        {% set alerts = state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) %}
+        {% set alert = alerts[2] if alerts is sequence and (alerts | count) > 2 else none %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and alert is mapping %}
           on
         {% else %}
           off
         {% endif %}
       attributes:
         alert_id: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].id }}
           {% else %}
             None
           {% endif %}
         alert_event: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].event }}
           {% else %}
             None
           {% endif %}
         alert_area: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].area }}
           {% else %}
             None
           {% endif %}
         alert_NWSheadline: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}
           {% else %}
             None
           {% endif %}
         alert_description: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].description  }}
           {% else %}
             None
           {% endif %}
         alert_messageType: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].messageType }}
           {% else %}
             None
           {% endif %}
         alert_status: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].status }}
           {% else %}
             None
           {% endif %}
         alert_category: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].category }}
           {% else %}
             None
           {% endif %}
         alert_urgency: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].urgency }}
           {% else %}
             None
           {% endif %}
         alert_severity: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].severity }}
           {% else %}
             None
           {% endif %}
         alert_certainty: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].certainty }}
           {% else %}
             None
           {% endif %}
         alert_response: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].response }}
           {% else %}
             None
           {% endif %}
         alert_instruction: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].instruction }}
           {% else %}
             None
           {% endif %}
         alert_sent: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].sent }}
           {% else %}
             None
           {% endif %}
         alert_effective: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].effective }}
           {% else %}
             None
           {% endif %}
         alert_onset: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].onset }}
           {% else %}
             None
           {% endif %}
         alert_expires: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].expires }}
           {% else %}
             None
           {% endif %}
         alert_title: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].title }}
           {% else %}
             None
           {% endif %}
         alert_zoneid: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].zoneid }}
           {% else %}
             None
           {% endif %}
         display_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].title }}
           {% else %}
             None
           {% endif %}
         display_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[2].NWSheadline != "null" %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}<br>
             {% endif %}
@@ -1815,13 +1821,13 @@ template:
             None
           {% endif %}
         spoken_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             Attention!!! Weather alert for {{ state_attr('sensor.nws_dakota_county_alerts', 'friendly_name') }}. A {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].title }}. {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') | capitalize }}.
           {% else %}
             None
           {% endif %}
         spoken_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_3', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 2)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 2) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].description | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[2].instruction != None %}
               {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[2].instruction | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
@@ -1962,141 +1968,143 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
           {% set state =  states['sensor.nws_dakota_county_alerts_alert_4'].attributes.alert_event %}
         {% else %}
           {% set state = 'unavailable' %}
         {% endif %}
         {{ mapper[state] if state in mapper else 'hass:alert-rhombus' }}
       state: >-
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[3] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[3] != null) and (as_timestamp(state_attr('sensor.nws_dakota_county_alerts', 'alerts')[3].endsExpires) - as_timestamp(now()) > 0)) %}
+        {% set alerts = state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) %}
+        {% set alert = alerts[3] if alerts is sequence and (alerts | count) > 3 else none %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and alert is mapping %}
           on
         {% else %}
           off
         {% endif %}
       attributes:
         alert_id: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].id }}
           {% else %}
             None
           {% endif %}
         alert_event: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].event }}
           {% else %}
             None
           {% endif %}
         alert_area: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].area }}
           {% else %}
             None
           {% endif %}
         alert_NWSheadline: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}
           {% else %}
             None
           {% endif %}
         alert_description: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].description  }}
           {% else %}
             None
           {% endif %}
         alert_messageType: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].messageType }}
           {% else %}
             None
           {% endif %}
         alert_status: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].status }}
           {% else %}
             None
           {% endif %}
         alert_category: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].category }}
           {% else %}
             None
           {% endif %}
         alert_urgency: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].urgency }}
           {% else %}
             None
           {% endif %}
         alert_severity: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].severity }}
           {% else %}
             None
           {% endif %}
         alert_certainty: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].certainty }}
           {% else %}
             None
           {% endif %}
         alert_response: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].response }}
           {% else %}
             None
           {% endif %}
         alert_instruction: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].instruction }}
           {% else %}
             None
           {% endif %}
         alert_sent: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].sent }}
           {% else %}
             None
           {% endif %}
         alert_effective: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].effective }}
           {% else %}
             None
           {% endif %}
         alert_onset: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].onset }}
           {% else %}
             None
           {% endif %}
         alert_expires: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].expires }}
           {% else %}
             None
           {% endif %}
         alert_title: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].title }}
           {% else %}
             None
           {% endif %}
         alert_zoneid: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].zoneid }}
           {% else %}
             None
           {% endif %}
         display_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].title }}
           {% else %}
             None
           {% endif %}
         display_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[3].NWSheadline != "null" %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}<br>
             {% endif %}
@@ -2114,13 +2122,13 @@ template:
             None
           {% endif %}
         spoken_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             Attention!!! Weather alert for {{ state_attr('sensor.nws_dakota_county_alerts', 'friendly_name') }}. A {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].title }}. {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') | capitalize }}.
           {% else %}
             None
           {% endif %}
         spoken_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_4', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 3)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 3) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].description | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[3].instruction != None %}
               {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[3].instruction | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
@@ -2261,141 +2269,143 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
           {% set state =  states['sensor.nws_dakota_county_alerts_alert_5'].attributes.alert_event %}
         {% else %}
           {% set state = 'unavailable' %}
         {% endif %}
         {{ mapper[state] if state in mapper else 'hass:alert-rhombus' }}
       state: >-
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[4] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[4] != null) and (as_timestamp(state_attr('sensor.nws_dakota_county_alerts', 'alerts')[4].endsExpires) - as_timestamp(now()) > 0)) %}
+        {% set alerts = state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) %}
+        {% set alert = alerts[4] if alerts is sequence and (alerts | count) > 4 else none %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and alert is mapping %}
           on
         {% else %}
           off
         {% endif %}
       attributes:
         alert_id: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].id }}
           {% else %}
             None
           {% endif %}
         alert_event: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].event }}
           {% else %}
             None
           {% endif %}
         alert_area: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].area }}
           {% else %}
             None
           {% endif %}
         alert_NWSheadline: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}
           {% else %}
             None
           {% endif %}
         alert_description: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].description  }}
           {% else %}
             None
           {% endif %}
         alert_messageType: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].messageType }}
           {% else %}
             None
           {% endif %}
         alert_status: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].status }}
           {% else %}
             None
           {% endif %}
         alert_category: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].category }}
           {% else %}
             None
           {% endif %}
         alert_urgency: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].urgency }}
           {% else %}
             None
           {% endif %}
         alert_severity: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].severity }}
           {% else %}
             None
           {% endif %}
         alert_certainty: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].certainty }}
           {% else %}
             None
           {% endif %}
         alert_response: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].response }}
           {% else %}
             None
           {% endif %}
         alert_instruction: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].instruction }}
           {% else %}
             None
           {% endif %}
         alert_sent: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].sent }}
           {% else %}
             None
           {% endif %}
         alert_effective: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].effective }}
           {% else %}
             None
           {% endif %}
         alert_onset: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].onset }}
           {% else %}
             None
           {% endif %}
         alert_expires: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].expires }}
           {% else %}
             None
           {% endif %}
         alert_title: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].title }}
           {% else %}
             None
           {% endif %}
         alert_zoneid: >-
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].zoneid }}
           {% else %}
             None
           {% endif %}
         display_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].title }}
           {% else %}
             None
           {% endif %}
         display_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[4].NWSheadline != "null" %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') }}<br>
             {% endif %}
@@ -2413,13 +2423,13 @@ template:
             None
           {% endif %}
         spoken_title: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             Attention!!! Weather alert for {{ state_attr('sensor.nws_dakota_county_alerts', 'friendly_name') }}. A {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].title }}. {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].NWSheadline | regex_replace('\[\'','') | regex_replace('\'\]','') | capitalize }}.
           {% else %}
             None
           {% endif %}
         spoken_message: >
-          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and is_state('sensor.nws_dakota_county_alerts_alert_5', 'on') or (is_number(states('sensor.nws_dakota_county_alerts')) and (states('sensor.nws_dakota_county_alerts')|int > 4)) %}
+          {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and ((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 4) %}
             {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].description | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
             {% if states.sensor.nws_dakota_county_alerts.attributes.alerts[4].instruction != None %}
               {{ states.sensor.nws_dakota_county_alerts.attributes.alerts[4].instruction | regex_replace('\n\n','<p>') | regex_replace('\n',' ') | regex_replace('\*','\n*') | regex_replace('<p>','\n\n') }}
@@ -2605,7 +2615,7 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0)) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0))) %}
           {% if states('sensor.nws_dakota_county_alerts_alert_1_most_recent_active_alert') == '' and states('sensor.nws_dakota_county_alerts_alert_1') != 'on' %}
             {% set state = 'unavailable' %}
           {% elif states('sensor.nws_dakota_county_alerts_alert_1_most_recent_active_alert') == 'unavailable' and states('sensor.nws_dakota_county_alerts_alert_1') != 'on' %}
@@ -2791,7 +2801,7 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0)) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0))) %}
           {% if states('sensor.nws_dakota_county_alerts_alert_2_most_recent_active_alert') == '' and states('sensor.nws_dakota_county_alerts_alert_2') != 'on' %}
             {% set state = 'unavailable' %}
           {% elif states('sensor.nws_dakota_county_alerts_alert_2_most_recent_active_alert') == 'unavailable' and states('sensor.nws_dakota_county_alerts_alert_2') != 'on' %}
@@ -2977,7 +2987,7 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0)) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0))) %}
           {% if states('sensor.nws_dakota_county_alerts_alert_3_most_recent_active_alert') == '' and states('sensor.nws_dakota_county_alerts_alert_3') != 'on' %}
             {% set state = 'unavailable' %}
           {% elif states('sensor.nws_dakota_county_alerts_alert_3_most_recent_active_alert') == 'unavailable' and states('sensor.nws_dakota_county_alerts_alert_3') != 'on' %}
@@ -3163,7 +3173,7 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0)) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0))) %}
           {% if states('sensor.nws_dakota_county_alerts_alert_4_most_recent_active_alert') == '' and states('sensor.nws_dakota_county_alerts_alert_4') != 'on' %}
             {% set state = 'unavailable' %}
           {% elif states('sensor.nws_dakota_county_alerts_alert_4_most_recent_active_alert') == 'unavailable' and states('sensor.nws_dakota_county_alerts_alert_4') != 'on' %}
@@ -3349,7 +3359,7 @@ template:
             'Winter Storm Warning' : 'hass:snowflake-alert',
             'Winter Storm Watch' : 'hass:snowflake-alert',
             'Winter Weather Advisory' : 'hass:snowflake-alert' } %}
-        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0] != null)) %}
+        {% if not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and not is_state('sensor.nws_dakota_county_alerts', 'unknown') and (((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0)) or (not is_state('sensor.nws_dakota_county_alerts', 'unavailable') and (((state_attr('sensor.nws_dakota_county_alerts', 'alerts') | default([], true) | count) > 0))) %}
           {% if states('sensor.nws_dakota_county_alerts_alert_5_most_recent_active_alert') == '' and states('sensor.nws_dakota_county_alerts_alert_5') != 'on' %}
             {% set state = 'unavailable' %}
           {% elif states('sensor.nws_dakota_county_alerts_alert_5_most_recent_active_alert') == 'unavailable' and states('sensor.nws_dakota_county_alerts_alert_5') != 'on' %}

--- a/tests/test_issue_weatheralerts_yaml_deprecation.py
+++ b/tests/test_issue_weatheralerts_yaml_deprecation.py
@@ -87,3 +87,27 @@ def test_weather_package_restores_legacy_nws_raw_source_from_ui_managed_payload(
     assert "raw_ends_expires = alert.get('EndsExpires', alert.get('endsExpires', none))" in text
     assert "raw_ends_expires not in [none, '', 'null', 'None', 'NULL']" in text
     assert "else (ends if ends is not none else expires)" in text
+
+
+def test_legacy_nws_alert_slots_guard_empty_source_lists_before_indexing() -> None:
+    text = WEATHER_PATH.read_text(encoding="utf-8")
+
+    assert "state_attr('sensor.nws_dakota_county_alerts', 'alerts')[0]" not in text
+    assert "state_attr('sensor.nws_dakota_county_alerts', 'alerts')[1]" not in text
+    assert "state_attr('sensor.nws_dakota_county_alerts', 'alerts')[2]" not in text
+    assert "state_attr('sensor.nws_dakota_county_alerts', 'alerts')[3]" not in text
+    assert "state_attr('sensor.nws_dakota_county_alerts', 'alerts')[4]" not in text
+
+    for slot, minimum_count in enumerate(range(1, 6), start=1):
+        assert (
+            f"set alert = alerts[{slot - 1}] if alerts is sequence and "
+            f"(alerts | count) > {slot - 1} else none"
+        ) in text
+        assert (
+            "is_state('sensor.nws_dakota_county_alerts_alert_"
+            f"{slot}', 'on') or (is_number(states('sensor.nws_dakota_county_alerts'))"
+        ) not in text
+        assert (
+            "state_attr('sensor.nws_dakota_county_alerts', 'alerts') "
+            f"| default([], true) | count) > {minimum_count - 1}"
+        ) in text


### PR DESCRIPTION
Fixes #828.

## Summary
- guard each legacy NWS Dakota County alert slot by the current raw alert list length before indexing `alerts[n]`
- remove the stale child-sensor-state fallback that let an old `alert_n=on` state index an empty parent alert list
- add regression coverage so the unsafe `state_attr(..., 'alerts')[n]` guard and stale `alert_n on OR count` pattern are not reintroduced

## Runtime evidence
- Live HA 2026.6.4 logged repeated `Wrapper object has no element 0` template errors on 2026-06-29 around `sensor.nws_dakota_county_alerts_alert_1`.
- Live `/homeassistant/packages/weather.yaml` matched the repo hash, so this was not deployment drift.
- The current live NWS path is otherwise active: `sensor.nws_alerts` and the compatibility `sensor.nws_dakota_county_alerts` both populated once an alert arrived.

## Validation
- `uv run --with pytest pytest tests/test_issue_weatheralerts_yaml_deprecation.py tests/test_weather_package.py tests/test_repair_regressions.py -q` - 12 passed
- `uv run --with pytest pytest` - 540 passed
- `python3 - <<'PY' ... yaml.safe_load('packages/weather.yaml') ... PY` - passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/weather.yaml` - passed
- `git diff --check` - passed
- DRY verifier: ran on `packages/weather.yaml`; findings are pre-existing and identical on `origin/develop` (duplicate weather alert/window automation triggers/conditions), not introduced by this PR

## Not run
- Local Home Assistant container `check_config`: blocked by local Podman socket refusing connections after `podman machine stop/start` (`connect: connection refused` against the active machine socket). No repo config-check result was produced in this run.
