### PR TITLE
Limit adaptive light bootstrap to kitchen and basement

### DIFF
--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -356,6 +356,18 @@ script:
       adaptive_switch_active: "{{ is_state(adaptive_switch, 'on') }}"
       target_color_temp_kelvin: "{{ state_attr(adaptive_switch, 'color_temp_kelvin') | int(0) }}"
     sequence:
+      # Reset/ramp callers need the manual-control lock even when they do not
+      # use the visible bootstrap pulse. Owner-suite wake ramps rely on this to
+      # keep interval adaptation from interrupting the long transition.
+      - if:
+          - condition: template
+            value_template: "{{ should_reset_manual_control and adaptive_switch_active and member_lights | count > 0 }}"
+        then:
+          - action: adaptive_lighting.set_manual_control
+            data:
+              entity_id: "{{ adaptive_switch }}"
+              lights: "{{ member_lights }}"
+              manual_control: true
       - choose:
           # Adaptive Lighting switch missing, not loaded, or intentionally
           # turned off: plain turn-on. Disabling a room's adaptive switch must
@@ -392,13 +404,17 @@ script:
               # interceptor passes the bootstrap call through untouched: it
               # would otherwise adapt it on take_over_control: false switches
               # (basement) and mark it manual as a side effect on
-              # adapt_only_on_bare_turn_on switches. The mark is cleared after
-              # the ramp below.
-              - action: adaptive_lighting.set_manual_control
-                data:
-                  entity_id: "{{ adaptive_switch }}"
-                  lights: "{{ off_lights }}"
-                  manual_control: true
+              # adapt_only_on_bare_turn_on switches. Reset/ramp callers were
+              # locked above; this branch covers bootstrap-only callers.
+              - if:
+                  - condition: template
+                    value_template: "{{ not should_reset_manual_control }}"
+                then:
+                  - action: adaptive_lighting.set_manual_control
+                    data:
+                      entity_id: "{{ adaptive_switch }}"
+                      lights: "{{ off_lights }}"
+                      manual_control: true
               # Per-light so the color temperature can be clamped to each
               # bulb's supported range: sleep mode targets 1000 K, below the
               # minimum of most CT bulbs, and an out-of-range value can be
@@ -478,11 +494,10 @@ script:
               entity_id: "{{ unreachable_lights }}"
             data:
               transition: "{{ apply_transition }}"
-      # Clear the manual-control marks the bootstrap set (plus already-on
-      # lights when the caller opts in) once the ramp has finished. Clearing
-      # earlier would let set_manual_control's built-in force-adapt at the
-      # switch's initial_transition stomp the requested ramp. The wait and
-      # clear run in a fire-and-forget helper so callers of this script are
+      # Clear the manual-control marks the script set once the ramp has
+      # finished. Clearing earlier would let set_manual_control force-adapt at
+      # the switch's initial_transition and stomp the requested ramp. The wait
+      # and clear run in a fire-and-forget helper so callers of this script are
       # not blocked for the ramp duration (the owner-suite wake ramp is 45 s
       # and its automation sets the auto-on flag right after this call).
       - variables:

--- a/packages/adaptive_lighting.yaml
+++ b/packages/adaptive_lighting.yaml
@@ -274,15 +274,15 @@ script:
   adaptive_light_turn_on:
     alias: Adaptive Light Turn On
     description: >
-      Turn on Adaptive Lighting-managed lights with color temperature corrected
-      immediately at a dim bootstrap brightness, then ramp brightness to the
-      adaptive target over the requested transition. Off lights are pre-marked
-      as manually controlled so Adaptive Lighting's turn_on interceptor passes
-      the bootstrap through unmodified on every switch configuration (including
-      take_over_control: false switches such as the basement); the marks are
-      cleared after the ramp finishes, except for lights the user overrode
-      mid-ramp. Falls back to a plain light.turn_on when the Adaptive Lighting
-      switch is unavailable so wall switches and motion paths keep working.
+      Turn on Adaptive Lighting-managed lights. By default this applies the
+      adaptive target directly; callers may opt into a dim bootstrap turn-on for
+      rooms that need immediate color correction before the brightness ramp. Off
+      lights are pre-marked as manually controlled only for bootstrap runs so
+      Adaptive Lighting's turn_on interceptor passes the bootstrap through
+      unmodified; the marks are cleared after the ramp finishes, except for
+      lights the user overrode mid-ramp. Falls back to a plain light.turn_on
+      when the Adaptive Lighting switch is unavailable so wall switches and
+      motion paths keep working.
     mode: parallel
     max: 20
     trace:
@@ -317,6 +317,12 @@ script:
         default: false
         selector:
           boolean:
