### PR TITLE
Add mail and package delivery lifecycle

### DIFF
--- a/packages/mail_packages.yaml
+++ b/packages/mail_packages.yaml
@@ -1,0 +1,475 @@
+# Home Assistant package for mail and package delivery state.
+# It combines the physical mailbox contact with Mail and Packages delivery
+# sensors so notifications reflect expected, delivered, still-outside, and
+# retrieved states instead of a single delivered flag.
+
+################################################################
+## Packages / Mail Packages
+################################################################
+
+################################################
+## Customize
+################################################
+
+homeassistant:
+  customize:
+    ################################################
+    ## Node Anchors
+    ################################################
+
+    package.node_anchors:
+      customize: &customize
+        package: "mail_packages"
+
+    ################################################
+    ## Automations
+    ################################################
+    automation.mail_package_delivery_state:
+      <<: *customize
+      friendly_name: "Mail Package Delivery State"
+      icon: mdi:package-variant-closed-check
+
+    automation.mail_package_still_outside_reminder:
+      <<: *customize
+      friendly_name: "Mail Package Still Outside Reminder"
+      icon: mdi:package-variant-closed-alert
+
+    ################################################
+    ## Helpers
+    ################################################
+    input_boolean.mail_delivered:
+      <<: *customize
+      friendly_name: "Mail Delivered"
+      icon: mdi:mailbox
+
+    input_select.mail_package_delivery_state:
+      <<: *customize
+      friendly_name: "Mail Package Delivery State"
+      icon: mdi:package-variant-closed
+
+    input_button.mail_package_mark_retrieved:
+      <<: *customize
+      friendly_name: "Mark Mail and Packages Retrieved"
+      icon: mdi:package-check
+
+########################
+# Automations
+########################
+automation:
+  - id: mail_package_delivery_state
+    alias: mail_package_delivery_state
+    description: >-
+      Reconciles mailbox contact activity and Mail and Packages sensors into a
+      durable delivery state while keeping input_boolean.mail_delivered for
+      existing dashboard consumers.
+    mode: queued
+    trace:
+      stored_traces: 10
+    trigger:
+      - trigger: homeassistant
+        event: start
+        id: startup_sync
+      - trigger: time
+        at: "01:00:00"
+        id: daily_reset
+      - trigger: state
+        entity_id: binary_sensor.mailbox_contact
+        from: "off"
+        to: "on"
+        id: mailbox_opened
+      - trigger: state
+        entity_id: input_button.mail_package_mark_retrieved
+        id: mark_retrieved
+      - trigger: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: MAIL_PACKAGE_RETRIEVED
+        id: mark_retrieved
+      - trigger: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: MAIL_PACKAGE_STILL_OUTSIDE
+        id: mark_still_outside
+      - trigger: state
+        entity_id:
+          - sensor.mail_usps_mail
+          - sensor.mail_usps_packages
+          - sensor.mail_ups_packages
+          - sensor.mail_fedex_packages
+          - sensor.mail_amazon_packages
+        id: expected_update
+      - trigger: state
+        entity_id:
+          - sensor.mail_usps_delivered
+          - sensor.mail_ups_delivered
+          - sensor.mail_fedex_delivered
+          - sensor.mail_amazon_packages_delivered
+        id: delivered_update
+    variables:
+      expected_entities:
+        - sensor.mail_usps_mail
+        - sensor.mail_usps_packages
+        - sensor.mail_ups_packages
+        - sensor.mail_fedex_packages
+        - sensor.mail_amazon_packages
+      delivered_entities:
+        - sensor.mail_usps_delivered
+        - sensor.mail_ups_delivered
+        - sensor.mail_fedex_delivered
+        - sensor.mail_amazon_packages_delivered
+      expected_count: >-
+        {% set ns = namespace(total=0) %}
+        {% for entity_id in expected_entities %}
+          {% set value = states(entity_id) %}
+          {% if value not in ['unknown', 'unavailable', 'none', ''] %}
+            {% set ns.total = ns.total + (value | int(0)) %}
+          {% endif %}
+        {% endfor %}
+        {{ ns.total }}
+      delivered_count: >-
+        {% set ns = namespace(total=0) %}
+        {% for entity_id in delivered_entities %}
+          {% set value = states(entity_id) %}
+          {% if value not in ['unknown', 'unavailable', 'none', ''] %}
+            {% set ns.total = ns.total + (value | int(0)) %}
+          {% endif %}
+        {% endfor %}
+        {{ ns.total }}
+      current_delivery_state: >-
+        {{ states('input_select.mail_package_delivery_state') }}
+      camera_candidates:
+        - camera.mail_generic_delivery_camera
+        - camera.mail_amazon_delivery_camera
+        - camera.mail_usps_camera
+      camera_entity: >-
+        {{ expand(camera_candidates)
+          | rejectattr('state', 'in', ['unknown', 'unavailable'])
+          | map(attribute='entity_id')
+          | list
+          | first
+          | default('', true) }}
+      delivery_summary: >-
+        {% set expected = expected_count | int(0) %}
+        {% set delivered = delivered_count | int(0) %}
+        {% if delivered > 0 %}
+          {{ delivered }} delivered package{{ '' if delivered == 1 else 's' }}
+        {% elif expected > 0 %}
+          {{ expected }} expected mail/package item{{ ''
+            if expected == 1 else 's' }}
+        {% else %}
+          mail or package activity
+        {% endif %}
+    action:
+      - choose:
+          - alias: "Mark delivery retrieved"
+            conditions:
+              - condition: or
+                conditions:
+                  - condition: trigger
+                    id: mark_retrieved
+                  - condition: and
+                    conditions:
+                      - condition: trigger
+                        id: mailbox_opened
+                      - condition: state
+                        entity_id: input_boolean.mail_delivered
+                        state: "on"
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_delivery_state
+                data:
+                  option: retrieved
+              - action: input_boolean.turn_off
+                target:
+                  entity_id: input_boolean.mail_delivered
+              - action: input_datetime.set_datetime
+                target:
+                  entity_id: input_datetime.mail_package_last_retrieved
+                data:
+                  datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+              - action: persistent_notification.dismiss
+                continue_on_error: true
+                data:
+                  notification_id: mail-package-delivery
+              - action: notify.all
+                continue_on_error: true
+                data:
+                  message: clear_notification
+                  data:
+                    tag: mail-package-delivery
+
+          - alias: "Notification action confirms delivery is still outside"
+            conditions:
+              - condition: trigger
+                id: mark_still_outside
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_delivery_state
+                data:
+                  option: still_outside
+
+          - alias: "Startup preserves an outstanding legacy delivery flag"
+            conditions:
+              - condition: trigger
+                id: startup_sync
+              - condition: state
+                entity_id: input_boolean.mail_delivered
+                state: "on"
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_delivery_state
+                data:
+                  option: still_outside
+
+          - alias: "Mailbox opened before known delivery marks mail delivered"
+            conditions:
+              - condition: trigger
+                id: mailbox_opened
+              - condition: state
+                entity_id: input_boolean.mail_delivered
+                state: "off"
+              - condition: state
+                entity_id: input_boolean.trip
+                state: "off"
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_delivery_state
+                data:
+                  option: delivered
+              - action: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.mail_delivered
+              - action: input_datetime.set_datetime
+                target:
+                  entity_id: input_datetime.mail_package_last_delivery
+                data:
+                  datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+              - action: notify.all
+                continue_on_error: true
+                data:
+                  title: "Mail Delivered"
+                  message: "Mailbox activity was detected. Check the mailbox."
+                  data:
+                    tag: mail-package-delivery
+                    group: mail-packages
+                    actions:
+                      - action: MAIL_PACKAGE_RETRIEVED
+                        title: "Retrieved"
+
+          - alias: "Carrier sensors report delivery"
+            conditions:
+              - condition: template
+                value_template: "{{ delivered_count | int(0) > 0 }}"
+              - condition: state
+                entity_id: input_boolean.mail_delivered
+                state: "off"
+            sequence:
+              - action: mail_and_packages.update_image
+                continue_on_error: true
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_delivery_state
+                data:
+                  option: delivered
+              - action: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.mail_delivered
+              - action: input_datetime.set_datetime
+                target:
+                  entity_id: input_datetime.mail_package_last_delivery
+                data:
+                  datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+              - action: persistent_notification.create
+                data:
+                  title: "Mail and Packages Delivered"
+                  message: >-
+                    {{ delivery_summary }} reported delivered. Mark it retrieved
+                    after bringing it in.
+                  notification_id: mail-package-delivery
+              - choose:
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ camera_entity | length > 0 }}"
+                    sequence:
+                      - action: notify.all
+                        continue_on_error: true
+                        data:
+                          title: "Mail and Packages Delivered"
+                          message: >-
+                            {{ delivery_summary }} reported delivered. Tap
+                            Retrieved after bringing it in.
+                          data:
+                            tag: mail-package-delivery
+                            group: mail-packages
+                            image: "{{ '/api/camera_proxy/' ~ camera_entity }}"
+                            actions:
+                              - action: MAIL_PACKAGE_RETRIEVED
+                                title: "Retrieved"
+                              - action: MAIL_PACKAGE_STILL_OUTSIDE
+                                title: "Still outside"
+                default:
+                  - action: notify.all
+                    continue_on_error: true
+                    data:
+                      title: "Mail and Packages Delivered"
+                      message: >-
+                        {{ delivery_summary }} reported delivered. Tap
+                        Retrieved after bringing it in.
+                      data:
+                        tag: mail-package-delivery
+                        group: mail-packages
+                        actions:
+                          - action: MAIL_PACKAGE_RETRIEVED
+                            title: "Retrieved"
+                          - action: MAIL_PACKAGE_STILL_OUTSIDE
+                            title: "Still outside"
+
+          - alias: "Carrier sensors report expected mail or packages"
+            conditions:
+              - condition: template
+                value_template: "{{ expected_count | int(0) > 0 }}"
+              - condition: state
+                entity_id: input_boolean.mail_delivered
+                state: "off"
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_delivery_state
+                data:
+                  option: expected
+
+          - alias: "Startup clears stale state when no delivery data remains"
+            conditions:
+              - condition: trigger
+                id: startup_sync
+              - condition: template
+                value_template: >-
+                  {{ expected_count | int(0) == 0
+                    and delivered_count | int(0) == 0 }}
+              - condition: state
+                entity_id: input_boolean.mail_delivered
+                state: "off"
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_delivery_state
+                data:
+                  option: clear
+
+          - alias: "Daily reset clears stale delivery state"
+            conditions:
+              - condition: trigger
+                id: daily_reset
+            sequence:
+              - action: input_select.select_option
+                target:
+                  entity_id: input_select.mail_package_delivery_state
+                data:
+                  option: clear
+              - action: input_boolean.turn_off
+                target:
+                  entity_id: input_boolean.mail_delivered
+              - action: persistent_notification.dismiss
+                continue_on_error: true
+                data:
+                  notification_id: mail-package-delivery
+              - action: notify.all
+                continue_on_error: true
+                data:
+                  message: clear_notification
+                  data:
+                    tag: mail-package-delivery
+
+  - id: mail_package_still_outside_reminder
+    alias: mail_package_still_outside_reminder
+    description: >-
+      Escalates a delivered mail/package state to still_outside once it has
+      not been acknowledged for 30 minutes.
+    mode: single
+    trace:
+      stored_traces: 10
+    trigger:
+      - trigger: state
+        entity_id: input_select.mail_package_delivery_state
+        to: delivered
+        for:
+          minutes: 30
+    condition:
+      - condition: state
+        entity_id: input_boolean.mail_delivered
+        state: "on"
+    action:
+      - action: input_select.select_option
+        target:
+          entity_id: input_select.mail_package_delivery_state
+        data:
+          option: still_outside
+      - action: persistent_notification.create
+        data:
+          title: "Mail or Packages Still Outside"
+          message: >-
+            Delivery was reported 30 minutes ago and has not been marked
+            retrieved.
+          notification_id: mail-package-delivery
+      - action: notify.all
+        continue_on_error: true
+        data:
+          title: "Mail or Packages Still Outside"
+          message: >-
+            Delivery was reported 30 minutes ago. Mark it retrieved after
+            bringing it in.
+          data:
+            tag: mail-package-delivery
+            group: mail-packages
+            actions:
+              - action: MAIL_PACKAGE_RETRIEVED
+                title: "Retrieved"
+
+########################
+# Input Booleans
+########################
+input_boolean:
+  mail_delivered:
+    name: Mail Delivered
+    icon: mdi:mailbox
+
+########################
+# Input Select
+########################
+input_select:
+  mail_package_delivery_state:
+    name: Mail Package Delivery State
+    options:
+      - clear
+      - expected
+      - delivered
+      - still_outside
+      - retrieved
+      - unavailable
+    initial: clear
+    icon: mdi:package-variant-closed
+
+########################
+# Input Buttons
+########################
+input_button:
+  mail_package_mark_retrieved:
+    name: Mark Mail and Packages Retrieved
+    icon: mdi:package-check
+
+########################
+# Input Datetimes
+########################
+input_datetime:
+  mail_package_last_delivery:
+    name: Mail Package Last Delivery
+    has_date: true
+    has_time: true
+  mail_package_last_retrieved:
+    name: Mail Package Last Retrieved
+    has_date: true
+    has_time: true

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -965,35 +965,6 @@ automation:
                     - input_boolean.master_bed_occupancy
               #       # - input_boolean.chatgpt_bed_occupied
 
