### PR TITLE
Fix README CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # The Brewery Home Assistant Configuration 🍺
-[![Build Status](https://api.travis-ci.com/rtclauss/hass-config.svg?branch=main)](https://app.travis-ci.com/github/rtclauss/hass-config)
+[![Validate Home Assistant Config](https://github.com/rtclauss/hass-config/actions/workflows/validate-config.yml/badge.svg?branch=main)](https://github.com/rtclauss/hass-config/actions/workflows/validate-config.yml?query=branch%3Amain)
 
 [Home Assistant](https://home-assistant.io/) configuration files (YAMLs) and [AppDaemon](https://appdaemon.readthedocs.io/en/latest/) apps.
 

--- a/tests/test_readme_ci_badge.py
+++ b/tests/test_readme_ci_badge.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+README_PATH = ROOT / "README.md"
+
+
+def test_readme_build_badge_targets_live_validation_workflow() -> None:
+    readme = README_PATH.read_text(encoding="utf-8")
+
+    assert (
+        "https://github.com/rtclauss/hass-config/actions/workflows/"
+        "validate-config.yml/badge.svg?branch=main"
+    ) in readme
+    assert (
+        "https://github.com/rtclauss/hass-config/actions/workflows/"
+        "validate-config.yml?query=branch%3Amain"
+    ) in readme
+    assert "travis-ci" not in readme.lower()


### PR DESCRIPTION
## Summary
- replace the retired Travis status badge with the live `validate-config.yml` GitHub Actions badge for `main`
- link the badge to filtered workflow runs on `main`
- add regression coverage preventing the README from reverting to Travis

Fixes #861

## Validation
- `uv run --with pytest pytest tests/test_readme_ci_badge.py`
- `uv run --with pytest pytest` (568 passed)
- `python3 scripts/allium_weed_check.py --changed-from origin/develop --format terminal`
- `rg -n -i "travis" README.md docs` (no matches)
- `git diff --check`