### PR TITLE
Fix #852 owner-suite light auto-on bed debounce

### DIFF
--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1399,6 +1399,11 @@ automation:
         entity_id: binary_sensor.presense
         to: "on"
         from: "off"
+      - trigger: state
+        entity_id: binary_sensor.bayesian_bed_occupancy
+        to: "off"
+        for:
+          seconds: 30
     condition:
       condition: and
       conditions:
@@ -1412,7 +1417,17 @@ automation:
           entity_id: binary_sensor.bayesian_bed_occupancy
           # entity_id: input_boolean.chatgpt_bed_occupied
           state: "off"
+          for:
+            seconds: 30
           # enabled: false
+        - condition: or
+          conditions:
+            - condition: state
+              entity_id: binary_sensor.bedroom_occupancy
+              state: "on"
+            - condition: state
+              entity_id: binary_sensor.presense
+              state: "on"
     action:
       - action: switch.turn_on
         target:

--- a/tests/test_issue_owner_suite_home_condition.py
+++ b/tests/test_issue_owner_suite_home_condition.py
@@ -52,6 +52,18 @@ def test_owner_suite_light_auto_on_uses_home_presence_sensor() -> None:
     assert "\n          color_temp_kelvin:" not in block
 
 
+def test_owner_suite_light_auto_on_debounces_bed_occupancy_clear() -> None:
+    block = _automation_block("owner_suite_light_auto_on")
+
+    assert "entity_id: binary_sensor.bayesian_bed_occupancy" in block
+    assert 'to: "off"' in block
+    assert "for:\n          seconds: 30" in block
+    assert "for:\n            seconds: 30" in block
+    assert "condition: or" in block
+    assert "entity_id: binary_sensor.bedroom_occupancy" in block
+    assert "entity_id: binary_sensor.presense" in block
+
+
 def test_owner_suite_light_auto_off_combines_latch_and_morning_paths() -> None:
     package = LIGHT_PATH.read_text(encoding="utf-8")
     block = _automation_block("owner_suite_light_auto_off")


### PR DESCRIPTION
## Summary
- Fixes #852.
- Debounces `automation.owner_suite_light_auto_on` so owner-suite lamps only auto-on after `binary_sensor.bayesian_bed_occupancy` has been stably `off` for 30 seconds.
- Adds a debounced bed-clear trigger with a room-activity guard so real get-up events can still turn lights on after the debounce, while short bed-presence dropouts are ignored.
- Adds regression coverage for the debounced trigger and stable-off condition.

## Runtime evidence
Nightly HA Runtime Sweep on 2026-07-07 found the issue #852 symptom in live recorder/logbook data:

- At `2026-07-07T11:20:24.652843Z` (`06:20:24` CDT), `binary_sensor.bayesian_bed_occupancy` flipped `on -> off`.
- At `2026-07-07T11:20:25.066960Z`, `automation.owner_suite_light_auto_on` triggered from `binary_sensor.presense=on` and called `script.adaptive_light_turn_on`.
- `light.owner_suite_lamps` turned `on` at `2026-07-07T11:20:26.201543Z`.
- At `2026-07-07T11:20:26.246763Z`, `binary_sensor.bayesian_bed_occupancy` returned to `on`, so the bed-clear signal lasted roughly 1.6 seconds.
- `input_select.house_mode` was `in_bed` and `input_boolean.wakeup_alarm_firing` was `off`, so this was not the intended alarm wake transition.

This contradicts the room/privacy intent for the owner suite and the alarm/wake Allium expectation that owner-suite morning lighting behavior should not run while the resident is still in bed.

## Validation
- `uv run --with pytest pytest tests/test_issue_owner_suite_home_condition.py tests/test_alarm_night_allium_alignment.py -q` -> 18 passed
- `uv run --with pytest pytest` -> 565 passed
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" packages/light.yaml` -> passed
- `python3 scripts/allium_weed_check.py --changed-from origin/develop --format terminal` -> passed with existing warnings/infos
- `git diff --check` -> passed

## Validation notes
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/light.yaml --strict` reports pre-existing duplication in `packages/light.yaml`, including shared conditions/triggers outside this one-defect fix. No new duplicate group was introduced by the debounce change; broader DRY cleanup remains out of scope for #852.
- Home Assistant container `check_config` was attempted with `ghcr.io/home-assistant/home-assistant:2026.7.1`. The direct worktree check reached HA but failed because the clean worktree has no local `secrets.yaml` (`home_latitude` missing). A temp-copy retry with placeholder secrets was blocked twice by Podman socket refusal after VM restart.
