### PR TITLE
Migrate water softener to ESP32 VL53L1X

### DIFF
--- a/esphome/archive/watersoftener-esp8266-vl53l0x.yaml
+++ b/esphome/archive/watersoftener-esp8266-vl53l0x.yaml
@@ -1,0 +1,83 @@
+# Archived 2026-07-13 before migrating the active water softener node to an
+# ESP32 and Adafruit VL53L1X. Keep this file as a reference; do not deploy it
+# alongside esphome/watersoftener.yaml because both configurations use the
+# same ESPHome node name.
+
+# ESPHome node attached to the water softener hardware.
+# It reports salt level and related sensors that the Home Assistant water softener package turns into inventory, reminder, and refill workflows.
+
+esphome:
+  name: watersoftener
+  libraries:
+    - "Wire"
+  #   - "VL53L0X"
+  # includes:
+  #   - "vl53l0x_sensor.h"
+
+esp8266:
+  board: esp01_1m
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  min_auth_mode: WPA2
+
+
+# Enable logging
+logger:
+  level: DEBUG
+  esp8266_store_log_strings_in_flash: False
+
+# Enable Home Assistant API
+api:
+
+ota:
+  - platform: esphome
+
+# Sync time with Home Assistant.
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+
+i2c:
+  sda: SDA
+  scl: SCL
+  scan: true
+  # id: bus_a
+
+sensor:
+# - platform: custom
+#   lambda: |-
+#     auto my_sensor = new VL53L0XSensor(300000);
+#     App.register_component(my_sensor);
+#     return {my_sensor};
+#   sensors:
+#     name: "My Water Softener VL53L0X Sensor"
+#     icon: "mdi:shaker-outline"
+#     unit_of_measurement: mm
+#     device_class: distance
+#     state_class: measurement
+#     filters:
+#       - exponential_moving_average:
+#           alpha: 0.1
+#           send_every: 15
+
+  - platform: vl53l0x
+    name: "My Water Softener VL53L0X Sensor"
+    icon: "mdi:shaker-outline"
+    id: distance1
+    device_class: distance
+    state_class: measurement
+    unit_of_measurement: "mm"
+    # address: 0x29
+    # enable_pin: D8
+    timeout: 1000ms
+    update_interval: 2s
+    long_range: true
+    filters:
+      # Convert to from m to mm
+      - lambda: return x * 1000;
+      - exponential_moving_average:
+          alpha: 0.1
+          send_every: 15
+      - round: 0

--- a/esphome/watersoftener.yaml
+++ b/esphome/watersoftener.yaml
@@ -3,14 +3,18 @@
 
 esphome:
   name: watersoftener
-  libraries:
-    - "Wire"
-  #   - "VL53L0X"
-  # includes:
-  #   - "vl53l0x_sensor.h"
 
-esp8266:
-  board: esp01_1m
+esp32:
+  variant: esp32
+  framework:
+    type: esp-idf
+
+# ESPHome does not currently include a native VL53L1X component. Pin the
+# external component to a stable release so firmware builds are reproducible.
+external_components:
+  - source: github://soldierkam/vl53l1x_sensor@v0.5.1
+    components:
+      - vl53l1x_sensor
 
 wifi:
   ssid: !secret wifi_ssid
@@ -21,7 +25,6 @@ wifi:
 # Enable logging
 logger:
   level: DEBUG
-  esp8266_store_log_strings_in_flash: False
 
 # Enable Home Assistant API
 api:
@@ -35,42 +38,30 @@ time:
     id: homeassistant_time
 
 i2c:
-  sda: SDA
-  scl: SCL
+  # Wiring confirmed from the ESP-WROOM-32 board pinout and assembled device:
+  # IO21 -> SDA, IO22 -> SCL, 3.3V -> VIN, and GND -> GND. The Adafruit
+  # breakout's XSHUT and GPIO pins are not needed for this single-sensor bus.
+  sda: GPIO21
+  scl: GPIO22
   scan: true
-  # id: bus_a
+  frequency: 400kHz
 
 sensor:
-# - platform: custom
-#   lambda: |-
-#     auto my_sensor = new VL53L0XSensor(300000);
-#     App.register_component(my_sensor);
-#     return {my_sensor};
-#   sensors:
-#     name: "My Water Softener VL53L0X Sensor"
-#     icon: "mdi:shaker-outline"
-#     unit_of_measurement: mm
-#     device_class: distance
-#     state_class: measurement
-#     filters:
-#       - exponential_moving_average:
-#           alpha: 0.1
-#           send_every: 15
-
-  - platform: vl53l0x
-    name: "My Water Softener VL53L0X Sensor"
+  - platform: vl53l1x_sensor
+    name: "My Water Softener VL53L1X Sensor"
     icon: "mdi:shaker-outline"
     id: distance1
     device_class: distance
     state_class: measurement
     unit_of_measurement: "mm"
