### PR TITLE
Add fermentor reboot dashboard control (#884)

### DIFF
--- a/.storage/lovelace.ryan_new_mushroom
+++ b/.storage/lovelace.ryan_new_mushroom
@@ -2849,6 +2849,25 @@
               },
               "entity": "automation.shutdown_proxmox_z2m_unavailable",
               "show_state": false
+            },
+            {
+              "show_name": true,
+              "show_icon": true,
+              "type": "button",
+              "entity": "script.reboot_fermentor",
+              "name": "Reboot Fermentor",
+              "icon": "mdi:restart-alert",
+              "show_state": false,
+              "tap_action": {
+                "action": "call-service",
+                "service": "script.turn_on",
+                "target": {
+                  "entity_id": "script.reboot_fermentor"
+                },
+                "confirmation": {
+                  "text": "Reboot fermentor? Services hosted there will be briefly unavailable."
+                }
+              }
             }
           ]
         },

--- a/docs/fermentor_reboot.md
+++ b/docs/fermentor_reboot.md
@@ -49,6 +49,7 @@ Create `/config/.ssh/config` in the Home Assistant Core filesystem:
 ```sshconfig
 Host fermentor
   HostName <fermentor-address>
+  HostKeyAlias <fermentor-address>
   User <restricted-user>
   IdentityFile /config/.ssh/fermentor_reboot_ed25519
   IdentitiesOnly yes

--- a/docs/fermentor_reboot.md
+++ b/docs/fermentor_reboot.md
@@ -1,0 +1,90 @@
+# Fermentor reboot control
+
+Home Assistant exposes `script.reboot_fermentor` for the confirmation-protected
+dashboard button. The script calls `shell_command.reboot_fermentor`, which uses
+an SSH host alias so no fermentor address, username, or private key is committed
+to this repository.
+
+## Home Assistant setup
+
+The preferred flow is to generate the dedicated key on Home Assistant, where
+the private key will be used:
+
+```sh
+mkdir -p /config/.ssh
+chmod 700 /config/.ssh
+ssh-keygen -t ed25519 -N '' \
+  -C home-assistant-fermentor-reboot \
+  -f /config/.ssh/fermentor_reboot_ed25519
+ssh-keyscan -H <fermentor-address> >> /config/.ssh/known_hosts
+chmod 600 /config/.ssh/fermentor_reboot_ed25519
+chmod 644 /config/.ssh/fermentor_reboot_ed25519.pub /config/.ssh/known_hosts
+```
+
+Copy the single line from
+`/config/.ssh/fermentor_reboot_ed25519.pub` into the restricted fermentor
+account's `~/.ssh/authorized_keys` as described below. Never copy the private
+key into `authorized_keys`.
+
+If the dedicated key pair was instead generated on fermentor, copy only its
+private half to Home Assistant and remove that private half from fermentor as
+soon as the transfer succeeds:
+
+```sh
+# Run on fermentor. Replace <ha-ssh-user> and <ha-address>.
+scp ./fermentor_reboot_ed25519 \
+  <ha-ssh-user>@<ha-address>:/config/.ssh/fermentor_reboot_ed25519
+ssh <ha-ssh-user>@<ha-address> \
+  'chmod 600 /config/.ssh/fermentor_reboot_ed25519'
+shred -u ./fermentor_reboot_ed25519
+```
+
+Keep `fermentor_reboot_ed25519.pub` on fermentor for the `authorized_keys`
+entry. If the Home Assistant SSH app does not expose `/config` to SCP, copy the
+file to that app's home directory first, then move it into `/config/.ssh` from
+the Home Assistant terminal.
+
+Create `/config/.ssh/config` in the Home Assistant Core filesystem:
+
+```sshconfig
+Host fermentor
+  HostName <fermentor-address>
+  User <restricted-user>
+  IdentityFile /config/.ssh/fermentor_reboot_ed25519
+  IdentitiesOnly yes
+  UserKnownHostsFile /config/.ssh/known_hosts
+```
+
+Install the private key at `/config/.ssh/fermentor_reboot_ed25519`, add
+fermentor's host key to `/config/.ssh/known_hosts`, and use restrictive
+permissions:
+
+```sh
+chmod 700 /config/.ssh
+chmod 600 /config/.ssh/config /config/.ssh/fermentor_reboot_ed25519
+chmod 644 /config/.ssh/known_hosts
+```
+
+The Home Assistant Core runtime must provide `/usr/bin/ssh`. Confirm that path
+inside the Core container before reloading `shell_command`.
+
+## Fermentor setup
+
+Prefer a dedicated unprivileged account. Permit only the reboot command in a
+sudoers drop-in, replacing `<restricted-user>` with the account from the SSH
+config:
+
+```sudoers
+<restricted-user> ALL=(root) NOPASSWD: /usr/bin/systemctl reboot
+```
+
+For defense in depth, restrict the public key in that user's
+`~/.ssh/authorized_keys` entry:
+
+```text
+restrict,command="sudo -n /usr/bin/systemctl reboot" ssh-ed25519 <public-key> home-assistant-fermentor-reboot
+```
+
+After the local files and remote authorization are ready, reload Shell Command
+and Scripts, then test `script.reboot_fermentor` from Home Assistant's action
+developer tool before using the dashboard button.

--- a/packages/fermentor.yaml
+++ b/packages/fermentor.yaml
@@ -1,0 +1,27 @@
+################################################################
+## Fermentor Host Controls
+################################################################
+
+# The "fermentor" SSH alias, key, and known-host entry are intentionally
+# machine-local. See docs/fermentor_reboot.md for the one-time setup.
+shell_command:
+  reboot_fermentor: >-
+    /usr/bin/ssh
+    -F /config/.ssh/config
+    -o BatchMode=yes
+    -o ConnectTimeout=10
+    -o StrictHostKeyChecking=yes
+    fermentor
+    "sudo -n /usr/bin/systemctl reboot"
+
+script:
+  reboot_fermentor:
+    alias: Reboot Fermentor
+    description: Reboot the fermentor host over its restricted SSH connection.
+    icon: mdi:restart-alert
+    mode: single
+    max_exceeded: silent
+    trace:
+      stored_traces: 10
+    sequence:
+      - action: shell_command.reboot_fermentor

--- a/tests/test_fermentor_reboot.py
+++ b/tests/test_fermentor_reboot.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_PATH = ROOT / "packages" / "fermentor.yaml"
+DASHBOARD_PATH = ROOT / ".storage" / "lovelace.ryan_new_mushroom"
+
+
+def test_fermentor_reboot_uses_restricted_noninteractive_ssh() -> None:
+    text = PACKAGE_PATH.read_text(encoding="utf-8")
+
+    assert "reboot_fermentor:" in text
+    assert "action: shell_command.reboot_fermentor" in text
+    assert "-o BatchMode=yes" in text
+    assert "-o StrictHostKeyChecking=yes" in text
+    assert "-F /config/.ssh/config" in text
+    assert '"sudo -n /usr/bin/systemctl reboot"' in text
+    assert "StrictHostKeyChecking=no" not in text
+
+
+def test_testing_dashboard_has_confirmed_fermentor_reboot_button() -> None:
+    dashboard = json.loads(DASHBOARD_PATH.read_text(encoding="utf-8"))
+    testing_view = next(
+        view
+        for view in dashboard["data"]["config"]["views"]
+        if view.get("path") == "testing"
+    )
+    reboot_card = next(
+        card
+        for card in testing_view["cards"]
+        if card.get("entity") == "script.reboot_fermentor"
+    )
+
+    assert reboot_card["name"] == "Reboot Fermentor"
+    assert reboot_card["icon"] == "mdi:restart-alert"
+    assert reboot_card["tap_action"] == {
+        "action": "call-service",
+        "service": "script.turn_on",
+        "target": {"entity_id": "script.reboot_fermentor"},
+        "confirmation": {
+            "text": "Reboot fermentor? Services hosted there will be briefly unavailable."
+        },
+    }

--- a/tests/test_fermentor_reboot.py
+++ b/tests/test_fermentor_reboot.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_PATH = ROOT / "packages" / "fermentor.yaml"
 DASHBOARD_PATH = ROOT / ".storage" / "lovelace.ryan_new_mushroom"
+DOCUMENTATION_PATH = ROOT / "docs" / "fermentor_reboot.md"
 
 
 def test_fermentor_reboot_uses_restricted_noninteractive_ssh() -> None:
@@ -19,6 +20,15 @@ def test_fermentor_reboot_uses_restricted_noninteractive_ssh() -> None:
     assert "-F /config/.ssh/config" in text
     assert '"sudo -n /usr/bin/systemctl reboot"' in text
     assert "StrictHostKeyChecking=no" not in text
+
+
+def test_fermentor_ssh_alias_matches_documented_known_hosts_entry() -> None:
+    text = DOCUMENTATION_PATH.read_text(encoding="utf-8")
+
+    assert "Host fermentor" in text
+    assert "HostName <fermentor-address>" in text
+    assert "HostKeyAlias <fermentor-address>" in text
+    assert "ssh-keyscan -H <fermentor-address>" in text
 
 
 def test_testing_dashboard_has_confirmed_fermentor_reboot_button() -> None:


### PR DESCRIPTION
Closes #884

## What changed

- add `script.reboot_fermentor` backed by a strict, noninteractive SSH shell command
- add a confirmation-protected Reboot Fermentor button to the Testing dashboard
- document least-privilege SSH key, host verification, and sudo setup
- add regression tests for the package security options and dashboard action

## Why

Fermentor had no dashboard reboot path comparable to the existing Proxmox shutdown control. The new script keeps all machine-specific SSH details local to Home Assistant and requires explicit confirmation before execution.

## Validation

- `uv run --with pytest pytest` — 581 passed
- targeted YAML DRY verification — no findings
- `yamllint` on `packages/fermentor.yaml`
- dashboard JSON parsed with `jq`
- `git diff --check`

## Runtime setup

The SSH alias, key, known-host entry, and restricted sudo authorization must be installed following `docs/fermentor_reboot.md` before the button is tested live.

## Known validation limitation

The live Home Assistant API was unreachable from the development environment, and the local Podman machine stopped unexpectedly before the containerized Home Assistant config check could run.