### PR TITLE
Require approval before Allium spec edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - Use `specs/alarm_wakeup.allium` as the source of truth for alarm, wake-up, snooze, and morning audio behavior.
 - Use `specs/night_routines.allium` as the source of truth for bedtime preparation and overnight goodnight behavior.
 - Before changing related Home Assistant automations, scripts, helpers, dashboards, or tests, read the relevant Allium spec first and keep implementation changes aligned with it.
+- Always compare behavior changes against the relevant Allium spec, but do not update `.allium` definitions unless the owner explicitly approves that spec change.
 
 ## E-Ink Displays
 - Use `docs/inky_displays.md` as the source of truth before changing e-ink payloads, renderer behavior, MQTT topics, Pi service deployment, display layouts, or display-triggering automations.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ python scripts/allium_weed_check.py --changed-from origin/develop
 
 `scripts/allium_weed_check.py` runs `allium check` when the CLI is installed,
 falls back to lightweight structural checks when it is not, and fails protected
-behavior changes that touch implementation scopes without updating the
-governing `.allium` spec or adding a classified gap in
-`specs/allium_weed_config.json`. CI installs Allium CLI 3.2.3 and runs with
-`--require-allium` so full language validation cannot be skipped silently.
+behavior changes that touch implementation scopes without an owner-approved
+update to the governing `.allium` spec or a classified gap in
+`specs/allium_weed_config.json`. Always compare changed behavior to the Allium
+reference first; do not edit `.allium` definitions automatically. CI installs
+Allium CLI 3.2.3 and runs with `--require-allium` so full language validation
+cannot be skipped silently.
 
 ## Music Assistant Media Flow
 

--- a/scripts/allium_weed_check.py
+++ b/scripts/allium_weed_check.py
@@ -409,6 +409,12 @@ def _paint(text: str, color: str, enabled: bool) -> str:
     return f"{COLOR[color]}{text}{COLOR['reset']}"
 
 
+UNCLASSIFIED_DRIFT_NEXT_STEP = (
+    "compare behavior to the governing Allium spec; only update the spec with owner approval, "
+    "otherwise add a classified gap with a reason and exact links"
+)
+
+
 def render_terminal(
     specs: list[Path],
     diagnostics: list[Diagnostic],
@@ -453,7 +459,7 @@ def render_terminal(
                 detail = finding.reason or "classified gap"
             else:
                 status = _paint("unclassified", "red", use_color)
-                detail = "update the spec or add a classified gap with a reason"
+                detail = UNCLASSIFIED_DRIFT_NEXT_STEP
             lines.append(f"- {status} {finding.scope.spec}: {', '.join(finding.changed_implementation)} ({detail})")
 
     if not diagnostics and not drift_findings:
@@ -507,7 +513,7 @@ def render_markdown(
                 next_step = finding.reason or "Review classified gap."
             else:
                 classification = "unclassified"
-                next_step = "Update the governing `.allium` spec or add a classified gap with a reason and exact links."
+                next_step = f"{UNCLASSIFIED_DRIFT_NEXT_STEP}."
             lines.append(f"| `{finding.scope.spec}` | {files} | {classification} | {next_step} |")
     else:
         lines.append("No protected implementation scopes changed.")

--- a/specs/README.md
+++ b/specs/README.md
@@ -6,4 +6,4 @@ These Allium files are the behavioral source of truth for the owner sleep/wake f
 - `night_routines.allium`: bedtime prep, CPAP-triggered goodnight integrity, privacy-aware overnight shutdown, and bedtime exception handling.
 - `z2m_lifecycle.allium`: Zigbee2MQTT join/leave/offline lifecycle handling, join-then-drop detection, systemic bridge-health escalation boundaries, and decommission reconciliation expectations.
 
-When wake-up, alarm, bedtime, overnight, or Zigbee2MQTT lifecycle behavior changes, update the relevant `.allium` file in the same change.
+When wake-up, alarm, bedtime, overnight, or Zigbee2MQTT lifecycle behavior changes, compare the implementation to the relevant `.allium` file before changing code. Do not update `.allium` definitions automatically; request owner approval for any spec change. If the implementation change is intentionally outside the spec or does not change governed behavior, document that as a classified gap in `specs/allium_weed_config.json` instead of editing the spec.

--- a/tests/test_allium_specs.py
+++ b/tests/test_allium_specs.py
@@ -90,3 +90,15 @@ def test_alarm_wakeup_spec_uses_checker_supported_context_events() -> None:
     assert "context.resident_in_bed becomes" not in text
     assert "context.bathroom_occupied becomes" not in text
     assert "target_room == bathroom" not in text
+
+
+def test_allium_guidance_requires_owner_approval_before_spec_edits() -> None:
+    specs_readme = (SPECS_DIR / "README.md").read_text(encoding="utf-8")
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    project_readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "compare the implementation to the relevant `.allium` file" in specs_readme
+    assert "Do not update `.allium` definitions automatically" in specs_readme
+    assert "request owner approval for any spec change" in specs_readme
+    assert "do not update `.allium` definitions unless the owner explicitly approves" in agents
+    assert "do not edit `.allium` definitions automatically" in project_readme

--- a/tests/test_allium_weed_check.py
+++ b/tests/test_allium_weed_check.py
@@ -239,6 +239,52 @@ def test_markdown_report_includes_line_links(monkeypatch: pytest.MonkeyPatch) ->
     assert "`allium.syntax.doubleEquals`" in report
 
 
+def test_markdown_report_requires_owner_approval_before_spec_update() -> None:
+    finding = weed.DriftFinding(
+        scope=weed.ProtectedScope(
+            spec="specs/night_routines.allium",
+            description="night behavior",
+            implementation_paths=("packages/tv.yaml",),
+        ),
+        changed_implementation=("packages/tv.yaml",),
+        changed_spec=False,
+    )
+
+    report = weed.render_markdown(
+        [Path("specs/night_routines.allium")],
+        [],
+        [finding],
+        [],
+    )
+
+    assert "compare behavior to the governing Allium spec" in report
+    assert "only update the spec with owner approval" in report
+    assert "otherwise add a classified gap" in report
+
+
+def test_terminal_report_requires_owner_approval_before_spec_update() -> None:
+    finding = weed.DriftFinding(
+        scope=weed.ProtectedScope(
+            spec="specs/night_routines.allium",
+            description="night behavior",
+            implementation_paths=("packages/tv.yaml",),
+        ),
+        changed_implementation=("packages/tv.yaml",),
+        changed_spec=False,
+    )
+
+    report = weed.render_terminal(
+        [Path("specs/night_routines.allium")],
+        [],
+        [finding],
+        [],
+    )
+
+    assert "compare behavior to the governing Allium spec" in report
+    assert "only update the spec with owner approval" in report
+    assert "otherwise add a classified gap" in report
+
+
 def test_config_json_is_valid() -> None:
     data = json.loads(weed.DEFAULT_CONFIG.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Summary
- Update agent and Allium docs to require owner approval before editing `.allium` definitions
- Adjust Allium weed-check drift guidance to compare behavior first and prefer an approved spec update or classified gap
- Add pytest coverage for the approval-gated guidance and report text

Fixes #418

## Validation
- `uv run --with pytest pytest tests/test_allium_specs.py tests/test_allium_weed_check.py`
- `uv run --with pytest pytest`
- `uv run python scripts/allium_weed_check.py --changed-from origin/develop`