-    # address: 0x29
-    # enable_pin: D8
-    timeout: 1000ms
+    address: 0x29
+    timeout: 1s
     update_interval: 2s
-    long_range: true
+    distance_mode: LONG
+    timing_budget: 200ms
     filters:
-      # Convert to from m to mm
+      # The component reports meters; retain the millimeter scale expected by
+      # the Home Assistant water softener package and its existing thresholds.
       - lambda: return x * 1000;
       - exponential_moving_average:
           alpha: 0.1

--- a/packages/water_softener.yaml
+++ b/packages/water_softener.yaml
@@ -528,7 +528,7 @@ script: {}
 ########################
 sensor:
   - platform: filter
-    entity_id: sensor.my_water_softener_vl53l0x_sensor
+    entity_id: sensor.my_water_softener_vl53l1x_sensor
     name: "Water Softener Salt Level"
     filters:
       - filter: lowpass

--- a/tests/test_esphome_water_softener.py
+++ b/tests/test_esphome_water_softener.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTIVE_CONFIG = ROOT / "esphome" / "watersoftener.yaml"
+LEGACY_CONFIG = (
+    ROOT / "esphome" / "archive" / "watersoftener-esp8266-vl53l0x.yaml"
+)
+HA_PACKAGE = ROOT / "packages" / "water_softener.yaml"
+
+
+def test_legacy_water_softener_configuration_is_archived() -> None:
+    text = LEGACY_CONFIG.read_text(encoding="utf-8")
+
+    assert "esp8266:" in text
+    assert "board: esp01_1m" in text
+    assert "platform: vl53l0x" in text
+    assert 'name: "My Water Softener VL53L0X Sensor"' in text
+
+
+def test_active_water_softener_uses_esp32_and_pinned_vl53l1x_component() -> None:
+    text = ACTIVE_CONFIG.read_text(encoding="utf-8")
+
+    assert "esp32:" in text
+    assert "variant: esp32" in text
+    assert "type: esp-idf" in text
+    assert "github://soldierkam/vl53l1x_sensor@v0.5.1" in text
+    assert "platform: vl53l1x_sensor" in text
+    assert "platform: vl53l0x" not in text
+    assert 'name: "My Water Softener VL53L1X Sensor"' in text
+
+
+def test_vl53l1x_wiring_and_measurement_contract_are_explicit() -> None:
+    text = ACTIVE_CONFIG.read_text(encoding="utf-8")
+
+    assert "sda: GPIO21" in text
+    assert "scl: GPIO22" in text
+    assert "frequency: 400kHz" in text
+    assert "address: 0x29" in text
+    assert "distance_mode: LONG" in text
+    assert "timing_budget: 200ms" in text
+    assert "unit_of_measurement: \"mm\"" in text
+    assert "lambda: return x * 1000;" in text
+    assert "update_interval: 2s" in text
+
+
+def test_home_assistant_package_consumes_new_sensor_entity() -> None:
+    text = HA_PACKAGE.read_text(encoding="utf-8")
+
+    assert "entity_id: sensor.my_water_softener_vl53l1x_sensor" in text
+    assert "entity_id: sensor.my_water_softener_vl53l0x_sensor" not in text


### PR DESCRIPTION
## Summary

- migrate the active water softener ESPHome node from ESP8266/VL53L0X to the photographed classic ESP-WROOM-32 and Adafruit VL53L1X
- configure ESP-IDF, GPIO21/GPIO22 I2C wiring, 400 kHz I2C, long-distance mode, and a 200 ms timing budget
- pin the ESPHome-native Soldierkam VL53L1X external component to stable release `v0.5.1`
- preserve the existing millimeter measurement and smoothing contract, and update the Home Assistant filter source entity
- archive the original ESP8266/VL53L0X YAML and add regression coverage

## Why

The physical water softener sensor is being replaced with an ESP32 and Adafruit VL53L1X. ESPHome does not currently ship a native VL53L1X sensor platform, so the configuration uses a pinned ESPHome external component while retaining the downstream units and filtering expected by the existing Home Assistant package.

## Hardware impact

Wire the photographed ESP-WROOM-32 board to the Adafruit breakout as follows:

- `3.3V` to `VIN`
- `GND` to `GND`
- `IO22` to `SCL`
- `IO21` to `SDA`

`XSHUT` and `GPIO` remain disconnected for this single-sensor I2C bus.

## Validation

- `uv run --with pytest pytest` — 579 passed
- `uv run --with esphome esphome config esphome/watersoftener.yaml` — valid with ESPHome 2026.6.5
- `uv run --with esphome esphome compile esphome/watersoftener.yaml` — ESP-IDF build succeeded for classic ESP32 (`esp32dev`), 724,115 bytes / 39.5% app flash
