### PR TITLE
Fix bedtime audio owner-suite scope

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1821,9 +1821,7 @@ script:
             {% set pindex = (range(0, (plists | length))|random) -%}
             {{ plists[pindex] }}
       - variables:
-          bedtime_playback_entity: >-
-            {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
-               else 'media_player.ma_group_everywhere' }}
+          bedtime_playback_entity: media_player.ma_group_guest
           bedtime_media_type: "{{ 'radio' if 'somafm.com' in playlist else '' }}"
           bedtime_pre_playback_fingerprint: >-
             {{ [
@@ -1856,8 +1854,6 @@ script:
           entity_id:
             - media_player.bedroom_sonos_2
             - media_player.bathroom_sonos_2
-            - media_player.office_sonos_2
-            - media_player.den_sonos_2
         data:
           volume_level: 0.20
       - alias: "Let bedtime volume settle before playback starts"
@@ -1946,27 +1942,22 @@ script:
             - delay_minutes: 0
               entity_id:
                 - media_player.bedroom_sonos_2
-                - media_player.office_sonos_2
                 - media_player.bathroom_sonos_2
-                - media_player.den_sonos_2
               volume_level: 0.1
             - delay_minutes: 2
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.bathroom_sonos_2
-                - media_player.office_sonos_2
               volume_level: 0.07
             - delay_minutes: 2
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.bathroom_sonos_2
-                - media_player.office_sonos_2
               volume_level: 0.05
             - delay_minutes: 2
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.bathroom_sonos_2
-                - media_player.office_sonos_2
               volume_level: 0.01
       - repeat:
           for_each: "{{ bedtime_rampdown_steps }}"

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -249,13 +249,13 @@ def test_arrival_music_sets_volume_on_selected_music_assistant_group_members() -
         )
 
 
-def test_bedtime_targets_guest_aware_sync_group_before_playing() -> None:
+def test_bedtime_targets_owner_suite_sync_group_before_playing() -> None:
     block = _script_block("spotify_bedtime")
 
     assert "bedtime_playback_entity" in block
     assert "media_player.ma_group_guest" in block
-    assert "media_player.ma_group_everywhere" in block
-    assert "input_boolean.guest_mode" in block
+    assert "media_player.ma_group_everywhere" not in block
+    assert "input_boolean.guest_mode" not in block
     assert 'action: script.music_assistant_prepare_bedroom_group' not in block
     assert 'action: script.music_assistant_play_item' in block
     assert block.index("media_player.ma_group_guest") < block.index(
@@ -578,6 +578,11 @@ def test_bedtime_volume_rampdown_is_data_driven_without_repeating_delay_actions(
     # rampdown, so the volume_set tolerates errors and no step opts out.
     assert "continue_on_error: true" in block
     assert "continue_on_error: false" not in block
+    assert block.count("- media_player.bedroom_sonos_2") == 4
+    assert block.count("- media_player.bathroom_sonos_2") == 4
+    assert "media_player.office_sonos_2" not in block
+    assert "media_player.den_sonos_2" not in block
+    assert "media_player.tiki_room_2" not in block
 
 
 def test_spotify_bedtime_reapplies_repeat_to_started_queue_before_rampdown() -> None:

--- a/tests/test_night_routines_allium_alignment.py
+++ b/tests/test_night_routines_allium_alignment.py
@@ -129,6 +129,31 @@ def test_spotify_bedtime_uses_bathroom_visit_or_timeout_before_rampdown() -> Non
         assert token in block
 
 
+def test_bedtime_audio_stays_within_allium_owner_suite_scope() -> None:
+    spec = (ROOT / "specs" / "night_routines.allium").read_text(encoding="utf-8")
+    bedtime_block = _script_block(MEDIA_PLAYER_PATH, "spotify_bedtime")
+    rampdown_block = _script_block(MEDIA_PLAYER_PATH, "spotify_bedtime_volume")
+
+    assert "ensures: BedtimeAudioRequested(bedroom_suite)" in spec
+    assert "bedtime_playback_entity: media_player.ma_group_guest" in bedtime_block
+
+    for unrelated_player in (
+        "media_player.ma_group_everywhere",
+        "media_player.office_sonos_2",
+        "media_player.den_sonos_2",
+        "media_player.tiki_room_2",
+    ):
+        assert unrelated_player not in bedtime_block
+        assert unrelated_player not in rampdown_block
+
+    for owner_suite_player in (
+        "media_player.bedroom_sonos_2",
+        "media_player.bathroom_sonos_2",
+    ):
+        assert owner_suite_player in bedtime_block
+        assert owner_suite_player in rampdown_block
+
+
 def test_goodnight_integrity_preserves_bedroom_audio_and_pauses_unrelated_rooms() -> None:
     block = _script_block(HOUSE_MODE_PATH, "goodnight_integrity")
 


### PR DESCRIPTION
Closes #871

## Summary

- always route bedtime playback through the existing Bedroom+Bathroom Music Assistant sync group
- remove Office and Den from the bedtime pre-volume and rampdown targets
- add focused Allium-alignment coverage so `BedtimeAudioRequested(bedroom_suite)` cannot drift back to whole-house playback

## Runtime evidence

The 2026-07-13 nightly runtime sweep correlated the latest successful bedtime trace with recorder history. `ma_group_everywhere` and Bedroom, Bathroom, Office, Den, and Tiki all entered `playing`, confirming the current deployed implementation expands owner-suite bedtime audio to unrelated rooms.

## Validation

- `uv run --with pytest pytest` — 568 passed
- focused Music Assistant/night Allium tests — 54 passed
- Allium spec/weed/alignment tests — 29 passed
- `allium check specs/night_routines.allium` — no errors
- `allium analyse specs/night_routines.allium` — no findings
- `yamllint` on `packages/media_player.yaml` — passed
- strict HA YAML DRY verification on `packages/media_player.yaml` — 38 parsed candidates, no duplicates or findings
