### PR TITLE
Audit Security dashboard activity coverage (#614)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ docker run --rm -v "$PWD:/config" ghcr.io/home-assistant/home-assistant:2026.5.0
 - [Home Assistant Label Model](docs/ha_labels.md)
 - [Room Intent Policy](docs/room_intent.yaml)
 - [Room Naming Model](docs/room_names.md)
+- [Built-In Security Dashboard](docs/security_dashboard.md)
 - [Inky E-Ink Displays](docs/inky_displays.md)
 - [ESPHome Layout And Bermuda BLE Proxy Notes](docs/esphome.md)
 - [EV Charging Tariff](docs/ev_charging_tariff.md)

--- a/docs/security_dashboard.md
+++ b/docs/security_dashboard.md
@@ -1,0 +1,63 @@
+# Built-In Security Dashboard
+
+Home Assistant's built-in Security dashboard is the primary automatic view for
+alarm, lock, cover, camera, door/window, motion, and person entities. The
+Activity sidebar is supplied by Logbook and shows the most recent 24 hours on
+wide screens.
+
+Official references:
+
+- [Home Assistant 2026.5 release notes](https://www.home-assistant.io/blog/2026/05/06/release-20265/#activity-log-on-the-security-dashboard)
+- [Built-in dashboard documentation](https://www.home-assistant.io/dashboards/dashboards/)
+- [Recorder filtering](https://www.home-assistant.io/integrations/recorder/#configure-filter)
+
+## Repository Contract
+
+- Keep `logbook:` enabled in `configuration.yaml`; the Activity sidebar depends
+  on it.
+- Record the security state domains used by Activity: `alarm_control_panel`,
+  `lock`, `cover`, `binary_sensor`, and `person`.
+- Keep the `camera` domain excluded from Recorder. Camera tiles still appear on
+  the Security dashboard, while door/window and camera-motion binary sensors
+  provide the useful activity events without retaining camera state history.
+- Give physical camera-motion binary sensors `device_class: motion`. A camera
+  entity alone does not replace the motion event source.
+- Assign devices to their real Home Assistant areas. Follow
+  `docs/room_intent.yaml`; in particular, the legacy living-room camera belongs
+  to `dining_room`.
+
+Removing the camera exclusion would record all camera-domain entities,
+including mail images, vacuum maps, printer feeds, and unavailable legacy
+cameras. That adds churn and retained metadata without improving the door,
+window, alarm, lock, cover, person, or camera-motion events already shown in
+Activity.
+
+## Runtime Audit — 2026-07-14
+
+Verified against the live Home Assistant 2026.7.2 instance:
+
+- `/security` rendered the Activity sidebar on a wide desktop viewport with
+  same-day door activity.
+- The dashboard grouped door/window, lock, cover, alarm, camera, and person
+  entities across the configured floors and areas.
+- Recorder history contained recent alarm, front-door, garage-door, and person
+  states. Physical camera entities had no retained states, as configured.
+- Front-door, office-window, guest-room-window, Tiki-camera-motion, and garage
+  devices were assigned to Hallway, Office, Guest room, Tiki Room, and Garage.
+- The legacy living-room camera device was moved through Home Assistant's
+  device-registry API to Dining room, matching the room-intent mapping.
+- `binary_sensor.tikiroomcam_motionsensor` lacked a device class. The package
+  customization now classifies it as `motion`, matching the living-room camera
+  sensor and making the entity eligible for security activity presentation
+  after the updated config is deployed.
+
+## Post-Deploy Check
+
+After deploying this config, reload customizations or restart Home Assistant,
+then open `/security` on a wide screen and confirm:
+
+1. The Activity sidebar is visible and shows recent security events.
+2. Tiki Room Camera Motion is classified as motion in Tiki Room.
+3. Camera tiles remain visible even though camera state history remains empty.
+4. Door/window, alarm, lock, cover, and person events continue to populate the
+   24-hour activity list.

--- a/packages/camera.yaml
+++ b/packages/camera.yaml
@@ -36,6 +36,11 @@ homeassistant:
       device_class: motion
       friendly_name: "Living Room Camera Motion"
 
+    binary_sensor.tikiroomcam_motionsensor:
+      <<: *customize
+      device_class: motion
+      friendly_name: "Tiki Room Camera Motion"
+
     ################################################
     ## Cameras
     ################################################

--- a/tests/test_security_dashboard_activity.py
+++ b/tests/test_security_dashboard_activity.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGURATION_PATH = ROOT / "configuration.yaml"
+CAMERA_PACKAGE_PATH = ROOT / "packages" / "camera.yaml"
+ALERTS_PACKAGE_PATH = ROOT / "packages" / "alerts.yaml"
+DOC_PATH = ROOT / "docs" / "security_dashboard.md"
+README_PATH = ROOT / "README.md"
+
+
+def _customize_block(text: str, entity_id: str) -> str:
+    lines = text.splitlines()
+    needle = f"    {entity_id}:"
+
+    try:
+        start = lines.index(needle)
+    except ValueError as exc:
+        raise AssertionError(f"Missing customize block for {entity_id}") from exc
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("    ") and not lines[index].startswith("      "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def test_security_activity_dependencies_and_privacy_filter_are_preserved() -> None:
+    text = CONFIGURATION_PATH.read_text(encoding="utf-8")
+    recorder_block = text.split("recorder:\n", 1)[1].split("\ninfluxdb:", 1)[0]
+    excluded_domains = {
+        line.removeprefix("      - ").strip()
+        for line in recorder_block.splitlines()
+        if line.startswith("      - ")
+    }
+
+    assert "logbook:\n" in text
+    assert "camera" in excluded_domains
+    assert {
+        "alarm_control_panel",
+        "lock",
+        "cover",
+        "binary_sensor",
+        "person",
+    }.isdisjoint(excluded_domains)
+
+
+def test_physical_camera_motion_entities_use_motion_device_class() -> None:
+    text = CAMERA_PACKAGE_PATH.read_text(encoding="utf-8")
+
+    for entity_id in (
+        "binary_sensor.livingroom_motion_sensor",
+        "binary_sensor.tikiroomcam_motionsensor",
+    ):
+        block = _customize_block(text, entity_id)
+        assert "device_class: motion" in block
+
+
+def test_camera_snapshot_notifications_use_the_classified_motion_entities() -> None:
+    text = ALERTS_PACKAGE_PATH.read_text(encoding="utf-8")
+    block = text.split("  - alias: send_pic_from_camera", 1)[1].split(
+        "  - alias: arm_alarm", 1
+    )[0]
+
+    assert "binary_sensor.livingroom_motion_sensor" in block
+    assert "binary_sensor.tikiroomcam_motionsensor" in block
+
+
+def test_security_dashboard_runtime_contract_is_discoverable() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    readme = README_PATH.read_text(encoding="utf-8")
+
+    assert "docs/security_dashboard.md" in readme
+    assert "Keep the `camera` domain excluded from Recorder" in doc
+    assert "Home Assistant 2026.7.2" in doc
+    assert "device-registry API to Dining room" in doc


### PR DESCRIPTION
Closes #614.

## Summary

- classify the Tiki Room camera motion entity as a native motion binary sensor
- document the built-in Security dashboard, Activity, Recorder, privacy, and area contract
- preserve the camera-domain Recorder exclusion because camera tiles remain visible and security event domains remain recorded
- add focused regression coverage for Logbook, Recorder filtering, camera-motion metadata, notification consumers, and documentation discoverability

## Runtime verification

Verified on the live Home Assistant 2026.7.2 instance:

- the wide-screen `/security` dashboard renders the Activity sidebar with same-day door events
- alarm, lock, cover, door/window, person, and camera tiles are present
- recent recorder history exists for alarm, front-door, garage-door, and person entities
- camera entities have no retained states, as intended by the privacy/storage filter
- moved the legacy living-room camera device to Dining room through the native device-registry API, matching `docs/room_intent.yaml`

## Validation

- `uv run --with pytest pytest` — 583 passed
- targeted tests — 9 passed
- Home Assistant 2026.5.1 container `check_config` — passed
- YAML lint — passed
- targeted YAML DRY verifier — 1 file, 0 findings, 0 parse errors
- Allium weed check — passed
- latest Home Assistant/Python compatibility check — passed
- `git diff --check` — passed