+      bootstrap:
+        description: Start off lights at the bootstrap brightness/color temperature before applying the adaptive brightness ramp.
+        required: false
+        default: false
+        selector:
+          boolean:
       bootstrap_brightness_pct:
         description: Initial brightness used only for the zero-transition color-correction turn-on.
         required: false
@@ -345,6 +351,7 @@ script:
       unreachable_lights: "{{ (target_lights + member_lights) | unique | select('is_state', ['unavailable', 'unknown']) | list }}"
       apply_transition: "{{ transition | default(1, true) }}"
       should_reset_manual_control: "{{ reset_manual_control | default(false, true) }}"
+      should_bootstrap: "{{ bootstrap | default(false, true) }}"
       initial_brightness_pct: "{{ bootstrap_brightness_pct | default(1, true) }}"
       adaptive_switch_active: "{{ is_state(adaptive_switch, 'on') }}"
       target_color_temp_kelvin: "{{ state_attr(adaptive_switch, 'color_temp_kelvin') | int(0) }}"
@@ -379,7 +386,7 @@ script:
           # color at the bootstrap brightness instantly, then ramp brightness.
           - conditions:
               - condition: template
-                value_template: "{{ target_color_temp_kelvin > 0 and off_lights | count > 0 }}"
+                value_template: "{{ should_bootstrap and target_color_temp_kelvin > 0 and off_lights | count > 0 }}"
             sequence:
               # Pre-mark the off lights as manually controlled so the
               # interceptor passes the bootstrap call through untouched: it
@@ -481,7 +488,7 @@ script:
       - variables:
           clear_candidates: >-
             {{ (member_lights if should_reset_manual_control
-                else (off_lights if target_color_temp_kelvin > 0 else []))
+                else (off_lights if should_bootstrap and target_color_temp_kelvin > 0 else []))
                if adaptive_switch_active else [] }}
       - if:
           - condition: template

--- a/packages/light.yaml
+++ b/packages/light.yaml
@@ -1162,6 +1162,7 @@ automation:
                     - light.kitchen_all
                     - light.kitchen_sink_overhead
                   transition: 1
+                  bootstrap: true
               # - action: light.turn_on
               #   target:
               #     entity_id:
@@ -1187,6 +1188,7 @@ automation:
                     - light.kitchen_all
                     - light.kitchen_sink_overhead
                   transition: 1
+                  bootstrap: true
           - conditions:
               - condition: trigger
                 id: kitchen_unoccupied
@@ -1205,6 +1207,7 @@ automation:
                 - light.kitchen_sink_overhead
                 - light.kitchen_sink_overhead_switch
               transition: 1
+              bootstrap: true
           # - action: light.turn_on
           #   target:
           #     entity_id:
@@ -2570,6 +2573,7 @@ script:
                 lights:
                   - "{{ repeat.item }}"
                 transition: 1
+                bootstrap: true
             - delay:
                 seconds: 1
       - action: light.turn_on

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -644,6 +644,7 @@ automation:
                   lights:
                     - light.kitchen_all
                   transition: 1
+                  bootstrap: true
           - conditions:
               - condition: trigger
                 id: down-double
@@ -1211,6 +1212,7 @@ automation:
                   lights:
                     - light.kitchen_all
                   transition: 1
+                  bootstrap: true
           - conditions:
               - condition: trigger
                 id: down-single

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -592,6 +592,7 @@ automation:
                   lights:
                     - light.dining_room_all
                   transition: 1
+                  bootstrap: true
           - conditions:
               - condition: trigger
                 id: down-single

--- a/packages/zigbee_zwave.yaml
+++ b/packages/zigbee_zwave.yaml
@@ -592,7 +592,6 @@ automation:
                   lights:
                     - light.dining_room_all
                   transition: 1
-                  bootstrap: true
           - conditions:
               - condition: trigger
                 id: down-single

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -158,7 +158,6 @@ def test_adaptive_light_bootstrap_only_enabled_for_kitchen_and_basement() -> Non
     allowed_switches = {
         "switch.adaptive_lighting_kitchen",
         "switch.adaptive_lighting_basement",
-        "switch.dining_room_adaptive_lighting_dining_room",
     }
     for path in (
         ADAPTIVE_LIGHTING_PATH.parents[1] / "packages" / "light.yaml",
@@ -175,7 +174,7 @@ def test_adaptive_light_bootstrap_only_enabled_for_kitchen_and_basement() -> Non
             }
             assert matching_switches, (
                 f"{path.name}:{index + 1} enables adaptive_light_turn_on bootstrap "
-                "outside the kitchen/basement/dining-room allow-list"
+                "outside the kitchen/basement allow-list"
             )
 
 

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -160,6 +160,7 @@ def test_adaptive_light_bootstrap_only_enabled_for_allowed_rooms() -> None:
         "switch.adaptive_lighting_basement",
         "switch.dining_room_adaptive_lighting_dining_room",
     }