-  - id: mail_delivered
-    alias: mail_delivered
-    trace:
-      stored_traces: 10
-    trigger:
-      - trigger: state
-        entity_id: binary_sensor.mailbox_contact
-        from: "off"
-        to: "on"
-    condition:
-      - condition: and
-        conditions:
-          - alias: "Mailbox empty"
-            condition: state
-            entity_id: input_boolean.mail_delivered
-            state: "off"
-          - alias: "On a trip"
-            condition: state
-            entity_id: input_boolean.trip
-            state: "off"
-    action:
-      - action: input_boolean.turn_on
-        target:
-          entity_id: input_boolean.mail_delivered
-      - action: notify.all
-        data:
-          message: >-
-            Mail delivered.
-
   - id: office_light_control_button
     alias: office_light_control_button
     trace:
@@ -1115,18 +1086,6 @@ automation:
           entity_id: cover.owner_suite_blinds_ha
         data:
           position: 50
-
-  - id: reset_mail_delivery
-    alias: reset_mail_delivery
-    trace:
-      stored_traces: 10
-    trigger:
-      - trigger: time
-        at: "01:00:00"
-    action:
-      - action: input_boolean.turn_off
-        target:
-          entity_id: input_boolean.mail_delivered
 
   - alias: guest_room_switch_actions
     id: guest_room_switch_actions
