### PR TITLE
Fix KSDJ Music Assistant library URI (#875)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Radio wake-up scripts now use Music Assistant item URIs instead of Sonos favorit
 
 Current examples:
 
-- `library://radio/12`
+- `library://radio/21`
 - `tunein--S3NwgspV://radio/s34350`
 - `tunein--S3NwgspV://radio/s20620`
 

--- a/packages/workday.yaml
+++ b/packages/workday.yaml
@@ -704,7 +704,7 @@ script:
     sequence:
       - action: script.music_assistant_radio_wake_up
         data:
-          radio_uri: "library://radio/12"
+          radio_uri: "library://radio/21"
 
   sonos_mpr_news_wake_up:
     alias: Sonos MPR News Wake Up

--- a/specs/allium_weed_config.json
+++ b/specs/allium_weed_config.json
@@ -57,6 +57,18 @@
     {
       "spec": "specs/alarm_wakeup.allium",
       "implementation_paths": [
+        "packages/workday.yaml"
+      ],
+      "allowed_changed_line_patterns": [
+        "-*radio_uri: \"library://radio/12\"",
+        "+*radio_uri: \"library://radio/21\""
+      ],
+      "classification": "media-library-record repair",
+      "reason": "Exact media URIs are explicitly excluded by specs/alarm_wakeup.allium; issue #875 and PR #876 replace KSDJ's stale Music Assistant library record without changing wake-up scheduling, playback verification, retry, fallback, grouping, or volume-ramp behavior."
+    },
+    {
+      "spec": "specs/alarm_wakeup.allium",
+      "implementation_paths": [
         "packages/media_player.yaml"
       ],
       "classification": "non-wakeup-scope change",

--- a/tests/test_allium_weed_check.py
+++ b/tests/test_allium_weed_check.py
@@ -187,6 +187,21 @@ def test_default_config_lists_existing_specs_and_scopes() -> None:
         },
         {
             "spec": "specs/alarm_wakeup.allium",
+            "implementation_paths": ["packages/workday.yaml"],
+            "allowed_changed_line_patterns": [
+                '-*radio_uri: "library://radio/12"',
+                '+*radio_uri: "library://radio/21"',
+            ],
+            "classification": "media-library-record repair",
+            "reason": (
+                "Exact media URIs are explicitly excluded by specs/alarm_wakeup.allium; "
+                "issue #875 and PR #876 replace KSDJ's stale Music Assistant library "
+                "record without changing wake-up scheduling, playback verification, "
+                "retry, fallback, grouping, or volume-ramp behavior."
+            ),
+        },
+        {
+            "spec": "specs/alarm_wakeup.allium",
             "implementation_paths": ["packages/media_player.yaml"],
             "classification": "non-wakeup-scope change",
             "reason": (

--- a/tests/test_workday_wakeup_wrappers.py
+++ b/tests/test_workday_wakeup_wrappers.py
@@ -30,6 +30,12 @@ def _script_block(script_id: str) -> str:
     return "\n".join(lines[start:end])
 
 
+def test_ksdj_wrapper_uses_current_music_assistant_library_item() -> None:
+    block = _script_block("sonos_ksdj_wake_up")
+
+    assert 'radio_uri: "library://radio/21"' in block
+
+
 def test_mpr_news_wrapper_prefers_direct_stream_then_tunein() -> None:
     block = _script_block("sonos_mpr_news_wake_up")
 


### PR DESCRIPTION
Closes #875.

## Summary

- update the KSDJ wake-up wrapper from stale Music Assistant item `12` to replacement item `21`
- update the radio URI documentation example
- add regression coverage for the KSDJ wrapper URI
- classify the exact media-URI repair as outside the behavioral scope of `alarm_wakeup.allium`

## Runtime verification

- hard-replaced stale KSDJ item `12` with `library://radio/21`
- confirmed KSDJ remains a favorite
- confirmed TuneIn mapping `s35264` is available and in-library
- validated Home Assistant configuration and reloaded scripts

## Tests

- `uv run --with pytest pytest` — 576 passed
- Allium weed check — passed