### PR TITLE
Fix wake-up Music Assistant group membership

### DIFF
--- a/docs/music_assistant.md
+++ b/docs/music_assistant.md
@@ -15,6 +15,11 @@ Behavior (what plays when) is owned by `specs/alarm_wakeup.allium` and
   - `media_player.ma_group_everywhere` — bedroom, bathroom, office, den, tiki
     (default whole-house target)
   - `media_player.ma_group_guest` — bedroom, bathroom (used when guest mode is on)
+- Wake-up scripts intentionally do not inherit `ma_group_everywhere` membership.
+  They dynamically prepare the exact wake group from MA `_sonos_2` players:
+  bedroom + bathroom in guest mode, and bedroom + bathroom + office + den when
+  guest mode is off. This keeps Tiki Room out of owner-suite wake-up audio even
+  when the whole-house sync group includes it.
 
 ## NEVER hardcode a Spotify provider-instance id
 

--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -424,8 +424,10 @@ automation:
           bathroom_was_playing: "{{ is_state('media_player.bathroom_sonos_2', 'playing') }}"
           bathroom_volume_above_min: "{{ state_attr('media_player.bathroom_sonos_2', 'volume_level') | float(0) > 0.1 }}"
           group_members: >-
-            {{ state_attr('media_player.ma_group_everywhere', 'group_members')
-               | default(['media_player.ma_group_everywhere']) }}
+            {{ ['media_player.bedroom_sonos_2', 'media_player.bathroom_sonos_2']
+               if is_state('input_boolean.guest_mode', 'on')
+               else ['media_player.bedroom_sonos_2', 'media_player.bathroom_sonos_2',
+                     'media_player.office_sonos_2', 'media_player.den_sonos_2'] }}
       - action: input_boolean.turn_on
         target:
           entity_id: input_boolean.morning_routine
@@ -1217,6 +1219,32 @@ script:
               media_type: "{{ source_media_type | default('radio', true) }}"
               enqueue: replace
 
+  music_assistant_prime_wake_group:
+    alias: "Prime exact wake-up MA Sonos group"
+    trace:
+      stored_traces: 10
+    mode: queued
+    fields:
+      group_members:
+        description: "Exact MA Sonos wake-up members to group and prime"
+      starting_volume:
+        description: "Initial per-member volume before playback starts"
+    sequence:
+      - alias: "Set each wake-up member to the starting volume"
+        continue_on_error: true
+        action: media_player.volume_set
+        target:
+          entity_id: "{{ group_members }}"
+        data:
+          volume_level: "{{ starting_volume | float(0.01) }}"
+      - alias: "Prepare exact wake-up group from MA Sonos players"
+        continue_on_error: true
+        action: media_player.join
+        target:
+          entity_id: media_player.bedroom_sonos_2
+        data:
+          group_members: "{{ group_members | reject('eq', 'media_player.bedroom_sonos_2') | list }}"
+
   music_assistant_radio_wake_up:
     alias: "Radio wake-up via Music Assistant"
     trace:
@@ -1243,9 +1271,7 @@ script:
       retry_backoff:
         description: "Seconds to wait before retrying the primary source once (default: 15)"
     variables:
-      playback_player: >-
-        {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
-           else 'media_player.ma_group_everywhere' }}
+      playback_player: media_player.bedroom_sonos_2
       effective_ramp_steps: "{{ ramp_steps | default(30) | int(30) }}"
       effective_k_factor: "{{ ramp_k_factor | default(120) | int(120) }}"
       effective_fallback_uri: >-
@@ -1254,7 +1280,10 @@ script:
       effective_verify_timeout: "{{ verify_timeout | default(20) | int(20) }}"
       effective_retry_backoff: "{{ retry_backoff | default(15) | int(15) }}"
       group_members: >-
-        {{ state_attr(playback_player, 'group_members') | default([playback_player]) }}
+        {{ ['media_player.bedroom_sonos_2', 'media_player.bathroom_sonos_2']
+           if is_state('input_boolean.guest_mode', 'on')
+           else ['media_player.bedroom_sonos_2', 'media_player.bathroom_sonos_2',
+                 'media_player.office_sonos_2', 'media_player.den_sonos_2'] }}
       pre_playback_fingerprint: >-
         {{ [
           state_attr(playback_player, 'media_content_id') | default('', true),
@@ -1263,13 +1292,11 @@ script:
           state_attr(playback_player, 'media_album_name') | default('', true)
         ] | join('|') }}
     sequence:
