### PR TITLE
Fix #844 bedtime fallback chain

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1905,17 +1905,17 @@ script:
               entity_id: "{{ bedtime_playback_entity }}"
               playlist_name: Bedtime LoFi fallback
               log_name: Spotify Bedtime fallback is
-          - alias: "Confirm LoFi fallback changed the group media"
-            wait_template: >-
-              {{ is_state(bedtime_playback_entity, 'playing') and [
-                  state_attr(bedtime_playback_entity, 'media_content_id') | default('', true),
-                  state_attr(bedtime_playback_entity, 'media_title') | default('', true),
-                  state_attr(bedtime_playback_entity, 'media_artist') | default('', true),
-                  state_attr(bedtime_playback_entity, 'media_album_name') | default('', true)
-                ] | join('|') != bedtime_pre_playback_fingerprint }}
-            timeout:
-              seconds: 15
-            continue_on_timeout: true
+      - alias: "Confirm LoFi fallback changed the group media"
+        wait_template: >-
+          {{ is_state(bedtime_playback_entity, 'playing') and [
+              state_attr(bedtime_playback_entity, 'media_content_id') | default('', true),
+              state_attr(bedtime_playback_entity, 'media_title') | default('', true),
+              state_attr(bedtime_playback_entity, 'media_artist') | default('', true),
+              state_attr(bedtime_playback_entity, 'media_album_name') | default('', true)
+            ] | join('|') != bedtime_pre_playback_fingerprint }}
+        timeout:
+          seconds: 15
+        continue_on_timeout: true
       - if:
           - condition: template
             value_template: "{{ not wait.completed }}"
@@ -1933,26 +1933,26 @@ script:
               entity_id: "{{ bedtime_playback_entity }}"
               media_item: "{{ bedtime_apple_music_fallback_uri }}"
               media_type: "{{ bedtime_apple_music_fallback_media_type }}"
-          - alias: "Confirm Apple Music fallback changed the group media"
-            wait_template: >-
-              {% set ns = namespace(parts=[]) %}
-              {% for attr in [
-                'media_content_id',
-                'media_title',
-                'media_artist',
-                'media_album_name'
-              ] %}
-                {% set value =
-                  state_attr(bedtime_playback_entity, attr)
-                  | default('', true)
-                %}
-                {% set ns.parts = ns.parts + [value] %}
-              {% endfor %}
-              {{ is_state(bedtime_playback_entity, 'playing')
-                 and ns.parts | join('|') != bedtime_pre_playback_fingerprint }}
-            timeout:
-              seconds: 15
-            continue_on_timeout: true
+      - alias: "Confirm Apple Music fallback changed the group media"
+        wait_template: >-
+          {% set ns = namespace(parts=[]) %}
+          {% for attr in [
+            'media_content_id',
+            'media_title',
+            'media_artist',
+            'media_album_name'
+          ] %}
+            {% set value =
+              state_attr(bedtime_playback_entity, attr)
+              | default('', true)
+            %}
+            {% set ns.parts = ns.parts + [value] %}
+          {% endfor %}
+          {{ is_state(bedtime_playback_entity, 'playing')
+             and ns.parts | join('|') != bedtime_pre_playback_fingerprint }}
+        timeout:
+          seconds: 15
+        continue_on_timeout: true
       - if:
           - condition: template
             value_template: "{{ not wait.completed }}"
@@ -1970,26 +1970,26 @@ script:
               entity_id: "{{ bedtime_playback_entity }}"
               media_item: "{{ bedtime_local_library_fallback_uri }}"
               media_type: "{{ bedtime_local_library_fallback_media_type }}"
