### PR TITLE
Show dual-unit integer temperatures on Inky (#873)

### DIFF
--- a/docs/inky_displays.md
+++ b/docs/inky_displays.md
@@ -81,7 +81,7 @@ Payloads are compact JSON. Required fields:
     {
       "type": "rows",
       "rows": [
-        {"icon": "mdi:weather-snowy", "label": "Weather", "value": "24F Snow", "level": "normal"},
+        {"icon": "mdi:weather-snowy", "label": "Weather", "value": "24F / -4C Snow", "level": "normal"},
         {"icon": "mdi:door-closed", "label": "Doors", "value": "Closed", "level": "normal"}
       ]
     }
@@ -208,7 +208,7 @@ Current owner-suite rows:
 
 | Row | Value source | Level behavior |
 | --- | --- | --- |
-| Weather | `sensor.outside_temperature` plus `sensor.active_weather_entity_id` weather state | `urgent` when NWS alerts are active |
+| Weather | `sensor.outside_temperature` converted and shown as Fahrenheit/Celsius, plus `sensor.active_weather_entity_id` weather state | `urgent` when NWS alerts are active |
 | Alarm | `input_datetime.weekday_alarm` or `input_datetime.weekend_alarm` when the matching alarm helper is on | Night-only; `emphasis` in `night_preview` when alarm is enabled |
 | Meeting | `input_datetime.next_work_meeting` when `input_boolean.special_meeting` is on | Night-only; shown when no urgent status is active |
 | Next | Next `calendar.ryan_claussen` event from `calendar.get_events` in the next 12 hours | Day-only; `emphasis` when an event is available |
@@ -234,6 +234,11 @@ meeting alarm or urgent `Status`. Meeting alarm details are night-only, and
 safety/exception status takes priority over the meeting row. The publish script
 also requests hourly forecast data at publish time for event-weather checks,
 with the legacy `forecast_json` attribute kept only as a fallback.
+
+All temperatures rendered in the owner-suite weather rows use the compact
+`73F / 23C` format. This includes current weather, tomorrow's forecast, and
+destination weather while a flight is active. Both units are rounded to whole
+numbers; the Inky never displays fractional temperature values.
 
 In `morning`, `up_for_day`, and `midday`, alarm and meeting-alarm rows are not
 shown. Those modes use current `Weather`, next calendar event time/title,

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -197,7 +197,10 @@ script:
             } %}
             {% set weather_icon = weather_icon_map.get(weather_state, 'mdi:weather-cloudy') %}
             {% set temperature = states('sensor.outside_temperature') %}
-            {% set weather_value = (temperature ~ 'F ' ~ weather_state.replace('-', ' ')) if temperature not in ['unknown', 'unavailable'] else weather_state.replace('-', ' ') %}
+            {% set temperature_f = temperature | float(default=none) %}
+            {% set temperature_f_rounded = temperature_f | round(0) | int if temperature_f is number else none %}
+            {% set temperature_c = ((temperature_f - 32) * 5 / 9) | round(0) | int if temperature_f is number else none %}
+            {% set weather_value = (temperature_f_rounded ~ 'F / ' ~ temperature_c ~ 'C ' ~ weather_state.replace('-', ' ')) if temperature_c is number else weather_state.replace('-', ' ') %}
             {% set daily_response = owner_suite_daily_forecast if owner_suite_daily_forecast is mapping else {} %}
             {% set hourly_response = owner_suite_hourly_forecast if owner_suite_hourly_forecast is mapping else {} %}
             {% set daily_forecast_rows = daily_response.get(weather_entity, daily_response.get(preferred_weather_entity, {})).get('forecast', []) | sort(attribute='datetime') %}
@@ -212,13 +215,14 @@ script:
               {% set forecast_ts = as_timestamp(forecast.datetime, default=none) %}
               {% if forecast_ts is number and forecast_ts >= tomorrow_start_ts and forecast_ts < tomorrow_end_ts and tomorrow.value == 'Unavailable' %}
                 {% set forecast_temp = forecast.temperature | int(default=none) %}
+                {% set forecast_temp_c = ((forecast_temp - 32) * 5 / 9) | round(0) | int if forecast_temp is number else none %}
                 {% set forecast_condition = forecast.condition | default('', true) | string | replace('-', ' ') %}
                 {% if forecast_temp is number and forecast_condition | trim != '' %}
-                  {% set tomorrow.value = forecast_temp ~ 'F ' ~ forecast_condition %}
+                  {% set tomorrow.value = forecast_temp ~ 'F / ' ~ forecast_temp_c ~ 'C ' ~ forecast_condition %}
                 {% elif forecast_condition | trim != '' %}
                   {% set tomorrow.value = forecast_condition %}
                 {% elif forecast_temp is number %}
-                  {% set tomorrow.value = forecast_temp ~ 'F' %}
+                  {% set tomorrow.value = forecast_temp ~ 'F / ' ~ forecast_temp_c ~ 'C' %}
                 {% endif %}
               {% endif %}
             {% endfor %}
@@ -308,11 +312,14 @@ script:
             {% set airport_value = (airport_origin ~ ' ' ~ airport_delay_minutes ~ 'm avg') if airport_delay_minutes is number and airport_origin not in ['', 'UNKNOWN', 'UNAVAILABLE'] else 'Airport n/a' %}
             {% set airport_level = 'urgent' if airport_delay_minutes is number and airport_delay_minutes >= 30 else 'normal' %}
             {% set destination_weather = states('sensor.next_travel_flight_destination_weather') %}