-      - alias: "Set each member directly to 0.01 — individual sets are absolute, no MA proportional scaling"
-        continue_on_error: true
-        action: media_player.volume_set
-        target:
-          entity_id: "{{ group_members }}"
+      - alias: "Prime the exact wake-up group to 0.01"
+        action: script.music_assistant_prime_wake_group
         data:
-          volume_level: 0.01
+          group_members: "{{ group_members }}"
+          starting_volume: 0.01
       - if:
           - condition: template
             value_template: "{{ (initial_delay | default(0) | int(0)) > 0 }}"
@@ -1998,11 +2025,12 @@ script:
       regroup_after_play:
         description: "Kept for backwards compatibility; ignored — sync groups manage membership"
     variables:
-      playback_player: >-
-        {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
-           else 'media_player.ma_group_everywhere' }}
+      playback_player: media_player.bedroom_sonos_2
       group_members: >-
-        {{ state_attr(playback_player, 'group_members') | default([playback_player]) }}
+        {{ ['media_player.bedroom_sonos_2', 'media_player.bathroom_sonos_2']
+           if is_state('input_boolean.guest_mode', 'on')
+           else ['media_player.bedroom_sonos_2', 'media_player.bathroom_sonos_2',
+                 'media_player.office_sonos_2', 'media_player.den_sonos_2'] }}
     sequence:
       - variables:
           playlist: >-
@@ -2095,13 +2123,11 @@ script:
               ] -%}
               {% set pindex =  (range(0, (plists | length))|random) -%}
               {{ plists[pindex] }}
-      - alias: "Prime each member to safe low volume — individual sets bypass MA proportional group scaling"
-        continue_on_error: true
-        action: media_player.volume_set
-        target:
-          entity_id: "{{ group_members }}"
+      - alias: "Prime the exact wake-up group to 0.05"
+        action: script.music_assistant_prime_wake_group
         data:
-          volume_level: 0.05
+          group_members: "{{ group_members }}"
+          starting_volume: 0.05
       - alias: "Enable Shuffle"
         continue_on_error: true
         action: media_player.shuffle_set

--- a/tests/test_alarm_night_allium_alignment.py
+++ b/tests/test_alarm_night_allium_alignment.py
@@ -224,20 +224,30 @@ def test_bathroom_morning_routine_uses_workday_owner_suite_led_policy() -> None:
     assert "number.owner_suite_bathroom_vanity_ledintensitywhenoff" not in block
 
 
-def test_wakeup_audio_uses_guest_aware_sync_groups() -> None:
+def test_wakeup_audio_uses_exact_guest_aware_wake_group() -> None:
     spotify_block = _script_block(MEDIA_PLAYER_PATH, "spotify_wake_up")
     radio_block = _script_block(MEDIA_PLAYER_PATH, "music_assistant_radio_wake_up")
+    prime_group_block = _script_block(MEDIA_PLAYER_PATH, "music_assistant_prime_wake_group")
 
-    for token in (
-        "input_boolean.guest_mode",
-        "media_player.ma_group_guest",
-        "media_player.ma_group_everywhere",
-    ):
-        assert token in spotify_block
-        assert token in radio_block
+    assert "input_boolean.guest_mode" in spotify_block
+    assert "input_boolean.guest_mode" in radio_block
+    for block in (spotify_block, radio_block):
+        assert "media_player.bedroom_sonos_2" in block
+        assert "media_player.bathroom_sonos_2" in block
+        assert "media_player.office_sonos_2" in block
+        assert "media_player.den_sonos_2" in block
+        assert "media_player.ma_group_guest" not in block
+        assert "media_player.ma_group_everywhere" not in block
+        assert "media_player.tiki_room_2" not in block
+        assert "script.music_assistant_prime_wake_group" in block
 
