### PR TITLE
Fix office switch missing adaptive lighting target

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -238,7 +238,6 @@ automation:
         - switch.adaptive_lighting_den
         - switch.adaptive_lighting_hallway
         - switch.adaptive_lighting_kitchen
-        - switch.adaptive_lighting_office
         - switch.adaptive_lighting_owner_suite
         - switch.dining_room_adaptive_lighting_dining_room
         - switch.adaptive_control

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -1435,12 +1435,9 @@ automation:
               - condition: trigger
                 id: up-single
             sequence:
-              - action: script.adaptive_light_turn_on
+              - action: light.turn_on
                 data:
-                  adaptive_switch: switch.adaptive_lighting_office
-                  lights:
-                    - light.office_ceiling
-                  transition: 1
+                  entity_id: light.office_ceiling
           - conditions:
               - condition: trigger
                 id: down-single

--- a/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
+++ b/tests/test_adaptive_lighting_inovelli_led_bar_sync.py
@@ -49,7 +49,7 @@ def test_nightly_adaptive_lighting_cycle_filters_missing_candidate_switches() ->
     block = _automation_block("nightly_adaptive_lighting_cycle_reset")
 
     assert "candidate_main_adaptive_switches:" in block
-    assert "switch.adaptive_lighting_office" in block
+    assert "switch.adaptive_lighting_office" not in block
     assert "states(entity_id) not in ['unknown', 'unavailable']" in block
     assert "main_adaptive_switches | count > 0" in block
     assert block.count('entity_id: "{{ main_adaptive_switches }}"') == 2

--- a/tests/test_repair_regressions.py
+++ b/tests/test_repair_regressions.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+ADAPTIVE_LIGHTING_PATH = ROOT / "packages" / "adaptive_lighting.yaml"
 CAMERA_PATH = ROOT / "packages" / "camera.yaml"
 CURLING_PATH = ROOT / "packages" / "curling.yaml"
 HOLIDAYS_PATH = ROOT / "packages" / "holidays.yaml"
@@ -26,6 +27,33 @@ def _script_block(path: Path, script_name: str) -> str:
     if match is None:
         raise AssertionError(f"Could not find script block {script_name!r} in {path.name}")
     return match.group(0)
+
+
+def _automation_block(path: Path, automation_id: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = None
+
+    for index, line in enumerate(lines):
+        if line not in (f"    id: {automation_id}", f"  - id: {automation_id}"):
+            continue
+
+        for candidate in range(index, -1, -1):
+            if lines[candidate].startswith("  - "):
+                start = candidate
+                break
+        if start is not None:
+            break
+
+    if start is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r} in {path.name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("  - "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
 
 
 def _group_block(path: Path, group_name: str) -> str:
@@ -133,6 +161,17 @@ def test_stale_hallway_motion_entity_is_fully_replaced() -> None:
     assert "binary_sensor.hallway_motion" not in light_text + zigbee_zwave_text
     assert "binary_sensor.hall_upstairs_motion_occupancy" in light_text
     assert "binary_sensor.hall_upstairs_motion_occupancy" in zigbee_zwave_text
+
+
+def test_office_switch_actions_do_not_target_missing_adaptive_lighting_switch() -> None:
+    block = _automation_block(ZIGBEE_ZWAVE_PATH, "office_switch_actions")
+    adaptive_lighting_text = ADAPTIVE_LIGHTING_PATH.read_text(encoding="utf-8")
+
+    assert "switch.adaptive_lighting_office" not in block
+    assert "switch.adaptive_lighting_office" not in adaptive_lighting_text
+    assert "action: script.adaptive_light_turn_on" not in block
+    assert "action: light.turn_on" in block
+    assert "entity_id: light.office_ceiling" in block
 
 
 def test_ios_alarm_sync_preserves_manual_workday_alarm_overrides() -> None:


### PR DESCRIPTION
## Summary
- Fixes #847 by restoring the office Inovelli up-single action to `light.turn_on` for `light.office_ceiling` because the live system has no Office Adaptive Lighting integration switch.
- Removes `switch.adaptive_lighting_office` from the nightly adaptive reset candidates so the live Repair no longer has a stale referenced entity.
- Adds regression coverage that prevents `office_switch_actions` and the adaptive lighting package from reintroducing the missing switch.

## Runtime evidence
- True GitHub `develop`, local `origin/develop`, and live `/homeassistant` all resolve to `94766a91e081868ef3b99974ac58e1a483f1c7a5`.
- Live Repair reports `automation.office_switch_actions` references unknown entity `switch.adaptive_lighting_office`.
- Live HA state lookup confirms `switch.adaptive_lighting_office` is missing, while `light.office_ceiling` exists.
- Live Adaptive Lighting integration entries do not include Office.

## Validation
- `uv run --with pytest pytest tests/test_adaptive_lighting_inovelli_led_bar_sync.py tests/test_repair_regressions.py`
- `uv run --with pytest pytest`
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/adaptive_lighting.yaml packages/zigbee_zwave.yaml`
- `git diff --check`
- `python3 scripts/allium_weed_check.py --format terminal`

## Notes
- Local HA container config check was attempted but blocked by the local Podman machine socket refusing connections after restart. Live HA `config_check` was valid before this patch.
- YAML DRY verification ran on the touched package files and reported pre-existing broader duplication in the Inovelli reset/day-mode scripts plus shared HA-start trigger structure. That refactor is outside the one-defect scope for #847.