### PR TITLE
Bound Inky renderer text columns

### DIFF
--- a/inky_display/renderer.py
+++ b/inky_display/renderer.py
@@ -22,6 +22,13 @@ HEIGHT = 300
 FOOTER_HEIGHT = 36
 FOOTER_TEXT_SCALE = 2
 FOOTER_TEXT_TOP = HEIGHT - 28
+FOOTER_TEXT_LEFT = 18
+FOOTER_TEXT_WIDTH = WIDTH - (FOOTER_TEXT_LEFT * 2)
+
+ROW_LABEL_LEFT = 56
+ROW_LABEL_WIDTH = 104
+ROW_VALUE_LEFT = 170
+ROW_VALUE_WIDTH = WIDTH - ROW_VALUE_LEFT - 18
 
 WHITE = (255, 255, 255)
 BLACK = (0, 0, 0)
@@ -54,7 +61,14 @@ def render_payload(payload: DisplayPayload) -> bytes:
 
     if payload.footer:
         canvas.rectangle(0, HEIGHT - FOOTER_HEIGHT, WIDTH, HEIGHT, BLACK)
-        canvas.text(18, FOOTER_TEXT_TOP, payload.footer, scale=FOOTER_TEXT_SCALE, color=WHITE)
+        canvas.text(
+            FOOTER_TEXT_LEFT,
+            FOOTER_TEXT_TOP,
+            payload.footer,
+            scale=FOOTER_TEXT_SCALE,
+            color=WHITE,
+            max_width=FOOTER_TEXT_WIDTH,
+        )
 
     return canvas.to_png()
 
@@ -137,8 +151,22 @@ def _render_row(canvas: Canvas, row: dict[str, str], accent: str, y: int) -> Non
         row_color = _text_color_for_background(background_color)
     label = row.get("label", "")
     canvas.icon(26, y - 4, row.get("icon", ""), scale=2, color=row_color)
-    canvas.text(56, y, label, scale=2, color=row_color)
-    canvas.text(170, y, row.get("value", ""), scale=2, color=row_color)
+    canvas.text(
+        ROW_LABEL_LEFT,
+        y,
+        label,
+        scale=2,
+        color=row_color,
+        max_width=ROW_LABEL_WIDTH,
+    )
+    canvas.text(
+        ROW_VALUE_LEFT,
+        y,
+        row.get("value", ""),
+        scale=2,
+        color=row_color,
+        max_width=ROW_VALUE_WIDTH,
+    )
 
 
 def _wrap_text(text: str, scale: int, max_width: int, max_lines: int) -> list[str]:
@@ -205,16 +233,18 @@ class Canvas:
         text: str,
         scale: int,
         color: tuple[int, int, int],
+        max_width: int | None = None,
     ) -> None:
+        max_width = max_width if max_width is not None else self.width - 8 - left
         font = _font_for_scale(scale)
         if font is not None:
             assert self.draw is not None
-            text = _clip_text_to_width(self.draw, text, font, self.width - 8 - left)
+            text = _clip_text_to_width(self.draw, text, font, max_width)
             self.draw.text((left, top), text, font=font, fill=color)
             return
 
         x = left
-        max_x = self.width - 8
+        max_x = min(self.width - 8, left + max_width)
         for char in text.upper():
             glyph = FONT.get(char, FONT["?"])
             if x + 5 * scale > max_x:

--- a/tests/test_inky_display_renderer.py
+++ b/tests/test_inky_display_renderer.py
@@ -169,6 +169,55 @@ def test_footer_uses_larger_distance_legible_text_band() -> None:
     assert renderer.FOOTER_TEXT_SCALE == 2
 
 
+def test_renderer_bounds_row_and_footer_text_columns(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+    original_text = renderer.Canvas.text
+
+    def spy_text(self, left, top, text, scale, color, max_width=None):
+        calls.append({"left": left, "text": text, "max_width": max_width})
+        return original_text(self, left, top, text, scale, color, max_width=max_width)
+
+    monkeypatch.setattr(renderer.Canvas, "text", spy_text)
+
+    data = _sample("owner_suite_night_preview.json")
+    data["footer"] = "Updated after a deliberately verbose diagnostic publish at 23:59"
+    data["sections"][0]["rows"][0]["label"] = "Weather Forecast Details"
+    data["sections"][0]["rows"][0]["value"] = "Thunderstorms likely with a long advisory headline"
+
+    rendered = render_payload(validate_payload(data))
+
+    assert _png_size(rendered) == (WIDTH, HEIGHT)
+    assert {
+        "left": renderer.ROW_LABEL_LEFT,
+        "text": "Weather Forecas...",
+        "max_width": renderer.ROW_LABEL_WIDTH,
+    } in calls
+    assert {
+        "left": renderer.ROW_VALUE_LEFT,
+        "text": "Thunderstorms likely with...",
+        "max_width": renderer.ROW_VALUE_WIDTH,
+    } in calls
+    assert {
+        "left": renderer.FOOTER_TEXT_LEFT,
+        "text": "Updated after a deliberately verbose diagnost...",
+        "max_width": renderer.FOOTER_TEXT_WIDTH,
+    } in calls
+
+
+def test_renderer_tolerates_extreme_text_without_changing_canvas_size() -> None:
+    data = _sample("owner_suite_morning.json")
+    data["title"] = "A very long owner suite title that should not spill off the e-ink panel"
+    data["subtitle"] = "A long subtitle still belongs inside the fixed 400 by 300 canvas"
+    data["footer"] = "Updated after a very long payload-rendering diagnostic check"
+    for row in data["sections"][0]["rows"]:
+        row["value"] = "Supercalifragilisticexpialidocious weather advisory phrase"
+
+    rendered = render_payload(validate_payload(data))
+
+    assert _png_size(rendered) == (WIDTH, HEIGHT)
+    assert len(rendered) > 1000
+
+
 def test_renderer_prefers_trebuchet_then_verdana_font_stack() -> None:
     bold_stack = "\n".join(renderer.BOLD_FONT_CANDIDATES)
 


### PR DESCRIPTION
## Summary
- Refs #313 by addressing the remaining long-string truncation/layout-fitting test item for the Inky display renderer.
- Add explicit row label, row value, and footer text bounds so long strings cannot draw across neighboring columns or past the footer band.
- Add renderer regression coverage for bounded row/footer columns and extreme title/subtitle/quote/footer text while preserving the fixed 400x300 canvas.

## Validation
- `python3 -m pytest tests/test_inky_display_renderer.py -q` passed: 18 tests.
- `uv run --with pytest python -m pytest tests/test_inky_display_renderer.py tests/test_inky_display_service.py tests/test_inky_displays_package.py -q` passed: 47 tests.
- `PYTHONPATH=$PWD uv run --with pytest pytest` passed: 569 tests.
- `python3 scripts/check_ha_python_support.py` passed for pinned Python 3.14.3 and Home Assistant 2026.7.1.
- `uv run --with yamllint yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints esphome packages zigbee2mqtt` passed.
- `git diff --check` passed.

## Not run
- Local Home Assistant container `check_config`: this branch touches only Python renderer/test files; additionally Docker is not installed and local Podman cannot connect to its VM/socket (`dial tcp 127.0.0.1:53019: connect: connection refused`).