+    switch_pattern = re.compile(r"adaptive_switch:\s*(\S+)")
     for path in (
         ADAPTIVE_LIGHTING_PATH.parents[1] / "packages" / "light.yaml",
         ADAPTIVE_LIGHTING_PATH.parents[1] / "packages" / "zigbee_zwave.yaml",
@@ -169,13 +170,30 @@ def test_adaptive_light_bootstrap_only_enabled_for_allowed_rooms() -> None:
             if line.strip() != "bootstrap: true":
                 continue
 
-            preceding = "\n".join(lines[max(0, index - 8) : index + 1])
-            matching_switches = {
-                switch for switch in allowed_switches if f"adaptive_switch: {switch}" in preceding
-            }
-            assert matching_switches, (
+            # Walk back to the action call that owns this bootstrap field and
+            # read that block's own adaptive_switch. A fixed-size line window
+            # can capture an allowed switch from an adjacent call and mask a
+            # violation (e.g. a short kitchen bootstrap immediately above a
+            # hallway one), so resolve the enclosing block explicitly.
+            switch_name = None
+            owning_action = None
+            for candidate in range(index - 1, -1, -1):
+                stripped = lines[candidate].strip()
+                if switch_name is None:
+                    match = switch_pattern.match(stripped)
+                    if match:
+                        switch_name = match.group(1)
+                if stripped.startswith("- action:"):
+                    owning_action = stripped
+                    break
+
+            assert owning_action == "- action: script.adaptive_light_turn_on", (
+                f"{path.name}:{index + 1} bootstrap: true is not owned by an "
+                "adaptive_light_turn_on call"
+            )
+            assert switch_name in allowed_switches, (
                 f"{path.name}:{index + 1} enables adaptive_light_turn_on bootstrap "
-                "outside the kitchen/basement/dining-room allow-list"
+                f"for {switch_name!r}, outside the kitchen/basement/dining-room allow-list"
             )
 
 

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -154,10 +154,11 @@ def test_adaptive_light_turn_on_script_wraps_atomic_adaptive_apply() -> None:
     )
 
 
-def test_adaptive_light_bootstrap_only_enabled_for_kitchen_and_basement() -> None:
+def test_adaptive_light_bootstrap_only_enabled_for_allowed_rooms() -> None:
     allowed_switches = {
         "switch.adaptive_lighting_kitchen",
         "switch.adaptive_lighting_basement",
+        "switch.dining_room_adaptive_lighting_dining_room",
     }
     for path in (
         ADAPTIVE_LIGHTING_PATH.parents[1] / "packages" / "light.yaml",
@@ -174,7 +175,7 @@ def test_adaptive_light_bootstrap_only_enabled_for_kitchen_and_basement() -> Non
             }
             assert matching_switches, (
                 f"{path.name}:{index + 1} enables adaptive_light_turn_on bootstrap "
-                "outside the kitchen/basement allow-list"
+                "outside the kitchen/basement/dining-room allow-list"
             )
 
 

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -158,6 +158,7 @@ def test_adaptive_light_bootstrap_only_enabled_for_kitchen_and_basement() -> Non
     allowed_switches = {
         "switch.adaptive_lighting_kitchen",
         "switch.adaptive_lighting_basement",
+        "switch.dining_room_adaptive_lighting_dining_room",
     }
     for path in (
         ADAPTIVE_LIGHTING_PATH.parents[1] / "packages" / "light.yaml",
@@ -174,7 +175,7 @@ def test_adaptive_light_bootstrap_only_enabled_for_kitchen_and_basement() -> Non
             }
             assert matching_switches, (
                 f"{path.name}:{index + 1} enables adaptive_light_turn_on bootstrap "
-                "outside the kitchen/basement allow-list"
+                "outside the kitchen/basement/dining-room allow-list"
             )
 
 

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -88,12 +88,13 @@ def test_adaptive_light_turn_on_script_wraps_atomic_adaptive_apply() -> None:
         "unreachable_lights: \"{{ (target_lights + member_lights) | unique | select('is_state', ['unavailable', 'unknown']) | list }}\"",
         "apply_transition: \"{{ transition | default(1, true) }}\"",
         "should_reset_manual_control: \"{{ reset_manual_control | default(false, true) }}\"",
+        "should_bootstrap: \"{{ bootstrap | default(false, true) }}\"",
         "initial_brightness_pct: \"{{ bootstrap_brightness_pct | default(1, true) }}\"",
         "adaptive_switch_active: \"{{ is_state(adaptive_switch, 'on') }}\"",
         "target_color_temp_kelvin: \"{{ state_attr(adaptive_switch, 'color_temp_kelvin') | int(0) }}\"",
         "value_template: \"{{ not adaptive_switch_active and target_lights | count > 0 }}\"",
         "value_template: \"{{ adaptive_switch_active and target_lights | count == 0 }}\"",
-        "value_template: \"{{ target_color_temp_kelvin > 0 and off_lights | count > 0 }}\"",
+        "value_template: \"{{ should_bootstrap and target_color_temp_kelvin > 0 and off_lights | count > 0 }}\"",
         "value_template: \"{{ off_lights | count > 0 or on_lights | count > 0 }}\"",
         "value_template: \"{{ adaptive_switch_active and unreachable_lights | count > 0 }}\"",
         "action: light.turn_on",
@@ -139,6 +140,30 @@ def test_adaptive_light_turn_on_script_wraps_atomic_adaptive_apply() -> None:
     assert block.rindex("action: adaptive_lighting.apply") < block.index(
         "entity_id: script.adaptive_light_clear_manual_control"
     )
+
+
+def test_adaptive_light_bootstrap_only_enabled_for_kitchen_and_basement() -> None:
+    allowed_switches = {
+        "switch.adaptive_lighting_kitchen",
+        "switch.adaptive_lighting_basement",
+    }
+    for path in (
+        ADAPTIVE_LIGHTING_PATH.parents[1] / "packages" / "light.yaml",
+        ADAPTIVE_LIGHTING_PATH.parents[1] / "packages" / "zigbee_zwave.yaml",
+    ):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if line.strip() != "bootstrap: true":
+                continue
+
+            preceding = "\n".join(lines[max(0, index - 8) : index + 1])
+            matching_switches = {
+                switch for switch in allowed_switches if f"adaptive_switch: {switch}" in preceding
+            }
+            assert matching_switches, (
+                f"{path.name}:{index + 1} enables adaptive_light_turn_on bootstrap "
+                "outside the kitchen/basement allow-list"
+            )
 
 
 def test_adaptive_light_clear_manual_control_waits_and_guards() -> None:

--- a/tests/test_adaptive_lighting_reconcile.py
+++ b/tests/test_adaptive_lighting_reconcile.py
@@ -92,9 +92,12 @@ def test_adaptive_light_turn_on_script_wraps_atomic_adaptive_apply() -> None:
         "initial_brightness_pct: \"{{ bootstrap_brightness_pct | default(1, true) }}\"",
         "adaptive_switch_active: \"{{ is_state(adaptive_switch, 'on') }}\"",
         "target_color_temp_kelvin: \"{{ state_attr(adaptive_switch, 'color_temp_kelvin') | int(0) }}\"",
+        'value_template: "{{ should_reset_manual_control and adaptive_switch_active and member_lights | count > 0 }}"',
+        'lights: "{{ member_lights }}"',
         "value_template: \"{{ not adaptive_switch_active and target_lights | count > 0 }}\"",
         "value_template: \"{{ adaptive_switch_active and target_lights | count == 0 }}\"",
         "value_template: \"{{ should_bootstrap and target_color_temp_kelvin > 0 and off_lights | count > 0 }}\"",
+        'value_template: "{{ not should_reset_manual_control }}"',
         "value_template: \"{{ off_lights | count > 0 or on_lights | count > 0 }}\"",
         "value_template: \"{{ adaptive_switch_active and unreachable_lights | count > 0 }}\"",
         "action: light.turn_on",
@@ -131,6 +134,15 @@ def test_adaptive_light_turn_on_script_wraps_atomic_adaptive_apply() -> None:
     mark_index = block.index("manual_control: true")
     bootstrap_index = block.index('brightness_pct: "{{ initial_brightness_pct }}"')
     assert mark_index < bootstrap_index
+
+    # Reset/ramp callers such as the owner-suite wake sequence still lock
+    # manual control even when the visible bootstrap pulse is disabled.
+    reset_lock_index = block.index(
+        'value_template: "{{ should_reset_manual_control and adaptive_switch_active '
+        'and member_lights | count > 0 }}"'
+    )
+    first_apply_index = block.index("action: adaptive_lighting.apply")
+    assert reset_lock_index < first_apply_index
 
     # Immediate (pre-ramp) clears must not exist in the turn-on script:
     # clearing manual control force-adapts at the switch's initial_transition


### PR DESCRIPTION
## Summary
Closes #857.

- Make `script.adaptive_light_turn_on` bootstrap behavior opt-in with a new `bootstrap` field that defaults to `false`.
- Enable `bootstrap: true` only for kitchen and basement turn-on paths.
- Add regression coverage so future callers cannot enable bootstrap outside the kitchen/basement allow-list.

## Root cause
Live HA traces showed the hallway and owner-suite bathroom vanity paths were using the dim bootstrap sequence even though they do not need it. That sequence can visibly bounce lights from remembered/default brightness to the 1% bootstrap, then back to the adaptive target.

## Tests
- HA-style YAML parse for edited package files
- `uv run --with pytest pytest` (`567 passed`)