-    # Both target the guest-aware sync group: spotify_wake_up plays directly,
-    # the radio wake-up routes playback through the source helper.
+    for token in ("media_player.volume_set", "media_player.join"):
+        assert token in prime_group_block
+    assert "media_player.bedroom_sonos_2" in prime_group_block
+    assert "media_player.tiki_room_2" not in prime_group_block
+
+    # Both play through the bedroom MA player after preparing the exact
+    # policy wake group; the radio wake-up routes playback through the source helper.
     assert 'entity_id: "{{ playback_player }}"' in spotify_block
     assert 'target_entity: "{{ playback_player }}"' in radio_block
 

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -276,41 +276,46 @@ def test_bedtime_join_retry_helper_is_stubbed_after_sync_group_migration() -> No
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' not in bedtime_block
 
 
-def test_radio_wakeup_uses_guest_aware_sync_group_without_manual_regrouping() -> None:
+def test_radio_wakeup_prepares_exact_guest_aware_wake_group() -> None:
     block = _script_block("music_assistant_radio_wake_up")
 
     assert 'playback_entity_id:' in block
     assert 'regroup_after_play:' in block
-    assert 'playback_player' in block
-    assert 'media_player.ma_group_guest' in block
-    assert 'media_player.ma_group_everywhere' in block
+    assert 'playback_player: media_player.bedroom_sonos_2' in block
     assert 'input_boolean.guest_mode' in block
     assert 'prepare_group_before_play:' not in block
     assert 'should_prepare_group_before_play' not in block
     assert 'should_regroup_after_play' not in block
     assert 'action: media_player.unjoin' not in block
     assert 'action: script.music_assistant_prepare_bedroom_group' not in block
-    # Playback is routed through the source helper, targeting the guest-aware group.
+    assert 'action: media_player.join' not in block
+    assert 'action: script.music_assistant_prime_wake_group' in block
+    assert 'starting_volume: 0.01' in block
+    # Playback is routed through the source helper after preparing the exact group.
     assert 'target_entity: "{{ playback_player }}"' in block
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' not in block
+    assert 'media_player.tiki_room_2' not in block
 
 
-def test_radio_wakeup_ramps_legacy_and_music_assistant_bedroom_bathroom_players() -> None:
+def test_radio_wakeup_ramps_policy_wake_group_members_not_whole_house_group() -> None:
     block = _script_block("music_assistant_radio_wake_up")
 
-    # Volume operations must target the MA sync group via playback_player,
-    # not individual native Sonos players. The group volume is what governs
-    # audible output when MA is playing.
+    # Volume operations target exact MA Sonos members, not the mutable
+    # whole-house MA sync group whose membership can include unrelated rooms.
     assert len(re.findall(r"^\s+- media_player\.bedroom_sonos$", block, re.MULTILINE)) == 0
-    assert len(re.findall(r"^\s+- media_player\.bedroom_sonos_2$", block, re.MULTILINE)) == 0
     assert len(re.findall(r"^\s+- media_player\.bathroom_sonos$", block, re.MULTILINE)) == 0
-    assert len(re.findall(r"^\s+- media_player\.bathroom_sonos_2$", block, re.MULTILINE)) == 0
-    assert 'playback_player' in block
-    assert 'media_player.ma_group_guest' in block
-    assert 'media_player.ma_group_everywhere' in block
+    for entity_id in (
+        "media_player.bedroom_sonos_2",
+        "media_player.bathroom_sonos_2",
+        "media_player.office_sonos_2",
+        "media_player.den_sonos_2",
+    ):
+        assert entity_id in block
+    assert "media_player.ma_group_everywhere" not in block
+    assert "media_player.ma_group_guest" not in block
+    assert "media_player.tiki_room_2" not in block
     assert block.count('target_entity: "{{ playback_player }}"') >= 1
-    assert block.count('entity_id: "{{ group_members }}"') >= 2
-    assert "volume_level: 0.01" in block
+    assert 'group_members: "{{ group_members }}"' in block
     assert 'volume_level: "{{ 0.01 * repeat.index }}"' in block
 
 
@@ -365,31 +370,53 @@ def test_play_wakeup_source_branches_url_vs_ma_uri() -> None:
     assert "enqueue: replace" in block
 
 
