### PR TITLE
Add predictive room temperature control (GBR + MPC-lite preemptor)

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -37,7 +37,10 @@ jobs:
         run: python -m pip install --upgrade pip uv
 
       - name: Run pytest
-        run: uv run --with pytest pytest
+        # pandas/numpy back the room-temp model tests (training-data build,
+        # junk-0 filter, coverage filter, train/infer feature parity); without
+        # them those tests skip instead of running.
+        run: uv run --with pytest --with pandas --with numpy pytest
 
   allium-weed:
     name: Allium Weed Check

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,15 @@ appdaemon/apps/*
 !appdaemon/apps/prediction_scorer.py
 
 ########################################
+# Allow the external room-temp model service
+########################################
+!room_temp_model_service/
+!room_temp_model_service/*.py
+!room_temp_model_service/*.txt
+!room_temp_model_service/*.json
+!room_temp_model_service/Dockerfile
+
+########################################
 # Explicitly ignore sensitive files
 ########################################
 AGENTS.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ appdaemon/*
 appdaemon/apps/*
 !appdaemon/apps/vacuum_stall_monitor.py
 !appdaemon/apps/vacuum_stall_monitor.yaml
+!appdaemon/apps/room_temp_predictor.py
+!appdaemon/apps/thermal_preemptor.py
 
 ########################################
 # Explicitly ignore sensitive files

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ appdaemon/apps/*
 !appdaemon/apps/vacuum_stall_monitor.yaml
 !appdaemon/apps/room_temp_predictor.py
 !appdaemon/apps/thermal_preemptor.py
+!appdaemon/apps/prediction_scorer.py
 
 ########################################
 # Explicitly ignore sensitive files

--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -512,24 +512,31 @@ room_temp_predictor:
   #   (TPH + ecobee remote): both -> mean; one available -> that one. This is
   #   the model target and the scored actual. Motion sensors and the auto_areas
   #   aggregate are excluded (they self-heat ~1-3 F).
+  # humidity_sensors is averaged the same way as temp_sensors (mean of the
+  # available members). Only the TPH sensor measures per-room humidity today
+  # (ecobee SmartSensors report temp+occupancy only); the list keeps it
+  # symmetric with temperature and ready for a second sensor later.
   rooms: &room_temp_rooms
     - name: owner_suite
       temp_sensors:
         - sensor.owner_suite_tph_temperature
         - sensor.bedroom_temperature
-      humidity_sensor: sensor.owner_suite_tph_humidity
+      humidity_sensors:
+        - sensor.owner_suite_tph_humidity
       confidence_sensor: sensor.bedroom_room_confidence
     - name: office
       temp_sensors:
         - sensor.office_tph_temperature
         - sensor.office_temperature
-      humidity_sensor: sensor.office_tph_humidity
+      humidity_sensors:
+        - sensor.office_tph_humidity
       confidence_sensor: sensor.office_room_confidence
     - name: guest_room
       temp_sensors:
         - sensor.guest_room_tph_temperature
         - sensor.guest_room_temperature
-      humidity_sensor: sensor.guest_room_tph_humidity
+      humidity_sensors:
+        - sensor.guest_room_tph_humidity
       confidence_sensor: null
 
 thermal_preemptor:

--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -507,23 +507,27 @@ room_temp_predictor:
   influxdb_port: 8086
   influxdb_database: home_assistant
   # Room-based config (anchored, shared with prediction_scorer below).
-  # temp_sensor = clean room-air sensor + model target/actual (has history).
-  # temp_fallback = auto_areas area aggregate, used only if the primary drops
-  #   out (runs ~1-2.6 F warm; not the target).
+  # temp_sensors = clean room-air sensors averaged into the room temperature
+  #   (TPH + ecobee remote): both -> mean; one available -> that one. This is
+  #   the model target and the scored actual. Motion sensors and the auto_areas
+  #   aggregate are excluded (they self-heat ~1-3 F).
   rooms: &room_temp_rooms
     - name: owner_suite
-      temp_sensor: sensor.owner_suite_tph_temperature
-      temp_fallback: sensor.bedroom_temperature_2
+      temp_sensors:
+        - sensor.owner_suite_tph_temperature
+        - sensor.bedroom_temperature
       humidity_sensor: sensor.owner_suite_tph_humidity
       confidence_sensor: sensor.bedroom_room_confidence
     - name: office
-      temp_sensor: sensor.office_tph_temperature
-      temp_fallback: sensor.office_temperature_2
+      temp_sensors:
+        - sensor.office_tph_temperature
+        - sensor.office_temperature
       humidity_sensor: sensor.office_tph_humidity
       confidence_sensor: sensor.office_room_confidence
     - name: guest_room
-      temp_sensor: sensor.guest_room_tph_temperature
-      temp_fallback: sensor.guest_room_temperature_2
+      temp_sensors:
+        - sensor.guest_room_tph_temperature
+        - sensor.guest_room_temperature
       humidity_sensor: sensor.guest_room_tph_humidity
       confidence_sensor: null
 

--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -510,6 +510,13 @@ room_temp_predictor:
 thermal_preemptor:
   module: thermal_preemptor
   class: ThermalPreemptor
+  climate_entity: climate.my_ecobee
+  enable_switch: input_boolean.thermal_preemptor_enabled
+  comfort_margin: input_number.thermal_preemptor_comfort_margin
+  # Preemption is skipped while this is `on` so we never fight an open window.
+  window_gate: binary_sensor.any_window_open
+  rate_sensor: sensor.ecobee_modeled_rate_deg_per_min
+  outside_temp_sensor: sensor.canonical_outside_temperature
 
 # groups:
 #   module: group_all

--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -501,11 +501,12 @@ thermostat_stats:
 room_temp_predictor:
   module: room_temp_predictor
   class: RoomTempPredictor
-  model_dir: /config/appdaemon/models
-  min_training_samples: 500
-  influxdb_host: localhost
-  influxdb_port: 8086
-  influxdb_database: home_assistant
+  # Thin shim only — training + inference live in the external
+  # room_temp_model_service container. This publishes live features to MQTT
+  # and relays the retrain button; the service publishes the prediction
+  # sensors back via MQTT discovery.
+  mqtt_base_topic: room_temp_model
+  climate_entity: climate.my_ecobee
   # Room-based config (anchored, shared with prediction_scorer below).
   # temp_sensors = clean room-air sensors averaged into the room temperature
   #   (TPH + ecobee remote): both -> mean; one available -> that one. This is

--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -506,6 +506,26 @@ room_temp_predictor:
   influxdb_host: localhost
   influxdb_port: 8086
   influxdb_database: home_assistant
+  # Room-based config (anchored, shared with prediction_scorer below).
+  # temp_sensor = clean room-air sensor + model target/actual (has history).
+  # temp_fallback = auto_areas area aggregate, used only if the primary drops
+  #   out (runs ~1-2.6 F warm; not the target).
+  rooms: &room_temp_rooms
+    - name: owner_suite
+      temp_sensor: sensor.owner_suite_tph_temperature
+      temp_fallback: sensor.bedroom_temperature_2
+      humidity_sensor: sensor.owner_suite_tph_humidity
+      confidence_sensor: sensor.bedroom_room_confidence
+    - name: office
+      temp_sensor: sensor.office_tph_temperature
+      temp_fallback: sensor.office_temperature_2
+      humidity_sensor: sensor.office_tph_humidity
+      confidence_sensor: sensor.office_room_confidence
+    - name: guest_room
+      temp_sensor: sensor.guest_room_tph_temperature
+      temp_fallback: sensor.guest_room_temperature_2
+      humidity_sensor: sensor.guest_room_tph_humidity
+      confidence_sensor: null
 
 thermal_preemptor:
   module: thermal_preemptor
@@ -529,6 +549,8 @@ prediction_scorer:
   influx_measurement: room_temp_prediction_error
   retrain_ratio_helper: input_number.prediction_retrain_rmse_ratio
   nudge_switch: input_boolean.prediction_scorer_nudge_enabled
+  # Same room map as the predictor so the scored "actual" is the exact target.
+  rooms: *room_temp_rooms
   # Optional: also route the retrain nudge to a mobile notifier, e.g.
   # notify_service: notify/mobile_app_ryan
 

--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -518,6 +518,20 @@ thermal_preemptor:
   rate_sensor: sensor.ecobee_modeled_rate_deg_per_min
   outside_temp_sensor: sensor.canonical_outside_temperature
 
+prediction_scorer:
+  module: prediction_scorer
+  class: PredictionScorer
+  model_dir: /config/appdaemon/models
+  window_days: 7
+  influxdb_host: localhost
+  influxdb_port: 8086
+  influxdb_database: home_assistant
+  influx_measurement: room_temp_prediction_error
+  retrain_ratio_helper: input_number.prediction_retrain_rmse_ratio
+  nudge_switch: input_boolean.prediction_scorer_nudge_enabled
+  # Optional: also route the retrain nudge to a mobile notifier, e.g.
+  # notify_service: notify/mobile_app_ryan
+
 # groups:
 #   module: group_all
 #   class: GroupAll

--- a/appdaemon/apps/apps.yaml
+++ b/appdaemon/apps/apps.yaml
@@ -493,6 +493,23 @@ thermostat_stats:
   house_average_temp: sensor.average_house_temp
   house_average_humidity: sensor.average_house_humidity
   sun: sun.sun
+  owner_suite_temp: sensor.owner_suite_tph_temperature
+  office_temp: sensor.office_tph_temperature
+  bedroom_room_confidence: sensor.bedroom_room_confidence
+  office_room_confidence: sensor.office_room_confidence
+
+room_temp_predictor:
+  module: room_temp_predictor
+  class: RoomTempPredictor
+  model_dir: /config/appdaemon/models
+  min_training_samples: 500
+  influxdb_host: localhost
+  influxdb_port: 8086
+  influxdb_database: home_assistant
+
+thermal_preemptor:
+  module: thermal_preemptor
+  class: ThermalPreemptor
 
 # groups:
 #   module: group_all

--- a/appdaemon/apps/prediction_scorer.py
+++ b/appdaemon/apps/prediction_scorer.py
@@ -24,15 +24,25 @@ import hassapi as hass
 
 HORIZONS = [15, 30, 60]
 
-ROOM_TEMP = {
-    "owner_suite": "sensor.owner_suite_tph_temperature",
-    "office": "sensor.office_tph_temperature",
-    "guest_room": "sensor.guest_room_tph_temperature",
-}
+# Fallback when apps.yaml provides no `rooms:` list. Kept in sync with
+# room_temp_predictor so the scored "actual" is the model's exact target.
+DEFAULT_ROOMS = [
+    {"name": "owner_suite", "temp_sensor": "sensor.owner_suite_tph_temperature",
+     "temp_fallback": "sensor.bedroom_temperature_2"},
+    {"name": "office", "temp_sensor": "sensor.office_tph_temperature",
+     "temp_fallback": "sensor.office_temperature_2"},
+    {"name": "guest_room", "temp_sensor": "sensor.guest_room_tph_temperature",
+     "temp_fallback": "sensor.guest_room_temperature_2"},
+]
 
 
 class PredictionScorer(hass.Hass):
     def initialize(self):
+        self.rooms = {}
+        for entry in (self.args.get("rooms") or DEFAULT_ROOMS):
+            self.rooms[entry["name"]] = [
+                s for s in [entry["temp_sensor"], entry.get("temp_fallback")] if s
+            ]
         self.model_dir = self.args.get("model_dir", "/config/appdaemon/models")
         self.window_days = int(self.args.get("window_days", 7))
         self.tol_min = float(self.args.get("match_tolerance_min", 2.5))
@@ -116,6 +126,14 @@ class PredictionScorer(hass.Hass):
             self.get_state(f"sensor.room_temp_prediction_{room}", attribute=attr)
         )
 
+    def _actual(self, room):
+        """Actual room temp: first configured sensor that reads numeric."""
+        for ent in self.rooms.get(room, []):
+            v = self._safe_float(self.get_state(ent))
+            if v is not None:
+                return v
+        return None
+
     # ------------------------------------------------------------------
     # Scoring loop
     # ------------------------------------------------------------------
@@ -124,7 +142,7 @@ class PredictionScorer(hass.Hass):
         now = datetime.now(timezone.utc)
 
         # 1. Stamp the current predictions for each room.
-        for room in ROOM_TEMP:
+        for room in self.rooms:
             preds = {str(h): self._pred_attr(room, f"t{h}") for h in HORIZONS}
             if all(v is None for v in preds.values()):
                 continue
@@ -148,7 +166,7 @@ class PredictionScorer(hass.Hass):
                 if h in done_h:
                     continue
                 if abs(age_min - h) <= self.tol_min:
-                    actual = self._safe_float(self.get_state(ROOM_TEMP[rec["room"]]))
+                    actual = self._actual(rec["room"])
                     pred = self._safe_float(rec["preds"].get(str(h)))
                     if actual is not None and pred is not None:
                         sp = {
@@ -204,7 +222,7 @@ class PredictionScorer(hass.Hass):
     def _publish_metrics(self):
         worst_rmse = None
         worst_where = None
-        for room in ROOM_TEMP:
+        for room in self.rooms:
             m = self._room_metrics(room)
             rmse60 = m[60]["rmse"]
             attrs = {"window_days": self.window_days,
@@ -282,7 +300,7 @@ class PredictionScorer(hass.Hass):
         ratio = self._safe_float(self.get_state(self.ratio_helper), self.rmse_ratio_default)
 
         offenders = []
-        for room in ROOM_TEMP:
+        for room in self.rooms:
             m = self._room_metrics(room)
             live = m[60]["rmse"]
             n = m[60]["n"]

--- a/appdaemon/apps/prediction_scorer.py
+++ b/appdaemon/apps/prediction_scorer.py
@@ -66,6 +66,14 @@ class PredictionScorer(hass.Hass):
             "influx_measurement", "room_temp_prediction_error"
         )
 
+        # Daily rollup: how did yesterday's predictions do, and what did the
+        # weather and the HVAC actually do?
+        self.daily_report_time = self.args.get("daily_report_time", "00:05:00")
+        self.hvac_sensor = self.args.get("hvac_sensor", "sensor.hvac_activity")
+        self.outside_temp_sensors = self.args.get("outside_temp_sensors", [
+            "sensor.canonical_outside_temperature", "sensor.outside_temperature",
+        ])
+
         self.pending = []      # [{ts, room, preds:{'15','30','60'}, source, scored:[h,...]}]
         self.scored = []       # [{scored_ts, pred_ts, room, horizon, predicted, actual, error, source}]
         self.last_nudge = None
@@ -74,6 +82,7 @@ class PredictionScorer(hass.Hass):
 
         start = datetime.now(timezone.utc) + timedelta(seconds=90)
         self.run_every(self._score, start, 300)
+        self.run_daily(self._daily_report, self.parse_time(self.daily_report_time))
 
     # ------------------------------------------------------------------
     # Persistence
@@ -206,11 +215,13 @@ class PredictionScorer(hass.Hass):
     # Metrics
     # ------------------------------------------------------------------
 
-    def _room_metrics(self, room):
-        """Return {horizon: {mae, rmse, bias, n}} for a room over the window."""
+    def _room_metrics(self, room, records=None):
+        """Return {horizon: {mae, rmse, bias, n}} for a room over `records`
+        (defaults to the whole rolling window)."""
+        records = self.scored if records is None else records
         out = {}
         for h in HORIZONS:
-            errs = [s["error"] for s in self.scored if s["room"] == room and s["horizon"] == h]
+            errs = [s["error"] for s in records if s["room"] == room and s["horizon"] == h]
             if not errs:
                 out[h] = {"mae": None, "rmse": None, "bias": None, "n": 0}
                 continue
@@ -293,6 +304,134 @@ class PredictionScorer(hass.Hass):
             ])
         except Exception as e:
             self.log(f"InfluxDB write failed: {e}", level="WARNING")
+
+    # ------------------------------------------------------------------
+    # Daily rollup
+    # ------------------------------------------------------------------
+
+    def _day_outside_temp(self, start, end):
+        """(min, max, mean) outside temp over the window, junk 0s discarded."""
+        for ent in self.outside_temp_sensors:
+            try:
+                hist = self.get_history(entity_id=ent, start_time=start, end_time=end)
+            except Exception:
+                continue
+            if not hist or not hist[0]:
+                continue
+            vals = []
+            for s in hist[0]:
+                v = self._safe_float(s.get("state"))
+                # A literal 0 is the template's fallback when the weather source
+                # drops out; a genuine 0°F reading is indistinguishable, so this
+                # discards it too. Acceptable for a summary statistic.
+                if v is not None and v != 0:
+                    vals.append(v)
+            if vals:
+                return round(min(vals), 1), round(max(vals), 1), round(sum(vals) / len(vals), 1)
+        return None, None, None
+
+    def _day_hvac_runtime(self, start, end):
+        """Fraction of the window spent cooling / heating (time-weighted)."""
+        try:
+            hist = self.get_history(entity_id=self.hvac_sensor, start_time=start, end_time=end)
+        except Exception:
+            return None, None
+        if not hist or not hist[0]:
+            return None, None
+        rows = []
+        for s in hist[0]:
+            try:
+                rows.append((self._parse(s["last_changed"]), s.get("state")))
+            except Exception:
+                continue
+        if not rows:
+            return None, None
+        rows.sort(key=lambda r: r[0])
+        total = (end - start).total_seconds()
+        if total <= 0:
+            return None, None
+        secs = {"cooling": 0.0, "heating": 0.0}
+        for i, (ts, state) in enumerate(rows):
+            nxt = rows[i + 1][0] if i + 1 < len(rows) else end
+            span = (min(nxt, end) - max(ts, start)).total_seconds()
+            if span > 0 and state in secs:
+                secs[state] += span
+        return round(secs["cooling"] / total, 3), round(secs["heating"] / total, 3)
+
+    def _daily_report(self, kwargs):
+        """At the configured time, summarise the previous local day."""
+        now_local = self.datetime(aware=True)
+        end = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+        start = end - timedelta(days=1)
+
+        day = [s for s in self.scored
+               if start <= self._parse(s["scored_ts"]).astimezone(end.tzinfo) < end]
+
+        per_room = {}
+        worst_rmse, worst_where = None, None
+        for room in self.rooms:
+            m = self._room_metrics(room, records=day)
+            per_room[room] = m
+            for h in HORIZONS:
+                r = m[h]["rmse"]
+                if r is not None and (worst_rmse is None or r > worst_rmse):
+                    worst_rmse, worst_where = r, f"{room}/t{h}"
+
+        t_min, t_max, t_mean = self._day_outside_temp(start, end)
+        cool_frac, heat_frac = self._day_hvac_runtime(start, end)
+
+        attrs = {
+            "date": start.date().isoformat(),
+            "outside_temp_min": t_min,
+            "outside_temp_max": t_max,
+            "outside_temp_mean": t_mean,
+            "hvac_cooling_fraction": cool_frac,
+            "hvac_heating_fraction": heat_frac,
+            "worst": worst_where,
+            "friendly_name": "Room Temp Daily Prediction Report",
+            "unit_of_measurement": "°F",
+        }
+        for room, m in per_room.items():
+            for h in HORIZONS:
+                attrs[f"{room}_rmse_{h}m"] = m[h]["rmse"]
+                attrs[f"{room}_bias_{h}m"] = m[h]["bias"]
+                attrs[f"{room}_n_{h}m"] = m[h]["n"]
+
+        self.set_state(
+            "sensor.room_temp_daily_report",
+            state=worst_rmse if worst_rmse is not None else "no_data",
+            attributes=attrs,
+        )
+
+        lines = [f"Room-temp predictions for {start.date().isoformat()}:"]
+        for room, m in per_room.items():
+            r60, b60, n60 = m[60]["rmse"], m[60]["bias"], m[60]["n"]
+            if n60:
+                lines.append(f"• {room}: T+60 RMSE {r60}°F, bias {b60:+}°F (n={n60})")
+            else:
+                lines.append(f"• {room}: no scored predictions")
+        if t_min is not None:
+            lines.append(f"Outside: {t_min}–{t_max}°F (mean {t_mean}°F)")
+        if cool_frac is not None:
+            lines.append(f"HVAC: cooling {cool_frac * 100:.0f}% / heating {heat_frac * 100:.0f}% of the day")
+
+        message = "\n".join(lines)
+        self.fire_event("room_temp_daily_report", date=start.date().isoformat(),
+                        per_room=per_room, outside_temp_min=t_min, outside_temp_max=t_max,
+                        hvac_cooling_fraction=cool_frac)
+        self.call_service(
+            "persistent_notification/create",
+            title="Room-temp daily prediction report",
+            message=message,
+            notification_id=f"room_temp_daily_report_{start.date().isoformat()}",
+        )
+        if self.notify_service:
+            try:
+                domain, service = self.notify_service.split("/", 1)
+                self.call_service(f"{domain}/{service}", message=message)
+            except Exception as e:
+                self.log(f"notify_service call failed: {e}", level="WARNING")
+        self.log(message)
 
     # ------------------------------------------------------------------
     # Retrain nudge

--- a/appdaemon/apps/prediction_scorer.py
+++ b/appdaemon/apps/prediction_scorer.py
@@ -1,0 +1,334 @@
+"""Score room-temperature predictions against what actually happened.
+
+room_temp_predictor publishes T+15/30/60 predictions but only reports
+training-time CV RMSE. This app closes the loop: every 5 minutes it stamps the
+current predictions, and once a horizon matures (e.g. the T+60 stamped 60 min
+ago) it compares that prediction to the actual room temperature now.
+
+It publishes live rolling accuracy (MAE / RMSE / signed bias per horizon per
+room), writes each scored point to InfluxDB for Grafana trend dashboards, and
+fires a retrain-nudge (event + notification) when live RMSE persistently
+exceeds the model's training CV RMSE — a data-driven signal for when to press
+input_button.retrain_room_temp_models.
+
+State is persisted to disk so a restart doesn't lose the in-flight window
+(AppDaemon instance vars reset on reload).
+"""
+
+import json
+import math
+import os
+from datetime import datetime, timedelta, timezone
+
+import hassapi as hass
+
+HORIZONS = [15, 30, 60]
+
+ROOM_TEMP = {
+    "owner_suite": "sensor.owner_suite_tph_temperature",
+    "office": "sensor.office_tph_temperature",
+    "guest_room": "sensor.guest_room_tph_temperature",
+}
+
+
+class PredictionScorer(hass.Hass):
+    def initialize(self):
+        self.model_dir = self.args.get("model_dir", "/config/appdaemon/models")
+        self.window_days = int(self.args.get("window_days", 7))
+        self.tol_min = float(self.args.get("match_tolerance_min", 2.5))
+        self.min_samples = int(self.args.get("min_samples_for_nudge", 50))
+        self.nudge_cooldown_h = float(self.args.get("nudge_cooldown_hours", 24))
+        self.rmse_ratio_default = float(self.args.get("retrain_rmse_ratio", 2.0))
+        self.ratio_helper = self.args.get(
+            "retrain_ratio_helper", "input_number.prediction_retrain_rmse_ratio"
+        )
+        self.nudge_switch = self.args.get(
+            "nudge_switch", "input_boolean.prediction_scorer_nudge_enabled"
+        )
+        self.notify_service = self.args.get("notify_service")  # optional, e.g. "notify/mobile_app_x"
+
+        self.influxdb_host = self.args.get("influxdb_host", "localhost")
+        self.influxdb_port = int(self.args.get("influxdb_port", 8086))
+        self.influxdb_db = self.args.get("influxdb_database", "home_assistant")
+        self.influx_measurement = self.args.get(
+            "influx_measurement", "room_temp_prediction_error"
+        )
+
+        self.pending = []      # [{ts, room, preds:{'15','30','60'}, source, scored:[h,...]}]
+        self.scored = []       # [{scored_ts, pred_ts, room, horizon, predicted, actual, error, source}]
+        self.last_nudge = None
+        os.makedirs(self.model_dir, exist_ok=True)
+        self._load()
+
+        start = datetime.now(timezone.utc) + timedelta(seconds=90)
+        self.run_every(self._score, start, 300)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def _state_path(self):
+        return os.path.join(self.model_dir, "prediction_scores.json")
+
+    def _load(self):
+        path = self._state_path()
+        if not os.path.exists(path):
+            return
+        try:
+            with open(path) as f:
+                data = json.load(f)
+            self.pending = data.get("pending", [])
+            self.scored = data.get("scored", [])
+            self.last_nudge = data.get("last_nudge")
+            self.log(f"Loaded {len(self.scored)} scored / {len(self.pending)} pending records")
+        except Exception as e:
+            self.log(f"Failed to load scorer state: {e}", level="WARNING")
+
+    def _save(self):
+        try:
+            with open(self._state_path(), "w") as f:
+                json.dump(
+                    {"pending": self.pending, "scored": self.scored, "last_nudge": self.last_nudge},
+                    f,
+                )
+        except Exception as e:
+            self.log(f"Failed to save scorer state: {e}", level="WARNING")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _safe_float(value, default=None):
+        if value in (None, "unknown", "unavailable", ""):
+            return default
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _parse(ts):
+        return datetime.fromisoformat(ts)
+
+    def _pred_attr(self, room, attr):
+        return self._safe_float(
+            self.get_state(f"sensor.room_temp_prediction_{room}", attribute=attr)
+        )
+
+    # ------------------------------------------------------------------
+    # Scoring loop
+    # ------------------------------------------------------------------
+
+    def _score(self, kwargs):
+        now = datetime.now(timezone.utc)
+
+        # 1. Stamp the current predictions for each room.
+        for room in ROOM_TEMP:
+            preds = {str(h): self._pred_attr(room, f"t{h}") for h in HORIZONS}
+            if all(v is None for v in preds.values()):
+                continue
+            self.pending.append({
+                "ts": now.isoformat(),
+                "room": room,
+                "preds": preds,
+                "source": self.get_state(
+                    f"sensor.room_temp_prediction_{room}", attribute="prediction_source"
+                ),
+                "scored": [],
+            })
+
+        # 2. Mature & score any prediction whose horizon has just elapsed.
+        new_points = []
+        still_pending = []
+        for rec in self.pending:
+            age_min = (now - self._parse(rec["ts"])).total_seconds() / 60.0
+            done_h = rec.setdefault("scored", [])
+            for h in HORIZONS:
+                if h in done_h:
+                    continue
+                if abs(age_min - h) <= self.tol_min:
+                    actual = self._safe_float(self.get_state(ROOM_TEMP[rec["room"]]))
+                    pred = self._safe_float(rec["preds"].get(str(h)))
+                    if actual is not None and pred is not None:
+                        sp = {
+                            "scored_ts": now.isoformat(),
+                            "pred_ts": rec["ts"],
+                            "room": rec["room"],
+                            "horizon": h,
+                            "predicted": pred,
+                            "actual": actual,
+                            "error": round(actual - pred, 3),
+                            "source": rec.get("source"),
+                        }
+                        self.scored.append(sp)
+                        new_points.append(sp)
+                    done_h.append(h)
+                elif age_min > h + self.tol_min:
+                    done_h.append(h)  # missed the match window (app was down) — give up
+            if len(done_h) < len(HORIZONS) and age_min <= max(HORIZONS) + self.tol_min:
+                still_pending.append(rec)
+        self.pending = still_pending
+
+        # 3. Prune scored history to the rolling window.
+        cutoff = now - timedelta(days=self.window_days)
+        self.scored = [s for s in self.scored if self._parse(s["scored_ts"]) >= cutoff]
+
+        # 4. Persist to InfluxDB (Grafana), publish sensors, maybe nudge, save.
+        self._influx_write(new_points)
+        self._publish_metrics()
+        self._maybe_nudge(now)
+        self._save()
+
+    # ------------------------------------------------------------------
+    # Metrics
+    # ------------------------------------------------------------------
+
+    def _room_metrics(self, room):
+        """Return {horizon: {mae, rmse, bias, n}} for a room over the window."""
+        out = {}
+        for h in HORIZONS:
+            errs = [s["error"] for s in self.scored if s["room"] == room and s["horizon"] == h]
+            if not errs:
+                out[h] = {"mae": None, "rmse": None, "bias": None, "n": 0}
+                continue
+            n = len(errs)
+            out[h] = {
+                "mae": round(sum(abs(e) for e in errs) / n, 3),
+                "rmse": round(math.sqrt(sum(e * e for e in errs) / n), 3),
+                "bias": round(sum(errs) / n, 3),
+                "n": n,
+            }
+        return out
+
+    def _publish_metrics(self):
+        worst_rmse = None
+        worst_where = None
+        for room in ROOM_TEMP:
+            m = self._room_metrics(room)
+            rmse60 = m[60]["rmse"]
+            attrs = {"window_days": self.window_days,
+                     "prediction_source": self.get_state(
+                         f"sensor.room_temp_prediction_{room}", attribute="prediction_source")}
+            for h in HORIZONS:
+                attrs[f"mae_{h}m"] = m[h]["mae"]
+                attrs[f"rmse_{h}m"] = m[h]["rmse"]
+                attrs[f"bias_{h}m"] = m[h]["bias"]
+                attrs[f"n_{h}m"] = m[h]["n"]
+            attrs["friendly_name"] = f"Prediction Error {room.replace('_', ' ').title()}"
+            attrs["unit_of_measurement"] = "°F"
+            self.set_state(
+                f"sensor.room_temp_prediction_error_{room}",
+                state=rmse60 if rmse60 is not None else "no_data",
+                attributes=attrs,
+            )
+            for h in HORIZONS:
+                r = m[h]["rmse"]
+                if r is not None and (worst_rmse is None or r > worst_rmse):
+                    worst_rmse = r
+                    worst_where = f"{room}/t{h}"
+
+        self.set_state(
+            "sensor.room_temp_model_health",
+            state=worst_rmse if worst_rmse is not None else "no_data",
+            attributes={
+                "worst": worst_where,
+                "window_days": self.window_days,
+                "unit_of_measurement": "°F",
+                "friendly_name": "Room Temp Model Health (worst RMSE)",
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # InfluxDB
+    # ------------------------------------------------------------------
+
+    def _influx_write(self, points):
+        if not points:
+            return
+        try:
+            from influxdb import InfluxDBClient
+            client = InfluxDBClient(
+                host=self.influxdb_host, port=self.influxdb_port, database=self.influxdb_db
+            )
+            client.write_points([
+                {
+                    "measurement": self.influx_measurement,
+                    "tags": {
+                        "room": p["room"],
+                        "horizon": str(p["horizon"]),
+                        "source": p.get("source") or "unknown",
+                    },
+                    "time": p["scored_ts"],
+                    "fields": {
+                        "error": float(p["error"]),
+                        "abs_error": abs(float(p["error"])),
+                        "predicted": float(p["predicted"]),
+                        "actual": float(p["actual"]),
+                    },
+                }
+                for p in points
+            ])
+        except Exception as e:
+            self.log(f"InfluxDB write failed: {e}", level="WARNING")
+
+    # ------------------------------------------------------------------
+    # Retrain nudge
+    # ------------------------------------------------------------------
+
+    def _maybe_nudge(self, now):
+        if self.get_state(self.nudge_switch) == "off":
+            return
+        ratio = self._safe_float(self.get_state(self.ratio_helper), self.rmse_ratio_default)
+
+        offenders = []
+        for room in ROOM_TEMP:
+            m = self._room_metrics(room)
+            live = m[60]["rmse"]
+            n = m[60]["n"]
+            cv = self._pred_attr(room, "rmse_60m_cv_mean")
+            if live is None or cv is None or n < self.min_samples:
+                continue
+            if live > cv * ratio:
+                offenders.append((room, live, cv, n))
+
+        if not offenders:
+            return
+        if self.last_nudge:
+            try:
+                if (now - self._parse(self.last_nudge)).total_seconds() < self.nudge_cooldown_h * 3600:
+                    return
+            except Exception:
+                pass
+
+        detail = ", ".join(
+            f"{r}: live RMSE {live:.2f}°F vs CV {cv:.2f}°F (n={n})"
+            for r, live, cv, n in offenders
+        )
+        message = (
+            f"Room-temp model drift detected over {self.window_days}d — {detail}. "
+            f"Consider pressing input_button.retrain_room_temp_models."
+        )
+        self.fire_event(
+            "room_temp_retrain_suggested",
+            offenders=[
+                {"room": r, "live_rmse_60m": live, "cv_rmse_60m": cv, "n": n}
+                for r, live, cv, n in offenders
+            ],
+            ratio=ratio,
+        )
+        self.call_service(
+            "persistent_notification/create",
+            title="Room-temp model: retrain suggested",
+            message=message,
+            notification_id="room_temp_retrain_suggested",
+        )
+        if self.notify_service:
+            try:
+                domain, service = self.notify_service.split("/", 1)
+                self.call_service(f"{domain}/{service}", message=message)
+            except Exception as e:
+                self.log(f"notify_service call failed: {e}", level="WARNING")
+
+        self.last_nudge = now.isoformat()
+        self.log(f"Retrain nudge fired: {detail}")

--- a/appdaemon/apps/prediction_scorer.py
+++ b/appdaemon/apps/prediction_scorer.py
@@ -25,14 +25,15 @@ import hassapi as hass
 HORIZONS = [15, 30, 60]
 
 # Fallback when apps.yaml provides no `rooms:` list. Kept in sync with
-# room_temp_predictor so the scored "actual" is the model's exact target.
+# room_temp_predictor so the scored "actual" is the model's exact target:
+# the mean of the configured room-air sensors (TPH + ecobee remote).
 DEFAULT_ROOMS = [
-    {"name": "owner_suite", "temp_sensor": "sensor.owner_suite_tph_temperature",
-     "temp_fallback": "sensor.bedroom_temperature_2"},
-    {"name": "office", "temp_sensor": "sensor.office_tph_temperature",
-     "temp_fallback": "sensor.office_temperature_2"},
-    {"name": "guest_room", "temp_sensor": "sensor.guest_room_tph_temperature",
-     "temp_fallback": "sensor.guest_room_temperature_2"},
+    {"name": "owner_suite",
+     "temp_sensors": ["sensor.owner_suite_tph_temperature", "sensor.bedroom_temperature"]},
+    {"name": "office",
+     "temp_sensors": ["sensor.office_tph_temperature", "sensor.office_temperature"]},
+    {"name": "guest_room",
+     "temp_sensors": ["sensor.guest_room_tph_temperature", "sensor.guest_room_temperature"]},
 ]
 
 
@@ -40,9 +41,10 @@ class PredictionScorer(hass.Hass):
     def initialize(self):
         self.rooms = {}
         for entry in (self.args.get("rooms") or DEFAULT_ROOMS):
-            self.rooms[entry["name"]] = [
-                s for s in [entry["temp_sensor"], entry.get("temp_fallback")] if s
-            ]
+            sensors = entry.get("temp_sensors")
+            if not sensors:
+                sensors = [s for s in [entry.get("temp_sensor"), entry.get("temp_fallback")] if s]
+            self.rooms[entry["name"]] = sensors
         self.model_dir = self.args.get("model_dir", "/config/appdaemon/models")
         self.window_days = int(self.args.get("window_days", 7))
         self.tol_min = float(self.args.get("match_tolerance_min", 2.5))
@@ -127,12 +129,14 @@ class PredictionScorer(hass.Hass):
         )
 
     def _actual(self, room):
-        """Actual room temp: first configured sensor that reads numeric."""
-        for ent in self.rooms.get(room, []):
-            v = self._safe_float(self.get_state(ent))
-            if v is not None:
-                return v
-        return None
+        """Actual room temp: mean of the configured sensors that read numeric.
+
+        Matches room_temp_predictor's target (mean of TPH + ecobee remote), so
+        the scored error is against the exact quantity the model predicts.
+        """
+        vals = [self._safe_float(self.get_state(e)) for e in self.rooms.get(room, [])]
+        vals = [v for v in vals if v is not None]
+        return sum(vals) / len(vals) if vals else None
 
     # ------------------------------------------------------------------
     # Scoring loop

--- a/appdaemon/apps/room_temp_predictor.py
+++ b/appdaemon/apps/room_temp_predictor.py
@@ -96,6 +96,12 @@ class RoomTempPredictor(hass.Hass):
                 return v
         return default
 
+    def _avg_history_slope(self, entities, minutes=30):
+        """Average slope across all available sensors — matches the averaged room_temp feature."""
+        slopes = [self._history_slope(e, minutes) for e in entities]
+        slopes = [s for s in slopes if s is not None]
+        return sum(slopes) / len(slopes) if slopes else 0.0
+
     def _history_slope(self, entity_id, minutes=30):
         """°F/min slope from recent history (no numpy — plain least squares)."""
         try:
@@ -198,7 +204,7 @@ class RoomTempPredictor(hass.Hass):
                 "occupancy": self._safe_float(self.get_state(conf), 0) if conf else 0,
                 "hvac_heating": hvac_heating,
                 "hvac_cooling": hvac_cooling,
-                "room_temp_rate_15m": self._history_slope(cfg["temp_sensors"][0], 15),
+                "room_temp_rate_15m": self._avg_history_slope(cfg["temp_sensors"], 15),
                 "outside_delta_3h": outside_delta_3h,
                 "forecast": forecast,
             }

--- a/appdaemon/apps/room_temp_predictor.py
+++ b/appdaemon/apps/room_temp_predictor.py
@@ -256,6 +256,13 @@ class RoomTempPredictor(hass.Hass):
         outside_temp = self._query_generic(client, "sensor.outside_temperature") or pd.Series(dtype=float)
         outside_humidity = self._query_generic(client, "sensor.outside_humidity") or pd.Series(dtype=float)
         cloud_cover = self._query_generic(client, "sensor.tomorrow_io_the_brewery_cloud_cover") or pd.Series(dtype=float)
+        # Local Ambient Weather PWS + OpenWeatherMap sensors (wind/rain/UV).
+        # These were added recently, so they may have little/no history yet —
+        # the coverage filter below drops any feature without enough history,
+        # and a future retrain picks them up automatically once it accrues.
+        wind_speed = self._query_generic(client, "sensor.pinehotties_wind_speed") or pd.Series(dtype=float)
+        precipitation = self._query_generic(client, "sensor.pinehotties_hourly_rain") or pd.Series(dtype=float)
+        uv_index = self._query_generic(client, "sensor.pinehotties_uv_index") or pd.Series(dtype=float)
         # sensor.hvac_activity is a categorical string (heating/cooling/idle) —
         # query it without a float cast, or every sample silently becomes 0.
         hvac_series = self._query_categorical(client, "sensor.hvac_activity")
@@ -271,6 +278,9 @@ class RoomTempPredictor(hass.Hass):
         df["outside_temp"] = outside_temp.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
         df["outside_humidity"] = outside_humidity.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
         df["cloud_cover"] = cloud_cover.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        df["wind_speed"] = wind_speed.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        df["precipitation"] = precipitation.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        df["uv_index"] = uv_index.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
         df["occupancy"] = confidence.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min")).fillna(0)
 
         # Drop junk 0s: sensor.outside_temperature/_humidity emit a literal 0
@@ -321,15 +331,17 @@ class RoomTempPredictor(hass.Hass):
         df["sun_azimuth_cos"] = np.cos(np.radians([v[1] for v in sun_vals]))
 
         # ---- oracle forecast features (actual t+N observations as training proxy) ----
-        # At inference these come from a real hourly forecast (NWS/Open-Meteo).
-        # Wind/precipitation are intentionally excluded — no recorded sensor
-        # exists to train them (they live only in weather-entity attributes),
-        # and including all-NaN columns here collapsed the whole training set
-        # through the final dropna().
+        # At inference these come from a real hourly forecast (OpenWeatherMap,
+        # then NWS/Open-Meteo). Any candidate without enough recorded history is
+        # pruned by the coverage filter below (and so is its oracle shift), so
+        # new sensors never collapse the training set.
         for h, slots in HORIZON_SLOTS.items():
             df[f"cloud_cover_{h}m"] = df["cloud_cover"].shift(-slots)
             df[f"outside_temp_{h}m"] = df["outside_temp"].shift(-slots)
             df[f"outside_humidity_{h}m"] = df["outside_humidity"].shift(-slots)
+            df[f"wind_speed_{h}m"] = df["wind_speed"].shift(-slots)
+            df[f"precipitation_{h}m"] = df["precipitation"].shift(-slots)
+            df[f"uv_index_{h}m"] = df["uv_index"].shift(-slots)
             sun_future = []
             for ts in df.index:
                 dt_f = (ts + timedelta(minutes=h)).to_pydatetime().replace(tzinfo=timezone.utc)
@@ -344,6 +356,19 @@ class RoomTempPredictor(hass.Hass):
         for h, slots in HORIZON_SLOTS.items():
             future_temp = df["room_temp"].shift(-slots)
             y_dict[f"delta_{h}"] = future_temp - df["room_temp"]
+
+        # ---- coverage filter ----
+        # Drop candidate feature columns without enough recorded history (e.g.
+        # sensors added recently) BEFORE the row-wise dropna, so a sparse column
+        # can't collapse the whole training set. Surviving columns define the
+        # model's feature set; inference self-syncs via meta['feature_cols'].
+        # Time/sun features are always fully covered and always survive.
+        min_coverage = 0.5
+        feature_like = [c for c in df.columns if not c.startswith("delta_")]
+        dropped = [c for c in feature_like if df[c].notna().mean() < min_coverage]
+        if dropped:
+            df = df.drop(columns=dropped)
+            self.log(f"{room}: skipping low-history features {sorted(dropped)}")
 
         # ---- interleaved week CV fold assignment ----
         df["fold"] = df.index.isocalendar().week % 5
@@ -434,17 +459,18 @@ class RoomTempPredictor(hass.Hass):
     # Inference helpers
     # ------------------------------------------------------------------
 
-    # Hourly-forecast entities in priority order. NWS carries both temperature
-    # and humidity per entry; Open-Meteo carries temperature; both are far
-    # better than the daily Tomorrow.io entity for 15/30/60-minute horizons.
+    # Hourly-forecast entities in priority order. OpenWeatherMap is richest —
+    # every entry carries cloud_coverage, temperature, humidity, wind_speed,
+    # uv_index and precipitation. NWS/Open-Meteo/met.no are fallbacks.
     FORECAST_ENTITIES = [
+        "weather.openweathermap",
         "weather.kmsp",
         "weather.the_brewery",
         "weather.forecast_home",
     ]
 
     def _get_weather_forecasts(self):
-        """Return dict: horizon_minutes -> {temperature, humidity, cloud_cover}."""
+        """Return dict: horizon_minutes -> forecast field dict (missing keys None)."""
         forecasts = []
         for entity_id in self.FORECAST_ENTITIES:
             try:
@@ -473,9 +499,10 @@ class RoomTempPredictor(hass.Hass):
                 result[minutes_ahead] = {
                     "temperature": entry.get("temperature"),
                     "humidity": entry.get("humidity"),
-                    # No provider exposes forecast cloud %; carried forward at
-                    # the call site until a numeric cloud source lands (#866).
                     "cloud_cover": entry.get("cloud_coverage"),
+                    "wind_speed": entry.get("wind_speed"),
+                    "uv_index": entry.get("uv_index"),
+                    "precipitation": entry.get("precipitation"),
                 }
             except Exception:
                 continue
@@ -540,7 +567,13 @@ class RoomTempPredictor(hass.Hass):
         outside_humidity = first_float(
             ["sensor.canonical_outside_humidity", "sensor.outside_humidity"]
         )
-        cloud_cover = safe_float(self.get_state("sensor.tomorrow_io_the_brewery_cloud_cover"))
+        # Canonical multi-source values (fall back to legacy where relevant).
+        cloud_cover = first_float(
+            ["sensor.canonical_cloud_cover", "sensor.tomorrow_io_the_brewery_cloud_cover"]
+        )
+        wind_speed = safe_float(self.get_state("sensor.canonical_wind_speed"))
+        uv_index = safe_float(self.get_state("sensor.canonical_uv_index"))
+        precipitation = safe_float(self.get_state("sensor.canonical_precipitation"))
         occupancy = safe_float(self.get_state(cfg["confidence_sensor"]) if cfg["confidence_sensor"] else None, 0)
 
         hvac_action = self.get_state("climate.my_ecobee", attribute="hvac_action") or ""
@@ -554,11 +587,17 @@ class RoomTempPredictor(hass.Hass):
         hours = now.hour + now.minute / 60.0
         doy = now.timetuple().tm_yday
 
+        # Full candidate feature superset. Whichever features the trained model
+        # actually uses is selected downstream via meta['feature_cols']; extras
+        # (e.g. wind/uv/precip before they have training history) are ignored.
         row = {
             "room_temp": room_temp,
             "outside_temp": outside_temp,
             "outside_humidity": outside_humidity,
             "cloud_cover": cloud_cover,
+            "wind_speed": wind_speed,
+            "precipitation": precipitation,
+            "uv_index": uv_index,
             "occupancy": occupancy,
             "hvac_heating": hvac_heating,
             "hvac_cooling": hvac_cooling,
@@ -576,9 +615,10 @@ class RoomTempPredictor(hass.Hass):
         for h in HORIZONS:
             fc = self._nearest_forecast(forecasts, h)
             elev_f, azim_f = self._sun_position(lat, lon, now + timedelta(minutes=h))
-            # cloud forecast is unavailable from every provider — carry the
-            # current value forward until a numeric cloud source lands (#866).
             row[f"cloud_cover_{h}m"] = safe_float(fc.get("cloud_cover"), cloud_cover)
+            row[f"wind_speed_{h}m"] = safe_float(fc.get("wind_speed"), wind_speed)
+            row[f"uv_index_{h}m"] = safe_float(fc.get("uv_index"), uv_index)
+            row[f"precipitation_{h}m"] = safe_float(fc.get("precipitation"), precipitation)
             row[f"outside_temp_{h}m"] = safe_float(fc.get("temperature"), outside_temp)
             row[f"outside_humidity_{h}m"] = safe_float(fc.get("humidity"), outside_humidity)
             row[f"sun_elevation_{h}m"] = elev_f

--- a/appdaemon/apps/room_temp_predictor.py
+++ b/appdaemon/apps/room_temp_predictor.py
@@ -1,783 +1,221 @@
-"""Predictive per-room temperature app using GradientBoostingRegressor.
+"""Thin feature-publisher shim for the external room-temperature model service.
 
-Training data comes from InfluxDB (multi-year history). Models are saved as
-joblib files and loaded at startup. Retrain is triggered manually via
-input_button.retrain_room_temp_models or the event 'retrain_room_temp_models'.
-Every 5 minutes the prediction loop publishes sensor.room_temp_prediction_<room>
-with t15/t30/t60 attributes.
+The heavy ML (training + inference) now lives in a standalone container
+(room_temp_model_service/) that speaks MQTT + InfluxDB — this keeps sklearn /
+pandas / astral out of the AppDaemon process (the thread/memory trouble that
+got the bed-side predictor disabled).
+
+This app only does light HA I/O:
+  * every 5 min, gather each room's live features + a short weather forecast
+    and publish them to `<base>/features` over MQTT (via HA's mqtt.publish).
+  * relay the retrain button/event to `<base>/train`.
+
+The service predicts and publishes `sensor.room_temp_prediction_<room>` back
+via MQTT discovery; thermal_preemptor and prediction_scorer consume those
+unchanged. No models, joblib, sklearn, pandas, numpy or astral here.
 """
 
+import json
 import math
-import os
 from datetime import datetime, timedelta, timezone
 
 import hassapi as hass
 
 HORIZONS = [15, 30, 60]
-SLOT_MIN = 5
-HORIZON_SLOTS = {h: h // SLOT_MIN for h in HORIZONS}
-PURGE_SLOTS = 48  # 4-hour autocorrelation purge at fold boundaries
 
-# Default room config, used only when apps.yaml provides no `rooms:` list.
-# `temp_sensors` is the ordered list of clean room-air sensors averaged into
-# the room temperature (TPH + ecobee remote): if both report, they are
-# averaged; if only one is available, that one is used. The motion-sensor and
-# auto_areas aggregate are intentionally excluded — they self-heat ~1-3°F.
-# The first entry is treated as primary for rate/history slope (it carries the
-# longest recorded history).
-DEFAULT_ROOMS = [
-    {
-        "name": "owner_suite",
-        "temp_sensors": ["sensor.owner_suite_tph_temperature", "sensor.bedroom_temperature"],
-        "humidity_sensor": "sensor.owner_suite_tph_humidity",
-        "confidence_sensor": "sensor.bedroom_room_confidence",
-    },
-    {
-        "name": "office",
-        "temp_sensors": ["sensor.office_tph_temperature", "sensor.office_temperature"],
-        "humidity_sensor": "sensor.office_tph_humidity",
-        "confidence_sensor": "sensor.office_room_confidence",
-    },
-    {
-        "name": "guest_room",
-        "temp_sensors": ["sensor.guest_room_tph_temperature", "sensor.guest_room_temperature"],
-        "humidity_sensor": "sensor.guest_room_tph_humidity",
-        "confidence_sensor": None,
-    },
+# Hourly-forecast entities in priority order (OpenWeatherMap richest).
+FORECAST_ENTITIES = [
+    "weather.openweathermap",
+    "weather.kmsp",
+    "weather.the_brewery",
+    "weather.forecast_home",
 ]
 
-
-def _rooms_from_args(rooms_arg):
-    """Build an ordered {name: cfg} map from the apps.yaml `rooms:` list."""
-    rooms = {}
-    for entry in (rooms_arg or DEFAULT_ROOMS):
-        name = entry["name"]
-        # Accept a `temp_sensors` list, or a legacy singular `temp_sensor`
-        # (+ optional `temp_fallback`) for backward compatibility.
-        sensors = entry.get("temp_sensors")
-        if not sensors:
-            sensors = [s for s in [entry.get("temp_sensor"), entry.get("temp_fallback")] if s]
-        rooms[name] = {
-            "temp_sensors": sensors,
-            "humidity_sensor": entry.get("humidity_sensor"),
-            "confidence_sensor": entry.get("confidence_sensor"),
-        }
-    return rooms
+DEFAULT_ROOMS = [
+    {"name": "owner_suite",
+     "temp_sensors": ["sensor.owner_suite_tph_temperature", "sensor.bedroom_temperature"],
+     "humidity_sensor": "sensor.owner_suite_tph_humidity",
+     "confidence_sensor": "sensor.bedroom_room_confidence"},
+    {"name": "office",
+     "temp_sensors": ["sensor.office_tph_temperature", "sensor.office_temperature"],
+     "humidity_sensor": "sensor.office_tph_humidity",
+     "confidence_sensor": "sensor.office_room_confidence"},
+    {"name": "guest_room",
+     "temp_sensors": ["sensor.guest_room_tph_temperature", "sensor.guest_room_temperature"],
+     "humidity_sensor": "sensor.guest_room_tph_humidity",
+     "confidence_sensor": None},
+]
 
 
 class RoomTempPredictor(hass.Hass):
     def initialize(self):
-        self.model_dir = self.args.get("model_dir", "/config/appdaemon/models")
-        self.min_samples = int(self.args.get("min_training_samples", 500))
-        self.influxdb_host = self.args.get("influxdb_host", "localhost")
-        self.influxdb_port = int(self.args.get("influxdb_port", 8086))
-        self.influxdb_db = self.args.get("influxdb_database", "home_assistant")
-        self.rooms = _rooms_from_args(self.args.get("rooms"))
-
-        self.models = {room: {} for room in self.rooms}
-        self.train_meta = {room: {} for room in self.rooms}
-
-        os.makedirs(self.model_dir, exist_ok=True)
-        self._load_models_from_disk()
+        self.base_topic = self.args.get("mqtt_base_topic", "room_temp_model")
+        self.climate_entity = self.args.get("climate_entity", "climate.my_ecobee")
+        self.rooms = []
+        for entry in (self.args.get("rooms") or DEFAULT_ROOMS):
+            sensors = entry.get("temp_sensors")
+            if not sensors:
+                sensors = [s for s in [entry.get("temp_sensor"), entry.get("temp_fallback")] if s]
+            self.rooms.append({
+                "name": entry["name"],
+                "temp_sensors": sensors,
+                "humidity_sensor": entry.get("humidity_sensor"),
+                "confidence_sensor": entry.get("confidence_sensor"),
+            })
 
         start = datetime.now(timezone.utc) + timedelta(seconds=30)
-        self.run_every(self._update_predictions, start, 300)
-
-        self.listen_state(self._on_retrain_button, "input_button.retrain_room_temp_models")
+        self.run_every(self._publish_features, start, 300)
+        self.listen_state(self._on_retrain, "input_button.retrain_room_temp_models")
         self.listen_event(self._on_retrain_event, "retrain_room_temp_models")
 
     # ------------------------------------------------------------------
-    # Model persistence
-    # ------------------------------------------------------------------
-
-    def _model_path(self, room, horizon):
-        return os.path.join(self.model_dir, f"room_temp_{room}_{horizon}m.joblib")
-
-    def _load_models_from_disk(self):
-        try:
-            import joblib
-        except ImportError:
-            self.log("joblib not available; starting with linear fallback", level="WARNING")
-            return
-        for room in self.rooms:
-            loaded = {}
-            for h in HORIZONS:
-                path = self._model_path(room, h)
-                if os.path.exists(path):
-                    try:
-                        loaded[h] = joblib.load(path)
-                    except Exception as e:
-                        self.log(f"Failed to load model {path}: {e}", level="WARNING")
-            if loaded:
-                self.models[room] = loaded
-                meta_path = self._model_path(room, "meta").replace(".joblib", ".json")
-                if os.path.exists(meta_path):
-                    import json
-                    with open(meta_path) as f:
-                        self.train_meta[room] = json.load(f)
-                self.log(f"Loaded {len(loaded)} models for {room}")
-
-    def _save_meta(self, room, meta):
-        import json
-        meta_path = self._model_path(room, "meta").replace(".joblib", ".json")
-        with open(meta_path, "w") as f:
-            json.dump(meta, f)
-
-    # ------------------------------------------------------------------
-    # InfluxDB helpers
-    # ------------------------------------------------------------------
-
-    def _influx_client(self):
-        from influxdb import InfluxDBClient
-        return InfluxDBClient(
-            host=self.influxdb_host,
-            port=self.influxdb_port,
-            database=self.influxdb_db,
-        )
-
-    def _query_series(self, client, entity_id, start_days=730):
-        """Return a pandas Series of numeric state values resampled to 5-min grid."""
-        import pandas as pd
-        start_str = (datetime.utcnow() - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
-        # Try °F measurement first (room temps), then unitless/% for ratios
-        for measurement in ['"°F"', '"%" ', '"W/m²"', '/.*/']:
-            q = (
-                f'SELECT value FROM {measurement} '
-                f"WHERE entity_id='{entity_id}' AND time>='{start_str}' "
-                f"ORDER BY time ASC"
-            )
-            try:
-                result = client.query(q)
-                points = list(result.get_points())
-                if points:
-                    df = pd.DataFrame(points)
-                    df["time"] = pd.to_datetime(df["time"])
-                    df = df.set_index("time").sort_index()
-                    series = df["value"].astype(float)
-                    return series.resample("5min").mean().ffill(limit=12)
-            except Exception:
-                continue
-        return None
-
-    def _query_generic(self, client, entity_id, start_days=730):
-        """Query any numeric entity regardless of measurement name."""
-        import pandas as pd
-        start_str = (datetime.utcnow() - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
-        q = (
-            f"SELECT value FROM /.*/ "
-            f"WHERE entity_id='{entity_id}' AND time>='{start_str}' "
-            f"ORDER BY time ASC"
-        )
-        try:
-            result = client.query(q)
-            all_points = []
-            for _key, points in result.items():
-                all_points.extend(list(points))
-            if not all_points:
-                return None
-            df = pd.DataFrame(all_points)
-            df["time"] = pd.to_datetime(df["time"])
-            df = df.set_index("time").sort_index()
-            if "value" not in df.columns:
-                return None
-            series = df["value"].astype(float)
-            return series.resample("5min").mean().ffill(limit=12)
-        except Exception as e:
-            self.log(f"InfluxDB query failed for {entity_id}: {e}", level="WARNING")
-            return None
-
-    def _query_categorical(self, client, entity_id, start_days=730):
-        """Query a string-state entity (e.g. hvac_activity) with no float cast."""
-        import pandas as pd
-        start_str = (datetime.utcnow() - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
-        q = (
-            f"SELECT value FROM /.*/ "
-            f"WHERE entity_id='{entity_id}' AND time>='{start_str}' "
-            f"ORDER BY time ASC"
-        )
-        try:
-            result = client.query(q)
-            all_points = []
-            for _key, points in result.items():
-                all_points.extend(list(points))
-            if not all_points:
-                return pd.Series(dtype=object)
-            df = pd.DataFrame(all_points)
-            df["time"] = pd.to_datetime(df["time"])
-            df = df.set_index("time").sort_index()
-            if "value" not in df.columns:
-                return pd.Series(dtype=object)
-            return df["value"].astype(str).resample("5min").ffill()
-        except Exception as e:
-            self.log(f"InfluxDB categorical query failed for {entity_id}: {e}", level="WARNING")
-            return pd.Series(dtype=object)
-
-    # ------------------------------------------------------------------
-    # Sun position computation via astral
+    # Helpers
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _sun_position(lat, lon, dt):
-        """Return (elevation_deg, azimuth_deg) for a UTC datetime."""
+    def _safe_float(value, default=None):
+        if value in (None, "unknown", "unavailable", ""):
+            return default
         try:
-            from astral import LocationInfo
-            from astral.sun import sun as astral_sun
-            loc = LocationInfo(latitude=lat, longitude=lon)
-            s = astral_sun(loc.observer, date=dt.date(), tzinfo=timezone.utc)
-            # astral doesn't give elevation directly from sun(); use formula
-            import math as _math
-            # Solar elevation via simple formula as fallback
-            # Use astral's SolarAltitude if available
-            try:
-                from astral.sun import elevation as astral_elevation
-                from astral.sun import azimuth as astral_azimuth
-                elev = astral_elevation(loc.observer, dt)
-                azim = astral_azimuth(loc.observer, dt)
-                return float(elev), float(azim)
-            except ImportError:
-                pass
-        except ImportError:
-            pass
-        # Pure-math fallback (approximate, good to ~1°)
-        import math as _math
-        lat_r = _math.radians(lat)
-        doy = dt.timetuple().tm_yday
-        hour_utc = dt.hour + dt.minute / 60.0
-        # Solar declination
-        decl = _math.radians(23.45 * _math.sin(_math.radians(360 / 365 * (doy - 81))))
-        # Hour angle (approximate: no equation-of-time, lon offset)
-        hour_angle = _math.radians(15 * (hour_utc + lon / 15 - 12))
-        sin_elev = (_math.sin(lat_r) * _math.sin(decl)
-                    + _math.cos(lat_r) * _math.cos(decl) * _math.cos(hour_angle))
-        elev = _math.degrees(_math.asin(max(-1.0, min(1.0, sin_elev))))
-        cos_az = (_math.sin(decl) - _math.sin(_math.radians(elev)) * _math.sin(lat_r)) / (
-            _math.cos(_math.radians(elev)) * _math.cos(lat_r) + 1e-9
-        )
-        azim = _math.degrees(_math.acos(max(-1.0, min(1.0, cos_az))))
-        if _math.sin(hour_angle) > 0:
-            azim = 360 - azim
-        return elev, azim
-
-    def _latlon(self):
-        """Home lat/lon via zone.home (stable AppDaemon-supported API)."""
-        try:
-            return (
-                float(self.get_state("zone.home", attribute="latitude")),
-                float(self.get_state("zone.home", attribute="longitude")),
-            )
+            return float(value)
         except (TypeError, ValueError):
-            return 0.0, 0.0
+            return default
 
-    # ------------------------------------------------------------------
-    # Training
-    # ------------------------------------------------------------------
+    def _avg(self, entities, default=None):
+        vals = [self._safe_float(self.get_state(e)) for e in entities]
+        vals = [v for v in vals if v is not None]
+        return sum(vals) / len(vals) if vals else default
 
-    def _build_training_data(self, room, cfg):
-        import numpy as np
-        import pandas as pd
+    def _first(self, entities, default=None):
+        for e in entities:
+            v = self._safe_float(self.get_state(e))
+            if v is not None:
+                return v
+        return default
 
-        client = self._influx_client()
-        lat, lon = self._latlon()
-
-        # ---- pull raw series ----
-        # Room temperature = mean of the configured room-air sensors, aligned
-        # on a common 5-min grid (NaN-skipping so a sensor with shorter history
-        # just contributes where it has data). Same rule as inference/scoring.
-        members = [self._query_generic(client, s) for s in cfg["temp_sensors"]]
-        members = [m for m in members if m is not None and not m.empty]
-        if not members:
-            self.log(f"{room}: insufficient room_temp data", level="WARNING")
-            return None, None
-        room_temp = pd.concat(members, axis=1).mean(axis=1).dropna()
-        if len(room_temp) < self.min_samples:
-            self.log(f"{room}: insufficient room_temp data", level="WARNING")
-            return None, None
-
-        outside_temp = self._query_generic(client, "sensor.outside_temperature") or pd.Series(dtype=float)
-        outside_humidity = self._query_generic(client, "sensor.outside_humidity") or pd.Series(dtype=float)
-        cloud_cover = self._query_generic(client, "sensor.tomorrow_io_the_brewery_cloud_cover") or pd.Series(dtype=float)
-        # Local Ambient Weather PWS + OpenWeatherMap sensors (wind/rain/UV).
-        # These were added recently, so they may have little/no history yet —
-        # the coverage filter below drops any feature without enough history,
-        # and a future retrain picks them up automatically once it accrues.
-        wind_speed = self._query_generic(client, "sensor.pinehotties_wind_speed") or pd.Series(dtype=float)
-        precipitation = self._query_generic(client, "sensor.pinehotties_hourly_rain") or pd.Series(dtype=float)
-        uv_index = self._query_generic(client, "sensor.pinehotties_uv_index") or pd.Series(dtype=float)
-        # sensor.hvac_activity is a categorical string (heating/cooling/idle) —
-        # query it without a float cast, or every sample silently becomes 0.
-        hvac_series = self._query_categorical(client, "sensor.hvac_activity")
-
-        if cfg["confidence_sensor"]:
-            confidence = self._query_generic(client, cfg["confidence_sensor"]) or pd.Series(dtype=float)
-        else:
-            confidence = pd.Series(dtype=float)
-
-        # Per-room indoor humidity (from the room's TPH sensor) — a proxy for
-        # latent load / occupancy (showers, people) and mild thermal signal.
-        hum_sensor = cfg.get("humidity_sensor")
-        room_humidity = (self._query_generic(client, hum_sensor) if hum_sensor else None)
-        if room_humidity is None:
-            room_humidity = pd.Series(dtype=float)
-
-        # ---- align to room_temp index ----
-        idx = room_temp.index
-        df = pd.DataFrame({"room_temp": room_temp}, index=idx)
-        df["room_humidity"] = room_humidity.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        df["outside_temp"] = outside_temp.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        df["outside_humidity"] = outside_humidity.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        df["cloud_cover"] = cloud_cover.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        df["wind_speed"] = wind_speed.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        df["precipitation"] = precipitation.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        df["uv_index"] = uv_index.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        df["occupancy"] = confidence.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min")).fillna(0)
-
-        # Drop junk 0s: sensor.outside_temperature/_humidity emit a literal 0
-        # whenever the upstream weather entity briefly lacks the attribute
-        # (`| int(default=0)`). Humidity is never legitimately 0 here, so a
-        # <= 0 humidity marks the junk sample — blank both columns so real
-        # sub-zero winter temps (which still carry real humidity) survive,
-        # then forward-fill a short gap. See #866.
-        junk = df["outside_humidity"] <= 0
-        df.loc[junk, ["outside_temp", "outside_humidity"]] = np.nan
-        df["outside_temp"] = df["outside_temp"].ffill(limit=12)
-        df["outside_humidity"] = df["outside_humidity"].ffill(limit=12)
-
-        # HVAC: encode as hvac_heating / hvac_cooling booleans
-        if not hvac_series.empty:
-            hvac_str = hvac_series.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        else:
-            hvac_str = pd.Series(index=idx, dtype=object)
-        df["hvac_heating"] = (hvac_str == "heating").astype(float)
-        df["hvac_cooling"] = (hvac_str == "cooling").astype(float)
-
-        # ---- engineered features ----
-        # 15-min rolling OLS rate (3-slot window)
-        df["room_temp_rate_15m"] = (
-            df["room_temp"].rolling(3, min_periods=2)
-            .apply(lambda x: np.polyfit(range(len(x)), x, 1)[0] if len(x) >= 2 else 0, raw=True)
-        )
-        # 3-hour outside temp delta
-        df["outside_delta_3h"] = df["outside_temp"].diff(36)
-
-        # Time cyclic features
-        hours = df.index.hour + df.index.minute / 60.0
-        doy = df.index.dayofyear
-        df["hour_sin"] = np.sin(2 * np.pi * hours / 24)
-        df["hour_cos"] = np.cos(2 * np.pi * hours / 24)
-        df["doy_sin"] = np.sin(2 * np.pi * doy / 365.25)
-        df["doy_cos"] = np.cos(2 * np.pi * doy / 365.25)
-
-        # Sun position via astral for each timestamp (vectorized as apply)
-        def sun_features(ts):
-            dt = ts.to_pydatetime().replace(tzinfo=timezone.utc)
-            elev, azim = self._sun_position(lat, lon, dt)
-            return elev, azim
-
-        sun_vals = [sun_features(ts) for ts in df.index]
-        df["sun_elevation"] = [v[0] for v in sun_vals]
-        df["sun_azimuth_sin"] = np.sin(np.radians([v[1] for v in sun_vals]))
-        df["sun_azimuth_cos"] = np.cos(np.radians([v[1] for v in sun_vals]))
-
-        # ---- oracle forecast features (actual t+N observations as training proxy) ----
-        # At inference these come from a real hourly forecast (OpenWeatherMap,
-        # then NWS/Open-Meteo). Any candidate without enough recorded history is
-        # pruned by the coverage filter below (and so is its oracle shift), so
-        # new sensors never collapse the training set.
-        for h, slots in HORIZON_SLOTS.items():
-            df[f"cloud_cover_{h}m"] = df["cloud_cover"].shift(-slots)
-            df[f"outside_temp_{h}m"] = df["outside_temp"].shift(-slots)
-            df[f"outside_humidity_{h}m"] = df["outside_humidity"].shift(-slots)
-            df[f"wind_speed_{h}m"] = df["wind_speed"].shift(-slots)
-            df[f"precipitation_{h}m"] = df["precipitation"].shift(-slots)
-            df[f"uv_index_{h}m"] = df["uv_index"].shift(-slots)
-            sun_future = []
-            for ts in df.index:
-                dt_f = (ts + timedelta(minutes=h)).to_pydatetime().replace(tzinfo=timezone.utc)
-                elev_f, azim_f = self._sun_position(lat, lon, dt_f)
-                sun_future.append((elev_f, azim_f))
-            df[f"sun_elevation_{h}m"] = [v[0] for v in sun_future]
-            df[f"sun_azimuth_sin_{h}m"] = np.sin(np.radians([v[1] for v in sun_future]))
-            df[f"sun_azimuth_cos_{h}m"] = np.cos(np.radians([v[1] for v in sun_future]))
-
-        # ---- targets ----
-        y_dict = {}
-        for h, slots in HORIZON_SLOTS.items():
-            future_temp = df["room_temp"].shift(-slots)
-            y_dict[f"delta_{h}"] = future_temp - df["room_temp"]
-
-        # ---- coverage filter ----
-        # Drop candidate feature columns without enough recorded history (e.g.
-        # sensors added recently) BEFORE the row-wise dropna, so a sparse column
-        # can't collapse the whole training set. Surviving columns define the
-        # model's feature set; inference self-syncs via meta['feature_cols'].
-        # Time/sun features are always fully covered and always survive.
-        min_coverage = 0.5
-        feature_like = [c for c in df.columns if not c.startswith("delta_")]
-        dropped = [c for c in feature_like if df[c].notna().mean() < min_coverage]
-        if dropped:
-            df = df.drop(columns=dropped)
-            self.log(f"{room}: skipping low-history features {sorted(dropped)}")
-
-        # ---- interleaved week CV fold assignment ----
-        df["fold"] = df.index.isocalendar().week % 5
-
-        df = df.dropna()
-        if len(df) < self.min_samples:
-            self.log(f"{room}: only {len(df)} clean samples after dropna", level="WARNING")
-            return None, None
-
-        return df, y_dict
-
-    def _train_for_room(self, room, cfg):
+    def _history_slope(self, entity_id, minutes=30):
+        """°F/min slope from recent history (no numpy — plain least squares)."""
         try:
-            import joblib
-            import numpy as np
-            from sklearn.ensemble import GradientBoostingRegressor
-            from sklearn.metrics import mean_squared_error
-        except ImportError as e:
-            self.log(f"Missing ML dependency: {e}", level="ERROR")
-            return {}, {}
-
-        self.log(f"Starting training for {room}...")
-        df, y_dict = self._build_training_data(room, cfg)
-        if df is None:
-            return {}, {}
-
-        feature_cols = [c for c in df.columns if c not in ("fold",) and not c.startswith("delta_")]
-
-        room_models = {}
-        metrics = {}
-
-        for h in HORIZONS:
-            y = y_dict[f"delta_{h}"]
-            y = y.reindex(df.index)
-
-            # 5-fold purged interleaved CV for evaluation
-            cv_rmses = []
-            for fold_k in range(5):
-                test_mask = df["fold"] == fold_k
-                # purge: drop rows within PURGE_SLOTS of any fold-boundary crossing
-                test_positions = df.index[test_mask]
-                if len(test_positions) == 0:
-                    continue
-                purge_set = set()
-                for i, idx_val in enumerate(df.index):
-                    if test_mask.iloc[i]:
-                        for j in range(max(0, i - PURGE_SLOTS), min(len(df), i + PURGE_SLOTS + 1)):
-                            if j != i:
-                                purge_set.add(df.index[j])
-                keep = ~df.index.isin(purge_set)
-                train_mask = keep & (df["fold"] != fold_k)
-                if train_mask.sum() < 100 or test_mask.sum() < 10:
-                    continue
-                X_tr = df.loc[train_mask, feature_cols]
-                y_tr = y[train_mask]
-                X_te = df.loc[test_mask, feature_cols]
-                y_te = y[test_mask]
-                m = GradientBoostingRegressor(
-                    n_estimators=100, max_depth=4, min_samples_leaf=20, random_state=42
-                )
-                m.fit(X_tr, y_tr)
-                preds = m.predict(X_te)
-                cv_rmses.append(math.sqrt(mean_squared_error(y_te, preds)))
-
-            cv_mean = round(float(np.mean(cv_rmses)), 3) if cv_rmses else None
-            cv_std = round(float(np.std(cv_rmses)), 3) if cv_rmses else None
-
-            # Final model trained on all data
-            X_all = df[feature_cols]
-            y_all = y
-            final_model = GradientBoostingRegressor(
-                n_estimators=100, max_depth=4, min_samples_leaf=20, random_state=42
-            )
-            final_model.fit(X_all, y_all)
-            joblib.dump(final_model, self._model_path(room, h))
-            room_models[h] = final_model
-            metrics[f"rmse_{h}m_cv_mean"] = cv_mean
-            metrics[f"rmse_{h}m_cv_std"] = cv_std
-            self.log(f"{room} T+{h}m CV RMSE: {cv_mean} ± {cv_std}")
-
-        metrics["trained_at"] = datetime.utcnow().isoformat()
-        metrics["n_samples"] = len(df)
-        metrics["feature_cols"] = feature_cols
-        self._save_meta(room, metrics)
-        return room_models, metrics
-
-    # ------------------------------------------------------------------
-    # Inference helpers
-    # ------------------------------------------------------------------
-
-    # Hourly-forecast entities in priority order. OpenWeatherMap is richest —
-    # every entry carries cloud_coverage, temperature, humidity, wind_speed,
-    # uv_index and precipitation. NWS/Open-Meteo/met.no are fallbacks.
-    FORECAST_ENTITIES = [
-        "weather.openweathermap",
-        "weather.kmsp",
-        "weather.the_brewery",
-        "weather.forecast_home",
-    ]
-
-    def _get_weather_forecasts(self):
-        """Return dict: horizon_minutes -> forecast field dict (missing keys None)."""
-        forecasts = []
-        for entity_id in self.FORECAST_ENTITIES:
-            try:
-                raw = self.call_service(
-                    "weather/get_forecasts",
-                    entity_id=entity_id,
-                    type="hourly",
-                    return_response=True,
-                )
-                entries = (raw or {}).get(entity_id, {}).get("forecast", [])
-                if entries:
-                    forecasts = entries
-                    break
-            except Exception:
-                continue
-
-        now = datetime.now(timezone.utc)
-        result = {}
-        for entry in forecasts:
-            try:
-                dt_str = entry.get("datetime")
-                if not dt_str:
-                    continue
-                dt = datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
-                minutes_ahead = int((dt - now).total_seconds() / 60)
-                result[minutes_ahead] = {
-                    "temperature": entry.get("temperature"),
-                    "humidity": entry.get("humidity"),
-                    "cloud_cover": entry.get("cloud_coverage"),
-                    "wind_speed": entry.get("wind_speed"),
-                    "uv_index": entry.get("uv_index"),
-                    "precipitation": entry.get("precipitation"),
-                }
-            except Exception:
-                continue
-        return result
-
-    def _nearest_forecast(self, forecasts, horizon_min):
-        """Pick the forecast entry closest to horizon_min."""
-        if not forecasts:
-            return {}
-        best_key = min(forecasts.keys(), key=lambda k: abs(k - horizon_min))
-        if abs(best_key - horizon_min) > 90:
-            return {}
-        return forecasts[best_key]
-
-    def _get_history_slope(self, entity_id, minutes=30):
-        """Return °F/min slope from recent history, or 0.0 on failure."""
-        try:
-            import numpy as np
             end = datetime.now(timezone.utc)
             start = end - timedelta(minutes=minutes)
             hist = self.get_history(entity_id=entity_id, start_time=start, end_time=end)
             if not hist or not hist[0]:
                 return 0.0
-            points = [(i, float(s["state"])) for i, s in enumerate(hist[0])
-                      if s.get("state") not in (None, "unknown", "unavailable", "")]
-            if len(points) < 2:
+            pts = [(i, float(s["state"])) for i, s in enumerate(hist[0])
+                   if s.get("state") not in (None, "unknown", "unavailable", "")]
+            if len(pts) < 2:
                 return 0.0
-            xs, ys = zip(*points)
-            coeffs = np.polyfit(xs, ys, 1)
-            # slope is per-index-step; convert to per minute (approx steps are every 5 min)
-            steps_per_min = len(points) / minutes
-            return float(coeffs[0]) * steps_per_min
+            n = len(pts)
+            sx = sum(x for x, _ in pts)
+            sy = sum(y for _, y in pts)
+            sxx = sum(x * x for x, _ in pts)
+            sxy = sum(x * y for x, y in pts)
+            denom = n * sxx - sx * sx
+            if denom == 0:
+                return 0.0
+            slope_per_step = (n * sxy - sx * sy) / denom
+            return slope_per_step * (n / minutes)  # per-step -> per-minute
         except Exception:
             return 0.0
 
-    def _build_current_features(self, room, cfg, forecasts, lat, lon):
-        """Build single-row feature dict for inference."""
+    # ------------------------------------------------------------------
+    # Weather forecast (OWM-first hourly)
+    # ------------------------------------------------------------------
 
-        def safe_float(val, default=None):
-            if val in (None, "unknown", "unavailable", ""):
-                return default
+    def _forecasts(self):
+        entries = []
+        for entity_id in FORECAST_ENTITIES:
             try:
-                return float(val)
-            except (TypeError, ValueError):
-                return default
-
-        def first_float(entities, default=None):
-            """First entity that reports a usable numeric state."""
-            for ent in entities:
-                v = safe_float(self.get_state(ent))
-                if v is not None:
-                    return v
-            return default
-
-        def avg_float(entities, default=None):
-            """Mean of the entities that report a numeric state (else default)."""
-            vals = [safe_float(self.get_state(e)) for e in entities]
-            vals = [v for v in vals if v is not None]
-            return sum(vals) / len(vals) if vals else default
-
+                raw = self.call_service("weather/get_forecasts", entity_id=entity_id,
+                                        type="hourly", return_response=True)
+                e = (raw or {}).get(entity_id, {}).get("forecast", [])
+                if e:
+                    entries = e
+                    break
+            except Exception:
+                continue
         now = datetime.now(timezone.utc)
-        # Room temp = mean of the configured room-air sensors (TPH + ecobee);
-        # if only one reports, that one is used. Matches training/scoring.
-        room_temp = avg_float(cfg["temp_sensors"])
-        room_humidity = safe_float(
-            self.get_state(cfg["humidity_sensor"]) if cfg.get("humidity_sensor") else None
-        )
-        # Prefer the canonical two-source averages (clean, junk-0 free); fall
-        # back to the legacy shared sensors if canonical is unavailable.
-        outside_temp = first_float(
-            ["sensor.canonical_outside_temperature", "sensor.outside_temperature"]
-        )
-        outside_humidity = first_float(
-            ["sensor.canonical_outside_humidity", "sensor.outside_humidity"]
-        )
-        # Canonical multi-source values (fall back to legacy where relevant).
-        cloud_cover = first_float(
-            ["sensor.canonical_cloud_cover", "sensor.tomorrow_io_the_brewery_cloud_cover"]
-        )
-        wind_speed = safe_float(self.get_state("sensor.canonical_wind_speed"))
-        uv_index = safe_float(self.get_state("sensor.canonical_uv_index"))
-        precipitation = safe_float(self.get_state("sensor.canonical_precipitation"))
-        occupancy = safe_float(self.get_state(cfg["confidence_sensor"]) if cfg["confidence_sensor"] else None, 0)
-
-        hvac_action = self.get_state("climate.my_ecobee", attribute="hvac_action") or ""
-        hvac_heating = 1.0 if "heat" in hvac_action.lower() else 0.0
-        hvac_cooling = 1.0 if "cool" in hvac_action.lower() else 0.0
-
-        slope = self._get_history_slope(cfg["temp_sensors"][0], 15)
-        outside_delta_3h = self._get_history_slope("sensor.canonical_outside_temperature", 180) * 180
-
-        elev, azim = self._sun_position(lat, lon, now)
-        hours = now.hour + now.minute / 60.0
-        doy = now.timetuple().tm_yday
-
-        # Full candidate feature superset. Whichever features the trained model
-        # actually uses is selected downstream via meta['feature_cols']; extras
-        # (e.g. wind/uv/precip before they have training history) are ignored.
-        row = {
-            "room_temp": room_temp,
-            "room_humidity": room_humidity,
-            "outside_temp": outside_temp,
-            "outside_humidity": outside_humidity,
-            "cloud_cover": cloud_cover,
-            "wind_speed": wind_speed,
-            "precipitation": precipitation,
-            "uv_index": uv_index,
-            "occupancy": occupancy,
-            "hvac_heating": hvac_heating,
-            "hvac_cooling": hvac_cooling,
-            "room_temp_rate_15m": slope,
-            "outside_delta_3h": outside_delta_3h,
-            "hour_sin": math.sin(2 * math.pi * hours / 24),
-            "hour_cos": math.cos(2 * math.pi * hours / 24),
-            "doy_sin": math.sin(2 * math.pi * doy / 365.25),
-            "doy_cos": math.cos(2 * math.pi * doy / 365.25),
-            "sun_elevation": elev,
-            "sun_azimuth_sin": math.sin(math.radians(azim)),
-            "sun_azimuth_cos": math.cos(math.radians(azim)),
-        }
-
-        for h in HORIZONS:
-            fc = self._nearest_forecast(forecasts, h)
-            elev_f, azim_f = self._sun_position(lat, lon, now + timedelta(minutes=h))
-            row[f"cloud_cover_{h}m"] = safe_float(fc.get("cloud_cover"), cloud_cover)
-            row[f"wind_speed_{h}m"] = safe_float(fc.get("wind_speed"), wind_speed)
-            row[f"uv_index_{h}m"] = safe_float(fc.get("uv_index"), uv_index)
-            row[f"precipitation_{h}m"] = safe_float(fc.get("precipitation"), precipitation)
-            row[f"outside_temp_{h}m"] = safe_float(fc.get("temperature"), outside_temp)
-            row[f"outside_humidity_{h}m"] = safe_float(fc.get("humidity"), outside_humidity)
-            row[f"sun_elevation_{h}m"] = elev_f
-            row[f"sun_azimuth_sin_{h}m"] = math.sin(math.radians(azim_f))
-            row[f"sun_azimuth_cos_{h}m"] = math.cos(math.radians(azim_f))
-
-        return row, room_temp
-
-    def _linear_rate_fallback(self, temp_sensor):
-        return self._get_history_slope(temp_sensor, 30)
-
-    # ------------------------------------------------------------------
-    # Prediction loop
-    # ------------------------------------------------------------------
-
-    def _update_predictions(self, kwargs):
-        lat, lon = self._latlon()
-
-        forecasts = self._get_weather_forecasts()
-
-        for room, cfg in self.rooms.items():
+        by_min = {}
+        for entry in entries:
             try:
-                room_models = self.models.get(room, {})
-                meta = self.train_meta.get(room, {})
-
-                if not room_models:
-                    rate = self._linear_rate_fallback(cfg["temp_sensors"][0])
-                    vals = []
-                    for ent in cfg["temp_sensors"]:
-                        raw = self.get_state(ent)
-                        if raw not in (None, "unknown", "unavailable", ""):
-                            try:
-                                vals.append(float(raw))
-                            except (TypeError, ValueError):
-                                pass
-                    if not vals:
-                        continue
-                    current_temp = sum(vals) / len(vals)
-                    t15 = current_temp + rate * 15
-                    t30 = current_temp + rate * 30
-                    t60 = current_temp + rate * 60
-                    source = "fallback_linear"
-                else:
-                    row, current_temp = self._build_current_features(room, cfg, forecasts, lat, lon)
-                    if current_temp is None:
-                        continue
-                    feature_cols = meta.get("feature_cols")
-                    if feature_cols:
-                        import pandas as pd
-                        X = pd.DataFrame([row])[feature_cols].fillna(0)
-                        feat = X.values[0]
-                    else:
-                        import numpy as np
-                        feat = [row.get(k, 0) or 0 for k in sorted(row.keys())]
-                    t15 = current_temp + float(room_models[15].predict([feat])[0])
-                    t30 = current_temp + float(room_models[30].predict([feat])[0])
-                    t60 = current_temp + float(room_models[60].predict([feat])[0])
-                    source = "gbr_model"
-
-                self.set_state(
-                    f"sensor.room_temp_prediction_{room}",
-                    state=round(t30, 1),
-                    attributes={
-                        "t15": round(t15, 2),
-                        "t30": round(t30, 2),
-                        "t60": round(t60, 2),
-                        "prediction_source": source,
-                        "trained_at": meta.get("trained_at"),
-                        "rmse_15m_cv_mean": meta.get("rmse_15m_cv_mean"),
-                        "rmse_30m_cv_mean": meta.get("rmse_30m_cv_mean"),
-                        "rmse_60m_cv_mean": meta.get("rmse_60m_cv_mean"),
-                        "n_training_samples": meta.get("n_samples"),
-                        "unit_of_measurement": "°F",
-                        "friendly_name": f"Predicted Temp {room.replace('_', ' ').title()} T+30",
-                        "updated_at": datetime.utcnow().isoformat(),
-                    },
-                )
-            except Exception as e:
-                self.log(f"Prediction error for {room}: {e}", level="WARNING")
+                dt = datetime.fromisoformat(entry["datetime"].replace("Z", "+00:00"))
+                by_min[int((dt - now).total_seconds() / 60)] = entry
+            except Exception:
+                continue
+        out = {}
+        for h in HORIZONS:
+            if not by_min:
+                out[str(h)] = {}
+                continue
+            key = min(by_min.keys(), key=lambda k: abs(k - h))
+            fc = by_min[key] if abs(key - h) <= 90 else {}
+            out[str(h)] = {
+                "temperature": fc.get("temperature"),
+                "humidity": fc.get("humidity"),
+                "cloud_cover": fc.get("cloud_coverage"),
+                "wind_speed": fc.get("wind_speed"),
+                "uv_index": fc.get("uv_index"),
+                "precipitation": fc.get("precipitation"),
+            }
+        return out
 
     # ------------------------------------------------------------------
-    # Retrain triggers
+    # Publish loop
     # ------------------------------------------------------------------
 
-    def _on_retrain_button(self, entity, attribute, old, new, kwargs):
-        self.log("Retrain triggered via input_button")
-        self._retrain_all()
+    def _publish_features(self, kwargs):
+        hvac_action = (self.get_state(self.climate_entity, attribute="hvac_action") or "").lower()
+        hvac_heating = 1.0 if "heat" in hvac_action else 0.0
+        hvac_cooling = 1.0 if "cool" in hvac_action else 0.0
+
+        outside_temp = self._first(["sensor.canonical_outside_temperature", "sensor.outside_temperature"])
+        outside_humidity = self._first(["sensor.canonical_outside_humidity", "sensor.outside_humidity"])
+        cloud_cover = self._first(["sensor.canonical_cloud_cover", "sensor.tomorrow_io_the_brewery_cloud_cover"])
+        wind_speed = self._safe_float(self.get_state("sensor.canonical_wind_speed"))
+        uv_index = self._safe_float(self.get_state("sensor.canonical_uv_index"))
+        precipitation = self._safe_float(self.get_state("sensor.canonical_precipitation"))
+        outside_delta_3h = self._history_slope("sensor.canonical_outside_temperature", 180) * 180
+        forecast = self._forecasts()
+
+        rooms = {}
+        for cfg in self.rooms:
+            temp = self._avg(cfg["temp_sensors"])
+            if temp is None:
+                continue
+            conf = cfg["confidence_sensor"]
+            rooms[cfg["name"]] = {
+                "room_temp": temp,
+                "room_humidity": self._safe_float(self.get_state(cfg["humidity_sensor"])) if cfg["humidity_sensor"] else None,
+                "outside_temp": outside_temp,
+                "outside_humidity": outside_humidity,
+                "cloud_cover": cloud_cover,
+                "wind_speed": wind_speed,
+                "uv_index": uv_index,
+                "precipitation": precipitation,
+                "occupancy": self._safe_float(self.get_state(conf), 0) if conf else 0,
+                "hvac_heating": hvac_heating,
+                "hvac_cooling": hvac_cooling,
+                "room_temp_rate_15m": self._history_slope(cfg["temp_sensors"][0], 15),
+                "outside_delta_3h": outside_delta_3h,
+                "forecast": forecast,
+            }
+
+        if not rooms:
+            return
+        payload = {"ts": datetime.now(timezone.utc).isoformat(), "rooms": rooms}
+        self.call_service("mqtt/publish", topic=f"{self.base_topic}/features",
+                          payload=json.dumps(payload))
+
+    # ------------------------------------------------------------------
+    # Retrain relay
+    # ------------------------------------------------------------------
+
+    def _on_retrain(self, entity, attribute, old, new, kwargs):
+        self._relay_train()
 
     def _on_retrain_event(self, event_name, data, kwargs):
-        self.log("Retrain triggered via event")
-        self._retrain_all()
+        self._relay_train()
 
-    def _retrain_all(self):
-        for room, cfg in self.rooms.items():
-            try:
-                new_models, meta = self._train_for_room(room, cfg)
-                if new_models:
-                    self.models[room] = new_models
-                    self.train_meta[room] = meta
-                    self.log(f"Retrained {room}: {meta}")
-            except Exception as e:
-                self.log(f"Training failed for {room}: {e}", level="ERROR")
+    def _relay_train(self):
+        self.log("Relaying retrain trigger to model service")
+        self.call_service("mqtt/publish", topic=f"{self.base_topic}/train", payload="{}")

--- a/appdaemon/apps/room_temp_predictor.py
+++ b/appdaemon/apps/room_temp_predictor.py
@@ -19,30 +19,28 @@ HORIZON_SLOTS = {h: h // SLOT_MIN for h in HORIZONS}
 PURGE_SLOTS = 48  # 4-hour autocorrelation purge at fold boundaries
 
 # Default room config, used only when apps.yaml provides no `rooms:` list.
-# The TPH sensors are the clean, purpose-built room-air sensors and carry
-# years of history — kept as the model target/actual. `temp_fallback` is the
-# area-level auto_areas aggregate, used only if the primary drops out at
-# inference (it runs ~1-2.6°F warm because it blends self-heating device
-# sensors, so it is a fallback, not the target).
+# `temp_sensors` is the ordered list of clean room-air sensors averaged into
+# the room temperature (TPH + ecobee remote): if both report, they are
+# averaged; if only one is available, that one is used. The motion-sensor and
+# auto_areas aggregate are intentionally excluded — they self-heat ~1-3°F.
+# The first entry is treated as primary for rate/history slope (it carries the
+# longest recorded history).
 DEFAULT_ROOMS = [
     {
         "name": "owner_suite",
-        "temp_sensor": "sensor.owner_suite_tph_temperature",
-        "temp_fallback": "sensor.bedroom_temperature_2",
+        "temp_sensors": ["sensor.owner_suite_tph_temperature", "sensor.bedroom_temperature"],
         "humidity_sensor": "sensor.owner_suite_tph_humidity",
         "confidence_sensor": "sensor.bedroom_room_confidence",
     },
     {
         "name": "office",
-        "temp_sensor": "sensor.office_tph_temperature",
-        "temp_fallback": "sensor.office_temperature_2",
+        "temp_sensors": ["sensor.office_tph_temperature", "sensor.office_temperature"],
         "humidity_sensor": "sensor.office_tph_humidity",
         "confidence_sensor": "sensor.office_room_confidence",
     },
     {
         "name": "guest_room",
-        "temp_sensor": "sensor.guest_room_tph_temperature",
-        "temp_fallback": "sensor.guest_room_temperature_2",
+        "temp_sensors": ["sensor.guest_room_tph_temperature", "sensor.guest_room_temperature"],
         "humidity_sensor": "sensor.guest_room_tph_humidity",
         "confidence_sensor": None,
     },
@@ -54,9 +52,13 @@ def _rooms_from_args(rooms_arg):
     rooms = {}
     for entry in (rooms_arg or DEFAULT_ROOMS):
         name = entry["name"]
+        # Accept a `temp_sensors` list, or a legacy singular `temp_sensor`
+        # (+ optional `temp_fallback`) for backward compatibility.
+        sensors = entry.get("temp_sensors")
+        if not sensors:
+            sensors = [s for s in [entry.get("temp_sensor"), entry.get("temp_fallback")] if s]
         rooms[name] = {
-            "temp_sensor": entry["temp_sensor"],
-            "temp_fallback": entry.get("temp_fallback"),
+            "temp_sensors": sensors,
             "humidity_sensor": entry.get("humidity_sensor"),
             "confidence_sensor": entry.get("confidence_sensor"),
         }
@@ -278,8 +280,16 @@ class RoomTempPredictor(hass.Hass):
         lat, lon = self._latlon()
 
         # ---- pull raw series ----
-        room_temp = self._query_generic(client, cfg["temp_sensor"])
-        if room_temp is None or len(room_temp) < self.min_samples:
+        # Room temperature = mean of the configured room-air sensors, aligned
+        # on a common 5-min grid (NaN-skipping so a sensor with shorter history
+        # just contributes where it has data). Same rule as inference/scoring.
+        members = [self._query_generic(client, s) for s in cfg["temp_sensors"]]
+        members = [m for m in members if m is not None and not m.empty]
+        if not members:
+            self.log(f"{room}: insufficient room_temp data", level="WARNING")
+            return None, None
+        room_temp = pd.concat(members, axis=1).mean(axis=1).dropna()
+        if len(room_temp) < self.min_samples:
             self.log(f"{room}: insufficient room_temp data", level="WARNING")
             return None, None
 
@@ -595,10 +605,16 @@ class RoomTempPredictor(hass.Hass):
                     return v
             return default
 
+        def avg_float(entities, default=None):
+            """Mean of the entities that report a numeric state (else default)."""
+            vals = [safe_float(self.get_state(e)) for e in entities]
+            vals = [v for v in vals if v is not None]
+            return sum(vals) / len(vals) if vals else default
+
         now = datetime.now(timezone.utc)
-        # Primary is the clean room-air sensor (also the training target); the
-        # area aggregate is a robustness fallback only if the primary drops out.
-        room_temp = first_float([cfg["temp_sensor"], cfg.get("temp_fallback")])
+        # Room temp = mean of the configured room-air sensors (TPH + ecobee);
+        # if only one reports, that one is used. Matches training/scoring.
+        room_temp = avg_float(cfg["temp_sensors"])
         room_humidity = safe_float(
             self.get_state(cfg["humidity_sensor"]) if cfg.get("humidity_sensor") else None
         )
@@ -623,7 +639,7 @@ class RoomTempPredictor(hass.Hass):
         hvac_heating = 1.0 if "heat" in hvac_action.lower() else 0.0
         hvac_cooling = 1.0 if "cool" in hvac_action.lower() else 0.0
 
-        slope = self._get_history_slope(cfg["temp_sensor"], 15)
+        slope = self._get_history_slope(cfg["temp_sensors"][0], 15)
         outside_delta_3h = self._get_history_slope("sensor.canonical_outside_temperature", 180) * 180
 
         elev, azim = self._sun_position(lat, lon, now)
@@ -689,11 +705,18 @@ class RoomTempPredictor(hass.Hass):
                 meta = self.train_meta.get(room, {})
 
                 if not room_models:
-                    rate = self._linear_rate_fallback(cfg["temp_sensor"])
-                    current_temp_raw = self.get_state(cfg["temp_sensor"])
-                    if current_temp_raw in (None, "unknown", "unavailable"):
+                    rate = self._linear_rate_fallback(cfg["temp_sensors"][0])
+                    vals = []
+                    for ent in cfg["temp_sensors"]:
+                        raw = self.get_state(ent)
+                        if raw not in (None, "unknown", "unavailable", ""):
+                            try:
+                                vals.append(float(raw))
+                            except (TypeError, ValueError):
+                                pass
+                    if not vals:
                         continue
-                    current_temp = float(current_temp_raw)
+                    current_temp = sum(vals) / len(vals)
                     t15 = current_temp + rate * 15
                     t30 = current_temp + rate * 30
                     t60 = current_temp + rate * 60

--- a/appdaemon/apps/room_temp_predictor.py
+++ b/appdaemon/apps/room_temp_predictor.py
@@ -1,0 +1,628 @@
+"""Predictive per-room temperature app using GradientBoostingRegressor.
+
+Training data comes from InfluxDB (multi-year history). Models are saved as
+joblib files and loaded at startup. Retrain is triggered manually via
+input_button.retrain_room_temp_models or the event 'retrain_room_temp_models'.
+Every 5 minutes the prediction loop publishes sensor.room_temp_prediction_<room>
+with t15/t30/t60 attributes.
+"""
+
+import math
+import os
+from datetime import datetime, timedelta, timezone
+
+import hassapi as hass
+
+HORIZONS = [15, 30, 60]
+SLOT_MIN = 5
+HORIZON_SLOTS = {h: h // SLOT_MIN for h in HORIZONS}
+PURGE_SLOTS = 48  # 4-hour autocorrelation purge at fold boundaries
+
+ROOMS = {
+    "owner_suite": {
+        "temp_sensor": "sensor.owner_suite_tph_temperature",
+        "confidence_sensor": "sensor.bedroom_room_confidence",
+    },
+    "office": {
+        "temp_sensor": "sensor.office_tph_temperature",
+        "confidence_sensor": "sensor.office_room_confidence",
+    },
+    "guest_room": {
+        "temp_sensor": "sensor.guest_room_tph_temperature",
+        "confidence_sensor": None,
+    },
+}
+
+
+class RoomTempPredictor(hass.Hass):
+    def initialize(self):
+        self.model_dir = self.args.get("model_dir", "/config/appdaemon/models")
+        self.min_samples = int(self.args.get("min_training_samples", 500))
+        self.influxdb_host = self.args.get("influxdb_host", "localhost")
+        self.influxdb_port = int(self.args.get("influxdb_port", 8086))
+        self.influxdb_db = self.args.get("influxdb_database", "home_assistant")
+
+        self.models = {room: {} for room in ROOMS}
+        self.train_meta = {room: {} for room in ROOMS}
+
+        os.makedirs(self.model_dir, exist_ok=True)
+        self._load_models_from_disk()
+
+        start = datetime.now(timezone.utc) + timedelta(seconds=30)
+        self.run_every(self._update_predictions, start, 300)
+
+        self.listen_state(self._on_retrain_button, "input_button.retrain_room_temp_models")
+        self.listen_event(self._on_retrain_event, "retrain_room_temp_models")
+
+    # ------------------------------------------------------------------
+    # Model persistence
+    # ------------------------------------------------------------------
+
+    def _model_path(self, room, horizon):
+        return os.path.join(self.model_dir, f"room_temp_{room}_{horizon}m.joblib")
+
+    def _load_models_from_disk(self):
+        try:
+            import joblib
+        except ImportError:
+            self.log("joblib not available; starting with linear fallback", level="WARNING")
+            return
+        for room in ROOMS:
+            loaded = {}
+            for h in HORIZONS:
+                path = self._model_path(room, h)
+                if os.path.exists(path):
+                    try:
+                        loaded[h] = joblib.load(path)
+                    except Exception as e:
+                        self.log(f"Failed to load model {path}: {e}", level="WARNING")
+            if loaded:
+                self.models[room] = loaded
+                meta_path = self._model_path(room, "meta").replace(".joblib", ".json")
+                if os.path.exists(meta_path):
+                    import json
+                    with open(meta_path) as f:
+                        self.train_meta[room] = json.load(f)
+                self.log(f"Loaded {len(loaded)} models for {room}")
+
+    def _save_meta(self, room, meta):
+        import json
+        meta_path = self._model_path(room, "meta").replace(".joblib", ".json")
+        with open(meta_path, "w") as f:
+            json.dump(meta, f)
+
+    # ------------------------------------------------------------------
+    # InfluxDB helpers
+    # ------------------------------------------------------------------
+
+    def _influx_client(self):
+        from influxdb import InfluxDBClient
+        return InfluxDBClient(
+            host=self.influxdb_host,
+            port=self.influxdb_port,
+            database=self.influxdb_db,
+        )
+
+    def _query_series(self, client, entity_id, start_days=730):
+        """Return a pandas Series of numeric state values resampled to 5-min grid."""
+        import pandas as pd
+        start_str = (datetime.utcnow() - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # Try °F measurement first (room temps), then unitless/% for ratios
+        for measurement in ['"°F"', '"%" ', '"W/m²"', '/.*/']:
+            q = (
+                f'SELECT value FROM {measurement} '
+                f"WHERE entity_id='{entity_id}' AND time>='{start_str}' "
+                f"ORDER BY time ASC"
+            )
+            try:
+                result = client.query(q)
+                points = list(result.get_points())
+                if points:
+                    df = pd.DataFrame(points)
+                    df["time"] = pd.to_datetime(df["time"])
+                    df = df.set_index("time").sort_index()
+                    series = df["value"].astype(float)
+                    return series.resample("5min").mean().ffill(limit=12)
+            except Exception:
+                continue
+        return None
+
+    def _query_generic(self, client, entity_id, start_days=730):
+        """Query any numeric entity regardless of measurement name."""
+        import pandas as pd
+        start_str = (datetime.utcnow() - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        q = (
+            f"SELECT value FROM /.*/ "
+            f"WHERE entity_id='{entity_id}' AND time>='{start_str}' "
+            f"ORDER BY time ASC"
+        )
+        try:
+            result = client.query(q)
+            all_points = []
+            for _key, points in result.items():
+                all_points.extend(list(points))
+            if not all_points:
+                return None
+            df = pd.DataFrame(all_points)
+            df["time"] = pd.to_datetime(df["time"])
+            df = df.set_index("time").sort_index()
+            if "value" not in df.columns:
+                return None
+            series = df["value"].astype(float)
+            return series.resample("5min").mean().ffill(limit=12)
+        except Exception as e:
+            self.log(f"InfluxDB query failed for {entity_id}: {e}", level="WARNING")
+            return None
+
+    # ------------------------------------------------------------------
+    # Sun position computation via astral
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _sun_position(lat, lon, dt):
+        """Return (elevation_deg, azimuth_deg) for a UTC datetime."""
+        try:
+            from astral import LocationInfo
+            from astral.sun import sun as astral_sun
+            loc = LocationInfo(latitude=lat, longitude=lon)
+            s = astral_sun(loc.observer, date=dt.date(), tzinfo=timezone.utc)
+            # astral doesn't give elevation directly from sun(); use formula
+            import math as _math
+            # Solar elevation via simple formula as fallback
+            # Use astral's SolarAltitude if available
+            try:
+                from astral.sun import elevation as astral_elevation
+                from astral.sun import azimuth as astral_azimuth
+                elev = astral_elevation(loc.observer, dt)
+                azim = astral_azimuth(loc.observer, dt)
+                return float(elev), float(azim)
+            except ImportError:
+                pass
+        except ImportError:
+            pass
+        # Pure-math fallback (approximate, good to ~1°)
+        import math as _math
+        lat_r = _math.radians(lat)
+        doy = dt.timetuple().tm_yday
+        hour_utc = dt.hour + dt.minute / 60.0
+        # Solar declination
+        decl = _math.radians(23.45 * _math.sin(_math.radians(360 / 365 * (doy - 81))))
+        # Hour angle (approximate: no equation-of-time, lon offset)
+        hour_angle = _math.radians(15 * (hour_utc + lon / 15 - 12))
+        sin_elev = (_math.sin(lat_r) * _math.sin(decl)
+                    + _math.cos(lat_r) * _math.cos(decl) * _math.cos(hour_angle))
+        elev = _math.degrees(_math.asin(max(-1.0, min(1.0, sin_elev))))
+        cos_az = (_math.sin(decl) - _math.sin(_math.radians(elev)) * _math.sin(lat_r)) / (
+            _math.cos(_math.radians(elev)) * _math.cos(lat_r) + 1e-9
+        )
+        azim = _math.degrees(_math.acos(max(-1.0, min(1.0, cos_az))))
+        if _math.sin(hour_angle) > 0:
+            azim = 360 - azim
+        return elev, azim
+
+    # ------------------------------------------------------------------
+    # Training
+    # ------------------------------------------------------------------
+
+    def _build_training_data(self, room, cfg):
+        import numpy as np
+        import pandas as pd
+
+        client = self._influx_client()
+        lat = float(self.AD.config.latitude)
+        lon = float(self.AD.config.longitude)
+
+        # ---- pull raw series ----
+        room_temp = self._query_generic(client, cfg["temp_sensor"])
+        if room_temp is None or len(room_temp) < self.min_samples:
+            self.log(f"{room}: insufficient room_temp data", level="WARNING")
+            return None, None
+
+        outside_temp = self._query_generic(client, "sensor.outside_temperature") or pd.Series(dtype=float)
+        outside_humidity = self._query_generic(client, "sensor.outside_humidity") or pd.Series(dtype=float)
+        cloud_cover = self._query_generic(client, "sensor.tomorrow_io_the_brewery_cloud_cover") or pd.Series(dtype=float)
+        wind_speed = self._query_generic(client, "sensor.tomorrow_io_the_brewery_wind_speed") or pd.Series(dtype=float)
+        wind_bearing = self._query_generic(client, "sensor.tomorrow_io_the_brewery_wind_direction") or pd.Series(dtype=float)
+        precipitation = self._query_generic(client, "sensor.tomorrow_io_the_brewery_precipitation_intensity") or pd.Series(dtype=float)
+        hvac_series = self._query_generic(client, "sensor.hvac_activity") or pd.Series(dtype=float)
+
+        if cfg["confidence_sensor"]:
+            confidence = self._query_generic(client, cfg["confidence_sensor"]) or pd.Series(dtype=float)
+        else:
+            confidence = pd.Series(dtype=float)
+
+        # ---- align to room_temp index ----
+        idx = room_temp.index
+        df = pd.DataFrame({"room_temp": room_temp}, index=idx)
+        df["outside_temp"] = outside_temp.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        df["outside_humidity"] = outside_humidity.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        df["cloud_cover"] = cloud_cover.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        df["wind_speed"] = wind_speed.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        df["wind_bearing"] = wind_bearing.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        df["precipitation"] = precipitation.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        df["occupancy"] = confidence.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min")).fillna(0)
+
+        # HVAC: encode as hvac_heating / hvac_cooling booleans
+        hvac_str = hvac_series.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        df["hvac_heating"] = (hvac_str == "heating").astype(float)
+        df["hvac_cooling"] = (hvac_str == "cooling").astype(float)
+
+        # ---- engineered features ----
+        # 15-min rolling OLS rate (3-slot window)
+        df["room_temp_rate_15m"] = (
+            df["room_temp"].rolling(3, min_periods=2)
+            .apply(lambda x: np.polyfit(range(len(x)), x, 1)[0] if len(x) >= 2 else 0, raw=True)
+        )
+        # 3-hour outside temp delta
+        df["outside_delta_3h"] = df["outside_temp"].diff(36)
+
+        # Cyclic wind bearing
+        wb_rad = np.radians(df["wind_bearing"].fillna(0))
+        df["wind_bearing_sin"] = np.sin(wb_rad)
+        df["wind_bearing_cos"] = np.cos(wb_rad)
+
+        # Time cyclic features
+        hours = df.index.hour + df.index.minute / 60.0
+        doy = df.index.dayofyear
+        df["hour_sin"] = np.sin(2 * np.pi * hours / 24)
+        df["hour_cos"] = np.cos(2 * np.pi * hours / 24)
+        df["doy_sin"] = np.sin(2 * np.pi * doy / 365.25)
+        df["doy_cos"] = np.cos(2 * np.pi * doy / 365.25)
+
+        # Sun position via astral for each timestamp (vectorized as apply)
+        def sun_features(ts):
+            dt = ts.to_pydatetime().replace(tzinfo=timezone.utc)
+            elev, azim = self._sun_position(lat, lon, dt)
+            return elev, azim
+
+        sun_vals = [sun_features(ts) for ts in df.index]
+        df["sun_elevation"] = [v[0] for v in sun_vals]
+        df["sun_azimuth_sin"] = np.sin(np.radians([v[1] for v in sun_vals]))
+        df["sun_azimuth_cos"] = np.cos(np.radians([v[1] for v in sun_vals]))
+
+        # ---- oracle forecast features (actual t+N observations as training proxy) ----
+        for h, slots in HORIZON_SLOTS.items():
+            df[f"cloud_cover_{h}m"] = df["cloud_cover"].shift(-slots)
+            df[f"outside_temp_{h}m"] = df["outside_temp"].shift(-slots)
+            df[f"outside_humidity_{h}m"] = df["outside_humidity"].shift(-slots)
+            df[f"precipitation_{h}m"] = df["precipitation"].shift(-slots)
+            df[f"wind_speed_{h}m"] = df["wind_speed"].shift(-slots)
+            wb_shifted = df["wind_bearing"].shift(-slots).fillna(0)
+            wb_shifted_rad = np.radians(wb_shifted)
+            df[f"wind_bearing_sin_{h}m"] = np.sin(wb_shifted_rad)
+            df[f"wind_bearing_cos_{h}m"] = np.cos(wb_shifted_rad)
+            sun_future = []
+            for ts in df.index:
+                dt_f = (ts + timedelta(minutes=h)).to_pydatetime().replace(tzinfo=timezone.utc)
+                elev_f, azim_f = self._sun_position(lat, lon, dt_f)
+                sun_future.append((elev_f, azim_f))
+            df[f"sun_elevation_{h}m"] = [v[0] for v in sun_future]
+            df[f"sun_azimuth_sin_{h}m"] = np.sin(np.radians([v[1] for v in sun_future]))
+            df[f"sun_azimuth_cos_{h}m"] = np.cos(np.radians([v[1] for v in sun_future]))
+
+        # ---- targets ----
+        y_dict = {}
+        for h, slots in HORIZON_SLOTS.items():
+            future_temp = df["room_temp"].shift(-slots)
+            y_dict[f"delta_{h}"] = future_temp - df["room_temp"]
+
+        # ---- interleaved week CV fold assignment ----
+        df["fold"] = df.index.isocalendar().week % 5
+
+        df = df.dropna()
+        if len(df) < self.min_samples:
+            self.log(f"{room}: only {len(df)} clean samples after dropna", level="WARNING")
+            return None, None
+
+        return df, y_dict
+
+    def _train_for_room(self, room, cfg):
+        try:
+            import joblib
+            import numpy as np
+            from sklearn.ensemble import GradientBoostingRegressor
+            from sklearn.metrics import mean_squared_error
+        except ImportError as e:
+            self.log(f"Missing ML dependency: {e}", level="ERROR")
+            return {}, {}
+
+        self.log(f"Starting training for {room}...")
+        df, y_dict = self._build_training_data(room, cfg)
+        if df is None:
+            return {}, {}
+
+        feature_cols = [c for c in df.columns if c not in ("fold",) and not c.startswith("delta_")]
+
+        room_models = {}
+        metrics = {}
+
+        for h in HORIZONS:
+            y = y_dict[f"delta_{h}"]
+            y = y.reindex(df.index)
+
+            # 5-fold purged interleaved CV for evaluation
+            cv_rmses = []
+            for fold_k in range(5):
+                test_mask = df["fold"] == fold_k
+                # purge: drop rows within PURGE_SLOTS of any fold-boundary crossing
+                test_positions = df.index[test_mask]
+                if len(test_positions) == 0:
+                    continue
+                purge_set = set()
+                for i, idx_val in enumerate(df.index):
+                    if test_mask.iloc[i]:
+                        for j in range(max(0, i - PURGE_SLOTS), min(len(df), i + PURGE_SLOTS + 1)):
+                            if j != i:
+                                purge_set.add(df.index[j])
+                keep = ~df.index.isin(purge_set)
+                train_mask = keep & (df["fold"] != fold_k)
+                if train_mask.sum() < 100 or test_mask.sum() < 10:
+                    continue
+                X_tr = df.loc[train_mask, feature_cols]
+                y_tr = y[train_mask]
+                X_te = df.loc[test_mask, feature_cols]
+                y_te = y[test_mask]
+                m = GradientBoostingRegressor(
+                    n_estimators=100, max_depth=4, min_samples_leaf=20, random_state=42
+                )
+                m.fit(X_tr, y_tr)
+                preds = m.predict(X_te)
+                cv_rmses.append(math.sqrt(mean_squared_error(y_te, preds)))
+
+            cv_mean = round(float(np.mean(cv_rmses)), 3) if cv_rmses else None
+            cv_std = round(float(np.std(cv_rmses)), 3) if cv_rmses else None
+
+            # Final model trained on all data
+            X_all = df[feature_cols]
+            y_all = y
+            final_model = GradientBoostingRegressor(
+                n_estimators=100, max_depth=4, min_samples_leaf=20, random_state=42
+            )
+            final_model.fit(X_all, y_all)
+            joblib.dump(final_model, self._model_path(room, h))
+            room_models[h] = final_model
+            metrics[f"rmse_{h}m_cv_mean"] = cv_mean
+            metrics[f"rmse_{h}m_cv_std"] = cv_std
+            self.log(f"{room} T+{h}m CV RMSE: {cv_mean} ± {cv_std}")
+
+        metrics["trained_at"] = datetime.utcnow().isoformat()
+        metrics["n_samples"] = len(df)
+        metrics["feature_cols"] = feature_cols
+        self._save_meta(room, metrics)
+        return room_models, metrics
+
+    # ------------------------------------------------------------------
+    # Inference helpers
+    # ------------------------------------------------------------------
+
+    def _get_weather_forecasts(self):
+        """Return dict: horizon_minutes -> {cloud_cover, temperature, precipitation, wind_speed, wind_bearing, humidity}."""
+        try:
+            raw = self.call_service(
+                "weather/get_forecasts",
+                entity_id="weather.tomorrow_io_the_brewery_daily",
+                type="hourly",
+                return_response=True,
+            )
+            forecasts = raw.get("weather.tomorrow_io_the_brewery_daily", {}).get("forecast", [])
+        except Exception:
+            return {}
+
+        now = datetime.now(timezone.utc)
+        result = {}
+        for entry in forecasts:
+            try:
+                dt_str = entry.get("datetime")
+                if not dt_str:
+                    continue
+                dt = datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
+                minutes_ahead = int((dt - now).total_seconds() / 60)
+                result[minutes_ahead] = {
+                    "cloud_cover": entry.get("cloud_coverage"),
+                    "temperature": entry.get("temperature"),
+                    "precipitation": entry.get("precipitation"),
+                    "wind_speed": entry.get("wind_speed"),
+                    "wind_bearing": entry.get("wind_bearing"),
+                    "humidity": entry.get("humidity"),
+                }
+            except Exception:
+                continue
+        return result
+
+    def _nearest_forecast(self, forecasts, horizon_min):
+        """Pick the forecast entry closest to horizon_min."""
+        if not forecasts:
+            return {}
+        best_key = min(forecasts.keys(), key=lambda k: abs(k - horizon_min))
+        if abs(best_key - horizon_min) > 90:
+            return {}
+        return forecasts[best_key]
+
+    def _get_history_slope(self, entity_id, minutes=30):
+        """Return °F/min slope from recent history, or 0.0 on failure."""
+        try:
+            import numpy as np
+            end = datetime.now(timezone.utc)
+            start = end - timedelta(minutes=minutes)
+            hist = self.get_history(entity_id=entity_id, start_time=start, end_time=end)
+            if not hist or not hist[0]:
+                return 0.0
+            points = [(i, float(s["state"])) for i, s in enumerate(hist[0])
+                      if s.get("state") not in (None, "unknown", "unavailable", "")]
+            if len(points) < 2:
+                return 0.0
+            xs, ys = zip(*points)
+            coeffs = np.polyfit(xs, ys, 1)
+            # slope is per-index-step; convert to per minute (approx steps are every 5 min)
+            steps_per_min = len(points) / minutes
+            return float(coeffs[0]) * steps_per_min
+        except Exception:
+            return 0.0
+
+    def _build_current_features(self, room, cfg, forecasts, lat, lon):
+        """Build single-row feature dict for inference."""
+        import numpy as np
+
+        def safe_float(val, default=None):
+            if val in (None, "unknown", "unavailable", ""):
+                return default
+            try:
+                return float(val)
+            except (TypeError, ValueError):
+                return default
+
+        now = datetime.now(timezone.utc)
+        room_temp = safe_float(self.get_state(cfg["temp_sensor"]))
+        outside_temp = safe_float(self.get_state("sensor.outside_temperature"))
+        outside_humidity = safe_float(self.get_state("sensor.outside_humidity"))
+        cloud_cover = safe_float(self.get_state("sensor.tomorrow_io_the_brewery_cloud_cover"))
+        wind_speed = safe_float(self.get_state("sensor.tomorrow_io_the_brewery_wind_speed"))
+        wind_bearing = safe_float(self.get_state("sensor.tomorrow_io_the_brewery_wind_direction"), 0)
+        precipitation = safe_float(self.get_state("sensor.tomorrow_io_the_brewery_precipitation_intensity"), 0)
+        occupancy = safe_float(self.get_state(cfg["confidence_sensor"]) if cfg["confidence_sensor"] else None, 0)
+
+        hvac_action = self.get_state("climate.my_ecobee", attribute="hvac_action") or ""
+        hvac_heating = 1.0 if "heat" in hvac_action.lower() else 0.0
+        hvac_cooling = 1.0 if "cool" in hvac_action.lower() else 0.0
+
+        slope = self._get_history_slope(cfg["temp_sensor"], 15)
+        outside_delta_3h = self._get_history_slope("sensor.outside_temperature", 180) * 180
+
+        elev, azim = self._sun_position(lat, lon, now)
+        hours = now.hour + now.minute / 60.0
+        doy = now.timetuple().tm_yday
+        wb_rad = math.radians(wind_bearing or 0)
+
+        row = {
+            "room_temp": room_temp,
+            "outside_temp": outside_temp,
+            "outside_humidity": outside_humidity,
+            "cloud_cover": cloud_cover,
+            "wind_speed": wind_speed,
+            "wind_bearing": wind_bearing,
+            "precipitation": precipitation,
+            "occupancy": occupancy,
+            "hvac_heating": hvac_heating,
+            "hvac_cooling": hvac_cooling,
+            "room_temp_rate_15m": slope,
+            "outside_delta_3h": outside_delta_3h,
+            "wind_bearing_sin": math.sin(wb_rad),
+            "wind_bearing_cos": math.cos(wb_rad),
+            "hour_sin": math.sin(2 * math.pi * hours / 24),
+            "hour_cos": math.cos(2 * math.pi * hours / 24),
+            "doy_sin": math.sin(2 * math.pi * doy / 365.25),
+            "doy_cos": math.cos(2 * math.pi * doy / 365.25),
+            "sun_elevation": elev,
+            "sun_azimuth_sin": math.sin(math.radians(azim)),
+            "sun_azimuth_cos": math.cos(math.radians(azim)),
+        }
+
+        for h in HORIZONS:
+            fc = self._nearest_forecast(forecasts, h)
+            fc_wb = fc.get("wind_bearing") or 0
+            fc_wb_rad = math.radians(fc_wb)
+            elev_f, azim_f = self._sun_position(lat, lon, now + timedelta(minutes=h))
+            row[f"cloud_cover_{h}m"] = fc.get("cloud_cover", cloud_cover)
+            row[f"outside_temp_{h}m"] = fc.get("temperature", outside_temp)
+            row[f"outside_humidity_{h}m"] = fc.get("humidity", outside_humidity)
+            row[f"precipitation_{h}m"] = fc.get("precipitation", precipitation)
+            row[f"wind_speed_{h}m"] = fc.get("wind_speed", wind_speed)
+            row[f"wind_bearing_sin_{h}m"] = math.sin(fc_wb_rad)
+            row[f"wind_bearing_cos_{h}m"] = math.cos(fc_wb_rad)
+            row[f"sun_elevation_{h}m"] = elev_f
+            row[f"sun_azimuth_sin_{h}m"] = math.sin(math.radians(azim_f))
+            row[f"sun_azimuth_cos_{h}m"] = math.cos(math.radians(azim_f))
+
+        return row, room_temp
+
+    def _linear_rate_fallback(self, temp_sensor):
+        return self._get_history_slope(temp_sensor, 30)
+
+    # ------------------------------------------------------------------
+    # Prediction loop
+    # ------------------------------------------------------------------
+
+    def _update_predictions(self, kwargs):
+        try:
+            lat = float(self.AD.config.latitude)
+            lon = float(self.AD.config.longitude)
+        except Exception:
+            lat, lon = 0.0, 0.0
+
+        forecasts = self._get_weather_forecasts()
+
+        for room, cfg in ROOMS.items():
+            try:
+                room_models = self.models.get(room, {})
+                meta = self.train_meta.get(room, {})
+
+                if not room_models:
+                    rate = self._linear_rate_fallback(cfg["temp_sensor"])
+                    current_temp_raw = self.get_state(cfg["temp_sensor"])
+                    if current_temp_raw in (None, "unknown", "unavailable"):
+                        continue
+                    current_temp = float(current_temp_raw)
+                    t15 = current_temp + rate * 15
+                    t30 = current_temp + rate * 30
+                    t60 = current_temp + rate * 60
+                    source = "fallback_linear"
+                else:
+                    row, current_temp = self._build_current_features(room, cfg, forecasts, lat, lon)
+                    if current_temp is None:
+                        continue
+                    feature_cols = meta.get("feature_cols")
+                    if feature_cols:
+                        import pandas as pd
+                        X = pd.DataFrame([row])[feature_cols].fillna(0)
+                        feat = X.values[0]
+                    else:
+                        import numpy as np
+                        feat = [row.get(k, 0) or 0 for k in sorted(row.keys())]
+                    t15 = current_temp + float(room_models[15].predict([feat])[0])
+                    t30 = current_temp + float(room_models[30].predict([feat])[0])
+                    t60 = current_temp + float(room_models[60].predict([feat])[0])
+                    source = "gbr_model"
+
+                self.set_state(
+                    f"sensor.room_temp_prediction_{room}",
+                    state=round(t30, 1),
+                    attributes={
+                        "t15": round(t15, 2),
+                        "t30": round(t30, 2),
+                        "t60": round(t60, 2),
+                        "prediction_source": source,
+                        "trained_at": meta.get("trained_at"),
+                        "rmse_15m_cv_mean": meta.get("rmse_15m_cv_mean"),
+                        "rmse_30m_cv_mean": meta.get("rmse_30m_cv_mean"),
+                        "rmse_60m_cv_mean": meta.get("rmse_60m_cv_mean"),
+                        "n_training_samples": meta.get("n_samples"),
+                        "unit_of_measurement": "°F",
+                        "friendly_name": f"Predicted Temp {room.replace('_', ' ').title()} T+30",
+                        "updated_at": datetime.utcnow().isoformat(),
+                    },
+                )
+            except Exception as e:
+                self.log(f"Prediction error for {room}: {e}", level="WARNING")
+
+    # ------------------------------------------------------------------
+    # Retrain triggers
+    # ------------------------------------------------------------------
+
+    def _on_retrain_button(self, entity, attribute, old, new, kwargs):
+        self.log("Retrain triggered via input_button")
+        self._retrain_all()
+
+    def _on_retrain_event(self, event_name, data, kwargs):
+        self.log("Retrain triggered via event")
+        self._retrain_all()
+
+    def _retrain_all(self):
+        for room, cfg in ROOMS.items():
+            try:
+                new_models, meta = self._train_for_room(room, cfg)
+                if new_models:
+                    self.models[room] = new_models
+                    self.train_meta[room] = meta
+                    self.log(f"Retrained {room}: {meta}")
+            except Exception as e:
+                self.log(f"Training failed for {room}: {e}", level="ERROR")

--- a/appdaemon/apps/room_temp_predictor.py
+++ b/appdaemon/apps/room_temp_predictor.py
@@ -18,20 +18,49 @@ SLOT_MIN = 5
 HORIZON_SLOTS = {h: h // SLOT_MIN for h in HORIZONS}
 PURGE_SLOTS = 48  # 4-hour autocorrelation purge at fold boundaries
 
-ROOMS = {
-    "owner_suite": {
+# Default room config, used only when apps.yaml provides no `rooms:` list.
+# The TPH sensors are the clean, purpose-built room-air sensors and carry
+# years of history — kept as the model target/actual. `temp_fallback` is the
+# area-level auto_areas aggregate, used only if the primary drops out at
+# inference (it runs ~1-2.6°F warm because it blends self-heating device
+# sensors, so it is a fallback, not the target).
+DEFAULT_ROOMS = [
+    {
+        "name": "owner_suite",
         "temp_sensor": "sensor.owner_suite_tph_temperature",
+        "temp_fallback": "sensor.bedroom_temperature_2",
+        "humidity_sensor": "sensor.owner_suite_tph_humidity",
         "confidence_sensor": "sensor.bedroom_room_confidence",
     },
-    "office": {
+    {
+        "name": "office",
         "temp_sensor": "sensor.office_tph_temperature",
+        "temp_fallback": "sensor.office_temperature_2",
+        "humidity_sensor": "sensor.office_tph_humidity",
         "confidence_sensor": "sensor.office_room_confidence",
     },
-    "guest_room": {
+    {
+        "name": "guest_room",
         "temp_sensor": "sensor.guest_room_tph_temperature",
+        "temp_fallback": "sensor.guest_room_temperature_2",
+        "humidity_sensor": "sensor.guest_room_tph_humidity",
         "confidence_sensor": None,
     },
-}
+]
+
+
+def _rooms_from_args(rooms_arg):
+    """Build an ordered {name: cfg} map from the apps.yaml `rooms:` list."""
+    rooms = {}
+    for entry in (rooms_arg or DEFAULT_ROOMS):
+        name = entry["name"]
+        rooms[name] = {
+            "temp_sensor": entry["temp_sensor"],
+            "temp_fallback": entry.get("temp_fallback"),
+            "humidity_sensor": entry.get("humidity_sensor"),
+            "confidence_sensor": entry.get("confidence_sensor"),
+        }
+    return rooms
 
 
 class RoomTempPredictor(hass.Hass):
@@ -41,9 +70,10 @@ class RoomTempPredictor(hass.Hass):
         self.influxdb_host = self.args.get("influxdb_host", "localhost")
         self.influxdb_port = int(self.args.get("influxdb_port", 8086))
         self.influxdb_db = self.args.get("influxdb_database", "home_assistant")
+        self.rooms = _rooms_from_args(self.args.get("rooms"))
 
-        self.models = {room: {} for room in ROOMS}
-        self.train_meta = {room: {} for room in ROOMS}
+        self.models = {room: {} for room in self.rooms}
+        self.train_meta = {room: {} for room in self.rooms}
 
         os.makedirs(self.model_dir, exist_ok=True)
         self._load_models_from_disk()
@@ -67,7 +97,7 @@ class RoomTempPredictor(hass.Hass):
         except ImportError:
             self.log("joblib not available; starting with linear fallback", level="WARNING")
             return
-        for room in ROOMS:
+        for room in self.rooms:
             loaded = {}
             for h in HORIZONS:
                 path = self._model_path(room, h)
@@ -272,9 +302,17 @@ class RoomTempPredictor(hass.Hass):
         else:
             confidence = pd.Series(dtype=float)
 
+        # Per-room indoor humidity (from the room's TPH sensor) — a proxy for
+        # latent load / occupancy (showers, people) and mild thermal signal.
+        hum_sensor = cfg.get("humidity_sensor")
+        room_humidity = (self._query_generic(client, hum_sensor) if hum_sensor else None)
+        if room_humidity is None:
+            room_humidity = pd.Series(dtype=float)
+
         # ---- align to room_temp index ----
         idx = room_temp.index
         df = pd.DataFrame({"room_temp": room_temp}, index=idx)
+        df["room_humidity"] = room_humidity.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
         df["outside_temp"] = outside_temp.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
         df["outside_humidity"] = outside_humidity.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
         df["cloud_cover"] = cloud_cover.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
@@ -558,7 +596,12 @@ class RoomTempPredictor(hass.Hass):
             return default
 
         now = datetime.now(timezone.utc)
-        room_temp = safe_float(self.get_state(cfg["temp_sensor"]))
+        # Primary is the clean room-air sensor (also the training target); the
+        # area aggregate is a robustness fallback only if the primary drops out.
+        room_temp = first_float([cfg["temp_sensor"], cfg.get("temp_fallback")])
+        room_humidity = safe_float(
+            self.get_state(cfg["humidity_sensor"]) if cfg.get("humidity_sensor") else None
+        )
         # Prefer the canonical two-source averages (clean, junk-0 free); fall
         # back to the legacy shared sensors if canonical is unavailable.
         outside_temp = first_float(
@@ -592,6 +635,7 @@ class RoomTempPredictor(hass.Hass):
         # (e.g. wind/uv/precip before they have training history) are ignored.
         row = {
             "room_temp": room_temp,
+            "room_humidity": room_humidity,
             "outside_temp": outside_temp,
             "outside_humidity": outside_humidity,
             "cloud_cover": cloud_cover,
@@ -639,7 +683,7 @@ class RoomTempPredictor(hass.Hass):
 
         forecasts = self._get_weather_forecasts()
 
-        for room, cfg in ROOMS.items():
+        for room, cfg in self.rooms.items():
             try:
                 room_models = self.models.get(room, {})
                 meta = self.train_meta.get(room, {})
@@ -705,7 +749,7 @@ class RoomTempPredictor(hass.Hass):
         self._retrain_all()
 
     def _retrain_all(self):
-        for room, cfg in ROOMS.items():
+        for room, cfg in self.rooms.items():
             try:
                 new_models, meta = self._train_for_room(room, cfg)
                 if new_models:

--- a/appdaemon/apps/room_temp_predictor.py
+++ b/appdaemon/apps/room_temp_predictor.py
@@ -154,6 +154,32 @@ class RoomTempPredictor(hass.Hass):
             self.log(f"InfluxDB query failed for {entity_id}: {e}", level="WARNING")
             return None
 
+    def _query_categorical(self, client, entity_id, start_days=730):
+        """Query a string-state entity (e.g. hvac_activity) with no float cast."""
+        import pandas as pd
+        start_str = (datetime.utcnow() - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        q = (
+            f"SELECT value FROM /.*/ "
+            f"WHERE entity_id='{entity_id}' AND time>='{start_str}' "
+            f"ORDER BY time ASC"
+        )
+        try:
+            result = client.query(q)
+            all_points = []
+            for _key, points in result.items():
+                all_points.extend(list(points))
+            if not all_points:
+                return pd.Series(dtype=object)
+            df = pd.DataFrame(all_points)
+            df["time"] = pd.to_datetime(df["time"])
+            df = df.set_index("time").sort_index()
+            if "value" not in df.columns:
+                return pd.Series(dtype=object)
+            return df["value"].astype(str).resample("5min").ffill()
+        except Exception as e:
+            self.log(f"InfluxDB categorical query failed for {entity_id}: {e}", level="WARNING")
+            return pd.Series(dtype=object)
+
     # ------------------------------------------------------------------
     # Sun position computation via astral
     # ------------------------------------------------------------------
@@ -200,6 +226,16 @@ class RoomTempPredictor(hass.Hass):
             azim = 360 - azim
         return elev, azim
 
+    def _latlon(self):
+        """Home lat/lon via zone.home (stable AppDaemon-supported API)."""
+        try:
+            return (
+                float(self.get_state("zone.home", attribute="latitude")),
+                float(self.get_state("zone.home", attribute="longitude")),
+            )
+        except (TypeError, ValueError):
+            return 0.0, 0.0
+
     # ------------------------------------------------------------------
     # Training
     # ------------------------------------------------------------------
@@ -209,8 +245,7 @@ class RoomTempPredictor(hass.Hass):
         import pandas as pd
 
         client = self._influx_client()
-        lat = float(self.AD.config.latitude)
-        lon = float(self.AD.config.longitude)
+        lat, lon = self._latlon()
 
         # ---- pull raw series ----
         room_temp = self._query_generic(client, cfg["temp_sensor"])
@@ -221,10 +256,9 @@ class RoomTempPredictor(hass.Hass):
         outside_temp = self._query_generic(client, "sensor.outside_temperature") or pd.Series(dtype=float)
         outside_humidity = self._query_generic(client, "sensor.outside_humidity") or pd.Series(dtype=float)
         cloud_cover = self._query_generic(client, "sensor.tomorrow_io_the_brewery_cloud_cover") or pd.Series(dtype=float)
-        wind_speed = self._query_generic(client, "sensor.tomorrow_io_the_brewery_wind_speed") or pd.Series(dtype=float)
-        wind_bearing = self._query_generic(client, "sensor.tomorrow_io_the_brewery_wind_direction") or pd.Series(dtype=float)
-        precipitation = self._query_generic(client, "sensor.tomorrow_io_the_brewery_precipitation_intensity") or pd.Series(dtype=float)
-        hvac_series = self._query_generic(client, "sensor.hvac_activity") or pd.Series(dtype=float)
+        # sensor.hvac_activity is a categorical string (heating/cooling/idle) —
+        # query it without a float cast, or every sample silently becomes 0.
+        hvac_series = self._query_categorical(client, "sensor.hvac_activity")
 
         if cfg["confidence_sensor"]:
             confidence = self._query_generic(client, cfg["confidence_sensor"]) or pd.Series(dtype=float)
@@ -237,13 +271,24 @@ class RoomTempPredictor(hass.Hass):
         df["outside_temp"] = outside_temp.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
         df["outside_humidity"] = outside_humidity.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
         df["cloud_cover"] = cloud_cover.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        df["wind_speed"] = wind_speed.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        df["wind_bearing"] = wind_bearing.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
-        df["precipitation"] = precipitation.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
         df["occupancy"] = confidence.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min")).fillna(0)
 
+        # Drop junk 0s: sensor.outside_temperature/_humidity emit a literal 0
+        # whenever the upstream weather entity briefly lacks the attribute
+        # (`| int(default=0)`). Humidity is never legitimately 0 here, so a
+        # <= 0 humidity marks the junk sample — blank both columns so real
+        # sub-zero winter temps (which still carry real humidity) survive,
+        # then forward-fill a short gap. See #866.
+        junk = df["outside_humidity"] <= 0
+        df.loc[junk, ["outside_temp", "outside_humidity"]] = np.nan
+        df["outside_temp"] = df["outside_temp"].ffill(limit=12)
+        df["outside_humidity"] = df["outside_humidity"].ffill(limit=12)
+
         # HVAC: encode as hvac_heating / hvac_cooling booleans
-        hvac_str = hvac_series.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        if not hvac_series.empty:
+            hvac_str = hvac_series.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+        else:
+            hvac_str = pd.Series(index=idx, dtype=object)
         df["hvac_heating"] = (hvac_str == "heating").astype(float)
         df["hvac_cooling"] = (hvac_str == "cooling").astype(float)
 
@@ -255,11 +300,6 @@ class RoomTempPredictor(hass.Hass):
         )
         # 3-hour outside temp delta
         df["outside_delta_3h"] = df["outside_temp"].diff(36)
-
-        # Cyclic wind bearing
-        wb_rad = np.radians(df["wind_bearing"].fillna(0))
-        df["wind_bearing_sin"] = np.sin(wb_rad)
-        df["wind_bearing_cos"] = np.cos(wb_rad)
 
         # Time cyclic features
         hours = df.index.hour + df.index.minute / 60.0
@@ -281,16 +321,15 @@ class RoomTempPredictor(hass.Hass):
         df["sun_azimuth_cos"] = np.cos(np.radians([v[1] for v in sun_vals]))
 
         # ---- oracle forecast features (actual t+N observations as training proxy) ----
+        # At inference these come from a real hourly forecast (NWS/Open-Meteo).
+        # Wind/precipitation are intentionally excluded — no recorded sensor
+        # exists to train them (they live only in weather-entity attributes),
+        # and including all-NaN columns here collapsed the whole training set
+        # through the final dropna().
         for h, slots in HORIZON_SLOTS.items():
             df[f"cloud_cover_{h}m"] = df["cloud_cover"].shift(-slots)
             df[f"outside_temp_{h}m"] = df["outside_temp"].shift(-slots)
             df[f"outside_humidity_{h}m"] = df["outside_humidity"].shift(-slots)
-            df[f"precipitation_{h}m"] = df["precipitation"].shift(-slots)
-            df[f"wind_speed_{h}m"] = df["wind_speed"].shift(-slots)
-            wb_shifted = df["wind_bearing"].shift(-slots).fillna(0)
-            wb_shifted_rad = np.radians(wb_shifted)
-            df[f"wind_bearing_sin_{h}m"] = np.sin(wb_shifted_rad)
-            df[f"wind_bearing_cos_{h}m"] = np.cos(wb_shifted_rad)
             sun_future = []
             for ts in df.index:
                 dt_f = (ts + timedelta(minutes=h)).to_pydatetime().replace(tzinfo=timezone.utc)
@@ -395,18 +434,32 @@ class RoomTempPredictor(hass.Hass):
     # Inference helpers
     # ------------------------------------------------------------------
 
+    # Hourly-forecast entities in priority order. NWS carries both temperature
+    # and humidity per entry; Open-Meteo carries temperature; both are far
+    # better than the daily Tomorrow.io entity for 15/30/60-minute horizons.
+    FORECAST_ENTITIES = [
+        "weather.kmsp",
+        "weather.the_brewery",
+        "weather.forecast_home",
+    ]
+
     def _get_weather_forecasts(self):
-        """Return dict: horizon_minutes -> {cloud_cover, temperature, precipitation, wind_speed, wind_bearing, humidity}."""
-        try:
-            raw = self.call_service(
-                "weather/get_forecasts",
-                entity_id="weather.tomorrow_io_the_brewery_daily",
-                type="hourly",
-                return_response=True,
-            )
-            forecasts = raw.get("weather.tomorrow_io_the_brewery_daily", {}).get("forecast", [])
-        except Exception:
-            return {}
+        """Return dict: horizon_minutes -> {temperature, humidity, cloud_cover}."""
+        forecasts = []
+        for entity_id in self.FORECAST_ENTITIES:
+            try:
+                raw = self.call_service(
+                    "weather/get_forecasts",
+                    entity_id=entity_id,
+                    type="hourly",
+                    return_response=True,
+                )
+                entries = (raw or {}).get(entity_id, {}).get("forecast", [])
+                if entries:
+                    forecasts = entries
+                    break
+            except Exception:
+                continue
 
         now = datetime.now(timezone.utc)
         result = {}
@@ -418,12 +471,11 @@ class RoomTempPredictor(hass.Hass):
                 dt = datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
                 minutes_ahead = int((dt - now).total_seconds() / 60)
                 result[minutes_ahead] = {
-                    "cloud_cover": entry.get("cloud_coverage"),
                     "temperature": entry.get("temperature"),
-                    "precipitation": entry.get("precipitation"),
-                    "wind_speed": entry.get("wind_speed"),
-                    "wind_bearing": entry.get("wind_bearing"),
                     "humidity": entry.get("humidity"),
+                    # No provider exposes forecast cloud %; carried forward at
+                    # the call site until a numeric cloud source lands (#866).
+                    "cloud_cover": entry.get("cloud_coverage"),
                 }
             except Exception:
                 continue
@@ -461,7 +513,6 @@ class RoomTempPredictor(hass.Hass):
 
     def _build_current_features(self, room, cfg, forecasts, lat, lon):
         """Build single-row feature dict for inference."""
-        import numpy as np
 
         def safe_float(val, default=None):
             if val in (None, "unknown", "unavailable", ""):
@@ -471,14 +522,25 @@ class RoomTempPredictor(hass.Hass):
             except (TypeError, ValueError):
                 return default
 
+        def first_float(entities, default=None):
+            """First entity that reports a usable numeric state."""
+            for ent in entities:
+                v = safe_float(self.get_state(ent))
+                if v is not None:
+                    return v
+            return default
+
         now = datetime.now(timezone.utc)
         room_temp = safe_float(self.get_state(cfg["temp_sensor"]))
-        outside_temp = safe_float(self.get_state("sensor.outside_temperature"))
-        outside_humidity = safe_float(self.get_state("sensor.outside_humidity"))
+        # Prefer the canonical two-source averages (clean, junk-0 free); fall
+        # back to the legacy shared sensors if canonical is unavailable.
+        outside_temp = first_float(
+            ["sensor.canonical_outside_temperature", "sensor.outside_temperature"]
+        )
+        outside_humidity = first_float(
+            ["sensor.canonical_outside_humidity", "sensor.outside_humidity"]
+        )
         cloud_cover = safe_float(self.get_state("sensor.tomorrow_io_the_brewery_cloud_cover"))
-        wind_speed = safe_float(self.get_state("sensor.tomorrow_io_the_brewery_wind_speed"))
-        wind_bearing = safe_float(self.get_state("sensor.tomorrow_io_the_brewery_wind_direction"), 0)
-        precipitation = safe_float(self.get_state("sensor.tomorrow_io_the_brewery_precipitation_intensity"), 0)
         occupancy = safe_float(self.get_state(cfg["confidence_sensor"]) if cfg["confidence_sensor"] else None, 0)
 
         hvac_action = self.get_state("climate.my_ecobee", attribute="hvac_action") or ""
@@ -486,28 +548,22 @@ class RoomTempPredictor(hass.Hass):
         hvac_cooling = 1.0 if "cool" in hvac_action.lower() else 0.0
 
         slope = self._get_history_slope(cfg["temp_sensor"], 15)
-        outside_delta_3h = self._get_history_slope("sensor.outside_temperature", 180) * 180
+        outside_delta_3h = self._get_history_slope("sensor.canonical_outside_temperature", 180) * 180
 
         elev, azim = self._sun_position(lat, lon, now)
         hours = now.hour + now.minute / 60.0
         doy = now.timetuple().tm_yday
-        wb_rad = math.radians(wind_bearing or 0)
 
         row = {
             "room_temp": room_temp,
             "outside_temp": outside_temp,
             "outside_humidity": outside_humidity,
             "cloud_cover": cloud_cover,
-            "wind_speed": wind_speed,
-            "wind_bearing": wind_bearing,
-            "precipitation": precipitation,
             "occupancy": occupancy,
             "hvac_heating": hvac_heating,
             "hvac_cooling": hvac_cooling,
             "room_temp_rate_15m": slope,
             "outside_delta_3h": outside_delta_3h,
-            "wind_bearing_sin": math.sin(wb_rad),
-            "wind_bearing_cos": math.cos(wb_rad),
             "hour_sin": math.sin(2 * math.pi * hours / 24),
             "hour_cos": math.cos(2 * math.pi * hours / 24),
             "doy_sin": math.sin(2 * math.pi * doy / 365.25),
@@ -519,16 +575,12 @@ class RoomTempPredictor(hass.Hass):
 
         for h in HORIZONS:
             fc = self._nearest_forecast(forecasts, h)
-            fc_wb = fc.get("wind_bearing") or 0
-            fc_wb_rad = math.radians(fc_wb)
             elev_f, azim_f = self._sun_position(lat, lon, now + timedelta(minutes=h))
-            row[f"cloud_cover_{h}m"] = fc.get("cloud_cover", cloud_cover)
-            row[f"outside_temp_{h}m"] = fc.get("temperature", outside_temp)
-            row[f"outside_humidity_{h}m"] = fc.get("humidity", outside_humidity)
-            row[f"precipitation_{h}m"] = fc.get("precipitation", precipitation)
-            row[f"wind_speed_{h}m"] = fc.get("wind_speed", wind_speed)
-            row[f"wind_bearing_sin_{h}m"] = math.sin(fc_wb_rad)
-            row[f"wind_bearing_cos_{h}m"] = math.cos(fc_wb_rad)
+            # cloud forecast is unavailable from every provider — carry the
+            # current value forward until a numeric cloud source lands (#866).
+            row[f"cloud_cover_{h}m"] = safe_float(fc.get("cloud_cover"), cloud_cover)
+            row[f"outside_temp_{h}m"] = safe_float(fc.get("temperature"), outside_temp)
+            row[f"outside_humidity_{h}m"] = safe_float(fc.get("humidity"), outside_humidity)
             row[f"sun_elevation_{h}m"] = elev_f
             row[f"sun_azimuth_sin_{h}m"] = math.sin(math.radians(azim_f))
             row[f"sun_azimuth_cos_{h}m"] = math.cos(math.radians(azim_f))
@@ -543,11 +595,7 @@ class RoomTempPredictor(hass.Hass):
     # ------------------------------------------------------------------
 
     def _update_predictions(self, kwargs):
-        try:
-            lat = float(self.AD.config.latitude)
-            lon = float(self.AD.config.longitude)
-        except Exception:
-            lat, lon = 0.0, 0.0
+        lat, lon = self._latlon()
 
         forecasts = self._get_weather_forecasts()
 

--- a/appdaemon/apps/room_temp_predictor.py
+++ b/appdaemon/apps/room_temp_predictor.py
@@ -34,15 +34,15 @@ FORECAST_ENTITIES = [
 DEFAULT_ROOMS = [
     {"name": "owner_suite",
      "temp_sensors": ["sensor.owner_suite_tph_temperature", "sensor.bedroom_temperature"],
-     "humidity_sensor": "sensor.owner_suite_tph_humidity",
+     "humidity_sensors": ["sensor.owner_suite_tph_humidity"],
      "confidence_sensor": "sensor.bedroom_room_confidence"},
     {"name": "office",
      "temp_sensors": ["sensor.office_tph_temperature", "sensor.office_temperature"],
-     "humidity_sensor": "sensor.office_tph_humidity",
+     "humidity_sensors": ["sensor.office_tph_humidity"],
      "confidence_sensor": "sensor.office_room_confidence"},
     {"name": "guest_room",
      "temp_sensors": ["sensor.guest_room_tph_temperature", "sensor.guest_room_temperature"],
-     "humidity_sensor": "sensor.guest_room_tph_humidity",
+     "humidity_sensors": ["sensor.guest_room_tph_humidity"],
      "confidence_sensor": None},
 ]
 
@@ -56,10 +56,13 @@ class RoomTempPredictor(hass.Hass):
             sensors = entry.get("temp_sensors")
             if not sensors:
                 sensors = [s for s in [entry.get("temp_sensor"), entry.get("temp_fallback")] if s]
+            hum = entry.get("humidity_sensors")
+            if not hum:
+                hum = [s for s in [entry.get("humidity_sensor")] if s]
             self.rooms.append({
                 "name": entry["name"],
                 "temp_sensors": sensors,
-                "humidity_sensor": entry.get("humidity_sensor"),
+                "humidity_sensors": hum,
                 "confidence_sensor": entry.get("confidence_sensor"),
             })
 
@@ -185,7 +188,7 @@ class RoomTempPredictor(hass.Hass):
             conf = cfg["confidence_sensor"]
             rooms[cfg["name"]] = {
                 "room_temp": temp,
-                "room_humidity": self._safe_float(self.get_state(cfg["humidity_sensor"])) if cfg["humidity_sensor"] else None,
+                "room_humidity": self._avg(cfg["humidity_sensors"]) if cfg["humidity_sensors"] else None,
                 "outside_temp": outside_temp,
                 "outside_humidity": outside_humidity,
                 "cloud_cover": cloud_cover,

--- a/appdaemon/apps/thermal_preemptor.py
+++ b/appdaemon/apps/thermal_preemptor.py
@@ -1,69 +1,59 @@
 """Deterministic MPC-lite thermostat preemptor.
 
-Reads T+60 predictions from room_temp_predictor, and if any room is predicted
-to overshoot the cooling setpoint by more than the configured margin, it
-preemptively lowers the Ecobee cooling setpoint. A timer reverts the hold
-after the estimated HVAC lead time elapses.
+Reads T+60 room-temperature predictions from room_temp_predictor and, if any
+monitored room is predicted to breach the Ecobee's active comfort setpoint by
+more than the configured margin, preemptively nudges the setpoint so the HVAC
+starts working ahead of the drift. A timer reverts to the Ecobee's own comfort
+schedule (via ecobee.resume_program) after the estimated HVAC lead time.
 
-All rooms share one Ecobee, so the worst-case gap across all monitored rooms
-drives a single set_temperature call.
+The controller is mode-aware and works with the Ecobee's native comfort
+settings rather than hard-coded temperatures:
+
+  * cool       -> single `temperature` target; precool when rooms overshoot
+  * heat       -> single `temperature` target; preheat when rooms undershoot
+  * heat_cool  -> range; adjust `target_temp_high` (cool) or `target_temp_low`
+                  (heat), whichever bound is predicted to be breached
+  * off        -> do nothing
+
+Preemption is skipped entirely while a window is open (configurable gate), so
+the system never fights fresh air. All rooms share one Ecobee, so the
+worst-case room drives a single set_temperature call.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import hassapi as hass
 
 MONITORED_ROOMS = ["owner_suite", "office", "guest_room"]
-MAX_SETPOINT_DROP_F = 3.0
+MAX_SETPOINT_SHIFT_F = 3.0  # never move the setpoint more than this from schedule
 
 
 class ThermalPreemptor(hass.Hass):
     def initialize(self):
-        self.active_hold = None  # {'revert_handle': ..., 'started': datetime, 'reason': str}
+        self.active_hold = None  # {'revert_handle', 'started', 'reason', ...}
 
-        start = datetime.now(timezone.utc)
-        import datetime as _dt
-        start = start + _dt.timedelta(seconds=60)
+        self.climate_entity = self.args.get("climate_entity", "climate.my_ecobee")
+        self.enable_switch = self.args.get(
+            "enable_switch", "input_boolean.thermal_preemptor_enabled"
+        )
+        self.margin_number = self.args.get(
+            "comfort_margin", "input_number.thermal_preemptor_comfort_margin"
+        )
+        # Open-window gate — preemption is skipped while this is `on`.
+        self.window_gate = self.args.get("window_gate", "binary_sensor.any_window_open")
+        self.rate_sensor = self.args.get(
+            "rate_sensor", "sensor.ecobee_modeled_rate_deg_per_min"
+        )
+        self.outside_temp_sensor = self.args.get(
+            "outside_temp_sensor", "sensor.canonical_outside_temperature"
+        )
+
+        start = datetime.now(timezone.utc) + timedelta(seconds=60)
         self.run_every(self._control_loop, start, 300)
 
     # ------------------------------------------------------------------
-    # HVAC rate
+    # Small helpers
     # ------------------------------------------------------------------
-
-    def _hvac_rate_estimate(self):
-        """Return |°F/min| cooling rate. Falls back to parametric formula when idle."""
-        rate_state = self.get_state("sensor.ecobee_modeled_rate_deg_per_min")
-        if rate_state not in (None, "unknown", "unavailable", ""):
-            try:
-                return abs(float(rate_state))
-            except (TypeError, ValueError):
-                pass
-        # Parametric fallback replicating climate.yaml formula for cooling
-        t_out_str = self.get_state("sensor.outside_temperature")
-        try:
-            t_out = float(t_out_str)
-        except (TypeError, ValueError):
-            t_out = 75.0
-        return max(0.008, min(0.016, 0.028 - 0.00023 * t_out))
-
-    # ------------------------------------------------------------------
-    # Setpoint helpers
-    # ------------------------------------------------------------------
-
-    def _get_cooling_setpoint(self):
-        t_high = self.get_state("climate.my_ecobee", attribute="target_temp_high")
-        if t_high not in (None, "unknown", "unavailable"):
-            try:
-                return float(t_high)
-            except (TypeError, ValueError):
-                pass
-        t_single = self.get_state("climate.my_ecobee", attribute="temperature")
-        if t_single not in (None, "unknown", "unavailable"):
-            try:
-                return float(t_single)
-            except (TypeError, ValueError):
-                pass
-        return 74.0
 
     @staticmethod
     def _safe_attr_float(value):
@@ -74,70 +64,129 @@ class ThermalPreemptor(hass.Hass):
         except (TypeError, ValueError):
             return None
 
-    # ------------------------------------------------------------------
-    # Control loop
-    # ------------------------------------------------------------------
+    def _attr(self, name):
+        return self._safe_attr_float(self.get_state(self.climate_entity, attribute=name))
 
-    def _control_loop(self, kwargs):
-        if self.get_state("input_boolean.thermal_preemptor_enabled") != "on":
-            return
+    def _margin(self):
+        m = self._safe_attr_float(self.get_state(self.margin_number))
+        return m if m is not None else 0.5
 
-        margin_str = self.get_state("input_number.thermal_preemptor_comfort_margin")
-        try:
-            margin = float(margin_str)
-        except (TypeError, ValueError):
-            margin = 0.5
+    def _hvac_rate_estimate(self):
+        """Return |°F/min| HVAC rate. Falls back to a parametric formula."""
+        rate_state = self._safe_attr_float(self.get_state(self.rate_sensor))
+        if rate_state is not None:
+            return abs(rate_state)
+        # Parametric fallback replicating the climate.yaml cooling formula.
+        t_out = self._safe_attr_float(self.get_state(self.outside_temp_sensor))
+        if t_out is None:
+            t_out = 75.0
+        return max(0.008, min(0.016, 0.028 - 0.00023 * t_out))
 
-        rate = self._hvac_rate_estimate()
-        setpoint = self._get_cooling_setpoint()
+    def _worst_breach(self, setpoint, cooling):
+        """Largest predicted breach of `setpoint` across monitored rooms.
 
-        # Find worst-case predicted overshoot across all rooms
+        cooling=True  -> breach is t60 above setpoint (overshoot).
+        cooling=False -> breach is t60 below setpoint (undershoot).
+        Returns (gap_degrees, room) with gap >= 0.
+        """
         worst_gap = 0.0
         worst_room = None
-
         for room in MONITORED_ROOMS:
             t60 = self._safe_attr_float(
                 self.get_state(f"sensor.room_temp_prediction_{room}", attribute="t60")
             )
             if t60 is None:
                 continue
-            gap = t60 - setpoint
+            gap = (t60 - setpoint) if cooling else (setpoint - t60)
             if gap > worst_gap:
                 worst_gap = gap
                 worst_room = room
+        return worst_gap, worst_room
 
-        if worst_gap < margin or worst_room is None:
+    # ------------------------------------------------------------------
+    # Control loop
+    # ------------------------------------------------------------------
+
+    def _control_loop(self, kwargs):
+        if self.get_state(self.enable_switch) != "on":
             return
-
         if self.active_hold is not None:
-            # Already preempting — don't stack another hold
+            # Already preempting — let the revert timer clear it.
+            return
+        if self.get_state(self.window_gate) == "on":
             return
 
-        # How many minutes does HVAC need to cool by worst_gap °F?
-        lead_min = int(worst_gap / rate) + 5  # 5-min buffer
+        mode = self.get_state(self.climate_entity)
+        if mode in (None, "off", "unavailable", "unknown"):
+            return
 
-        new_setpoint = setpoint - worst_gap
-        # Cap: never drop more than MAX_SETPOINT_DROP_F below scheduled
-        new_setpoint = max(new_setpoint, setpoint - MAX_SETPOINT_DROP_F)
+        margin = self._margin()
 
-        self.call_service(
-            "climate/set_temperature",
-            entity_id="climate.my_ecobee",
-            target_temp_high=round(new_setpoint, 1),
-        )
+        # Resolve which bound(s) to defend based on the active mode, and pick
+        # the single most-breached candidate (all rooms share one Ecobee).
+        candidates = []  # (gap, room, cooling, setpoint, temp_field)
+        if mode == "cool":
+            sp = self._attr("temperature")
+            if sp is not None:
+                gap, room = self._worst_breach(sp, cooling=True)
+                candidates.append((gap, room, True, sp, "temperature"))
+        elif mode == "heat":
+            sp = self._attr("temperature")
+            if sp is not None:
+                gap, room = self._worst_breach(sp, cooling=False)
+                candidates.append((gap, room, False, sp, "temperature"))
+        elif mode == "heat_cool":
+            cool_sp = self._attr("target_temp_high")
+            heat_sp = self._attr("target_temp_low")
+            if cool_sp is not None:
+                gap, room = self._worst_breach(cool_sp, cooling=True)
+                candidates.append((gap, room, True, cool_sp, "target_temp_high"))
+            if heat_sp is not None:
+                gap, room = self._worst_breach(heat_sp, cooling=False)
+                candidates.append((gap, room, False, heat_sp, "target_temp_low"))
 
-        handle = self.run_in(self._revert, lead_min * 60, room=worst_room)
+        candidates = [c for c in candidates if c[1] is not None]
+        if not candidates:
+            return
+        gap, room, cooling, setpoint, temp_field = max(candidates, key=lambda c: c[0])
+        if gap < margin:
+            return
+
+        rate = self._hvac_rate_estimate()
+        lead_min = int(gap / rate) + 5 if rate > 0 else 15  # +5min buffer
+
+        # Nudge toward the breach, capped at MAX_SETPOINT_SHIFT_F from schedule.
+        shift = min(gap, MAX_SETPOINT_SHIFT_F)
+        new_setpoint = round(setpoint - shift if cooling else setpoint + shift, 1)
+
+        data = {"entity_id": self.climate_entity}
+        if temp_field == "temperature":
+            data["temperature"] = new_setpoint
+        else:
+            # heat_cool range mode requires BOTH bounds on every call; move the
+            # breached bound and keep the other at its scheduled value.
+            cool_sp = self._attr("target_temp_high")
+            heat_sp = self._attr("target_temp_low")
+            data["target_temp_high"] = new_setpoint if temp_field == "target_temp_high" else cool_sp
+            data["target_temp_low"] = new_setpoint if temp_field == "target_temp_low" else heat_sp
+
+        self.call_service("climate/set_temperature", **data)
+
+        handle = self.run_in(self._revert, lead_min * 60, room=room)
         self.active_hold = {
             "revert_handle": handle,
             "started": datetime.now(timezone.utc).isoformat(),
-            "reason": worst_room,
-            "gap": round(worst_gap, 2),
+            "reason": room,
+            "mode": mode,
+            "direction": "cool" if cooling else "heat",
+            "gap": round(gap, 2),
             "lead_min": lead_min,
-            "new_setpoint": round(new_setpoint, 1),
+            "new_setpoint": new_setpoint,
         }
         self.log(
-            f"Preempting for {worst_room}: predicted +{worst_gap:.1f}°F overshoot; "
-            f"set T_high={new_setpoint:.1f}°F, revert in {lead_min}min"
+            f"Preempting {'cool' if cooling else 'heat'} for {room} ({mode}): "
+            f"predicted {gap:.1f}°F breach; set {temp_field}={new_setpoint}°F, "
+            f"revert in {lead_min}min"
         )
 
     # ------------------------------------------------------------------
@@ -148,8 +197,8 @@ class ThermalPreemptor(hass.Hass):
         room = kwargs.get("room", "unknown")
         self.call_service(
             "ecobee/resume_program",
-            entity_id="climate.my_ecobee",
+            entity_id=self.climate_entity,
             resume_all=True,
         )
         self.active_hold = None
-        self.log(f"Reverted preempt hold (triggered by {room} prediction)")
+        self.log(f"Reverted preempt hold to comfort schedule (was driven by {room})")

--- a/appdaemon/apps/thermal_preemptor.py
+++ b/appdaemon/apps/thermal_preemptor.py
@@ -1,0 +1,155 @@
+"""Deterministic MPC-lite thermostat preemptor.
+
+Reads T+60 predictions from room_temp_predictor, and if any room is predicted
+to overshoot the cooling setpoint by more than the configured margin, it
+preemptively lowers the Ecobee cooling setpoint. A timer reverts the hold
+after the estimated HVAC lead time elapses.
+
+All rooms share one Ecobee, so the worst-case gap across all monitored rooms
+drives a single set_temperature call.
+"""
+
+from datetime import datetime, timezone
+
+import hassapi as hass
+
+MONITORED_ROOMS = ["owner_suite", "office", "guest_room"]
+MAX_SETPOINT_DROP_F = 3.0
+
+
+class ThermalPreemptor(hass.Hass):
+    def initialize(self):
+        self.active_hold = None  # {'revert_handle': ..., 'started': datetime, 'reason': str}
+
+        start = datetime.now(timezone.utc)
+        import datetime as _dt
+        start = start + _dt.timedelta(seconds=60)
+        self.run_every(self._control_loop, start, 300)
+
+    # ------------------------------------------------------------------
+    # HVAC rate
+    # ------------------------------------------------------------------
+
+    def _hvac_rate_estimate(self):
+        """Return |°F/min| cooling rate. Falls back to parametric formula when idle."""
+        rate_state = self.get_state("sensor.ecobee_modeled_rate_deg_per_min")
+        if rate_state not in (None, "unknown", "unavailable", ""):
+            try:
+                return abs(float(rate_state))
+            except (TypeError, ValueError):
+                pass
+        # Parametric fallback replicating climate.yaml formula for cooling
+        t_out_str = self.get_state("sensor.outside_temperature")
+        try:
+            t_out = float(t_out_str)
+        except (TypeError, ValueError):
+            t_out = 75.0
+        return max(0.008, min(0.016, 0.028 - 0.00023 * t_out))
+
+    # ------------------------------------------------------------------
+    # Setpoint helpers
+    # ------------------------------------------------------------------
+
+    def _get_cooling_setpoint(self):
+        t_high = self.get_state("climate.my_ecobee", attribute="target_temp_high")
+        if t_high not in (None, "unknown", "unavailable"):
+            try:
+                return float(t_high)
+            except (TypeError, ValueError):
+                pass
+        t_single = self.get_state("climate.my_ecobee", attribute="temperature")
+        if t_single not in (None, "unknown", "unavailable"):
+            try:
+                return float(t_single)
+            except (TypeError, ValueError):
+                pass
+        return 74.0
+
+    @staticmethod
+    def _safe_attr_float(value):
+        if value in (None, "unknown", "unavailable", ""):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    # ------------------------------------------------------------------
+    # Control loop
+    # ------------------------------------------------------------------
+
+    def _control_loop(self, kwargs):
+        if self.get_state("input_boolean.thermal_preemptor_enabled") != "on":
+            return
+
+        margin_str = self.get_state("input_number.thermal_preemptor_comfort_margin")
+        try:
+            margin = float(margin_str)
+        except (TypeError, ValueError):
+            margin = 0.5
+
+        rate = self._hvac_rate_estimate()
+        setpoint = self._get_cooling_setpoint()
+
+        # Find worst-case predicted overshoot across all rooms
+        worst_gap = 0.0
+        worst_room = None
+
+        for room in MONITORED_ROOMS:
+            t60 = self._safe_attr_float(
+                self.get_state(f"sensor.room_temp_prediction_{room}", attribute="t60")
+            )
+            if t60 is None:
+                continue
+            gap = t60 - setpoint
+            if gap > worst_gap:
+                worst_gap = gap
+                worst_room = room
+
+        if worst_gap < margin or worst_room is None:
+            return
+
+        if self.active_hold is not None:
+            # Already preempting — don't stack another hold
+            return
+
+        # How many minutes does HVAC need to cool by worst_gap °F?
+        lead_min = int(worst_gap / rate) + 5  # 5-min buffer
+
+        new_setpoint = setpoint - worst_gap
+        # Cap: never drop more than MAX_SETPOINT_DROP_F below scheduled
+        new_setpoint = max(new_setpoint, setpoint - MAX_SETPOINT_DROP_F)
+
+        self.call_service(
+            "climate/set_temperature",
+            entity_id="climate.my_ecobee",
+            target_temp_high=round(new_setpoint, 1),
+        )
+
+        handle = self.run_in(self._revert, lead_min * 60, room=worst_room)
+        self.active_hold = {
+            "revert_handle": handle,
+            "started": datetime.now(timezone.utc).isoformat(),
+            "reason": worst_room,
+            "gap": round(worst_gap, 2),
+            "lead_min": lead_min,
+            "new_setpoint": round(new_setpoint, 1),
+        }
+        self.log(
+            f"Preempting for {worst_room}: predicted +{worst_gap:.1f}°F overshoot; "
+            f"set T_high={new_setpoint:.1f}°F, revert in {lead_min}min"
+        )
+
+    # ------------------------------------------------------------------
+    # Revert
+    # ------------------------------------------------------------------
+
+    def _revert(self, kwargs):
+        room = kwargs.get("room", "unknown")
+        self.call_service(
+            "ecobee/resume_program",
+            entity_id="climate.my_ecobee",
+            resume_all=True,
+        )
+        self.active_hold = None
+        self.log(f"Reverted preempt hold (triggered by {room} prediction)")

--- a/appdaemon/apps/thermostat_stats.py
+++ b/appdaemon/apps/thermostat_stats.py
@@ -45,6 +45,11 @@ class ThermostatChanges(Base):
     house_average_humidity = Column(Float)
     house_average_temp = Column(Float)
 
+    owner_suite_temp = Column(Float)
+    office_temp = Column(Float)
+    bedroom_room_confidence = Column(Float)
+    office_room_confidence = Column(Float)
+
     outside_temp = Column(Float)
     outside_temp_feels_like = Column(Float)
     outside_humidity = Column(Float)
@@ -146,6 +151,10 @@ class ThermostatStats(hass.Hass):
         self.wind_bearing_sensor = self.args.get("wind_bearing") or self.args.get("wind_bearing_sensor")
         self.humidifier_sensor = self.args.get("humidifier") or self.args.get("humidifier_sensor")
         self.humidifier_target_sensor = self.args.get("humidifier_target") or self.args.get("humidifier_target_sensor")
+        self.owner_suite_temp_sensor = self.args.get("owner_suite_temp")
+        self.office_temp_sensor = self.args.get("office_temp")
+        self.bedroom_room_confidence_sensor = self.args.get("bedroom_room_confidence")
+        self.office_room_confidence_sensor = self.args.get("office_room_confidence")
 
         self.listen_state(self.state_changed, self.thermostat, attribute="all")
         self.listen_state(self.state_changed, self.house_average_temp_sensor, attribute="all")
@@ -157,6 +166,10 @@ class ThermostatStats(hass.Hass):
             self.wind_bearing_sensor,
             self.humidifier_sensor,
             self.humidifier_target_sensor,
+            self.owner_suite_temp_sensor,
+            self.office_temp_sensor,
+            self.bedroom_room_confidence_sensor,
+            self.office_room_confidence_sensor,
         ]
         for entity_id in optional_entities:
             if entity_id:
@@ -213,6 +226,10 @@ class ThermostatStats(hass.Hass):
             "ALTER TABLE thermostat ADD COLUMN IF NOT EXISTS context_user_id VARCHAR",
             "ALTER TABLE thermostat ADD COLUMN IF NOT EXISTS context_parent_id VARCHAR",
             "ALTER TABLE thermostat ADD COLUMN IF NOT EXISTS thermostat_attrs_json TEXT",
+            "ALTER TABLE thermostat ADD COLUMN IF NOT EXISTS owner_suite_temp DOUBLE PRECISION",
+            "ALTER TABLE thermostat ADD COLUMN IF NOT EXISTS office_temp DOUBLE PRECISION",
+            "ALTER TABLE thermostat ADD COLUMN IF NOT EXISTS bedroom_room_confidence DOUBLE PRECISION",
+            "ALTER TABLE thermostat ADD COLUMN IF NOT EXISTS office_room_confidence DOUBLE PRECISION",
         ]
         with engine.begin() as conn:
             for statement in ddl:
@@ -373,6 +390,11 @@ class ThermostatStats(hass.Hass):
         )
         outside_humidity = self._safe_sensor_float(self.outside_humidity_sensor)
 
+        owner_suite_temp = self._safe_sensor_float(self.owner_suite_temp_sensor)
+        office_temp = self._safe_sensor_float(self.office_temp_sensor)
+        bedroom_room_confidence = self._safe_sensor_float(self.bedroom_room_confidence_sensor)
+        office_room_confidence = self._safe_sensor_float(self.office_room_confidence_sensor)
+
         sun_azimuth = self._safe_float(self.get_state(self.sun, attribute="azimuth"))
         sun_elevation = self._safe_float(self.get_state(self.sun, attribute="elevation"))
         sun_state = self.get_state(self.sun)
@@ -415,6 +437,10 @@ class ThermostatStats(hass.Hass):
             humidifier_attrs_json=humidifier_attrs_json,
             house_average_humidity=avg_house_humidity,
             house_average_temp=avg_house_temp,
+            owner_suite_temp=owner_suite_temp,
+            office_temp=office_temp,
+            bedroom_room_confidence=bedroom_room_confidence,
+            office_room_confidence=office_room_confidence,
             outside_temp=outside_temp,
             outside_temp_feels_like=outside_temp_feels_like,
             outside_humidity=outside_humidity,

--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -768,6 +768,11 @@ input_boolean:
     icon: mdi:thermometer-auto
     initial: on
 
+  prediction_scorer_nudge_enabled:
+    name: Room Temp Retrain Nudge Enabled
+    icon: mdi:bell-alert
+    initial: on
+
   window_climate_paused_by_windows:
     name: Climate paused by windows
     icon: mdi:air-conditioner
@@ -813,6 +818,16 @@ input_number:
     max: 3.0
     step: 0.25
     initial: 0.5
+    mode: box
+
+  prediction_retrain_rmse_ratio:
+    name: Retrain Nudge RMSE Ratio
+    icon: mdi:chart-bell-curve
+    # Nudge to retrain when live RMSE exceeds training CV RMSE by this factor.
+    min: 1.0
+    max: 5.0
+    step: 0.25
+    initial: 2.0
     mode: box
 
   air_filters_at_home:

--- a/packages/climate.yaml
+++ b/packages/climate.yaml
@@ -763,6 +763,11 @@ group:
 # Input Booleans
 ########################
 input_boolean:
+  thermal_preemptor_enabled:
+    name: Thermal Preemptor Enabled
+    icon: mdi:thermometer-auto
+    initial: on
+
   window_climate_paused_by_windows:
     name: Climate paused by windows
     icon: mdi:air-conditioner
@@ -792,7 +797,24 @@ input_text:
 ########################
 # Input Numbers
 ########################
+input_button:
+  retrain_room_temp_models:
+    name: Retrain Room Temp Prediction Models
+    icon: mdi:brain
+
+########################
+# Input Numbers
+########################
 input_number:
+  thermal_preemptor_comfort_margin:
+    name: Thermal Preemptor Comfort Margin (°F)
+    icon: mdi:thermometer-chevron-up
+    min: 0.25
+    max: 3.0
+    step: 0.25
+    initial: 0.5
+    mode: box
+
   air_filters_at_home:
     name: Air Filter Inventory at Home
     icon: mdi:shaker-outline
@@ -999,6 +1021,21 @@ sensor:
 ################################################
 template:
   - sensor:
+      - name: thermal_preemptor_status
+        unique_id: thermal_preemptor_status
+        state: >-
+          {% if is_state('input_boolean.thermal_preemptor_enabled', 'off') %}
+            disabled
+          {% elif states('sensor.room_temp_prediction_owner_suite') in ['unknown','unavailable'] %}
+            no_data
+          {% else %}
+            active
+          {% endif %}
+
+      - name: room_temp_model_trained_at
+        unique_id: room_temp_model_trained_at
+        state: "{{ state_attr('sensor.room_temp_prediction_owner_suite', 'trained_at') | default('never') }}"
+
       - name: bathroom_humidity_delta
         unique_id: bathroom_humidity_delta
         default_entity_id: sensor.bathroom_humidity_delta

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -3509,6 +3509,65 @@ template:
       unit_of_measurement: "°F"
       state: "{{ state_attr('sensor.active_weather_entity_id', 'temperature') | int(default=0) }}"
 
+    # ------------------------------------------------------------------
+    # Canonical two-source outdoor readings.
+    # Average every source that currently reports a numeric value; if only
+    # one is available use it; if none are available the sensor becomes
+    # `unavailable` (never a junk 0). Consumed by the predictive room-temp
+    # control (room_temp_predictor / thermal_preemptor) at inference time.
+    #   temperature: Open-Meteo + NWS
+    #   humidity:    NWS + ecobee   (Open-Meteo exposes no humidity)
+    #   wind_speed:  Open-Meteo + NWS
+    # Cloud cover intentionally omitted — no reliable second source; see #866.
+    # ------------------------------------------------------------------
+    - name: canonical_outside_temperature
+      unique_id: canonical_outside_temperature
+      device_class: temperature
+      unit_of_measurement: "°F"
+      availability: >-
+        {{ ['weather.the_brewery', 'weather.kmsp']
+           | map('state_attr', 'temperature') | select('is_number') | list | count > 0 }}
+      state: >-
+        {% set vals = ['weather.the_brewery', 'weather.kmsp']
+           | map('state_attr', 'temperature') | select('is_number') | map('float') | list %}
+        {{ (vals | sum / vals | count) | round(2) }}
+      attributes:
+        source_count: >-
+          {{ ['weather.the_brewery', 'weather.kmsp']
+             | map('state_attr', 'temperature') | select('is_number') | list | count }}
+
+    - name: canonical_outside_humidity
+      unique_id: canonical_outside_humidity
+      device_class: humidity
+      unit_of_measurement: "%"
+      availability: >-
+        {{ ['weather.kmsp', 'weather.my_ecobee']
+           | map('state_attr', 'humidity') | select('is_number') | list | count > 0 }}
+      state: >-
+        {% set vals = ['weather.kmsp', 'weather.my_ecobee']
+           | map('state_attr', 'humidity') | select('is_number') | map('float') | list %}
+        {{ (vals | sum / vals | count) | round(2) }}
+      attributes:
+        source_count: >-
+          {{ ['weather.kmsp', 'weather.my_ecobee']
+             | map('state_attr', 'humidity') | select('is_number') | list | count }}
+
+    - name: canonical_wind_speed
+      unique_id: canonical_wind_speed
+      device_class: wind_speed
+      unit_of_measurement: "mph"
+      availability: >-
+        {{ ['weather.the_brewery', 'weather.kmsp']
+           | map('state_attr', 'wind_speed') | select('is_number') | list | count > 0 }}
+      state: >-
+        {% set vals = ['weather.the_brewery', 'weather.kmsp']
+           | map('state_attr', 'wind_speed') | select('is_number') | map('float') | list %}
+        {{ (vals | sum / vals | count) | round(2) }}
+      attributes:
+        source_count: >-
+          {{ ['weather.the_brewery', 'weather.kmsp']
+             | map('state_attr', 'wind_speed') | select('is_number') | list | count }}
+
     - name: precip_next_15m
       unique_id: precip_next_15m
       unit_of_measurement: "%"

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -3510,63 +3510,115 @@ template:
       state: "{{ state_attr('sensor.active_weather_entity_id', 'temperature') | int(default=0) }}"
 
     # ------------------------------------------------------------------
-    # Canonical two-source outdoor readings.
+    # Canonical multi-source outdoor readings.
     # Average every source that currently reports a numeric value; if only
     # one is available use it; if none are available the sensor becomes
     # `unavailable` (never a junk 0). Consumed by the predictive room-temp
-    # control (room_temp_predictor / thermal_preemptor) at inference time.
-    #   temperature: Open-Meteo + NWS
-    #   humidity:    NWS + ecobee   (Open-Meteo exposes no humidity)
-    #   wind_speed:  Open-Meteo + NWS
-    # Cloud cover intentionally omitted — no reliable second source; see #866.
+    # control (room_temp_predictor / thermal_preemptor).
+    #
+    # Sources blend the local Ambient Weather PWS ("PineHOTTIES", on-site
+    # ground truth) with Open-Meteo, NWS, ecobee and OpenWeatherMap:
+    #   temperature: PWS + Open-Meteo + NWS + OpenWeatherMap
+    #   humidity:    PWS + NWS + ecobee + OpenWeatherMap
+    #   wind_speed:  PWS + Open-Meteo + NWS + OpenWeatherMap
+    #   cloud_cover: OpenWeatherMap + Tomorrow.io   (resolves #866)
+    #   uv_index:    PWS + OpenWeatherMap           (local solar-intensity proxy)
+    #   precipitation: PWS hourly rain + OpenWeatherMap rain intensity
+    # PWS states() are mixed with weather-entity state_attr() values; the
+    # `is_number` test keeps whichever are currently numeric.
     # ------------------------------------------------------------------
     - name: canonical_outside_temperature
       unique_id: canonical_outside_temperature
       device_class: temperature
       unit_of_measurement: "°F"
       availability: >-
-        {{ ['weather.the_brewery', 'weather.kmsp']
-           | map('state_attr', 'temperature') | select('is_number') | list | count > 0 }}
+        {{ [states('sensor.pinehotties_temperature'),
+            state_attr('weather.the_brewery', 'temperature'),
+            state_attr('weather.kmsp', 'temperature'),
+            state_attr('weather.openweathermap', 'temperature')]
+           | select('is_number') | list | count > 0 }}
       state: >-
-        {% set vals = ['weather.the_brewery', 'weather.kmsp']
-           | map('state_attr', 'temperature') | select('is_number') | map('float') | list %}
+        {% set vals = [states('sensor.pinehotties_temperature'),
+            state_attr('weather.the_brewery', 'temperature'),
+            state_attr('weather.kmsp', 'temperature'),
+            state_attr('weather.openweathermap', 'temperature')]
+           | select('is_number') | map('float') | list %}
         {{ (vals | sum / vals | count) | round(2) }}
-      attributes:
-        source_count: >-
-          {{ ['weather.the_brewery', 'weather.kmsp']
-             | map('state_attr', 'temperature') | select('is_number') | list | count }}
 
     - name: canonical_outside_humidity
       unique_id: canonical_outside_humidity
       device_class: humidity
       unit_of_measurement: "%"
       availability: >-
-        {{ ['weather.kmsp', 'weather.my_ecobee']
-           | map('state_attr', 'humidity') | select('is_number') | list | count > 0 }}
+        {{ [states('sensor.pinehotties_humidity'),
+            state_attr('weather.kmsp', 'humidity'),
+            state_attr('weather.my_ecobee', 'humidity'),
+            state_attr('weather.openweathermap', 'humidity')]
+           | select('is_number') | list | count > 0 }}
       state: >-
-        {% set vals = ['weather.kmsp', 'weather.my_ecobee']
-           | map('state_attr', 'humidity') | select('is_number') | map('float') | list %}
+        {% set vals = [states('sensor.pinehotties_humidity'),
+            state_attr('weather.kmsp', 'humidity'),
+            state_attr('weather.my_ecobee', 'humidity'),
+            state_attr('weather.openweathermap', 'humidity')]
+           | select('is_number') | map('float') | list %}
         {{ (vals | sum / vals | count) | round(2) }}
-      attributes:
-        source_count: >-
-          {{ ['weather.kmsp', 'weather.my_ecobee']
-             | map('state_attr', 'humidity') | select('is_number') | list | count }}
 
     - name: canonical_wind_speed
       unique_id: canonical_wind_speed
       device_class: wind_speed
       unit_of_measurement: "mph"
       availability: >-
-        {{ ['weather.the_brewery', 'weather.kmsp']
-           | map('state_attr', 'wind_speed') | select('is_number') | list | count > 0 }}
+        {{ [states('sensor.pinehotties_wind_speed'),
+            state_attr('weather.the_brewery', 'wind_speed'),
+            state_attr('weather.kmsp', 'wind_speed'),
+            state_attr('weather.openweathermap', 'wind_speed')]
+           | select('is_number') | list | count > 0 }}
       state: >-
-        {% set vals = ['weather.the_brewery', 'weather.kmsp']
-           | map('state_attr', 'wind_speed') | select('is_number') | map('float') | list %}
+        {% set vals = [states('sensor.pinehotties_wind_speed'),
+            state_attr('weather.the_brewery', 'wind_speed'),
+            state_attr('weather.kmsp', 'wind_speed'),
+            state_attr('weather.openweathermap', 'wind_speed')]
+           | select('is_number') | map('float') | list %}
         {{ (vals | sum / vals | count) | round(2) }}
-      attributes:
-        source_count: >-
-          {{ ['weather.the_brewery', 'weather.kmsp']
-             | map('state_attr', 'wind_speed') | select('is_number') | list | count }}
+
+    - name: canonical_cloud_cover
+      unique_id: canonical_cloud_cover
+      unit_of_measurement: "%"
+      availability: >-
+        {{ [state_attr('weather.openweathermap', 'cloud_coverage'),
+            states('sensor.tomorrow_io_the_brewery_cloud_cover')]
+           | select('is_number') | list | count > 0 }}
+      state: >-
+        {% set vals = [state_attr('weather.openweathermap', 'cloud_coverage'),
+            states('sensor.tomorrow_io_the_brewery_cloud_cover')]
+           | select('is_number') | map('float') | list %}
+        {{ (vals | sum / vals | count) | round(2) }}
+
+    - name: canonical_uv_index
+      unique_id: canonical_uv_index
+      availability: >-
+        {{ [states('sensor.pinehotties_uv_index'),
+            states('sensor.openweathermap_uv_index')]
+           | select('is_number') | list | count > 0 }}
+      state: >-
+        {% set vals = [states('sensor.pinehotties_uv_index'),
+            states('sensor.openweathermap_uv_index')]
+           | select('is_number') | map('float') | list %}
+        {{ (vals | sum / vals | count) | round(2) }}
+
+    - name: canonical_precipitation
+      unique_id: canonical_precipitation
+      device_class: precipitation_intensity
+      unit_of_measurement: "in/h"
+      availability: >-
+        {{ [states('sensor.pinehotties_hourly_rain'),
+            states('sensor.openweathermap_rain_intensity')]
+           | select('is_number') | list | count > 0 }}
+      state: >-
+        {% set vals = [states('sensor.pinehotties_hourly_rain'),
+            states('sensor.openweathermap_rain_intensity')]
+           | select('is_number') | map('float') | list %}
+        {{ (vals | sum / vals | count) | round(3) }}
 
     - name: precip_next_15m
       unique_id: precip_next_15m

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -3530,6 +3530,7 @@ template:
     - name: canonical_outside_temperature
       unique_id: canonical_outside_temperature
       device_class: temperature
+      state_class: measurement
       unit_of_measurement: "°F"
       availability: >-
         {{ [states('sensor.pinehotties_temperature'),
@@ -3548,6 +3549,7 @@ template:
     - name: canonical_outside_humidity
       unique_id: canonical_outside_humidity
       device_class: humidity
+      state_class: measurement
       unit_of_measurement: "%"
       availability: >-
         {{ [states('sensor.pinehotties_humidity'),
@@ -3566,6 +3568,7 @@ template:
     - name: canonical_wind_speed
       unique_id: canonical_wind_speed
       device_class: wind_speed
+      state_class: measurement
       unit_of_measurement: "mph"
       availability: >-
         {{ [states('sensor.pinehotties_wind_speed'),
@@ -3583,6 +3586,7 @@ template:
 
     - name: canonical_cloud_cover
       unique_id: canonical_cloud_cover
+      state_class: measurement
       unit_of_measurement: "%"
       availability: >-
         {{ [state_attr('weather.openweathermap', 'cloud_coverage'),
@@ -3596,6 +3600,7 @@ template:
 
     - name: canonical_uv_index
       unique_id: canonical_uv_index
+      state_class: measurement
       availability: >-
         {{ [states('sensor.pinehotties_uv_index'),
             states('sensor.openweathermap_uv_index')]
@@ -3609,6 +3614,7 @@ template:
     - name: canonical_precipitation
       unique_id: canonical_precipitation
       device_class: precipitation_intensity
+      state_class: measurement
       unit_of_measurement: "in/h"
       availability: >-
         {{ [states('sensor.pinehotties_hourly_rain'),

--- a/room_temp_model_service/Dockerfile
+++ b/room_temp_model_service/Dockerfile
@@ -1,0 +1,17 @@
+# Room-temperature model service — trains + serves predictions over MQTT.
+# Runs off the Home Assistant host so training never touches HA resources.
+# Uses the Debian-slim image (not Alpine) so scikit-learn/numpy install from
+# prebuilt wheels — no C-extension compilation.
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY model.py service.py ./
+
+# Persist trained models across restarts by mounting a volume here.
+VOLUME ["/models"]
+ENV MODEL_DIR=/models
+
+CMD ["python", "-u", "service.py"]

--- a/room_temp_model_service/README.md
+++ b/room_temp_model_service/README.md
@@ -1,0 +1,61 @@
+# Room-temperature model service
+
+Trains and serves the per-room temperature-prediction models **off** the Home
+Assistant host, so the CPU/memory-heavy training never touches AppDaemon (the
+problem that got the AppDaemon bed-side predictor disabled).
+
+It is HA-agnostic: it speaks only **MQTT** and **InfluxDB**. No HA token.
+
+```
+AppDaemon shim ──(features)──► MQTT ──► this service ──► GBR model
+   (light HA I/O)                          │  trains from InfluxDB
+                                           └─(predictions via HA discovery)─► sensor.room_temp_prediction_*
+                                                                                   │
+                                                          thermal_preemptor + prediction_scorer (unchanged)
+```
+
+## What runs where
+
+| Component | Host | Work |
+|---|---|---|
+| `room_temp_predictor.py` (AppDaemon) | HA host | Thin shim: gather live features + forecasts, publish to MQTT; relay retrain button. No ML libs. |
+| **this service** | any Docker host | Training (InfluxDB) + inference; publishes predictions via MQTT discovery. |
+| `thermal_preemptor.py`, `prediction_scorer.py` (AppDaemon) | HA host | Unchanged — consume the prediction sensors. |
+
+## MQTT topics
+
+| Topic | Dir | Payload |
+|---|---|---|
+| `room_temp_model/features` | in | `{"ts": iso, "rooms": {name: {room_temp, room_humidity, outside_temp, outside_humidity, cloud_cover, wind_speed, uv_index, precipitation, occupancy, hvac_heating, hvac_cooling, room_temp_rate_15m, outside_delta_3h, forecast: {"15": {...}, "30": {...}, "60": {...}}}}}` |
+| `room_temp_model/train` | in | optional `{"rooms": ["office"]}` (empty = all) |
+| `room_temp_model/prediction/<room>` | out (retained) | `{t15,t30,t60,prediction_source,rmse_*_cv_mean,trained_at,...}` |
+| `room_temp_model/status` | out (retained) | service + last-train status |
+| `homeassistant/sensor/room_temp_prediction_<room>/config` | out (retained) | HA MQTT discovery |
+
+## Deploy
+
+1. Copy `rooms.example.json` → `rooms.json` (already matches the current setup).
+2. Fill in `docker-compose.example.yml` (MQTT + InfluxDB reachable from this
+   host; lat/lon) and save as `docker-compose.yml`.
+3. `docker compose up -d --build`
+4. Trigger the first training: press `input_button.retrain_room_temp_models`
+   in HA (the shim relays it), or `mosquitto_pub -t room_temp_model/train -m '{}'`.
+5. Watch `room_temp_model/status`; once `train: done`, predictions start
+   flowing and `sensor.room_temp_prediction_*` populate via discovery.
+
+## Environment variables
+
+`MQTT_HOST` `MQTT_PORT` `MQTT_USERNAME` `MQTT_PASSWORD` `MQTT_BASE_TOPIC`
+`MQTT_DISCOVERY_PREFIX` `MQTT_CLIENT_ID` · `INFLUXDB_HOST` `INFLUXDB_PORT`
+`INFLUXDB_DATABASE` · `LATITUDE` `LONGITUDE` `MIN_TRAINING_SAMPLES` `MODEL_DIR`
+· `ROOMS_FILE` or `ROOMS_JSON`.
+
+## Notes
+
+- Training reads the recorded sensors' history from InfluxDB directly. Feature
+  engineering (sun/time/oracle-forecast/coverage-filter) lives in `model.py`
+  and is shared by train and inference, so they cannot drift.
+- `MODEL_DIR` holds the joblib models; mount it as a volume to survive
+  restarts. Point it only at a trusted location (joblib = pickle).
+- The shim only *publishes* features; if the service or its host is down,
+  predictions simply pause and the preemptor no-ops (it checks for `t60`).

--- a/room_temp_model_service/docker-compose.example.yml
+++ b/room_temp_model_service/docker-compose.example.yml
@@ -1,0 +1,22 @@
+services:
+  room-temp-model:
+    build: .
+    # or: image: room-temp-model:latest
+    restart: unless-stopped
+    environment:
+      MQTT_HOST: 10.24.1.11          # broker reachable from this host
+      MQTT_PORT: "1883"
+      MQTT_USERNAME: room_temp_model
+      MQTT_PASSWORD: change-me
+      MQTT_BASE_TOPIC: room_temp_model
+      MQTT_DISCOVERY_PREFIX: homeassistant
+      INFLUXDB_HOST: 10.24.1.11
+      INFLUXDB_PORT: "8086"
+      INFLUXDB_DATABASE: home_assistant
+      LATITUDE: "44.761712"
+      LONGITUDE: "-93.203609"
+      MIN_TRAINING_SAMPLES: "500"
+      ROOMS_FILE: /config/rooms.json
+    volumes:
+      - ./models:/models
+      - ./rooms.json:/config/rooms.json:ro

--- a/room_temp_model_service/docker-compose.example.yml
+++ b/room_temp_model_service/docker-compose.example.yml
@@ -10,7 +10,9 @@ services:
       MQTT_PASSWORD: change-me
       MQTT_BASE_TOPIC: room_temp_model
       MQTT_DISCOVERY_PREFIX: homeassistant
-      INFLUXDB_HOST: 10.24.1.11
+      # InfluxDB v1 host (reads currently require no auth on the LAN; if you
+      # enable auth, pass credentials via an untracked .env — never commit them).
+      INFLUXDB_HOST: 10.24.1.99
       INFLUXDB_PORT: "8086"
       INFLUXDB_DATABASE: home_assistant
       LATITUDE: "44.761712"

--- a/room_temp_model_service/model.py
+++ b/room_temp_model_service/model.py
@@ -113,10 +113,25 @@ class RoomTempModel:
         from influxdb import InfluxDBClient
         return InfluxDBClient(host=self.influx_host, port=self.influx_port, database=self.influx_db)
 
+    @staticmethod
+    def _influx_where(entity_id):
+        """Build the WHERE clause for a fully-qualified Home Assistant entity_id.
+
+        HA's InfluxDB integration does NOT store the fully-qualified entity_id:
+        it tags each point with the bare object_id plus a separate `domain` tag.
+        Querying entity_id='sensor.outside_temperature' matches nothing. The
+        domain filter matters because the same object_id can exist in more than
+        one domain (this database has both `sensor` and `number`).
+        """
+        if "." in entity_id:
+            domain, object_id = entity_id.split(".", 1)
+            return f"entity_id='{object_id}' AND domain='{domain}'"
+        return f"entity_id='{entity_id}'"
+
     def _query_generic(self, client, entity_id, start_days=730):
         import pandas as pd
-        start = (datetime.utcnow() - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
-        q = (f"SELECT value FROM /.*/ WHERE entity_id='{entity_id}' "
+        start = (datetime.now(timezone.utc) - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        q = (f"SELECT value FROM /.*/ WHERE {self._influx_where(entity_id)} "
              f"AND time>='{start}' ORDER BY time ASC")
         try:
             result = client.query(q)
@@ -135,25 +150,39 @@ class RoomTempModel:
             return None
 
     def _query_categorical(self, client, entity_id, start_days=730):
+        """Read a string-valued sensor (e.g. sensor.hvac_activity).
+
+        Home Assistant writes non-numeric states differently from numeric ones:
+        the field is `state` (not `value`) and the measurement is the
+        fully-qualified entity_id rather than the unit. Selecting `value` here
+        returns nothing, which silently turns the HVAC one-hots into constant
+        zeros — and because they are 0.0 rather than NaN, the coverage filter
+        keeps them. `value` is kept as a fallback for odd writers.
+        """
         import pandas as pd
-        start = (datetime.utcnow() - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
-        q = (f"SELECT value FROM /.*/ WHERE entity_id='{entity_id}' "
-             f"AND time>='{start}' ORDER BY time ASC")
-        try:
-            result = client.query(q)
-            pts = []
-            for _k, points in result.items():
-                pts.extend(list(points))
-            if not pts:
-                return pd.Series(dtype=object)
-            df = pd.DataFrame(pts)
-            df["time"] = pd.to_datetime(df["time"])
-            df = df.set_index("time").sort_index()
-            if "value" not in df.columns:
-                return pd.Series(dtype=object)
-            return df["value"].astype(str).resample("5min").ffill()
-        except Exception:
-            return pd.Series(dtype=object)
+        start = (datetime.now(timezone.utc) - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for field in ("state", "value"):
+            q = (f"SELECT {field} FROM /.*/ WHERE {self._influx_where(entity_id)} "
+                 f"AND time>='{start}' ORDER BY time ASC")
+            try:
+                result = client.query(q)
+                pts = []
+                for _k, points in result.items():
+                    pts.extend(list(points))
+                if not pts:
+                    continue
+                df = pd.DataFrame(pts)
+                if field not in df.columns:
+                    continue
+                df["time"] = pd.to_datetime(df["time"])
+                df = df.set_index("time").sort_index()
+                series = df[field].dropna()
+                if series.empty:
+                    continue
+                return series.astype(str).resample("5min").ffill()
+            except Exception:
+                continue
+        return pd.Series(dtype=object)
 
     # ------------------------------------------------------------------
     # Training
@@ -329,7 +358,7 @@ class RoomTempModel:
                 joblib.dump(final, self._model_path(room, h))
                 room_models[h] = final
                 metrics[f"rmse_{h}m_cv_mean"] = cv_mean
-            metrics["trained_at"] = datetime.utcnow().isoformat()
+            metrics["trained_at"] = datetime.now(timezone.utc).isoformat()
             metrics["n_samples"] = len(df)
             metrics["feature_cols"] = feature_cols
             with open(self._meta_path(room), "w") as f:

--- a/room_temp_model_service/model.py
+++ b/room_temp_model_service/model.py
@@ -181,9 +181,13 @@ class RoomTempModel:
         uv_index = self._query_generic(client, "sensor.pinehotties_uv_index") or pd.Series(dtype=float)
         hvac_series = self._query_categorical(client, "sensor.hvac_activity")
 
-        hum_sensor = cfg.get("humidity_sensor")
-        room_humidity = self._query_generic(client, hum_sensor) if hum_sensor else None
-        room_humidity = room_humidity if room_humidity is not None else pd.Series(dtype=float)
+        hum_sensors = cfg.get("humidity_sensors")
+        if not hum_sensors:
+            hum_sensors = [cfg["humidity_sensor"]] if cfg.get("humidity_sensor") else []
+        hum_members = [self._query_generic(client, s) for s in hum_sensors]
+        hum_members = [m for m in hum_members if m is not None and not m.empty]
+        room_humidity = (pd.concat(hum_members, axis=1).mean(axis=1)
+                         if hum_members else pd.Series(dtype=float))
 
         conf = cfg.get("confidence_sensor")
         confidence = (self._query_generic(client, conf) if conf else None) or pd.Series(dtype=float)

--- a/room_temp_model_service/model.py
+++ b/room_temp_model_service/model.py
@@ -173,12 +173,19 @@ class RoomTempModel:
         if len(room_temp) < self.min_samples:
             return None, None
 
-        outside_temp = self._query_generic(client, "sensor.outside_temperature") or pd.Series(dtype=float)
-        outside_humidity = self._query_generic(client, "sensor.outside_humidity") or pd.Series(dtype=float)
-        cloud_cover = self._query_generic(client, "sensor.tomorrow_io_the_brewery_cloud_cover") or pd.Series(dtype=float)
-        wind_speed = self._query_generic(client, "sensor.pinehotties_wind_speed") or pd.Series(dtype=float)
-        precipitation = self._query_generic(client, "sensor.pinehotties_hourly_rain") or pd.Series(dtype=float)
-        uv_index = self._query_generic(client, "sensor.pinehotties_uv_index") or pd.Series(dtype=float)
+        # NB: never write `query(...) or pd.Series(...)` — bool() on a non-empty
+        # Series raises "truth value is ambiguous", which the caller's except
+        # would swallow into a silent training failure.
+        def q(entity_id):
+            s = self._query_generic(client, entity_id) if entity_id else None
+            return s if s is not None else pd.Series(dtype=float)
+
+        outside_temp = q("sensor.outside_temperature")
+        outside_humidity = q("sensor.outside_humidity")
+        cloud_cover = q("sensor.tomorrow_io_the_brewery_cloud_cover")
+        wind_speed = q("sensor.pinehotties_wind_speed")
+        precipitation = q("sensor.pinehotties_hourly_rain")
+        uv_index = q("sensor.pinehotties_uv_index")
         hvac_series = self._query_categorical(client, "sensor.hvac_activity")
 
         hum_sensors = cfg.get("humidity_sensors")
@@ -189,12 +196,17 @@ class RoomTempModel:
         room_humidity = (pd.concat(hum_members, axis=1).mean(axis=1)
                          if hum_members else pd.Series(dtype=float))
 
-        conf = cfg.get("confidence_sensor")
-        confidence = (self._query_generic(client, conf) if conf else None) or pd.Series(dtype=float)
+        confidence = q(cfg.get("confidence_sensor"))
 
         idx = room_temp.index
 
         def align(s):
+            # An empty series carries a RangeIndex; reindexing that onto a
+            # DatetimeIndex with method="nearest" raises. A sensor with no
+            # history must become an all-NaN column so the coverage filter
+            # below can drop it.
+            if s is None or len(s) == 0:
+                return pd.Series(float("nan"), index=idx)
             return s.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
 
         df = pd.DataFrame({"room_temp": room_temp}, index=idx)

--- a/room_temp_model_service/model.py
+++ b/room_temp_model_service/model.py
@@ -274,8 +274,21 @@ class RoomTempModel:
         df["doy_sin"] = np.sin(2 * np.pi * doy / 365.25)
         df["doy_cos"] = np.cos(2 * np.pi * doy / 365.25)
 
-        sun_vals = [sun_position(self.lat, self.lon, ts.to_pydatetime().replace(tzinfo=timezone.utc))
-                    for ts in df.index]
+        # Sun position is the expensive per-row computation. The horizon-shifted
+        # times (t+15/30/60) land on the same 5-min grid as the base times, so a
+        # local memo turns ~4 astral calls per row into ~1 (most horizon lookups
+        # hit a base-time entry). Keyed by the UTC datetime.
+        _sun_cache = {}
+
+        def _sun(dt):
+            v = _sun_cache.get(dt)
+            if v is None:
+                v = sun_position(self.lat, self.lon, dt)
+                _sun_cache[dt] = v
+            return v
+
+        base_dts = [ts.to_pydatetime().replace(tzinfo=timezone.utc) for ts in df.index]
+        sun_vals = [_sun(dt) for dt in base_dts]
         df["sun_elevation"] = [v[0] for v in sun_vals]
         df["sun_azimuth_sin"] = np.sin(np.radians([v[1] for v in sun_vals]))
         df["sun_azimuth_cos"] = np.cos(np.radians([v[1] for v in sun_vals]))
@@ -287,9 +300,8 @@ class RoomTempModel:
             df[f"wind_speed_{h}m"] = df["wind_speed"].shift(-slots)
             df[f"precipitation_{h}m"] = df["precipitation"].shift(-slots)
             df[f"uv_index_{h}m"] = df["uv_index"].shift(-slots)
-            sun_future = [sun_position(self.lat, self.lon,
-                                       (ts + timedelta(minutes=h)).to_pydatetime().replace(tzinfo=timezone.utc))
-                          for ts in df.index]
+            delta = timedelta(minutes=h)
+            sun_future = [_sun(dt + delta) for dt in base_dts]
             df[f"sun_elevation_{h}m"] = [v[0] for v in sun_future]
             df[f"sun_azimuth_sin_{h}m"] = np.sin(np.radians([v[1] for v in sun_future]))
             df[f"sun_azimuth_cos_{h}m"] = np.cos(np.radians([v[1] for v in sun_future]))
@@ -328,36 +340,49 @@ class RoomTempModel:
                 report[room] = {"status": "insufficient_data"}
                 continue
             feature_cols = [c for c in df.columns if c != "fold" and not c.startswith("delta_")]
+            X_all = df[feature_cols].to_numpy()
+
+            # Purged interleaved-week folds. The fold split does not depend on
+            # the horizon, so compute the (train, test) index masks once. The
+            # purge zone is built with vectorized numpy slice-fills — O(n) — not
+            # the old membership test against a numpy array, which was O(n^2)
+            # and would not finish on multi-year data.
+            n = len(df)
+            fold_arr = df["fold"].to_numpy()
+            fold_masks = []
+            for fold_k in range(5):
+                test = fold_arr == fold_k
+                if test.sum() < 10:
+                    fold_masks.append(None)
+                    continue
+                purged = np.zeros(n, dtype=bool)
+                for i in np.flatnonzero(test):
+                    purged[max(0, i - PURGE_SLOTS):min(n, i + PURGE_SLOTS + 1)] = True
+                train = (~purged) & (fold_arr != fold_k)
+                fold_masks.append((train, test) if train.sum() >= 100 else None)
+
             room_models, metrics = {}, {}
             for h in HORIZONS:
-                y = y_dict[f"delta_{h}"].reindex(df.index)
+                y = y_dict[f"delta_{h}"].reindex(df.index).to_numpy()
                 cv_rmses = []
-                for fold_k in range(5):
-                    test_mask = df["fold"] == fold_k
-                    if test_mask.sum() < 10:
+                for masks in fold_masks:
+                    if masks is None:
                         continue
-                    purge = set()
-                    positions = np.where(test_mask.values)[0]
-                    for i in positions:
-                        for j in range(max(0, i - PURGE_SLOTS), min(len(df), i + PURGE_SLOTS + 1)):
-                            if j not in positions:
-                                purge.add(df.index[j])
-                    keep = ~df.index.isin(purge)
-                    train_mask = keep & (df["fold"] != fold_k)
-                    if train_mask.sum() < 100:
-                        continue
+                    train, test = masks
                     m = GradientBoostingRegressor(n_estimators=100, max_depth=4,
                                                   min_samples_leaf=20, random_state=42)
-                    m.fit(df.loc[train_mask, feature_cols], y[train_mask])
-                    preds = m.predict(df.loc[test_mask, feature_cols])
-                    cv_rmses.append(math.sqrt(mean_squared_error(y[test_mask], preds)))
+                    m.fit(X_all[train], y[train])
+                    preds = m.predict(X_all[test])
+                    cv_rmses.append(math.sqrt(mean_squared_error(y[test], preds)))
                 cv_mean = round(float(np.mean(cv_rmses)), 3) if cv_rmses else None
+                cv_std = round(float(np.std(cv_rmses)), 3) if cv_rmses else None
                 final = GradientBoostingRegressor(n_estimators=100, max_depth=4,
                                                   min_samples_leaf=20, random_state=42)
-                final.fit(df[feature_cols], y)
+                final.fit(X_all, y)
                 joblib.dump(final, self._model_path(room, h))
                 room_models[h] = final
                 metrics[f"rmse_{h}m_cv_mean"] = cv_mean
+                metrics[f"rmse_{h}m_cv_std"] = cv_std
             metrics["trained_at"] = datetime.now(timezone.utc).isoformat()
             metrics["n_samples"] = len(df)
             metrics["feature_cols"] = feature_cols

--- a/room_temp_model_service/model.py
+++ b/room_temp_model_service/model.py
@@ -1,0 +1,419 @@
+"""Pure-Python room-temperature model core (no Home Assistant / AppDaemon deps).
+
+Owns everything CPU/memory heavy so it can run in a standalone container off
+the Home Assistant host:
+
+  * training  — pulls multi-year history from InfluxDB v1, engineers features
+                (astral sun position, cyclic time, oracle forecast proxies),
+                fits a GradientBoostingRegressor per room per horizon with
+                purged interleaved-week CV, and saves joblib models + metadata.
+  * inference — given a raw feature payload (current sensor values + a short
+                weather forecast) it assembles the same feature vector and
+                returns T+15/30/60 predictions.
+
+Feature engineering is defined once here, so training and inference cannot
+drift. The service layer (service.py) handles all MQTT / transport concerns.
+"""
+
+import json
+import math
+import os
+from datetime import datetime, timedelta, timezone
+
+HORIZONS = [15, 30, 60]
+SLOT_MIN = 5
+HORIZON_SLOTS = {h: h // SLOT_MIN for h in HORIZONS}
+PURGE_SLOTS = 48  # 4-hour autocorrelation purge at fold boundaries
+MIN_COVERAGE = 0.5  # drop candidate features with < this fraction of history
+
+
+def sun_position(lat, lon, dt):
+    """(elevation_deg, azimuth_deg) for a UTC datetime, via astral or fallback."""
+    try:
+        from astral import LocationInfo
+        from astral.sun import azimuth as astral_azimuth
+        from astral.sun import elevation as astral_elevation
+        loc = LocationInfo(latitude=lat, longitude=lon)
+        return float(astral_elevation(loc.observer, dt)), float(astral_azimuth(loc.observer, dt))
+    except Exception:
+        pass
+    # Pure-math fallback (good to ~1°).
+    lat_r = math.radians(lat)
+    doy = dt.timetuple().tm_yday
+    hour_utc = dt.hour + dt.minute / 60.0
+    decl = math.radians(23.45 * math.sin(math.radians(360 / 365 * (doy - 81))))
+    hour_angle = math.radians(15 * (hour_utc + lon / 15 - 12))
+    sin_elev = (math.sin(lat_r) * math.sin(decl)
+                + math.cos(lat_r) * math.cos(decl) * math.cos(hour_angle))
+    elev = math.degrees(math.asin(max(-1.0, min(1.0, sin_elev))))
+    cos_az = (math.sin(decl) - math.sin(math.radians(elev)) * math.sin(lat_r)) / (
+        math.cos(math.radians(elev)) * math.cos(lat_r) + 1e-9
+    )
+    azim = math.degrees(math.acos(max(-1.0, min(1.0, cos_az))))
+    if math.sin(hour_angle) > 0:
+        azim = 360 - azim
+    return elev, azim
+
+
+class RoomTempModel:
+    def __init__(self, config):
+        """config: dict with model_dir, latitude, longitude, min_training_samples,
+        influxdb {host, port, database}, and rooms [{name, temp_sensors,
+        humidity_sensor, confidence_sensor}]."""
+        self.model_dir = config.get("model_dir", "/models")
+        self.lat = float(config.get("latitude", 0.0))
+        self.lon = float(config.get("longitude", 0.0))
+        self.min_samples = int(config.get("min_training_samples", 500))
+        influx = config.get("influxdb", {})
+        self.influx_host = influx.get("host", "localhost")
+        self.influx_port = int(influx.get("port", 8086))
+        self.influx_db = influx.get("database", "home_assistant")
+        self.rooms = {r["name"]: r for r in config.get("rooms", [])}
+
+        self.models = {room: {} for room in self.rooms}
+        self.meta = {room: {} for room in self.rooms}
+        os.makedirs(self.model_dir, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def _model_path(self, room, horizon):
+        return os.path.join(self.model_dir, f"room_temp_{room}_{horizon}m.joblib")
+
+    def _meta_path(self, room):
+        return os.path.join(self.model_dir, f"room_temp_{room}_meta.json")
+
+    def load(self):
+        # joblib.load deserializes pickle — safe here because these files are
+        # produced only by this service's own train() into its own model_dir
+        # volume (trusted, self-generated). Do not point model_dir at an
+        # untrusted/shared location.
+        import joblib
+        for room in self.rooms:
+            loaded = {}
+            for h in HORIZONS:
+                path = self._model_path(room, h)
+                if os.path.exists(path):
+                    try:
+                        loaded[h] = joblib.load(path)
+                    except Exception:
+                        pass
+            if loaded:
+                self.models[room] = loaded
+                if os.path.exists(self._meta_path(room)):
+                    with open(self._meta_path(room)) as f:
+                        self.meta[room] = json.load(f)
+
+    # ------------------------------------------------------------------
+    # InfluxDB helpers (training only)
+    # ------------------------------------------------------------------
+
+    def _influx_client(self):
+        from influxdb import InfluxDBClient
+        return InfluxDBClient(host=self.influx_host, port=self.influx_port, database=self.influx_db)
+
+    def _query_generic(self, client, entity_id, start_days=730):
+        import pandas as pd
+        start = (datetime.utcnow() - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        q = (f"SELECT value FROM /.*/ WHERE entity_id='{entity_id}' "
+             f"AND time>='{start}' ORDER BY time ASC")
+        try:
+            result = client.query(q)
+            pts = []
+            for _k, points in result.items():
+                pts.extend(list(points))
+            if not pts:
+                return None
+            df = pd.DataFrame(pts)
+            df["time"] = pd.to_datetime(df["time"])
+            df = df.set_index("time").sort_index()
+            if "value" not in df.columns:
+                return None
+            return df["value"].astype(float).resample("5min").mean().ffill(limit=12)
+        except Exception:
+            return None
+
+    def _query_categorical(self, client, entity_id, start_days=730):
+        import pandas as pd
+        start = (datetime.utcnow() - timedelta(days=start_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        q = (f"SELECT value FROM /.*/ WHERE entity_id='{entity_id}' "
+             f"AND time>='{start}' ORDER BY time ASC")
+        try:
+            result = client.query(q)
+            pts = []
+            for _k, points in result.items():
+                pts.extend(list(points))
+            if not pts:
+                return pd.Series(dtype=object)
+            df = pd.DataFrame(pts)
+            df["time"] = pd.to_datetime(df["time"])
+            df = df.set_index("time").sort_index()
+            if "value" not in df.columns:
+                return pd.Series(dtype=object)
+            return df["value"].astype(str).resample("5min").ffill()
+        except Exception:
+            return pd.Series(dtype=object)
+
+    # ------------------------------------------------------------------
+    # Training
+    # ------------------------------------------------------------------
+
+    def _build_training_data(self, room, cfg):
+        import numpy as np
+        import pandas as pd
+
+        client = self._influx_client()
+
+        members = [self._query_generic(client, s) for s in cfg["temp_sensors"]]
+        members = [m for m in members if m is not None and not m.empty]
+        if not members:
+            return None, None
+        room_temp = pd.concat(members, axis=1).mean(axis=1).dropna()
+        if len(room_temp) < self.min_samples:
+            return None, None
+
+        outside_temp = self._query_generic(client, "sensor.outside_temperature") or pd.Series(dtype=float)
+        outside_humidity = self._query_generic(client, "sensor.outside_humidity") or pd.Series(dtype=float)
+        cloud_cover = self._query_generic(client, "sensor.tomorrow_io_the_brewery_cloud_cover") or pd.Series(dtype=float)
+        wind_speed = self._query_generic(client, "sensor.pinehotties_wind_speed") or pd.Series(dtype=float)
+        precipitation = self._query_generic(client, "sensor.pinehotties_hourly_rain") or pd.Series(dtype=float)
+        uv_index = self._query_generic(client, "sensor.pinehotties_uv_index") or pd.Series(dtype=float)
+        hvac_series = self._query_categorical(client, "sensor.hvac_activity")
+
+        hum_sensor = cfg.get("humidity_sensor")
+        room_humidity = self._query_generic(client, hum_sensor) if hum_sensor else None
+        room_humidity = room_humidity if room_humidity is not None else pd.Series(dtype=float)
+
+        conf = cfg.get("confidence_sensor")
+        confidence = (self._query_generic(client, conf) if conf else None) or pd.Series(dtype=float)
+
+        idx = room_temp.index
+
+        def align(s):
+            return s.reindex(idx, method="nearest", tolerance=pd.Timedelta("10min"))
+
+        df = pd.DataFrame({"room_temp": room_temp}, index=idx)
+        df["room_humidity"] = align(room_humidity)
+        df["outside_temp"] = align(outside_temp)
+        df["outside_humidity"] = align(outside_humidity)
+        df["cloud_cover"] = align(cloud_cover)
+        df["wind_speed"] = align(wind_speed)
+        df["precipitation"] = align(precipitation)
+        df["uv_index"] = align(uv_index)
+        df["occupancy"] = align(confidence).fillna(0)
+
+        # Junk 0 filter on outside temp/humidity (humidity never legit 0 here).
+        junk = df["outside_humidity"] <= 0
+        df.loc[junk, ["outside_temp", "outside_humidity"]] = np.nan
+        df["outside_temp"] = df["outside_temp"].ffill(limit=12)
+        df["outside_humidity"] = df["outside_humidity"].ffill(limit=12)
+
+        if not hvac_series.empty:
+            hvac_str = align(hvac_series)
+        else:
+            hvac_str = pd.Series(index=idx, dtype=object)
+        df["hvac_heating"] = (hvac_str == "heating").astype(float)
+        df["hvac_cooling"] = (hvac_str == "cooling").astype(float)
+
+        df["room_temp_rate_15m"] = (
+            df["room_temp"].rolling(3, min_periods=2)
+            .apply(lambda x: np.polyfit(range(len(x)), x, 1)[0] if len(x) >= 2 else 0, raw=True)
+        )
+        df["outside_delta_3h"] = df["outside_temp"].diff(36)
+
+        hours = df.index.hour + df.index.minute / 60.0
+        doy = df.index.dayofyear
+        df["hour_sin"] = np.sin(2 * np.pi * hours / 24)
+        df["hour_cos"] = np.cos(2 * np.pi * hours / 24)
+        df["doy_sin"] = np.sin(2 * np.pi * doy / 365.25)
+        df["doy_cos"] = np.cos(2 * np.pi * doy / 365.25)
+
+        sun_vals = [sun_position(self.lat, self.lon, ts.to_pydatetime().replace(tzinfo=timezone.utc))
+                    for ts in df.index]
+        df["sun_elevation"] = [v[0] for v in sun_vals]
+        df["sun_azimuth_sin"] = np.sin(np.radians([v[1] for v in sun_vals]))
+        df["sun_azimuth_cos"] = np.cos(np.radians([v[1] for v in sun_vals]))
+
+        for h, slots in HORIZON_SLOTS.items():
+            df[f"cloud_cover_{h}m"] = df["cloud_cover"].shift(-slots)
+            df[f"outside_temp_{h}m"] = df["outside_temp"].shift(-slots)
+            df[f"outside_humidity_{h}m"] = df["outside_humidity"].shift(-slots)
+            df[f"wind_speed_{h}m"] = df["wind_speed"].shift(-slots)
+            df[f"precipitation_{h}m"] = df["precipitation"].shift(-slots)
+            df[f"uv_index_{h}m"] = df["uv_index"].shift(-slots)
+            sun_future = [sun_position(self.lat, self.lon,
+                                       (ts + timedelta(minutes=h)).to_pydatetime().replace(tzinfo=timezone.utc))
+                          for ts in df.index]
+            df[f"sun_elevation_{h}m"] = [v[0] for v in sun_future]
+            df[f"sun_azimuth_sin_{h}m"] = np.sin(np.radians([v[1] for v in sun_future]))
+            df[f"sun_azimuth_cos_{h}m"] = np.cos(np.radians([v[1] for v in sun_future]))
+
+        y_dict = {}
+        for h, slots in HORIZON_SLOTS.items():
+            y_dict[f"delta_{h}"] = df["room_temp"].shift(-slots) - df["room_temp"]
+
+        # Coverage filter — drop candidate features without enough history so a
+        # sparse new sensor can't collapse the set; survivors define feature_cols.
+        feature_like = [c for c in df.columns if not c.startswith("delta_")]
+        dropped = [c for c in feature_like if df[c].notna().mean() < MIN_COVERAGE]
+        if dropped:
+            df = df.drop(columns=dropped)
+
+        df["fold"] = df.index.isocalendar().week % 5
+        df = df.dropna()
+        if len(df) < self.min_samples:
+            return None, None
+        return df, y_dict
+
+    def train(self, rooms=None):
+        """Train models for the given rooms (all by default). Returns a report."""
+        import joblib
+        import numpy as np
+        from sklearn.ensemble import GradientBoostingRegressor
+        from sklearn.metrics import mean_squared_error
+
+        report = {}
+        for room in (rooms or list(self.rooms)):
+            cfg = self.rooms.get(room)
+            if not cfg:
+                continue
+            df, y_dict = self._build_training_data(room, cfg)
+            if df is None:
+                report[room] = {"status": "insufficient_data"}
+                continue
+            feature_cols = [c for c in df.columns if c != "fold" and not c.startswith("delta_")]
+            room_models, metrics = {}, {}
+            for h in HORIZONS:
+                y = y_dict[f"delta_{h}"].reindex(df.index)
+                cv_rmses = []
+                for fold_k in range(5):
+                    test_mask = df["fold"] == fold_k
+                    if test_mask.sum() < 10:
+                        continue
+                    purge = set()
+                    positions = np.where(test_mask.values)[0]
+                    for i in positions:
+                        for j in range(max(0, i - PURGE_SLOTS), min(len(df), i + PURGE_SLOTS + 1)):
+                            if j not in positions:
+                                purge.add(df.index[j])
+                    keep = ~df.index.isin(purge)
+                    train_mask = keep & (df["fold"] != fold_k)
+                    if train_mask.sum() < 100:
+                        continue
+                    m = GradientBoostingRegressor(n_estimators=100, max_depth=4,
+                                                  min_samples_leaf=20, random_state=42)
+                    m.fit(df.loc[train_mask, feature_cols], y[train_mask])
+                    preds = m.predict(df.loc[test_mask, feature_cols])
+                    cv_rmses.append(math.sqrt(mean_squared_error(y[test_mask], preds)))
+                cv_mean = round(float(np.mean(cv_rmses)), 3) if cv_rmses else None
+                final = GradientBoostingRegressor(n_estimators=100, max_depth=4,
+                                                  min_samples_leaf=20, random_state=42)
+                final.fit(df[feature_cols], y)
+                joblib.dump(final, self._model_path(room, h))
+                room_models[h] = final
+                metrics[f"rmse_{h}m_cv_mean"] = cv_mean
+            metrics["trained_at"] = datetime.utcnow().isoformat()
+            metrics["n_samples"] = len(df)
+            metrics["feature_cols"] = feature_cols
+            with open(self._meta_path(room), "w") as f:
+                json.dump(metrics, f)
+            self.models[room] = room_models
+            self.meta[room] = metrics
+            report[room] = {"status": "trained", "n_samples": len(df),
+                            "rmse_60m_cv_mean": metrics.get("rmse_60m_cv_mean")}
+        return report
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+
+    def _assemble_row(self, raw, ts):
+        """Build the feature row from a raw payload + timestamp (adds sun/time)."""
+        forecast = raw.get("forecast", {}) or {}
+        hours = ts.hour + ts.minute / 60.0
+        doy = ts.timetuple().tm_yday
+        elev, azim = sun_position(self.lat, self.lon, ts)
+
+        def num(v):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return None
+
+        row = {
+            "room_temp": num(raw.get("room_temp")),
+            "room_humidity": num(raw.get("room_humidity")),
+            "outside_temp": num(raw.get("outside_temp")),
+            "outside_humidity": num(raw.get("outside_humidity")),
+            "cloud_cover": num(raw.get("cloud_cover")),
+            "wind_speed": num(raw.get("wind_speed")),
+            "uv_index": num(raw.get("uv_index")),
+            "precipitation": num(raw.get("precipitation")),
+            "occupancy": num(raw.get("occupancy")) or 0,
+            "hvac_heating": num(raw.get("hvac_heating")) or 0,
+            "hvac_cooling": num(raw.get("hvac_cooling")) or 0,
+            "room_temp_rate_15m": num(raw.get("room_temp_rate_15m")) or 0,
+            "outside_delta_3h": num(raw.get("outside_delta_3h")) or 0,
+            "hour_sin": math.sin(2 * math.pi * hours / 24),
+            "hour_cos": math.cos(2 * math.pi * hours / 24),
+            "doy_sin": math.sin(2 * math.pi * doy / 365.25),
+            "doy_cos": math.cos(2 * math.pi * doy / 365.25),
+            "sun_elevation": elev,
+            "sun_azimuth_sin": math.sin(math.radians(azim)),
+            "sun_azimuth_cos": math.cos(math.radians(azim)),
+        }
+        for h in HORIZONS:
+            fc = forecast.get(str(h)) or forecast.get(h) or {}
+            elev_f, azim_f = sun_position(self.lat, self.lon, ts + timedelta(minutes=h))
+            row[f"cloud_cover_{h}m"] = num(fc.get("cloud_cover")) if fc.get("cloud_cover") is not None else row["cloud_cover"]
+            row[f"outside_temp_{h}m"] = num(fc.get("temperature")) if fc.get("temperature") is not None else row["outside_temp"]
+            row[f"outside_humidity_{h}m"] = num(fc.get("humidity")) if fc.get("humidity") is not None else row["outside_humidity"]
+            row[f"wind_speed_{h}m"] = num(fc.get("wind_speed")) if fc.get("wind_speed") is not None else row["wind_speed"]
+            row[f"precipitation_{h}m"] = num(fc.get("precipitation")) if fc.get("precipitation") is not None else row["precipitation"]
+            row[f"uv_index_{h}m"] = num(fc.get("uv_index")) if fc.get("uv_index") is not None else row["uv_index"]
+            row[f"sun_elevation_{h}m"] = elev_f
+            row[f"sun_azimuth_sin_{h}m"] = math.sin(math.radians(azim_f))
+            row[f"sun_azimuth_cos_{h}m"] = math.cos(math.radians(azim_f))
+        return row
+
+    def predict(self, room, raw, ts=None):
+        """Return {t15,t30,t60,prediction_source, ...cv metrics}. `raw` is the
+        feature payload from the AppDaemon shim; `ts` is a tz-aware UTC time."""
+        ts = ts or datetime.now(timezone.utc)
+        room_temp = raw.get("room_temp")
+        try:
+            room_temp = float(room_temp)
+        except (TypeError, ValueError):
+            return None
+
+        models = self.models.get(room, {})
+        meta = self.meta.get(room, {})
+        result = {"prediction_source": None, "trained_at": meta.get("trained_at")}
+
+        if not models:
+            rate = 0.0
+            try:
+                rate = float(raw.get("room_temp_rate_15m") or 0.0)
+            except (TypeError, ValueError):
+                rate = 0.0
+            for h in HORIZONS:
+                result[f"t{h}"] = round(room_temp + rate * h, 2)
+            result["prediction_source"] = "fallback_linear"
+            return result
+
+        row = self._assemble_row(raw, ts)
+        feature_cols = meta.get("feature_cols")
+        if feature_cols:
+            import pandas as pd
+            X = pd.DataFrame([row])[feature_cols].fillna(0)
+            feat = X.values[0]
+        else:
+            feat = [row.get(k, 0) or 0 for k in sorted(row.keys())]
+        for h in HORIZONS:
+            result[f"t{h}"] = round(room_temp + float(models[h].predict([feat])[0]), 2)
+        result["prediction_source"] = "gbr_model"
+        for h in HORIZONS:
+            result[f"rmse_{h}m_cv_mean"] = meta.get(f"rmse_{h}m_cv_mean")
+        result["n_training_samples"] = meta.get("n_samples")
+        return result

--- a/room_temp_model_service/requirements.txt
+++ b/room_temp_model_service/requirements.txt
@@ -1,0 +1,7 @@
+paho-mqtt>=1.6,<3
+scikit-learn>=1.3
+pandas>=2.0
+numpy>=1.24
+joblib>=1.3
+influxdb>=5.3
+astral>=3.2

--- a/room_temp_model_service/rooms.example.json
+++ b/room_temp_model_service/rooms.example.json
@@ -2,19 +2,19 @@
   {
     "name": "owner_suite",
     "temp_sensors": ["sensor.owner_suite_tph_temperature", "sensor.bedroom_temperature"],
-    "humidity_sensor": "sensor.owner_suite_tph_humidity",
+    "humidity_sensors": ["sensor.owner_suite_tph_humidity"],
     "confidence_sensor": "sensor.bedroom_room_confidence"
   },
   {
     "name": "office",
     "temp_sensors": ["sensor.office_tph_temperature", "sensor.office_temperature"],
-    "humidity_sensor": "sensor.office_tph_humidity",
+    "humidity_sensors": ["sensor.office_tph_humidity"],
     "confidence_sensor": "sensor.office_room_confidence"
   },
   {
     "name": "guest_room",
     "temp_sensors": ["sensor.guest_room_tph_temperature", "sensor.guest_room_temperature"],
-    "humidity_sensor": "sensor.guest_room_tph_humidity",
+    "humidity_sensors": ["sensor.guest_room_tph_humidity"],
     "confidence_sensor": null
   }
 ]

--- a/room_temp_model_service/rooms.example.json
+++ b/room_temp_model_service/rooms.example.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "owner_suite",
+    "temp_sensors": ["sensor.owner_suite_tph_temperature", "sensor.bedroom_temperature"],
+    "humidity_sensor": "sensor.owner_suite_tph_humidity",
+    "confidence_sensor": "sensor.bedroom_room_confidence"
+  },
+  {
+    "name": "office",
+    "temp_sensors": ["sensor.office_tph_temperature", "sensor.office_temperature"],
+    "humidity_sensor": "sensor.office_tph_humidity",
+    "confidence_sensor": "sensor.office_room_confidence"
+  },
+  {
+    "name": "guest_room",
+    "temp_sensors": ["sensor.guest_room_tph_temperature", "sensor.guest_room_temperature"],
+    "humidity_sensor": "sensor.guest_room_tph_humidity",
+    "confidence_sensor": null
+  }
+]

--- a/room_temp_model_service/service.py
+++ b/room_temp_model_service/service.py
@@ -96,6 +96,10 @@ class Service:
                 "json_attributes_topic": f"{self.base}/prediction/{room}",
                 "unit_of_measurement": "°F",
                 "device_class": "temperature",
+                # Mark unavailable after 2 missed publish cycles (5-min interval × 2).
+                # ThermalPreemptor's _safe_attr_float returns None for unavailable,
+                # so stale predictions never trigger a hold.
+                "expire_after": 660,
             }
             self.client.publish(f"{self.disc_prefix}/sensor/{uid}/config",
                                 json.dumps(cfg), retain=True)

--- a/room_temp_model_service/service.py
+++ b/room_temp_model_service/service.py
@@ -1,0 +1,167 @@
+"""MQTT service wrapper around RoomTempModel.
+
+Runs as a standalone container off the Home Assistant host. It is HA-agnostic:
+it speaks only MQTT (to the AppDaemon shim + HA discovery) and InfluxDB (for
+training). No Home Assistant token or API access required.
+
+Topics (all under MQTT_BASE_TOPIC, default `room_temp_model`):
+  <base>/features   (in)  — feature payload from the AppDaemon shim, per cycle:
+                            {"ts": iso, "rooms": {name: {room_temp, ...,
+                             forecast:{15:{...},30:{...},60:{...}}}}}
+  <base>/train      (in)  — retrain trigger (payload optional {"rooms":[...]})
+  <base>/status     (out, retained) — service + last-train status JSON
+
+Predictions are published via Home Assistant MQTT discovery so
+`sensor.room_temp_prediction_<room>` appear natively:
+  homeassistant/sensor/room_temp_prediction_<room>/config  (retained)
+  <base>/prediction/<room>                                 (state + attrs)
+
+Training runs on a background thread so the MQTT loop never blocks; only one
+training run happens at a time.
+"""
+
+import json
+import os
+import threading
+
+import paho.mqtt.client as mqtt
+
+from model import HORIZONS, RoomTempModel
+
+
+def _env(name, default=None):
+    v = os.environ.get(name)
+    return v if v is not None and v != "" else default
+
+
+def load_config():
+    """Config from env + a rooms JSON (ROOMS_JSON or /config/rooms.json)."""
+    rooms_json = _env("ROOMS_JSON")
+    if rooms_json:
+        rooms = json.loads(rooms_json)
+    else:
+        path = _env("ROOMS_FILE", "/config/rooms.json")
+        with open(path) as f:
+            rooms = json.load(f)
+    return {
+        "model_dir": _env("MODEL_DIR", "/models"),
+        "latitude": float(_env("LATITUDE", "0")),
+        "longitude": float(_env("LONGITUDE", "0")),
+        "min_training_samples": int(_env("MIN_TRAINING_SAMPLES", "500")),
+        "influxdb": {
+            "host": _env("INFLUXDB_HOST", "localhost"),
+            "port": int(_env("INFLUXDB_PORT", "8086")),
+            "database": _env("INFLUXDB_DATABASE", "home_assistant"),
+        },
+        "rooms": rooms,
+    }
+
+
+class Service:
+    def __init__(self):
+        self.cfg = load_config()
+        self.base = _env("MQTT_BASE_TOPIC", "room_temp_model")
+        self.disc_prefix = _env("MQTT_DISCOVERY_PREFIX", "homeassistant")
+        self.model = RoomTempModel(self.cfg)
+        self.model.load()
+        self._train_lock = threading.Lock()
+        self._training = False
+
+        self.client = mqtt.Client(client_id=_env("MQTT_CLIENT_ID", "room_temp_model_service"))
+        user = _env("MQTT_USERNAME")
+        if user:
+            self.client.username_pw_set(user, _env("MQTT_PASSWORD"))
+        self.client.on_connect = self._on_connect
+        self.client.on_message = self._on_message
+        self.client.will_set(f"{self.base}/status", json.dumps({"online": False}), retain=True)
+
+    # ------------------------------------------------------------------
+
+    def _on_connect(self, client, userdata, flags, rc):
+        client.subscribe(f"{self.base}/features")
+        client.subscribe(f"{self.base}/train")
+        self._publish_discovery()
+        loaded = {r: bool(self.model.models.get(r)) for r in self.model.rooms}
+        client.publish(f"{self.base}/status",
+                       json.dumps({"online": True, "models_loaded": loaded}), retain=True)
+
+    def _publish_discovery(self):
+        for room in self.model.rooms:
+            uid = f"room_temp_prediction_{room}"
+            cfg = {
+                "name": f"Predicted Temp {room.replace('_', ' ').title()} T+30",
+                "unique_id": uid,
+                "state_topic": f"{self.base}/prediction/{room}",
+                "value_template": "{{ value_json.t30 }}",
+                "json_attributes_topic": f"{self.base}/prediction/{room}",
+                "unit_of_measurement": "°F",
+                "device_class": "temperature",
+            }
+            self.client.publish(f"{self.disc_prefix}/sensor/{uid}/config",
+                                json.dumps(cfg), retain=True)
+
+    def _on_message(self, client, userdata, msg):
+        try:
+            payload = json.loads(msg.payload.decode() or "{}")
+        except Exception:
+            payload = {}
+        if msg.topic == f"{self.base}/features":
+            self._handle_features(payload)
+        elif msg.topic == f"{self.base}/train":
+            self._trigger_train(payload.get("rooms"))
+
+    # ------------------------------------------------------------------
+
+    def _handle_features(self, payload):
+        from datetime import datetime, timezone
+        ts_raw = payload.get("ts")
+        try:
+            ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00")) if ts_raw else datetime.now(timezone.utc)
+        except Exception:
+            ts = datetime.now(timezone.utc)
+        for room, raw in (payload.get("rooms") or {}).items():
+            if room not in self.model.rooms:
+                continue
+            try:
+                result = self.model.predict(room, raw, ts)
+            except Exception as e:
+                self.client.publish(f"{self.base}/status",
+                                    json.dumps({"predict_error": f"{room}: {e}"}))
+                continue
+            if result is None:
+                continue
+            result["room"] = room
+            result["updated_at"] = ts.isoformat()
+            self.client.publish(f"{self.base}/prediction/{room}", json.dumps(result), retain=True)
+
+    def _trigger_train(self, rooms):
+        if self._training:
+            self.client.publish(f"{self.base}/status", json.dumps({"train": "already_running"}))
+            return
+        threading.Thread(target=self._run_train, args=(rooms,), daemon=True).start()
+
+    def _run_train(self, rooms):
+        with self._train_lock:
+            self._training = True
+            self.client.publish(f"{self.base}/status", json.dumps({"train": "started", "rooms": rooms}))
+            try:
+                report = self.model.train(rooms)
+                self.client.publish(f"{self.base}/status",
+                                    json.dumps({"train": "done", "report": report}), retain=True)
+                self._publish_discovery()
+            except Exception as e:
+                self.client.publish(f"{self.base}/status", json.dumps({"train": "error", "error": str(e)}))
+            finally:
+                self._training = False
+
+    # ------------------------------------------------------------------
+
+    def run(self):
+        host = _env("MQTT_HOST", "localhost")
+        port = int(_env("MQTT_PORT", "1883"))
+        self.client.connect(host, port, keepalive=60)
+        self.client.loop_forever()
+
+
+if __name__ == "__main__":
+    Service().run()

--- a/tests/test_room_name_registry.py
+++ b/tests/test_room_name_registry.py
@@ -131,7 +131,7 @@ def test_room_name_registry_is_documented_in_readme() -> None:
 def test_validate_config_workflow_runs_pytest_for_room_name_enforcement() -> None:
     text = VALIDATE_WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "name: Pytest" in text
-    assert "uv run --with pytest pytest" in text
+    assert "uv run --with pytest --with pandas --with numpy pytest" in text
 
 
 def test_room_name_registry_keys_are_unique() -> None:

--- a/tests/test_room_name_registry.py
+++ b/tests/test_room_name_registry.py
@@ -131,7 +131,9 @@ def test_room_name_registry_is_documented_in_readme() -> None:
 def test_validate_config_workflow_runs_pytest_for_room_name_enforcement() -> None:
     text = VALIDATE_WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "name: Pytest" in text
-    assert "uv run --with pytest --with pandas --with numpy pytest" in text
+    # Tolerate extra `--with <pkg>` deps (e.g. pandas/numpy for the room-temp
+    # model tests) — the invariant is that CI runs pytest via uv.
+    assert re.search(r"uv run (?:--with \S+ )*pytest\b", text)
 
 
 def test_room_name_registry_keys_are_unique() -> None:

--- a/tests/test_room_temp_model.py
+++ b/tests/test_room_temp_model.py
@@ -1,0 +1,475 @@
+"""Unit tests for the external room-temperature model core.
+
+room_temp_model_service/model.py is pure Python (pandas/sklearn/astral are
+lazily imported inside the functions that need them), so the feature-assembly
+and prediction paths are testable without any of the heavy deps. The
+training-data tests need pandas and skip cleanly when it is absent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+MODEL_PATH = Path(__file__).resolve().parents[1] / "room_temp_model_service" / "model.py"
+
+
+def _load_model_module():
+    spec = importlib.util.spec_from_file_location("room_temp_model", MODEL_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["room_temp_model"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+model = _load_model_module()
+
+LAT, LON = 44.761712, -93.203609
+
+ROOMS = [
+    {
+        "name": "owner_suite",
+        "temp_sensors": ["sensor.owner_suite_tph_temperature", "sensor.bedroom_temperature"],
+        "humidity_sensors": ["sensor.owner_suite_tph_humidity"],
+        "confidence_sensor": "sensor.bedroom_room_confidence",
+    }
+]
+
+
+@pytest.fixture
+def rtm(tmp_path):
+    return model.RoomTempModel({
+        "model_dir": str(tmp_path),
+        "latitude": LAT,
+        "longitude": LON,
+        "min_training_samples": 10,
+        "influxdb": {"host": "x", "port": 8086, "database": "d"},
+        "rooms": ROOMS,
+    })
+
+
+def _raw(**overrides):
+    base = {
+        "room_temp": 72.0,
+        "room_humidity": 45.0,
+        "outside_temp": 80.0,
+        "outside_humidity": 50.0,
+        "cloud_cover": 40.0,
+        "wind_speed": 5.0,
+        "uv_index": 3.0,
+        "precipitation": 0.0,
+        "occupancy": 100.0,
+        "hvac_heating": 0.0,
+        "hvac_cooling": 1.0,
+        "room_temp_rate_15m": 0.02,
+        "outside_delta_3h": 1.5,
+        "forecast": {},
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------- sun_position
+
+
+def test_sun_position_is_high_at_local_solar_noon():
+    # ~17:30 UTC ≈ 12:30 local (CDT) on the summer solstice.
+    elev, azim = model.sun_position(LAT, LON, datetime(2026, 6, 21, 17, 30, tzinfo=timezone.utc))
+    assert elev > 30.0
+    assert 0.0 <= azim <= 360.0
+
+
+def test_sun_position_is_below_horizon_at_local_midnight():
+    # ~06:00 UTC ≈ 01:00 local.
+    elev, _ = model.sun_position(LAT, LON, datetime(2026, 6, 21, 6, 0, tzinfo=timezone.utc))
+    assert elev < 0.0
+
+
+def test_sun_position_winter_noon_lower_than_summer_noon():
+    summer, _ = model.sun_position(LAT, LON, datetime(2026, 6, 21, 17, 30, tzinfo=timezone.utc))
+    winter, _ = model.sun_position(LAT, LON, datetime(2026, 12, 21, 18, 0, tzinfo=timezone.utc))
+    assert winter < summer
+
+
+def test_sun_position_falls_back_when_astral_missing(monkeypatch):
+    """The pure-math fallback must still return sane values (no astral installed)."""
+    monkeypatch.setitem(sys.modules, "astral", None)  # force the except branch
+    elev, azim = model.sun_position(LAT, LON, datetime(2026, 6, 21, 17, 30, tzinfo=timezone.utc))
+    assert isinstance(elev, float) and isinstance(azim, float)
+    assert -90.0 <= elev <= 90.0
+    assert 0.0 <= azim <= 360.0
+
+
+# --------------------------------------------------------------- _assemble_row
+
+
+def test_assemble_row_emits_every_horizon_feature(rtm):
+    row = rtm._assemble_row(_raw(), datetime(2026, 7, 9, 18, 0, tzinfo=timezone.utc))
+    for h in model.HORIZONS:
+        for stem in ("cloud_cover", "outside_temp", "outside_humidity",
+                     "wind_speed", "precipitation", "uv_index",
+                     "sun_elevation", "sun_azimuth_sin", "sun_azimuth_cos"):
+            assert f"{stem}_{h}m" in row, f"missing {stem}_{h}m"
+
+
+def test_assemble_row_forecast_missing_falls_back_to_current_values(rtm):
+    row = rtm._assemble_row(_raw(forecast={}), datetime(2026, 7, 9, 18, 0, tzinfo=timezone.utc))
+    assert row["cloud_cover_60m"] == 40.0
+    assert row["outside_temp_60m"] == 80.0
+    assert row["wind_speed_30m"] == 5.0
+
+
+def test_assemble_row_uses_forecast_when_present(rtm):
+    fc = {"60": {"cloud_cover": 10, "temperature": 90, "humidity": 30,
+                 "wind_speed": 12, "uv_index": 8, "precipitation": 0.5}}
+    row = rtm._assemble_row(_raw(forecast=fc), datetime(2026, 7, 9, 18, 0, tzinfo=timezone.utc))
+    assert row["cloud_cover_60m"] == 10
+    assert row["outside_temp_60m"] == 90
+    assert row["precipitation_60m"] == 0.5
+    # A horizon with no forecast entry still falls back to current.
+    assert row["cloud_cover_15m"] == 40.0
+
+
+def test_assemble_row_cyclic_encodings_lie_on_unit_circle(rtm):
+    row = rtm._assemble_row(_raw(), datetime(2026, 7, 9, 18, 0, tzinfo=timezone.utc))
+    for s, c in (("hour_sin", "hour_cos"), ("doy_sin", "doy_cos"),
+                 ("sun_azimuth_sin", "sun_azimuth_cos")):
+        assert math.isclose(row[s] ** 2 + row[c] ** 2, 1.0, abs_tol=1e-9)
+
+
+def test_assemble_row_preserves_none_humidity_rather_than_zeroing(rtm):
+    """None must stay None so the caller's fillna is explicit, not a silent 0."""
+    row = rtm._assemble_row(_raw(room_humidity=None), datetime(2026, 7, 9, 18, 0, tzinfo=timezone.utc))
+    assert row["room_humidity"] is None
+
+
+def test_assemble_row_defaults_occupancy_and_rate_to_zero(rtm):
+    row = rtm._assemble_row(
+        _raw(occupancy=None, room_temp_rate_15m=None, outside_delta_3h=None),
+        datetime(2026, 7, 9, 18, 0, tzinfo=timezone.utc),
+    )
+    assert row["occupancy"] == 0
+    assert row["room_temp_rate_15m"] == 0
+    assert row["outside_delta_3h"] == 0
+
+
+# ------------------------------------------------------------------- predict()
+
+
+def test_predict_without_models_uses_linear_fallback(rtm):
+    out = rtm.predict("owner_suite", _raw(room_temp=70.0, room_temp_rate_15m=0.02))
+    assert out["prediction_source"] == "fallback_linear"
+    assert out["t15"] == pytest.approx(70.0 + 0.02 * 15)
+    assert out["t30"] == pytest.approx(70.0 + 0.02 * 30)
+    assert out["t60"] == pytest.approx(70.0 + 0.02 * 60)
+
+
+def test_predict_without_models_treats_missing_rate_as_flat(rtm):
+    out = rtm.predict("owner_suite", _raw(room_temp=70.0, room_temp_rate_15m=None))
+    assert out["t60"] == pytest.approx(70.0)
+
+
+def test_predict_returns_none_for_non_numeric_room_temp(rtm):
+    assert rtm.predict("owner_suite", _raw(room_temp="unavailable")) is None
+    assert rtm.predict("owner_suite", _raw(room_temp=None)) is None
+
+
+class _StubModel:
+    """Stands in for a fitted GradientBoostingRegressor; returns a fixed delta."""
+
+    def __init__(self, delta):
+        self.delta = delta
+        self.calls = 0
+
+    def predict(self, X):
+        self.calls += 1
+        return [self.delta]
+
+
+def test_predict_adds_model_delta_to_current_temp(rtm):
+    """The model predicts a DELTA; predict() must add it to the current temp."""
+    rtm.models["owner_suite"] = {15: _StubModel(0.5), 30: _StubModel(1.0), 60: _StubModel(2.5)}
+    rtm.meta["owner_suite"] = {"feature_cols": None, "trained_at": "2026-07-09T00:00:00"}
+
+    out = rtm.predict("owner_suite", _raw(room_temp=72.0))
+
+    assert out["prediction_source"] == "gbr_model"
+    assert out["t15"] == pytest.approx(72.5)
+    assert out["t30"] == pytest.approx(73.0)
+    assert out["t60"] == pytest.approx(74.5)
+
+
+def test_predict_surfaces_cv_metrics_and_trained_at(rtm):
+    rtm.models["owner_suite"] = {h: _StubModel(0.0) for h in model.HORIZONS}
+    rtm.meta["owner_suite"] = {
+        "feature_cols": None,
+        "trained_at": "2026-07-09T00:00:00",
+        "rmse_60m_cv_mean": 1.23,
+        "n_samples": 4242,
+    }
+    out = rtm.predict("owner_suite", _raw())
+    assert out["rmse_60m_cv_mean"] == 1.23
+    assert out["trained_at"] == "2026-07-09T00:00:00"
+    assert out["n_training_samples"] == 4242
+
+
+def test_predict_selects_only_trained_feature_cols(rtm):
+    """feature_cols drives the vector, so extra candidate features are ignored."""
+    pytest.importorskip("pandas")
+    captured = {}
+
+    class _Capturing:
+        def predict(self, X):
+            captured["n"] = len(X[0])
+            return [1.0]
+
+    cols = ["room_temp", "cloud_cover", "sun_elevation"]
+    rtm.models["owner_suite"] = {h: _Capturing() for h in model.HORIZONS}
+    rtm.meta["owner_suite"] = {"feature_cols": cols}
+
+    out = rtm.predict("owner_suite", _raw(room_temp=72.0))
+
+    assert captured["n"] == len(cols)
+    assert out["t60"] == pytest.approx(73.0)
+
+
+# -------------------------------------------------- _build_training_data (pandas)
+
+
+def _install_fake_influx(rtm, monkeypatch, numeric: dict, hvac=None):
+    """Point the model's InfluxDB reads at in-memory pandas Series."""
+    import pandas as pd
+
+    monkeypatch.setattr(rtm, "_influx_client", lambda: object())
+    monkeypatch.setattr(rtm, "_query_generic", lambda _c, entity_id, **kw: numeric.get(entity_id))
+    monkeypatch.setattr(
+        rtm, "_query_categorical",
+        lambda _c, entity_id, **kw: (hvac if hvac is not None else pd.Series(dtype=object)),
+    )
+
+
+def _index(n=240):
+    import pandas as pd
+    return pd.date_range("2026-06-01", periods=n, freq="5min", tz="UTC")
+
+
+def _series(idx, value):
+    import pandas as pd
+    return pd.Series([value] * len(idx), index=idx, dtype=float)
+
+
+def _base_numeric(idx, **overrides):
+    data = {
+        "sensor.owner_suite_tph_temperature": _series(idx, 72.0),
+        "sensor.bedroom_temperature": _series(idx, 74.0),
+        "sensor.owner_suite_tph_humidity": _series(idx, 45.0),
+        "sensor.bedroom_room_confidence": _series(idx, 100.0),
+        "sensor.outside_temperature": _series(idx, 80.0),
+        "sensor.outside_humidity": _series(idx, 50.0),
+        "sensor.tomorrow_io_the_brewery_cloud_cover": _series(idx, 40.0),
+        "sensor.pinehotties_wind_speed": _series(idx, 5.0),
+        "sensor.pinehotties_hourly_rain": _series(idx, 0.0),
+        "sensor.pinehotties_uv_index": _series(idx, 3.0),
+    }
+    data.update(overrides)
+    return data
+
+
+def test_room_temp_is_mean_of_member_sensors(rtm, monkeypatch):
+    pytest.importorskip("pandas")
+    idx = _index()
+    _install_fake_influx(rtm, monkeypatch, _base_numeric(idx))
+
+    df, _ = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+
+    assert df is not None
+    # mean(72, 74) == 73
+    assert df["room_temp"].round(3).eq(73.0).all()
+
+
+def test_room_temp_uses_single_member_when_other_has_no_history(rtm, monkeypatch):
+    pytest.importorskip("pandas")
+    idx = _index()
+    numeric = _base_numeric(idx)
+    numeric["sensor.bedroom_temperature"] = None  # ecobee not yet recording
+
+    _install_fake_influx(rtm, monkeypatch, numeric)
+    df, _ = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+
+    assert df is not None
+    assert df["room_temp"].round(3).eq(72.0).all()
+
+
+def test_humidity_sensors_list_is_averaged(rtm, monkeypatch):
+    pytest.importorskip("pandas")
+    idx = _index()
+    numeric = _base_numeric(idx)
+    numeric["sensor.second_humidity"] = _series(idx, 55.0)
+    rtm.rooms["owner_suite"]["humidity_sensors"] = [
+        "sensor.owner_suite_tph_humidity", "sensor.second_humidity",
+    ]
+
+    _install_fake_influx(rtm, monkeypatch, numeric)
+    df, _ = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+
+    assert df["room_humidity"].round(3).eq(50.0).all()  # mean(45, 55)
+
+
+def test_humidity_sensor_singular_key_is_backwards_compatible(rtm, monkeypatch):
+    pytest.importorskip("pandas")
+    idx = _index()
+    cfg = dict(rtm.rooms["owner_suite"])
+    cfg.pop("humidity_sensors")
+    cfg["humidity_sensor"] = "sensor.owner_suite_tph_humidity"
+
+    _install_fake_influx(rtm, monkeypatch, _base_numeric(idx))
+    df, _ = rtm._build_training_data("owner_suite", cfg)
+
+    assert df["room_humidity"].round(3).eq(45.0).all()
+
+
+def test_junk_zero_outside_humidity_blanks_the_paired_temperature(rtm, monkeypatch):
+    """outside_* emit a literal 0 when the weather source drops; drop those rows."""
+    pytest.importorskip("pandas")
+    idx = _index()
+    numeric = _base_numeric(idx)
+    hum = _series(idx, 50.0)
+    temp = _series(idx, 80.0)
+    hum.iloc[100] = 0.0   # junk marker
+    temp.iloc[100] = 0.0  # junk temperature that must not be learned
+    numeric["sensor.outside_humidity"] = hum
+    numeric["sensor.outside_temperature"] = temp
+
+    _install_fake_influx(rtm, monkeypatch, numeric)
+    df, _ = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+
+    # The junk 0 was blanked and forward-filled from the previous good sample.
+    assert (df["outside_temp"] > 0).all()
+    assert (df["outside_humidity"] > 0).all()
+
+
+def test_real_subzero_outside_temp_survives_the_junk_filter(rtm, monkeypatch):
+    """A genuine winter -5°F reading carries real humidity and must be kept."""
+    pytest.importorskip("pandas")
+    idx = _index()
+    numeric = _base_numeric(idx)
+    numeric["sensor.outside_temperature"] = _series(idx, -5.0)
+    numeric["sensor.outside_humidity"] = _series(idx, 70.0)
+
+    _install_fake_influx(rtm, monkeypatch, numeric)
+    df, _ = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+
+    assert df is not None and len(df) > 0
+    assert df["outside_temp"].eq(-5.0).all()
+
+
+def test_coverage_filter_drops_a_sensor_with_no_history_without_emptying_the_set(rtm, monkeypatch):
+    """A brand-new sensor (all-NaN) must be dropped, not collapse training."""
+    pytest.importorskip("pandas")
+    idx = _index()
+    numeric = _base_numeric(idx)
+    numeric["sensor.pinehotties_wind_speed"] = None
+    numeric["sensor.pinehotties_hourly_rain"] = None
+    numeric["sensor.pinehotties_uv_index"] = None
+
+    _install_fake_influx(rtm, monkeypatch, numeric)
+    df, _ = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+
+    assert df is not None and len(df) > 0, "no-history sensors collapsed the training set"
+    for stem in ("wind_speed", "precipitation", "uv_index"):
+        assert stem not in df.columns
+        for h in model.HORIZONS:
+            assert f"{stem}_{h}m" not in df.columns
+    # Well-covered features survive.
+    assert "cloud_cover" in df.columns
+    assert "room_temp" in df.columns
+
+
+def test_coverage_filter_keeps_a_mostly_populated_column(rtm, monkeypatch):
+    pytest.importorskip("pandas")
+    import numpy as np
+    idx = _index()
+    numeric = _base_numeric(idx)
+    wind = _series(idx, 5.0)
+    wind.iloc[:20] = np.nan  # ~92% coverage, above MIN_COVERAGE
+    numeric["sensor.pinehotties_wind_speed"] = wind
+
+    _install_fake_influx(rtm, monkeypatch, numeric)
+    df, _ = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+
+    assert "wind_speed" in df.columns
+
+
+def test_targets_are_future_minus_current_temperature(rtm, monkeypatch):
+    """The model learns a delta, not an absolute temperature."""
+    pytest.importorskip("pandas")
+    import numpy as np
+    idx = _index()
+    numeric = _base_numeric(idx)
+    # Ramp both members by 0.1°F per 5-min slot -> mean also ramps 0.1/slot.
+    ramp = np.arange(len(idx)) * 0.1
+    import pandas as pd
+    numeric["sensor.owner_suite_tph_temperature"] = pd.Series(72.0 + ramp, index=idx)
+    numeric["sensor.bedroom_temperature"] = pd.Series(72.0 + ramp, index=idx)
+
+    _install_fake_influx(rtm, monkeypatch, numeric)
+    df, y = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+
+    # T+60 == 12 slots ahead == +1.2°F
+    assert y["delta_60"].reindex(df.index).round(3).eq(1.2).all()
+    assert y["delta_15"].reindex(df.index).round(3).eq(0.3).all()
+
+
+def test_fold_assignment_is_isoweek_modulo_five(rtm, monkeypatch):
+    pytest.importorskip("pandas")
+    idx = _index()
+    _install_fake_influx(rtm, monkeypatch, _base_numeric(idx))
+    df, _ = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+
+    expected = df.index.isocalendar().week % 5
+    assert df["fold"].tolist() == list(expected)
+    assert df["fold"].between(0, 4).all()
+
+
+def test_insufficient_history_returns_none(rtm, monkeypatch):
+    pytest.importorskip("pandas")
+    idx = _index(n=5)  # below min_training_samples=10
+    _install_fake_influx(rtm, monkeypatch, _base_numeric(idx))
+    df, y = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+    assert df is None and y is None
+
+
+def test_no_room_temp_history_returns_none(rtm, monkeypatch):
+    pytest.importorskip("pandas")
+    idx = _index()
+    numeric = _base_numeric(idx)
+    numeric["sensor.owner_suite_tph_temperature"] = None
+    numeric["sensor.bedroom_temperature"] = None
+
+    _install_fake_influx(rtm, monkeypatch, numeric)
+    df, y = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+    assert df is None and y is None
+
+
+# ------------------------------------------------------------- train/infer parity
+
+
+def test_every_trained_feature_can_be_produced_at_inference(rtm, monkeypatch):
+    """The whole point of sharing feature code: inference must be able to supply
+    every column training selected, or predict() would KeyError."""
+    pytest.importorskip("pandas")
+    idx = _index()
+    _install_fake_influx(rtm, monkeypatch, _base_numeric(idx))
+
+    df, _ = rtm._build_training_data("owner_suite", rtm.rooms["owner_suite"])
+    feature_cols = [c for c in df.columns if c != "fold" and not c.startswith("delta_")]
+
+    row = rtm._assemble_row(_raw(), datetime(2026, 7, 9, 18, 0, tzinfo=timezone.utc))
+
+    missing = sorted(set(feature_cols) - set(row))
+    assert not missing, f"inference cannot supply trained features: {missing}"

--- a/tests/test_room_temp_model.py
+++ b/tests/test_room_temp_model.py
@@ -238,6 +238,93 @@ def test_predict_selects_only_trained_feature_cols(rtm):
     assert out["t60"] == pytest.approx(73.0)
 
 
+# ------------------------------------------------------------- InfluxDB queries
+
+
+def test_influx_where_uses_bare_object_id_and_domain_tag():
+    """HA's InfluxDB integration tags points with the object_id + a `domain`
+    tag, never the fully-qualified entity_id. Querying the qualified id matches
+    nothing, which silently yields 'insufficient data' for every room."""
+    where = model.RoomTempModel._influx_where("sensor.outside_temperature")
+    assert "entity_id='outside_temperature'" in where
+    assert "domain='sensor'" in where
+    assert "sensor.outside_temperature" not in where
+
+
+def test_influx_where_disambiguates_domains():
+    """The same object_id can exist under several domains (e.g. sensor + number)."""
+    assert "domain='number'" in model.RoomTempModel._influx_where("number.foo")
+    assert "domain='sensor'" in model.RoomTempModel._influx_where("sensor.foo")
+
+
+def test_influx_where_passes_through_unqualified_id():
+    assert model.RoomTempModel._influx_where("outside_temperature") == "entity_id='outside_temperature'"
+
+
+def test_categorical_query_reads_the_state_field_not_value(rtm):
+    """HA stores non-numeric states in a `state` field; selecting `value`
+    returns nothing and silently zeroes the HVAC one-hots."""
+    pytest.importorskip("pandas")
+    import pandas as pd
+    asked = []
+
+    class _Client:
+        def query(self, q):
+            asked.append(q)
+            class _R:
+                def items(self_inner):
+                    if "SELECT state" not in q:
+                        return []          # `value` field does not exist
+                    return [(("sensor.hvac_activity", None), [
+                        {"time": "2026-07-01T00:00:00Z", "state": "cooling"},
+                        {"time": "2026-07-01T00:05:00Z", "state": "idle"},
+                    ])]
+            return _R()
+
+    out = rtm._query_categorical(_Client(), "sensor.hvac_activity")
+
+    assert asked[0].startswith("SELECT state"), "must try the `state` field first"
+    assert not out.empty
+    assert out.iloc[0] == "cooling"
+
+
+def test_categorical_query_falls_back_to_value_field(rtm):
+    pytest.importorskip("pandas")
+
+    class _Client:
+        def query(self, q):
+            class _R:
+                def items(self_inner):
+                    if "SELECT value" not in q:
+                        return []
+                    return [(("m", None), [{"time": "2026-07-01T00:00:00Z", "value": "heating"}])]
+            return _R()
+
+    out = rtm._query_categorical(_Client(), "sensor.hvac_activity")
+    assert not out.empty and out.iloc[0] == "heating"
+
+
+def test_queries_are_built_with_the_object_id(rtm):
+    """Capture the InfluxQL actually sent to the client."""
+    pytest.importorskip("pandas")
+    seen = []
+
+    class _Client:
+        def query(self, q):
+            seen.append(q)
+            class _R:
+                def items(self_inner):
+                    return []
+            return _R()
+
+    rtm._query_generic(_Client(), "sensor.owner_suite_tph_temperature")
+    rtm._query_categorical(_Client(), "sensor.hvac_activity")
+
+    assert any("entity_id='owner_suite_tph_temperature'" in q and "domain='sensor'" in q for q in seen)
+    assert any("entity_id='hvac_activity'" in q and "domain='sensor'" in q for q in seen)
+    assert not any("sensor.owner_suite_tph_temperature" in q for q in seen)
+
+
 # -------------------------------------------------- _build_training_data (pandas)
 
 


### PR DESCRIPTION
## Summary

Adds a proactive thermostat control loop that predicts per-room temperatures 15/30/60 minutes ahead and preemptively cools before solar-gain rooms overshoot comfort targets. South/east/west-facing rooms on upper floors (owner suite, office, guest room) regularly gain 5–6°F in 30 minutes from solar gain + stratification; the Ecobee's reactive loop chases this drift. This system front-runs it.

## Changes

### New: `appdaemon/apps/room_temp_predictor.py`
- Per-room `GradientBoostingRegressor` models (T+15, T+30, T+60 delta prediction)
- Training data pulled from multi-year InfluxDB history (room temps, HVAC state, outside temp/humidity, cloud cover, precipitation, wind speed/direction)
- Sun elevation/azimuth computed via `astral` math fallback for every historical timestamp (sun domain excluded from HA recorder but available in InfluxDB)
- **Purged 5-fold interleaved week-level CV** (`fold = iso_week % 5`): each fold's test set spans all four seasons across all years; 4-hour purge gap at fold boundaries prevents autocorrelation leakage (Lopez de Prado framework)
- Oracle forecast features at training time (actual t+N observations as proxy); real `weather.get_forecasts()` data at inference
- Models saved as joblib files to `/config/appdaemon/models/`; loaded at startup; **retrain only on manual trigger** via `input_button.retrain_room_temp_models` or `fire_event('retrain_room_temp_models')`
- 5-min prediction loop publishes `sensor.room_temp_prediction_{owner_suite,office,guest_room}` with `t15`/`t30`/`t60` attributes and CV RMSE metrics
- Falls back to linear rate extrapolation from `get_history()` until models are trained

### New: `appdaemon/apps/thermal_preemptor.py`
- Deterministic MPC-lite controller running every 5 minutes
- Reads T+60 predictions across all rooms; finds worst-case overshoot vs. Ecobee cooling setpoint
- Makes a **single** `climate.set_temperature` call (all rooms share one Ecobee) capped at 3°F below scheduled setpoint
- Schedules revert via `ecobee.resume_program` after estimated HVAC lead time (`gap / rate + 5min buffer`)
- HVAC rate from `sensor.ecobee_modeled_rate_deg_per_min` when running; parametric formula fallback (`0.028 - 0.00023 * t_out`, clamped to 0.008–0.016 °F/min) when idle
- Kill switch: `input_boolean.thermal_preemptor_enabled`
- Adjustable comfort margin: `input_number.thermal_preemptor_comfort_margin`

### Modified: `appdaemon/apps/thermostat_stats.py`
Adds four new per-room columns to the PostgreSQL `thermostat` table for future correlation analysis:
- `owner_suite_temp`, `office_temp` — room temps at each HVAC cycle event
- `bedroom_room_confidence` (owner suite occupancy proxy), `office_room_confidence`

Uses the existing `_ensure_optional_columns()` / `ALTER TABLE IF NOT EXISTS` pattern for non-destructive schema migration.

### Modified: `appdaemon/apps/apps.yaml`
- Adds 4 room sensor args to the `thermostat_stats` block
- Registers `room_temp_predictor` and `thermal_preemptor` apps

### Modified: `packages/climate.yaml`
- `input_boolean.thermal_preemptor_enabled` (initial: on) — kill switch
- `input_number.thermal_preemptor_comfort_margin` (0.25–3.0°F, default 0.5°F) — minimum predicted overshoot before preempting
- `input_button.retrain_room_temp_models` — manual retrain trigger
- Template sensors: `thermal_preemptor_status` (active/disabled/no_data), `room_temp_model_trained_at`

### Modified: `.gitignore`
Adds `!appdaemon/apps/room_temp_predictor.py` and `!appdaemon/apps/thermal_preemptor.py` exceptions to the `appdaemon/apps/*` ignore rule.

## Deployment notes

**New Python dependencies** (add to AppDaemon's pip packages): `influxdb` (InfluxDB v1 client), `astral`, `scikit-learn`, `pandas`, `numpy`, `joblib` (included with scikit-learn).

**First-run flow:**
1. Deploy code → AppDaemon starts, finds no `.joblib` files, uses linear fallback
2. Press `input_button.retrain_room_temp_models` (or call `fire_event('retrain_room_temp_models')`) to trigger training against full InfluxDB history
3. Models save to `/config/appdaemon/models/`; prediction sensors switch from `fallback_linear` to `gbr_model`
4. Preemptor becomes active automatically once predictions are flowing

**Rooms in scope:** owner suite (east + upper floor stratification), office (south + east, upper floor), guest room (south + west, upper floor). All three have confirmed TPH sensors. Guest room has no room confidence sensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXu9aZuEZNGxDfTLKjU18P

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXu9aZuEZNGxDfTLKjU18P)_