### PR TITLE
Keep bedtime Music Assistant queues repeating (#853)

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1912,6 +1912,13 @@ script:
             timeout:
               seconds: 15
             continue_on_timeout: true
+      - alias: "Ensure bedtime queue repeats after playback starts"
+        action: media_player.repeat_set
+        continue_on_error: true
+        data:
+          repeat: all
+        target:
+          entity_id: "{{ bedtime_playback_entity }}"
       - wait_for_trigger:
           - trigger: state
             entity_id: binary_sensor.owner_suite_bathroom_room_occupancy

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -580,6 +580,36 @@ def test_bedtime_volume_rampdown_is_data_driven_without_repeating_delay_actions(
     assert "continue_on_error: false" not in block
 
 
+def test_spotify_bedtime_reapplies_repeat_to_started_queue_before_rampdown() -> None:
+    block = _script_block("spotify_bedtime")
+
+    tokens_in_order = (
+        "action: script.music_assistant_play_item",
+        "action: script.music_assistant_play_random_lofi_playlist",
+        "Ensure bedtime queue repeats after playback starts",
+        "action: media_player.repeat_set",
+        "entity_id: binary_sensor.owner_suite_bathroom_room_occupancy",
+        "entity_id: script.spotify_bedtime_volume",
+    )
+
+    cursor = -1
+    for token in tokens_in_order:
+        next_cursor = block.index(token, cursor + 1)
+        assert next_cursor > cursor, token
+        cursor = next_cursor
+
+    assert block.count("action: media_player.repeat_set") == 2
+    assert block.count("repeat: all") == 2
+
+    repeat_after_start = block.split("Ensure bedtime queue repeats after playback starts", 1)[1]
+    for token in (
+        "continue_on_error: true",
+        "repeat: all",
+        'entity_id: "{{ bedtime_playback_entity }}"',
+    ):
+        assert token in repeat_after_start
+
+
 def test_arrival_and_wakeup_scripts_use_sequence_level_playlist_selection() -> None:
     # Same caching concern as bedroom_playlist scripts.
     for script_id in ("spotify_arrival", "spotify_wake_up"):


### PR DESCRIPTION
## Summary
- Reapply `media_player.repeat_set` after bedtime playback/fallback starts so repeat mode applies to the active Music Assistant queue.
- Add a regression test that keeps the post-play repeat step before bathroom-visit/rampdown scheduling.

Fixes #853.

## Validation
- `uv run --with pytest pytest tests/test_media_player_music_assistant.py tests/test_night_routines_allium_alignment.py tests/test_alarm_night_allium_alignment.py -q`
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/media_player.yaml --strict`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt`
- `uv run --with pytest pytest`
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version`
- `python3 scripts/allium_weed_check.py specs/night_routines.allium --changed-from origin/develop`
- `git diff --check`

## Not run
- Home Assistant container `check_config`: attempted with Podman and CI image `ghcr.io/home-assistant/home-assistant:2026.5.1`, but the local Podman VM immediately returned to `stopped` after `podman machine start`, and Docker is not installed on this machine.