### PR TITLE
Fix bedtime audio owner-suite scope (#871)

### DIFF
--- a/packages/media_player.yaml
+++ b/packages/media_player.yaml
@@ -1848,9 +1848,7 @@ script:
             {% set pindex = (range(0, (plists | length))|random) -%}
             {{ plists[pindex] }}
       - variables:
-          bedtime_playback_entity: >-
-            {{ 'media_player.ma_group_guest' if is_state('input_boolean.guest_mode', 'on')
-               else 'media_player.ma_group_everywhere' }}
+          bedtime_playback_entity: media_player.ma_group_guest
           bedtime_media_type: "{{ 'radio' if 'somafm.com' in playlist else '' }}"
           bedtime_apple_music_fallback_uri: "apple_music://track/1492333325"
           bedtime_apple_music_fallback_media_type: ""
@@ -1887,8 +1885,6 @@ script:
           entity_id:
             - media_player.bedroom_sonos_2
             - media_player.bathroom_sonos_2
-            - media_player.office_sonos_2
-            - media_player.den_sonos_2
         data:
           volume_level: 0.20
       - alias: "Let bedtime volume settle before playback starts"
@@ -2062,27 +2058,22 @@ script:
             - delay_minutes: 0
               entity_id:
                 - media_player.bedroom_sonos_2
-                - media_player.office_sonos_2
                 - media_player.bathroom_sonos_2
-                - media_player.den_sonos_2
               volume_level: 0.1
             - delay_minutes: 2
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.bathroom_sonos_2
-                - media_player.office_sonos_2
               volume_level: 0.07
             - delay_minutes: 2
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.bathroom_sonos_2
-                - media_player.office_sonos_2
               volume_level: 0.05
             - delay_minutes: 2
               entity_id:
                 - media_player.bedroom_sonos_2
                 - media_player.bathroom_sonos_2
-                - media_player.office_sonos_2
               volume_level: 0.01
       - repeat:
           for_each: "{{ bedtime_rampdown_steps }}"

--- a/tests/test_media_player_music_assistant.py
+++ b/tests/test_media_player_music_assistant.py
@@ -249,18 +249,26 @@ def test_arrival_music_sets_volume_on_selected_music_assistant_group_members() -
         )
 
 
-def test_bedtime_targets_guest_aware_sync_group_before_playing() -> None:
+def test_bedtime_targets_owner_suite_sync_group_before_playing() -> None:
     block = _script_block("spotify_bedtime")
 
     assert "bedtime_playback_entity" in block
     assert "media_player.ma_group_guest" in block
-    assert "media_player.ma_group_everywhere" in block
-    assert "input_boolean.guest_mode" in block
+    assert "media_player.ma_group_everywhere" not in block
     assert 'action: script.music_assistant_prepare_bedroom_group' not in block
     assert 'action: script.music_assistant_play_item' in block
     assert block.index("media_player.ma_group_guest") < block.index(
         'action: script.music_assistant_play_item'
     )
+
+
+def test_bedtime_initial_volume_targets_only_owner_suite_members() -> None:
+    block = _script_block("spotify_bedtime")
+
+    assert "media_player.bedroom_sonos_2" in block
+    assert "media_player.bathroom_sonos_2" in block
+    assert "media_player.office_sonos_2" not in block
+    assert "media_player.den_sonos_2" not in block
 
 
 def test_bedtime_join_retry_helper_is_stubbed_after_sync_group_migration() -> None:
@@ -621,6 +629,15 @@ def test_bedtime_volume_rampdown_is_data_driven_without_repeating_delay_actions(
     # rampdown, so the volume_set tolerates errors and no step opts out.
     assert "continue_on_error: true" in block
     assert "continue_on_error: false" not in block
+
+
+def test_bedtime_volume_rampdown_targets_only_owner_suite_members() -> None:
+    block = _script_block("spotify_bedtime_volume")
+
+    assert "media_player.bedroom_sonos_2" in block
+    assert "media_player.bathroom_sonos_2" in block
+    assert "media_player.office_sonos_2" not in block
+    assert "media_player.den_sonos_2" not in block
 
 
 def test_spotify_bedtime_reapplies_repeat_to_started_queue_before_rampdown() -> None:


### PR DESCRIPTION
## Summary

- always route bedtime playback through the existing Bedroom+Bathroom Music Assistant sync group
- keep initial bedtime volume and rampdown limited to Bedroom+Bathroom
- add focused regressions for playback, initial volume, and rampdown room boundaries

## Runtime evidence

The latest retained bedtime trace targeted `media_player.ma_group_everywhere`; recorder and logbook correlation showed Bedroom, Bathroom, Office, Den, and Tiki all entered `playing`. This contradicts `StartBedtimePreparation -> BedtimeAudioRequested(bedroom_suite)` in `specs/night_routines.allium` and the guest-sensitive Office/Den policy in `docs/room_intent.yaml`.

Closes #871.

## Validation

- `uv run --with pytest pytest` — 581 passed
- targeted Music Assistant/night/alarm Allium alignment — 56 passed
- Allium weed/alignment subset — 39 passed
- CI-profile `yamllint` on `packages/media_player.yaml` — passed
- HA YAML DRY verifier strict — 1 file, 39 candidates, 0 parse errors/findings
- Home Assistant 2026.7.2 native `check_config` — exit 0
- `git diff --check` — passed