+            {% set destination_temp_f = destination_weather | replace('F', '') | float(default=none) %}
+            {% set destination_temp_c = ((destination_temp_f - 32) * 5 / 9) | round(0) | int if destination_temp_f is number else none %}
+            {% set destination_weather_value = (destination_weather ~ ' / ' ~ destination_temp_c ~ 'C') if destination_temp_c is number else weather_value %}
             {% set travel_rows = [
               {'label': 'Flight', 'value': (flight_label ~ ' ' ~ flight_destination ~ ' ' ~ flight_time) | trim, 'level': 'emphasis'},
               {'label': 'Status', 'value': flight_delay_value, 'level': 'urgent' if flight_status in ['cancelled', 'diverted'] or delay_minutes | int(0) >= 30 else 'normal'},
               {'label': 'ATC Delay', 'value': airport_value, 'level': airport_level},
-              {'icon': weather_icon, 'label': 'Dest Wx', 'value': destination_weather if destination_weather not in ['unknown', 'unavailable', ''] else weather_value, 'level': 'normal'}
+              {'icon': weather_icon, 'label': 'Dest Wx', 'value': destination_weather_value, 'level': 'normal'}
             ] %}
             {% if weather_alert %}
               {% set status_value = 'Weather alert' %}

--- a/packages/inky_displays.yaml
+++ b/packages/inky_displays.yaml
@@ -313,8 +313,9 @@ script:
             {% set airport_level = 'urgent' if airport_delay_minutes is number and airport_delay_minutes >= 30 else 'normal' %}
             {% set destination_weather = states('sensor.next_travel_flight_destination_weather') %}
             {% set destination_temp_f = destination_weather | replace('F', '') | float(default=none) %}
+            {% set destination_temp_f_rounded = destination_temp_f | round(0) | int if destination_temp_f is number else none %}
             {% set destination_temp_c = ((destination_temp_f - 32) * 5 / 9) | round(0) | int if destination_temp_f is number else none %}
-            {% set destination_weather_value = (destination_weather ~ ' / ' ~ destination_temp_c ~ 'C') if destination_temp_c is number else weather_value %}
+            {% set destination_weather_value = (destination_temp_f_rounded ~ 'F / ' ~ destination_temp_c ~ 'C') if destination_temp_c is number else weather_value %}
             {% set travel_rows = [
               {'label': 'Flight', 'value': (flight_label ~ ' ' ~ flight_destination ~ ' ' ~ flight_time) | trim, 'level': 'emphasis'},
               {'label': 'Status', 'value': flight_delay_value, 'level': 'urgent' if flight_status in ['cancelled', 'diverted'] or delay_minutes | int(0) >= 30 else 'normal'},

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -149,7 +149,9 @@ def test_owner_suite_travel_weather_includes_fahrenheit_and_celsius() -> None:
     block = _script_block("publish_owner_suite_inky_display")
 
     assert "destination_weather | replace('F', '') | float(default=none)" in block
-    assert "destination_weather ~ ' / ' ~ destination_temp_c ~ 'C'" in block
+    assert "destination_temp_f | round(0) | int if destination_temp_f is number else none" in block
+    assert "destination_temp_f_rounded ~ 'F / ' ~ destination_temp_c ~ 'C'" in block
+    assert "destination_weather ~ ' / '" not in block
     assert "'label': 'Dest Wx', 'value': destination_weather_value" in block
 
 

--- a/tests/test_inky_displays_package.py
+++ b/tests/test_inky_displays_package.py
@@ -133,6 +133,9 @@ def test_owner_suite_night_preview_includes_current_and_tomorrow_weather() -> No
     assert "forecast_rows = (state_attr('sensor.active_weather_entity_id', 'forecast_json')" in block
     assert "tomorrow_start_ts = as_timestamp(today_at('00:00') + timedelta(days=1))" in block
     assert "forecast.temperature | int(default=none)" in block
+    assert "temperature_f | round(0) | int if temperature_f is number else none" in block
+    assert "temperature_f_rounded ~ 'F / ' ~ temperature_c ~ 'C '" in block
+    assert "forecast_temp ~ 'F / ' ~ forecast_temp_c ~ 'C '" in block
     assert "resolved_mode == 'night_preview'" in block
     assert "'label': 'Tomorrow'" in block
     assert "'value': tomorrow.value" in block
@@ -140,6 +143,14 @@ def test_owner_suite_night_preview_includes_current_and_tomorrow_weather() -> No
     assert "night_detail_row" in night_block
     assert "'label': 'Alarm'" in night_block
     assert "'label': 'Meeting'" in night_block
+
+
+def test_owner_suite_travel_weather_includes_fahrenheit_and_celsius() -> None:
+    block = _script_block("publish_owner_suite_inky_display")
+
+    assert "destination_weather | replace('F', '') | float(default=none)" in block
+    assert "destination_weather ~ ' / ' ~ destination_temp_c ~ 'C'" in block
+    assert "'label': 'Dest Wx', 'value': destination_weather_value" in block
 
 
 def test_owner_suite_daytime_rows_use_calendar_or_quote_context_not_alarms() -> None:


### PR DESCRIPTION
Closes #873

## Summary
- show current owner-suite weather in Fahrenheit and Celsius
- show tomorrow and flight destination temperatures in both units
- round every displayed temperature to an integer
- document and test the payload format

## Testing
- `PYTHONPATH=. uv run --with pytest --with pillow pytest tests/test_inky_display_renderer.py tests/test_inky_display_service.py tests/test_inky_displays_package.py` (46 passed)
- `PYTHONPATH=. uv run --with pytest --with pillow pytest` (569 passed)