### PR TITLE
Fix #839: resilient Sonos recovery instead of full HA restart

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1936,7 +1936,6 @@ script:
       - variables:
           bedtime_rampdown_steps:
             - delay_minutes: 0
-              continue_on_error: true
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.office_sonos_2
@@ -1944,24 +1943,18 @@ script:
                 - media_player.den_sonos_2
               volume_level: 0.1
             - delay_minutes: 2
-              continue_on_error: true
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.bathroom_sonos_2
                 - media_player.office_sonos_2
               volume_level: 0.07
             - delay_minutes: 2
-              # Was continue_on_error: false — an unavailable member (e.g. a
-              # faulted bathroom Sonos, #839) aborted the whole rampdown. Let it
-              # degrade gracefully like every other step.
-              continue_on_error: true
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.bathroom_sonos_2
                 - media_player.office_sonos_2
               volume_level: 0.05
             - delay_minutes: 2
-              continue_on_error: true
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.bathroom_sonos_2
@@ -1976,23 +1969,14 @@ script:
               then:
                 - delay:
                     minutes: "{{ repeat.item.delay_minutes }}"
-            - choose:
-                - conditions:
-                    - condition: template
-                      value_template: "{{ repeat.item.continue_on_error }}"
-                  sequence:
-                    - action: media_player.volume_set
-                      continue_on_error: true
-                      target:
-                        entity_id: "{{ repeat.item.entity_id }}"
-                      data:
-                        volume_level: "{{ repeat.item.volume_level }}"
-              default:
-                - action: media_player.volume_set
-                  target:
-                    entity_id: "{{ repeat.item.entity_id }}"
-                  data:
-                    volume_level: "{{ repeat.item.volume_level }}"
+            # Every step tolerates an unavailable member (e.g. a faulted bathroom
+            # Sonos, #839) so one dropped speaker never aborts the rampdown.
+            - action: media_player.volume_set
+              continue_on_error: true
+              target:
+                entity_id: "{{ repeat.item.entity_id }}"
+              data:
+                volume_level: "{{ repeat.item.volume_level }}"
 
   spotify_wake_up:
     alias: "Spotify Wake Up"

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -544,9 +544,19 @@ automation:
 
   - id: restart_sonos_unavailable
     alias: restart_sonos_unavailable
+    description: >-
+      Bedroom-suite Sonos players occasionally drop to "unavailable" — either an
+      integration-level flap (recoverable by reloading the player's config entry)
+      or a hardware fault such as a red status LED, which only a physical
+      power-cycle can clear. After 30 min unavailable, try a cheap config-entry
+      reload first; if the player is still unavailable a minute later, notify so a
+      human can power-cycle it. The previous blanket homeassistant.restart was
+      removed: it disrupts the whole house and, for a hardware fault, cannot
+      recover the speaker (see #839).
     trace:
       stored_traces: 50
-    mode: single
+    mode: parallel
+    max: 4
     trigger:
       - trigger: state
         entity_id:
@@ -558,7 +568,28 @@ automation:
         for:
           minutes: 30
     action:
-      - action: homeassistant.restart
+      - alias: "Cheap first attempt — reload the player's config entry"
+        continue_on_error: true
+        action: homeassistant.reload_config_entry
+        target:
+          entity_id: "{{ trigger.entity_id }}"
+      - alias: "Give the reload time to bring the player back"
+        delay:
+          minutes: 1
+      - alias: "Still unavailable after reload — a human power-cycle is required"
+        if:
+          - condition: template
+            value_template: "{{ is_state(trigger.entity_id, 'unavailable') }}"
+        then:
+          - action: notify.all
+            continue_on_error: true
+            data:
+              title: "Sonos needs attention"
+              message: >-
+                {{ state_attr(trigger.entity_id, 'friendly_name') or trigger.entity_id }}
+                has been unavailable for 30+ minutes and a config-entry reload did not
+                recover it. Check the speaker for a red status LED — it likely needs a
+                physical power-cycle (unplug ~10s, plug back in).
 
   - id: bedtime_music_homekit_trigger
     alias: "Bedtime Music — HomeKit trigger"
@@ -1920,7 +1951,10 @@ script:
                 - media_player.office_sonos_2
               volume_level: 0.07
             - delay_minutes: 2
-              continue_on_error: false
+              # Was continue_on_error: false — an unavailable member (e.g. a
+              # faulted bathroom Sonos, #839) aborted the whole rampdown. Let it
+              # degrade gracefully like every other step.
+              continue_on_error: true
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.bathroom_sonos_2

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -522,8 +522,12 @@ def test_bedtime_volume_rampdown_is_data_driven_without_repeating_delay_actions(
         assert token in block
 
     assert block.count("- delay:") == 1
-    assert block.count("action: media_player.volume_set") == 2
-    assert "continue_on_error: false" in block
+    # Single data-driven volume_set that every step reuses.
+    assert block.count("action: media_player.volume_set") == 1
+    # Graceful degradation (#839): an unavailable member must never abort the
+    # rampdown, so the volume_set tolerates errors and no step opts out.
+    assert "continue_on_error: true" in block
+    assert "continue_on_error: false" not in block
 
 
 def test_arrival_and_wakeup_scripts_use_sequence_level_playlist_selection() -> None:


### PR DESCRIPTION
Closes #839.

## Root cause (verified against live HA)

`media_player.bathroom_sonos_2` is **not** renamed or replaced — the entity exists and, per 24h history, dropped to `unavailable` at 01:49 on 2026-07-01 and stayed down ~8.5h (covering the 02:20 / 08:20 sweep warnings) before recovering at 10:09. The speaker was displaying a **red status LED (hardware fault)** and was recovered by a **manual power-cycle**. No HA-side action could have fixed it, and there is no smart plug on the speaker to power-cycle it programmatically.

So this is a resilience/recovery issue, not an entity-id patch. Two weaknesses the outage exposed are fixed here.

## Changes (`packages/media_player.yaml`)

**1. `restart_sonos_unavailable` — graduated recovery, no more full-house restart.**
Previously ran `homeassistant.restart` after 30 min of unavailability. That restarts all of Home Assistant and, for a hardware fault, cannot recover the speaker — it fired last night and the player stayed dead 8 more hours. Now:
- Cheap first attempt: `homeassistant.reload_config_entry` on the specific dropped player.
- If still `unavailable` a minute later: `notify.all` telling a human to check for a red LED and power-cycle it (the one action only a human can take).
- `mode: parallel` (max 4) so each dropped bedroom-suite player is handled independently.

**2. Bedtime rampdown graceful degradation.**
The `0.05` step in `spotify_bedtime_volume` used `continue_on_error: false`, so an unavailable member aborted the entire goodnight rampdown. Aligned it with every other step (`continue_on_error: true`).

The other bathroom callers (wake ramp, guest-mode grouping, TV, pause-house) already use `continue_on_error: true`, so no changes were needed there.

## Validation
- `packages/media_player.yaml` parses cleanly.
- `uv run --with pytest pytest` — **548 passed**, including wake/bedtime and night-routine alignment suites.

## Follow-up (not in this PR)
For true auto-recovery next time, put the bathroom Sonos on a controllable smart plug; the recovery automation could then power-cycle it before notifying a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)