### PR TITLE
[codex] Improve open window pressure alerts

### DIFF
--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -1092,18 +1092,41 @@ template:
           {% for sensor in states.binary_sensor %}
             {% set entity_id = sensor.entity_id %}
             {% if entity_id not in ['binary_sensor.any_window_open', 'binary_sensor.fresh_air_open'] %}
+              {% set contact_slug = entity_id | replace('binary_sensor.', '') | replace('_contact', '') %}
+              {% set availability_entity_id = 'binary_sensor.z2m_' ~ contact_slug ~ '_availability' %}
               {% set device_class = sensor.attributes.device_class | default('', true) | lower %}
               {% set did = device_id(entity_id) %}
               {% set model = '' %}
               {% if did is not none and did != '' %}
                 {% set model = device_attr(did, 'model') | default('', true) | lower %}
               {% endif %}
-              {% if sensor.state == 'on' and device_class in ['opening', 'window'] and 'parasoll' in model and entity_id not in excluded %}
+              {% if sensor.state == 'on' and is_state(availability_entity_id, 'on') and device_class in ['opening', 'window'] and 'parasoll' in model and entity_id not in excluded %}
                 {% set matches.count = matches.count + 1 %}
               {% endif %}
             {% endif %}
           {% endfor %}
           {{ matches.count > 0 }}
+        attributes:
+          open_windows: >-
+            {% set excluded = states('input_text.any_window_open_exclude_entities').replace('\n', ',').split(',') | map('trim') | reject('equalto', '') | list %}
+            {% set open_windows = namespace(names=[]) %}
+            {% for sensor in states.binary_sensor %}
+              {% set entity_id = sensor.entity_id %}
+              {% if entity_id not in ['binary_sensor.any_window_open', 'binary_sensor.fresh_air_open'] %}
+                {% set contact_slug = entity_id | replace('binary_sensor.', '') | replace('_contact', '') %}
+                {% set availability_entity_id = 'binary_sensor.z2m_' ~ contact_slug ~ '_availability' %}
+                {% set device_class = sensor.attributes.device_class | default('', true) | lower %}
+                {% set did = device_id(entity_id) %}
+                {% set model = '' %}
+                {% if did is not none and did != '' %}
+                  {% set model = device_attr(did, 'model') | default('', true) | lower %}
+                {% endif %}
+                {% if sensor.state == 'on' and is_state(availability_entity_id, 'on') and device_class in ['opening', 'window'] and 'parasoll' in model and entity_id not in excluded %}
+                  {% set open_windows.names = open_windows.names + [sensor.name] %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+            {{ open_windows.names | join(', ') }}
         name: any_window_open
       - device_class: window
         default_entity_id: binary_sensor.fresh_air_open

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -222,7 +222,13 @@ automation:
       - action: notify.mobile_app_wethop
         data:
           title: "Open Window"
-          message: "Pressure is dropping quickly and a window is open. Close the windows."
+          message: >-
+            {% set open_windows = state_attr('binary_sensor.any_window_open', 'open_windows') | default('', true) %}
+            {% if open_windows %}
+              Pressure is dropping quickly and these windows are open: {{ open_windows }}. Close them.
+            {% else %}
+              Pressure is dropping quickly and a window is open. Close the windows.
+            {% endif %}
           data:
             tag: window-pressure-drop
             persistent: true

--- a/tests/test_weather_package.py
+++ b/tests/test_weather_package.py
@@ -40,3 +40,10 @@ def test_notify_weather_alert_uses_current_nws_alert_payload_shape() -> None:
     assert "primary_alert.Headline" in text
     assert "action: notify.notify_all" in text
     assert "message: >-\n            {{ state_attr('sensor.nws_alerts', 'Description') }}" not in text
+
+
+def test_pressure_drop_window_alert_names_open_windows() -> None:
+    text = WEATHER_PATH.read_text(encoding="utf-8")
+
+    assert "state_attr('binary_sensor.any_window_open', 'open_windows')" in text
+    assert "these windows are open: {{ open_windows }}" in text

--- a/tests/test_window_egress_automation_coverage.py
+++ b/tests/test_window_egress_automation_coverage.py
@@ -106,3 +106,13 @@ def test_fresh_air_open_reuses_any_window_open_state() -> None:
 
     assert 'default_entity_id: binary_sensor.fresh_air_open' in text
     assert 'state: "{{ is_state(\'binary_sensor.any_window_open\', \'on\') }}"' in text
+
+
+def test_any_window_open_ignores_unavailable_parasoll_contacts() -> None:
+    text = CLIMATE_PATH.read_text(encoding="utf-8")
+
+    assert "default_entity_id: binary_sensor.any_window_open" in text
+    assert "{% set availability_entity_id = 'binary_sensor.z2m_' ~ contact_slug ~ '_availability' %}" in text
+    assert "sensor.state == 'on' and is_state(availability_entity_id, 'on')" in text
+    assert "open_windows:" in text
+    assert "open_windows.names | join(', ')" in text


### PR DESCRIPTION
## Summary
- Require PARASOLL window contacts to have their matching Z2M availability sensor online before they count as open.
- Add an `open_windows` attribute to `binary_sensor.any_window_open` with friendly names for currently open windows.
- Update the pressure-drop window notification to name the open windows when available.

## Root Cause
The pressure-drop alert only checked the aggregate `binary_sensor.any_window_open`, so the notification could not identify which window was open. A stale contact left `on` by a dead/offline battery could also keep the aggregate true.

## Impact
Pressure-drop notifications should now be actionable and should not fire solely because a PARASOLL contact is unavailable with stale state.

## Tests
- `uv run --with pytest pytest` (`541 passed`)