-def test_spotify_wakeup_uses_guest_aware_sync_group_without_manual_regrouping() -> None:
+def test_prime_wake_group_sets_exact_member_volume_and_joins_to_bedroom() -> None:
+    block = _script_block("music_assistant_prime_wake_group")
+
+    assert 'action: media_player.volume_set' in block
+    assert 'entity_id: "{{ group_members }}"' in block
+    assert 'volume_level: "{{ starting_volume | float(0.01) }}"' in block
+    assert 'action: media_player.join' in block
+    assert 'entity_id: media_player.bedroom_sonos_2' in block
+    assert "group_members | reject('eq', 'media_player.bedroom_sonos_2') | list" in block
+    assert 'media_player.tiki_room_2' not in block
+
+
+def test_spotify_wakeup_prepares_exact_guest_aware_wake_group() -> None:
     block = _script_block("spotify_wake_up")
 
     assert 'playback_entity_id:' in block
     assert 'regroup_after_play:' in block
-    assert 'playback_player' in block
-    assert 'media_player.ma_group_guest' in block
-    assert 'media_player.ma_group_everywhere' in block
+    assert 'playback_player: media_player.bedroom_sonos_2' in block
     assert 'input_boolean.guest_mode' in block
     assert 'prepare_group_before_play:' not in block
     assert 'should_prepare_group_before_play' not in block
     assert 'should_regroup_after_play' not in block
     assert 'action: media_player.unjoin' not in block
     assert 'action: script.music_assistant_prepare_bedroom_group' not in block
+    assert 'action: media_player.join' not in block
+    assert 'action: script.music_assistant_prime_wake_group' in block
+    assert 'starting_volume: 0.05' in block
     assert 'entity_id: "{{ playback_player }}"' in block
     assert 'entity_id: script.music_assistant_try_join_bedroom_group_after_play' not in block
+    assert 'media_player.tiki_room_2' not in block
 
 
-def test_bathroom_wakeup_automation_uses_sync_group_playback() -> None:
+def test_bathroom_wakeup_automation_uses_policy_wake_group_members() -> None:
     block = _automation_block("play_music_in_bathroom_when_up")
 
     assert 'action: script.spotify_wake_up' in block
     assert block.count('playback_entity_id: media_player.ma_group_everywhere') == 2
     assert block.count('playback_entity_id: media_player.bedroom_sonos_2') == 0
     assert block.count('playback_entity_id: media_player.bathroom_sonos_2') == 0
+    for entity_id in (
+        "media_player.bedroom_sonos_2",
+        "media_player.bathroom_sonos_2",
+        "media_player.office_sonos_2",
+        "media_player.den_sonos_2",
+    ):
+        assert entity_id in block
+    assert "media_player.tiki_room_2" not in block
     assert 'regroup_after_play: true' not in block
     assert 'number.guest_room_fan_switch_ledintensitywhenoff' not in block
     assert 'media_player.media_stop' not in block


### PR DESCRIPTION
## Summary
- route wake-up Music Assistant playback through the bedroom MA player after explicitly priming the policy wake group
- keep Tiki Room out of owner-suite wake-up audio even when ma_group_everywhere includes it
- document the exact wake group policy and update Allium alignment/media tests

Fixes #862

## Validation
- uv run --with pytest pytest tests/test_media_player_music_assistant.py
- uv run --with pytest pytest tests/test_alarm_night_allium_alignment.py::test_wakeup_audio_uses_exact_guest_aware_wake_group tests/test_trace_storage.py::test_automation_and_script_traces_use_approved_bounded_counts tests/test_media_player_music_assistant.py
- uv run --with pytest pytest
- yamllint -d "{extends: relaxed, rules: {line-length: disable, empty-lines: disable, truthy: disable}}" configuration.yaml automations.yaml blueprints packages zigbee2mqtt
- python3 scripts/allium_weed_check.py --changed-from origin/develop --format terminal
- python3 /Users/rtclauss/.agents/skills/homeassistant-yaml-dry-verifier/scripts/verify_ha_yaml_dry.py packages/media_player.yaml --strict
- live HA MCP config_check: valid

Local container HA check could not run: docker is unavailable and the installed podman socket is not running.