### PR TITLE
Make available device inventory discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ docker run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:2026.5.0
 
 ## Feature Docs
 
+- [Available Device Inventory](inventory.md)
 - [House Transition Framework](docs/house_transition_framework.md)
 - [Home Assistant Label Model](docs/ha_labels.md)
 - [Room Intent Policy](docs/room_intent.yaml)

--- a/tests/test_inventory_markdown.py
+++ b/tests/test_inventory_markdown.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 INVENTORY_PATH = ROOT / "inventory.md"
+README_PATH = ROOT / "README.md"
 
 
 def _clean_cell(value: str) -> str:
@@ -56,6 +57,32 @@ def _table_rows(heading: str) -> list[dict[str, str]]:
         cells = [cell.strip() for cell in line.split("|")[1:-1]]
         rows.append(dict(zip(headers, cells, strict=True)))
     return rows
+
+
+def test_available_inventory_has_issue_163_fields_for_every_row() -> None:
+    rows = _table_rows("Inventory")
+    allowed_domains = {
+        "binary_sensor",
+        "button",
+        "light",
+        "plant",
+        "sensor",
+        "switch",
+    }
+
+    assert rows, "Available device inventory must not be empty"
+    for row in rows:
+        assert int(row["quantity"]) > 0
+        assert row["brand"]
+        assert row["model"]
+        assert row["technology"]
+        assert _clean_cell(row["possible_home_assistant_domain"]) in allowed_domains
+
+
+def test_available_inventory_is_linked_from_readme() -> None:
+    readme = README_PATH.read_text(encoding="utf-8")
+
+    assert "[Available Device Inventory](inventory.md)" in readme
 
 
 def test_inventory_rows_cover_issue_201_and_202_updates() -> None:


### PR DESCRIPTION
Closes #163.

## What changed
- link the existing available-device inventory from the README feature documentation index
- add regression coverage requiring every spare inventory row to include a positive quantity, brand, model, technology, and supported inferred Home Assistant domain
- protect the README link so the inventory remains discoverable

## Validation
- `uv run --with pytest pytest tests/test_inventory_markdown.py -q` — 9 passed
- `uv run --with pytest pytest` — 569 passed
- `python3 scripts/allium_weed_check.py --changed-from origin/develop --format terminal` — passed
- `python3 scripts/check_ha_python_support.py --python-version-file .python-version` — passed (Home Assistant 2026.7.2 requires Python >=3.14.2; pinned 3.14.3 satisfies it)
- `git diff --check` — passed

Home Assistant config validation, YAML lint, and the HA YAML DRY verifier are not applicable because this change touches only Markdown and its Python regression tests.