-          - alias: "Confirm local library fallback changed the group media"
-            wait_template: >-
-              {% set ns = namespace(parts=[]) %}
-              {% for attr in [
-                'media_content_id',
-                'media_title',
-                'media_artist',
-                'media_album_name'
-              ] %}
-                {% set value =
-                  state_attr(bedtime_playback_entity, attr)
-                  | default('', true)
-                %}
-                {% set ns.parts = ns.parts + [value] %}
-              {% endfor %}
-              {{ is_state(bedtime_playback_entity, 'playing')
-                 and ns.parts | join('|') != bedtime_pre_playback_fingerprint }}
-            timeout:
-              seconds: 15
-            continue_on_timeout: true
+      - alias: "Confirm local library fallback changed the group media"
+        wait_template: >-
+          {% set ns = namespace(parts=[]) %}
+          {% for attr in [
+            'media_content_id',
+            'media_title',
+            'media_artist',
+            'media_album_name'
+          ] %}
+            {% set value =
+              state_attr(bedtime_playback_entity, attr)
+              | default('', true)
+            %}
+            {% set ns.parts = ns.parts + [value] %}
+          {% endfor %}
+          {{ is_state(bedtime_playback_entity, 'playing')
+             and ns.parts | join('|') != bedtime_pre_playback_fingerprint }}
+        timeout:
+          seconds: 15
+        continue_on_timeout: true
       - if:
           - condition: template
             value_template: "{{ not wait.completed }}"

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1825,6 +1825,10 @@ script:
             {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
                else 'media_player.ma_group_everywhere' }}
           bedtime_media_type: "{{ 'radio' if 'somafm.com' in playlist else '' }}"