@@ -1667,7 +1626,6 @@ device_tracker: []
 ########################
 input_boolean:
   master_bed_occupancy:
-  mail_delivered:
   front_door_lock:
 
 ########################

--- a/tests/test_mail_packages_package.py
+++ b/tests/test_mail_packages_package.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIL_PACKAGES_PATH = ROOT / "packages" / "mail_packages.yaml"
+ZIGBEE_ZWAVE_PATH = ROOT / "packages" / "zigbee_zwave.yaml"
+
+
+def _automation_block(automation_id: str) -> str:
+    text = MAIL_PACKAGES_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^  - id: {re.escape(automation_id)}\n(.*?)(?=^  - id: |^input_boolean:)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"Could not find automation block {automation_id!r}")
+    return match.group(0)
+
+
+def test_mail_delivered_helper_moved_to_mail_package_domain_package() -> None:
+    mail_text = MAIL_PACKAGES_PATH.read_text(encoding="utf-8")
+    zigbee_text = ZIGBEE_ZWAVE_PATH.read_text(encoding="utf-8")
+
+    assert "input_boolean:\n  mail_delivered:" in mail_text
+    assert "id: mail_delivered" not in zigbee_text
+    assert re.search(r"^input_boolean:\n(?:  .+\n)*  mail_delivered:", zigbee_text, re.MULTILINE) is None
+
+
+def test_mail_package_state_helper_distinguishes_delivery_lifecycle() -> None:
+    text = MAIL_PACKAGES_PATH.read_text(encoding="utf-8")
+
+    assert "input_select:\n  mail_package_delivery_state:" in text
+    for state in ("clear", "expected", "delivered", "still_outside", "retrieved", "unavailable"):
+        assert f"      - {state}" in text
+    assert "input_button:\n  mail_package_mark_retrieved:" in text
+    assert "input_datetime:\n  mail_package_last_delivery:" in text
+    assert "mail_package_last_retrieved:" in text
+
+
+def test_mail_package_delivery_uses_mailbox_and_carrier_sensors_without_duplicate_spam() -> None:
+    block = _automation_block("mail_package_delivery_state")
+
+    assert "mode: queued" in block
+    assert "trigger: homeassistant" in block
+    assert "id: startup_sync" in block
+    assert "at: \"01:00:00\"" in block
+    assert "id: daily_reset" in block
+    assert "entity_id: binary_sensor.mailbox_contact" in block
+    assert "sensor.mail_usps_mail" in block
+    assert "sensor.mail_usps_packages" in block
+    assert "sensor.mail_ups_packages" in block
+    assert "sensor.mail_fedex_packages" in block
+    assert "sensor.mail_amazon_packages" in block
+    assert "sensor.mail_usps_delivered" in block
+    assert "sensor.mail_ups_delivered" in block
+    assert "sensor.mail_fedex_delivered" in block
+    assert "sensor.mail_amazon_packages_delivered" in block
+    assert "condition: state\n                entity_id: input_boolean.mail_delivered\n                state: \"off\"" in block
+    assert "action: mail_and_packages.update_image" in block
+    assert "continue_on_error: true" in block
+    assert "option: clear" in block
+
+
+def test_mail_package_notifications_are_actionable_and_camera_optional() -> None:
+    block = _automation_block("mail_package_delivery_state")
+
+    assert "event_type: mobile_app_notification_action" in block
+    assert "action: MAIL_PACKAGE_RETRIEVED" in block
+    assert "action: MAIL_PACKAGE_STILL_OUTSIDE" in block
+    assert "camera_candidates:" in block
+    assert "camera.mail_generic_delivery_camera" in block
+    assert "camera.mail_amazon_delivery_camera" in block
+    assert "camera.mail_usps_camera" in block
+    assert "image: \"{{ '/api/camera_proxy/' ~ camera_entity }}\"" in block
+    assert "persistent_notification.create" in block
+    assert "message: clear_notification" in block
+
+
+def test_mail_package_still_outside_reminder_escalates_once_after_delivery() -> None:
+    block = _automation_block("mail_package_still_outside_reminder")
+
+    assert "mode: single" in block
+    assert "to: delivered" in block
+    assert "minutes: 30" in block
+    assert "option: still_outside" in block
+    assert "notification_id: mail-package-delivery" in block
+    assert "action: MAIL_PACKAGE_RETRIEVED" in block


### PR DESCRIPTION
## Summary
- add a dedicated mail/package delivery package with expected, delivered, still_outside, retrieved, and clear states
- keep input_boolean.mail_delivered for existing dashboard compatibility while moving mail delivery behavior out of the Zigbee package
- add actionable notifications, optional Mail and Packages camera refresh/image attachment, retrieval actions, startup reconciliation, and daily stale-state reset

Fixes #116

## Validation
- uv run --with pytest pytest
- uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt
- python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/mail_packages.yaml --strict
- python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/mail_packages.yaml packages/zigbee_zwave.yaml --strict (deferred legacy findings in existing Inovelli switch scripts under packages/zigbee_zwave.yaml; no findings in the new mail package)

## Local config check
- Docker is not installed in this environment, so the CI Docker check_config command could not run locally.
- Fallback uv Home Assistant check_config could not complete because local placeholder secrets are schema-invalid for latitude/longitude/URLs/proxies and /config/media/vacuum_stalls does not exist on the host path.