### PR TITLE
Guard Music Assistant restart against false departures

### DIFF
--- a/packages/utilities.yaml
+++ b/packages/utilities.yaml
@@ -563,8 +563,9 @@ automation:
 
   - alias: Restart Music Assistant when Ryan leaves home
     description: >
-      Restart the Music Assistant app only when Ryan leaves home to refresh
-      Sonos discovery while the house is empty.
+      Restart the Music Assistant app only when Ryan has actually left home to
+      refresh Sonos discovery while the house is empty. Ignore source-tracker
+      zone churn while the aggregated person remains home or is indeterminate.
     id: restart_music_assistant_every_12_17_hours
     trace:
       stored_traces: 10
@@ -573,6 +574,15 @@ automation:
         entity_id: person.ryan
         zone: zone.home
         event: leave
+    condition:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: person.ryan
+            state:
+              - home
+              - unknown
+              - unavailable
     action:
       - action: hassio.addon_restart
         continue_on_error: true

--- a/tests/test_utilities_music_assistant_restart.py
+++ b/tests/test_utilities_music_assistant_restart.py
@@ -57,3 +57,19 @@ def test_music_assistant_restart_only_runs_when_ryan_leaves_home() -> None:
         "self-rescheduling loop",
     ):
         assert token not in block
+
+
+def test_music_assistant_restart_ignores_false_source_tracker_zone_leave() -> None:
+    block = _automation_block("restart_music_assistant_every_12_17_hours")
+
+    guard = """    condition:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: person.ryan
+            state:
+              - home
+              - unknown
+              - unavailable"""
+
+    assert guard in block


### PR DESCRIPTION
Closes #596.

## What changed

- keep the native `zone.home` leave trigger for the Music Assistant restart workaround
- require the aggregated person state to be genuinely away before restarting
- block the restart while the person state is `home`, `unknown`, or `unavailable`
- add regression coverage for source-tracker zone churn

## Root cause and impact

A contributing tracker briefly lost its zone membership while the aggregated person remained home. Home Assistant emitted a zone-leave event anyway, so the workaround restarted Music Assistant during occupied use. The live MA sync groups and Sonos members then became unavailable, interrupting audio and affecting wake, bedtime, and arrival surfaces.

## Validation

- `uv run --with pytest pytest` — 568 passed
- targeted restart/runtime tests — 28 passed
- Allium weed check — passed
- relaxed YAML lint — passed
- HA YAML DRY verifier — changed automation introduced no duplicate group; pre-existing unrelated `utilities.yaml` findings are deferred to their existing cleanup scope
- local HA container check — blocked by the known Podman VM socket failure after a reported successful start; CI Home Assistant Check Config is required