+          bedtime_apple_music_fallback_uri: "apple_music://track/1492333325"
+          bedtime_apple_music_fallback_media_type: ""
+          bedtime_local_library_fallback_uri: "library://radio/17"
+          bedtime_local_library_fallback_media_type: radio
           bedtime_pre_playback_fingerprint: >-
             {{ [
               state_attr(bedtime_playback_entity, 'media_content_id') | default('', true),
@@ -1912,6 +1916,91 @@ script:
             timeout:
               seconds: 15
             continue_on_timeout: true
+      - if:
+          - condition: template
+            value_template: "{{ not wait.completed }}"
+        then:
+          - action: logbook.log
+            data:
+              entity_id: "{{ bedtime_playback_entity }}"
+              domain: media_player
+              name: Apple Music bedtime fallback is
+              message: >-
+                Spotify bedtime and LoFi fallback failed; playing Apple Music
+                fallback: {{ bedtime_apple_music_fallback_uri }}
+          - action: script.music_assistant_play_item
+            data:
+              entity_id: "{{ bedtime_playback_entity }}"
+              media_item: "{{ bedtime_apple_music_fallback_uri }}"
+              media_type: "{{ bedtime_apple_music_fallback_media_type }}"
+          - alias: "Confirm Apple Music fallback changed the group media"
+            wait_template: >-
+              {% set ns = namespace(parts=[]) %}
+              {% for attr in [
+                'media_content_id',
+                'media_title',
+                'media_artist',
+                'media_album_name'
+              ] %}
+                {% set value =
+                  state_attr(bedtime_playback_entity, attr)
+                  | default('', true)
+                %}
+                {% set ns.parts = ns.parts + [value] %}
+              {% endfor %}
+              {{ is_state(bedtime_playback_entity, 'playing')
+                 and ns.parts | join('|') != bedtime_pre_playback_fingerprint }}
+            timeout:
+              seconds: 15
+            continue_on_timeout: true
+      - if:
+          - condition: template
+            value_template: "{{ not wait.completed }}"
+        then:
+          - action: logbook.log
+            data:
+              entity_id: "{{ bedtime_playback_entity }}"
+              domain: media_player
+              name: Local bedtime fallback is
+              message: >-
+                Apple Music bedtime fallback failed; playing local library
+                fallback: {{ bedtime_local_library_fallback_uri }}
+          - action: script.music_assistant_play_item
+            data:
+              entity_id: "{{ bedtime_playback_entity }}"
+              media_item: "{{ bedtime_local_library_fallback_uri }}"
+              media_type: "{{ bedtime_local_library_fallback_media_type }}"
+          - alias: "Confirm local library fallback changed the group media"
+            wait_template: >-
+              {% set ns = namespace(parts=[]) %}
+              {% for attr in [
+                'media_content_id',
+                'media_title',
+                'media_artist',
+                'media_album_name'
+              ] %}
+                {% set value =
+                  state_attr(bedtime_playback_entity, attr)
+                  | default('', true)
+                %}
+                {% set ns.parts = ns.parts + [value] %}
+              {% endfor %}
+              {{ is_state(bedtime_playback_entity, 'playing')
+                 and ns.parts | join('|') != bedtime_pre_playback_fingerprint }}
+            timeout:
+              seconds: 15
+            continue_on_timeout: true
+      - if:
+          - condition: template
+            value_template: "{{ not wait.completed }}"
+        then:
+          - action: persistent_notification.create
+            data:
+              notification_id: bedtime_audio_failed
+              title: "Bedtime audio failed"
+              message: >-
+                Spotify bedtime, LoFi, Apple Music, and local library fallbacks
+                all failed to start on {{ bedtime_playback_entity }}.
       - alias: "Ensure bedtime queue repeats after playback starts"
         action: media_player.repeat_set
         continue_on_error: true

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -437,7 +437,7 @@ def test_bedtime_playlist_includes_explicit_somafm_station_urls() -> None:
     assert "'somafm.com' in playlist" in block
 
 
-def test_bedtime_verifies_primary_playback_and_falls_back_to_lofi() -> None:
+def test_bedtime_verifies_primary_playback_and_falls_back_through_non_spotify_sources() -> None:
     block = _script_block("spotify_bedtime")
 
     for token in (
@@ -445,6 +445,13 @@ def test_bedtime_verifies_primary_playback_and_falls_back_to_lofi() -> None:
         "bedtime_pre_playback_fingerprint",
         "Confirm primary bedtime playback changed the group media",
         "Confirm LoFi fallback changed the group media",
+        "bedtime_apple_music_fallback_uri: \"apple_music://track/1492333325\"",
+        "bedtime_local_library_fallback_uri: \"library://radio/17\"",
+        "Apple Music bedtime fallback is",
+        "Confirm Apple Music fallback changed the group media",
+        "Local bedtime fallback is",
+        "Confirm local library fallback changed the group media",
+        "Bedtime audio failed",
         "state_attr(bedtime_playback_entity, 'media_content_id')",
         "state_attr(bedtime_playback_entity, 'media_title')",
         "!= bedtime_pre_playback_fingerprint",
@@ -462,6 +469,15 @@ def test_bedtime_verifies_primary_playback_and_falls_back_to_lofi() -> None:
         "action: script.music_assistant_play_random_lofi_playlist"
     )
     assert block.index("action: script.music_assistant_play_random_lofi_playlist") < block.index(
+        "entity_id: binary_sensor.owner_suite_bathroom_room_occupancy"
+    )
+    assert block.index("Confirm LoFi fallback changed the group media") < block.index(
+        "Apple Music bedtime fallback is"
+    )
+    assert block.index("Confirm Apple Music fallback changed the group media") < block.index(
+        "Local bedtime fallback is"
+    )
+    assert block.index("Confirm local library fallback changed the group media") < block.index(
         "entity_id: binary_sensor.owner_suite_bathroom_room_occupancy"
     )
     assert block.index("action: script.music_assistant_play_random_lofi_playlist") < block.index(


### PR DESCRIPTION
## Summary
- Fixes #844 by extending `script.spotify_bedtime` after the existing Spotify LoFi fallback.
- If primary Spotify and LoFi fallback do not prove playback changed the MA group, the script now tries an Apple Music URI and then a local Music Assistant library fallback.
- If all fallbacks fail, it creates a persistent notification instead of silently proceeding.

## Runtime evidence
- Live HA 2026.7.1 log on 2026-07-07 23:14-23:15 local showed `script.music_assistant_play_item` failures from `automation.tv_off_at_night_bed_prep`: `No playable items found` followed by an unresolved Spotify playlist.
- History showed `script.spotify_bedtime` and `script.music_assistant_play_item` ran in that window, while MA playback only changed later to a non-Spotify library/radio source.
- This matches open issue #844 and the owner comment requesting Apple Music then local media fallback.

## Validation
- `uv run --with pytest pytest tests/test_media_player_music_assistant.py -q` passed: 30 tests.
- `uv run --with pytest pytest tests/test_media_player_music_assistant.py tests/test_alarm_night_allium_alignment.py tests/test_night_routines_allium_alignment.py -q` passed: 53 tests.
- `uv run --with pytest pytest` passed: 567 tests.
- `python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py /Users/rtclauss/.codex/worktrees/7e85/New\ project/packages/media_player.yaml --strict` passed: 1 file, 0 findings.
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt` passed.
- `git diff --check` passed.

## Blocked validation
- Home Assistant container `check_config` could not run locally because `podman machine start` reports success but immediate `podman machine inspect` shows `State: stopped`, and `podman ps` fails to connect to the forwarded socket.
