### PR TITLE
Fix #846 arrival Sonos Music Assistant volume targets

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1586,6 +1586,12 @@ script:
       playback_entity: >-
         {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
            else 'media_player.ma_group_everywhere' }}
+      arrival_volume_entities: >-
+        {{ ['media_player.bedroom_sonos_2', 'media_player.bathroom_sonos_2']
+           if is_state('input_boolean.guest_mode', 'on')
+           else ['media_player.bedroom_sonos_2', 'media_player.bathroom_sonos_2',
+                 'media_player.den_sonos_2', 'media_player.office_sonos_2',
+                 'media_player.tiki_room_2'] }}
     sequence:
       - variables:
           playlist: >-
@@ -1686,12 +1692,7 @@ script:
       - action: media_player.volume_set
         continue_on_error: true
         target:
-          entity_id:
-            - media_player.bedroom_sonos
-            - media_player.bathroom_sonos_2
-            - media_player.den_sonos
-            - media_player.office_sonos
-            - media_player.tiki_room_3
+          entity_id: "{{ arrival_volume_entities }}"
         data:
           volume_level: 0.30
       - alias: "Play arrival music via Music Assistant"

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -199,6 +199,56 @@ def test_arrival_music_targets_guest_aware_sync_group_without_regroup_retry() ->
     assert 'entity_id: script.music_assistant_try_join_arrival_group_after_play' not in arrival_block
 
 
+def test_arrival_music_sets_volume_on_selected_music_assistant_group_members() -> None:
+    arrival_block = _script_block("spotify_arrival")
+
+    assert "arrival_volume_entities" in arrival_block
+    assert "'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')" in arrival_block
+    assert "if is_state('input_boolean.guest_mode', 'on')" in arrival_block
+    assert "entity_id: \"{{ arrival_volume_entities }}\"" in arrival_block
+
+    guest_volume_start = arrival_block.index("arrival_volume_entities")
+    everywhere_volume_start = arrival_block.index("else [", guest_volume_start)
+
+    guest_volume_block = arrival_block[guest_volume_start:everywhere_volume_start]
+    everywhere_volume_block = arrival_block[everywhere_volume_start:arrival_block.index("sequence:")]
+
+    for entity_id in (
+        "media_player.bedroom_sonos_2",
+        "media_player.bathroom_sonos_2",
+    ):
+        assert entity_id in guest_volume_block
+        assert entity_id in everywhere_volume_block
+
+    for guest_private_entity_id in (
+        "media_player.den_sonos_2",
+        "media_player.office_sonos_2",
+        "media_player.tiki_room_2",
+    ):
+        assert guest_private_entity_id not in guest_volume_block
+        assert guest_private_entity_id in everywhere_volume_block
+
+    for entity_id in (
+        "media_player.bedroom_sonos_2",
+        "media_player.bathroom_sonos_2",
+        "media_player.den_sonos_2",
+        "media_player.office_sonos_2",
+        "media_player.tiki_room_2",
+    ):
+        assert entity_id in arrival_block
+
+    for stale_entity_id in (
+        "media_player.bedroom_sonos",
+        "media_player.den_sonos",
+        "media_player.office_sonos",
+        "media_player.tiki_room_3",
+    ):
+        assert (
+            re.search(rf"^\s*-\s+{re.escape(stale_entity_id)}\s*$", arrival_block, re.MULTILINE)
+            is None
+        )
+
+
 def test_bedtime_targets_guest_aware_sync_group_before_playing() -> None:
     block = _script_block("spotify_bedtime")
 


### PR DESCRIPTION
## Summary
- Fixes #846.
- Updates `script.spotify_arrival` to set arrival volume on live Music Assistant Sonos member entities (`*_sonos_2`) instead of stale bare Sonos entities.
- Adds regression coverage preventing the stale arrival volume targets from returning.

## Runtime evidence
- Live HA log reported missing arrival volume targets: `media_player.bedroom_sonos`, `media_player.den_sonos`, `media_player.office_sonos`, and `media_player.tiki_room_3`.
- Live state lookup confirmed those bare entities are missing, while the corresponding Music Assistant entities are present.

## Validation
- `uv run --with pytest pytest tests/test_media_player_music_assistant.py -q`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/media_player.yaml --strict`
- `uv run --with pytest pytest`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/media_player.yaml`
- `python3 scripts/allium_weed_check.py --changed-from origin/develop --format terminal`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `podman run --name ha-check-config --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:2026.5.1 python -m homeassistant --config /config --script check_config`
